### PR TITLE
[Debug][AArch64] Do not crash on unknown subreg register sizes.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -154,7 +154,7 @@ bool DwarfExpression::addMachineReg(const TargetRegisterInfo &TRI,
     unsigned Size = TRI.getSubRegIdxSize(Idx);
     unsigned Offset = TRI.getSubRegIdxOffset(Idx);
     Reg = TRI.getDwarfRegNum(SR, false);
-    if (Reg < 0)
+    if (Reg < 0 || Offset + Size > RegSize)
       continue;
 
     // Used to build the intersection between the bits we already

--- a/llvm/test/CodeGen/AArch64/debug-info-sve-pair.mir
+++ b/llvm/test/CodeGen/AArch64/debug-info-sve-pair.mir
@@ -1,0 +1,344 @@
+# RUN: llc -start-before=aarch64-asm-printer -o - %s | FileCheck %s
+
+# Check that z30_z31 debug info does not crash.
+
+# CHECK: .Ldebug_loc0:
+# CHECK:        .byte   4                               // DW_LLE_offset_pair
+# CHECK:        .uleb128 .Ltmp2-.Lfunc_begin0           //   starting offset
+# CHECK:        .uleb128 .Ltmp3-.Lfunc_begin0           //   ending offset
+# CHECK:        .byte   2                               // Loc expr size
+# CHECK:        .byte   144                             // DW_OP_regx
+# CHECK:        .byte   126                             // 126
+# CHECK:        .byte   4                               // DW_LLE_offset_pair
+# CHECK:        .uleb128 .Ltmp3-.Lfunc_begin0           //   starting offset
+# CHECK:        .uleb128 .Lfunc_end0-.Lfunc_begin0      //   ending offset
+# CHECK:        .byte   6                               // Loc expr size
+# CHECK:        .byte   144                             // sub-register DW_OP_regx
+# CHECK:        .byte   94                              // 94
+# CHECK:        .byte   147                             // DW_OP_piece
+# CHECK:        .byte   16                              // 16
+# CHECK:        .byte   147                             // DW_OP_piece
+# CHECK:        .byte   31                              // 31
+# CHECK:        .byte   0                               // DW_LLE_end_of_list
+
+
+--- |
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+  target triple = "aarch64"
+
+  define void @_Z10Sort16RowsILi6EEv12SharedTraitsI10TraitsLaneEP22Trans_NS_hwy_float16_tiS4_(i8 %st.coerce, ptr noundef %keys, i32 noundef %0, ptr noundef %1) #2 !dbg !2 {
+      unreachable
+  }
+
+  attributes #2 = { mustprogress uwtable vscale_range(1,16) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="neoverse-n1" "target-features"="+aes,+crc,+dotprod,+fp-armv8,+fullfp16,+lse,+neon,+perfmon,+ras,+rcpc,+rdm,+sha2,+spe,+ssbs,+sve,+sve-aes,+sve2,+sve2-aes,+v8.1a,+v8.2a,+v8a,-fmv" "tune-cpu"="generic" }
+
+  !llvm.dbg.cu = !{!3}
+  !llvm.module.flags = !{!4, !5, !6, !7, !8, !9}
+  !llvm.ident = !{!10}
+
+  !2 = distinct !DISubprogram(name: "Sort16Rows<6>", linkageName: "_Z10Sort16RowsILi6EEv12SharedTraitsI10TraitsLaneEP22Trans_NS_hwy_float16_tiS4_", scope: !12, file: !12, line: 369, type: !18, scopeLine: 370, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !19, retainedNodes: !20, keyInstructions: true)
+  !3 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !14, producer: "clang version 22.0.0git (https://github.com/llvm/llvm-project.git)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+  !4 = !{i32 7, !"Dwarf Version", i32 5}
+  !5 = !{i32 2, !"Debug Info Version", i32 3}
+  !6 = !{i32 1, !"wchar_size", i32 4}
+  !7 = !{i32 7, !"uwtable", i32 2}
+  !8 = !{i32 7, !"frame-pointer", i32 1}
+  !9 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
+  !10 = !{!"clang version 22.0.0git (https://github.com/llvm/llvm-project.git)"}
+  !12 = !DIFile(filename: "example.cpp", directory: "/app", checksumkind: CSK_MD5, checksum: "5fbaafea0ede06ddd1ffc371aeee276e")
+  !14 = !DIFile(filename: "/app/example.cpp", directory: "/app", checksumkind: CSK_MD5, checksum: "5fbaafea0ede06ddd1ffc371aeee276e")
+  !17 = !DIBasicType(name: "__fp16", size: 16, encoding: DW_ATE_float)
+  !18 = !DISubroutineType(types: !21)
+  !19 = !{!120}
+  !20 = !{!77, !78, !79, !80, !81, !82, !83, !84, !85, !86, !87, !88, !89, !90, !91, !92, !93, !94, !95, !96, !97, !98, !99, !100, !101, !102, !103, !104, !105}
+  !21 = !{null, !22, !23, !24, !23}
+  !22 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "SharedTraits<TraitsLane>", file: !12, line: 272, size: 8, flags: DIFlagTypePassByValue, elements: !25, templateParams: !26, identifier: "_ZTS12SharedTraitsI10TraitsLaneE")
+  !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+  !24 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  !25 = !{!27}
+  !26 = !{!76}
+  !27 = !DIDerivedType(tag: DW_TAG_inheritance, scope: !22, baseType: !28, extraData: i32 0)
+  !28 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "TraitsLane", file: !12, line: 325, size: 8, flags: DIFlagTypePassByValue, elements: !29, identifier: "_ZTS10TraitsLane")
+  !29 = !{!30, !31, !32, !33}
+  !30 = !DIDerivedType(tag: DW_TAG_inheritance, scope: !28, baseType: !34, extraData: i32 0)
+  !31 = !DISubprogram(name: "Sort2", linkageName: "_ZN10TraitsLane5Sort2E4SimdI22Trans_NS_hwy_float16_tLi1ELi0EERu13__SVFloat16_tS4_", scope: !28, file: !12, line: 326, type: !70, scopeLine: 326, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+  !32 = !DISubprogram(name: "SortPairsDistance1", linkageName: "_ZN10TraitsLane18SortPairsDistance1E4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEu13__SVFloat16_t", scope: !28, file: !12, line: 344, type: !74, scopeLine: 344, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+  !33 = !DISubprogram(name: "SortPairsDistance4", linkageName: "_ZN10TraitsLane18SortPairsDistance4E4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEu13__SVFloat16_t", scope: !28, file: !12, line: 352, type: !74, scopeLine: 352, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+  !34 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "KeyLane", file: !12, line: 307, size: 8, flags: DIFlagTypePassByValue, elements: !35, identifier: "_ZTS7KeyLane")
+  !35 = !{!36, !37, !38}
+  !36 = !DISubprogram(name: "SwapAdjacentPairs", linkageName: "_ZN7KeyLane17SwapAdjacentPairsE4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEu13__SVFloat16_t", scope: !34, file: !12, line: 309, type: !39, scopeLine: 309, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+  !37 = !DISubprogram(name: "SwapAdjacentPairs", linkageName: "_ZN7KeyLane17SwapAdjacentPairsEu13__SVFloat32_t", scope: !34, file: !12, line: 314, type: !58, scopeLine: 314, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+  !38 = !DISubprogram(name: "OddEvenPairs", linkageName: "_ZN7KeyLane12OddEvenPairsE4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEu13__SVFloat16_tS3_", scope: !34, file: !12, line: 318, type: !68, scopeLine: 318, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+  !39 = !DISubroutineType(types: !40)
+  !40 = !{!41, !42, !43, !41}
+  !41 = !DIDerivedType(tag: DW_TAG_typedef, name: "Vec<Simd<Trans_NS_hwy_float16_t, 1, 0> >", file: !12, line: 270, baseType: !44)
+  !42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !43 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Simd<Trans_NS_hwy_float16_t, 1, 0>", file: !12, line: 83, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !51, identifier: "_ZTS4SimdI22Trans_NS_hwy_float16_tLi1ELi0EE")
+  !44 = !DIDerivedType(tag: DW_TAG_typedef, name: "VFromD<Simd<Trans_NS_hwy_float16_t, 1, 0> >", file: !12, line: 142, baseType: !45)
+  !45 = !DIDerivedType(tag: DW_TAG_typedef, name: "svfloat16_t", file: !12, line: 26, baseType: !46)
+  !46 = !DIDerivedType(tag: DW_TAG_typedef, name: "__SVFloat16_t", file: !12, baseType: !47)
+  !47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, flags: DIFlagVector, elements: !48)
+  !48 = !{!49}
+  !49 = !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_constu, 4, DW_OP_bregx, 46, 0, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+  !50 = !{}
+  !51 = !{!52, !53, !54}
+  !52 = !DITemplateTypeParameter(name: "Lane", type: !55)
+  !53 = !DITemplateValueParameter(type: !24, value: i32 1)
+  !54 = !DITemplateValueParameter(name: "kPow2", type: !24, value: i32 0)
+  !55 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Trans_NS_hwy_float16_t", file: !12, line: 6, size: 16, flags: DIFlagTypePassByValue, elements: !56, identifier: "_ZTS22Trans_NS_hwy_float16_t")
+  !56 = !{!57}
+  !57 = !DIDerivedType(tag: DW_TAG_member, name: "native", scope: !55, file: !12, line: 7, baseType: !17, size: 16)
+  !58 = !DISubroutineType(types: !59)
+  !59 = !{!60, !42, !60}
+  !60 = !DIDerivedType(tag: DW_TAG_typedef, name: "Vec<Simd<float, 0, 0> >", file: !12, line: 270, baseType: !61)
+  !61 = !DIDerivedType(tag: DW_TAG_typedef, name: "VFromD<Simd<float, 0, 0> >", file: !12, line: 142, baseType: !62)
+  !62 = !DIDerivedType(tag: DW_TAG_typedef, name: "svfloat32_t", file: !12, line: 27, baseType: !63)
+  !63 = !DIDerivedType(tag: DW_TAG_typedef, name: "__SVFloat32_t", file: !12, baseType: !64)
+  !64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !65, flags: DIFlagVector, elements: !66)
+  !65 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+  !66 = !{!67}
+  !67 = !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_constu, 2, DW_OP_bregx, 46, 0, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+  !68 = !DISubroutineType(types: !69)
+  !69 = !{!41, !42, !43, !41, !41}
+  !70 = !DISubroutineType(types: !71)
+  !71 = !{null, !72, !43, !73, !73}
+  !72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !73 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !41, size: 64)
+  !74 = !DISubroutineType(types: !75)
+  !75 = !{!41, !72, !43, !41}
+  !76 = !DITemplateTypeParameter(name: "Base", type: !28)
+  !77 = !DILocalVariable(name: "st", arg: 1, scope: !2, file: !12, line: 369, type: !22)
+  !78 = !DILocalVariable(name: "keys", arg: 2, scope: !2, file: !12, line: 369, type: !23)
+  !79 = !DILocalVariable(arg: 3, scope: !2, file: !12, line: 369, type: !24)
+  !80 = !DILocalVariable(arg: 4, scope: !2, file: !12, line: 370, type: !23)
+  !81 = !DILocalVariable(name: "d", scope: !2, file: !12, line: 371, type: !106)
+  !82 = !DILocalVariable(name: "v8", scope: !2, file: !12, line: 373, type: !112)
+  !83 = !DILocalVariable(name: "v9", scope: !2, file: !12, line: 373, type: !112)
+  !84 = !DILocalVariable(name: "va", scope: !2, file: !12, line: 373, type: !112)
+  !85 = !DILocalVariable(name: "vb", scope: !2, file: !12, line: 373, type: !112)
+  !86 = !DILocalVariable(name: "vc", scope: !2, file: !12, line: 373, type: !112)
+  !87 = !DILocalVariable(name: "vd", scope: !2, file: !12, line: 373, type: !112)
+  !88 = !DILocalVariable(name: "ve", scope: !2, file: !12, line: 373, type: !112)
+  !89 = !DILocalVariable(name: "vf", scope: !2, file: !12, line: 373, type: !112)
+  !90 = !DILocalVariable(name: "v2", scope: !2, file: !12, line: 373, type: !112)
+  !91 = !DILocalVariable(name: "v4", scope: !2, file: !12, line: 373, type: !112)
+  !92 = !DILocalVariable(name: "v7", scope: !2, file: !12, line: 373, type: !112)
+  !93 = !DILocalVariable(name: "v0", scope: !2, file: !12, line: 374, type: !112)
+  !94 = !DILocalVariable(name: "v3", scope: !2, file: !12, line: 375, type: !112)
+  !95 = !DILocalVariable(name: "v5", scope: !2, file: !12, line: 376, type: !112)
+  !96 = !DILocalVariable(name: "v6", scope: !2, file: !12, line: 377, type: !112)
+  !97 = !DILocalVariable(name: "kIota", scope: !2, file: !12, line: 378, type: !112)
+  !98 = !DILocalVariable(name: "m8", scope: !2, file: !12, line: 379, type: !113)
+  !99 = !DILocalVariable(name: "m9", scope: !2, file: !12, line: 380, type: !113)
+  !100 = !DILocalVariable(name: "ma", scope: !2, file: !12, line: 381, type: !113)
+  !101 = !DILocalVariable(name: "mb", scope: !2, file: !12, line: 382, type: !113)
+  !102 = !DILocalVariable(name: "mc", scope: !2, file: !12, line: 383, type: !113)
+  !103 = !DILocalVariable(name: "md", scope: !2, file: !12, line: 384, type: !113)
+  !104 = !DILocalVariable(name: "me", scope: !2, file: !12, line: 385, type: !113)
+  !105 = !DILocalVariable(name: "mf", scope: !2, file: !12, line: 386, type: !113)
+  !106 = !DIDerivedType(tag: DW_TAG_typedef, name: "CappedTag<Trans_NS_hwy_float16_t, 6>", file: !12, line: 97, baseType: !107)
+  !107 = !DIDerivedType(tag: DW_TAG_typedef, name: "type", scope: !108, file: !12, line: 89, baseType: !43)
+  !108 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "ClampNAndPow2<Trans_NS_hwy_float16_t, 1>", file: !12, line: 88, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !109, identifier: "_ZTS13ClampNAndPow2I22Trans_NS_hwy_float16_tLi1EE")
+  !109 = !{!110, !111}
+  !110 = !DITemplateTypeParameter(name: "T", type: !55)
+  !111 = !DITemplateValueParameter(name: "N", type: !24, value: i32 1)
+  !112 = !DIDerivedType(tag: DW_TAG_typedef, name: "V", scope: !2, file: !12, line: 372, baseType: !41)
+  !113 = !DIDerivedType(tag: DW_TAG_typedef, name: "Mask<Simd<Trans_NS_hwy_float16_t, 1, 0> >", file: !12, line: 271, baseType: !114)
+  !114 = !DIDerivedType(tag: DW_TAG_typedef, name: "svbool_t", file: !12, line: 28, baseType: !115)
+  !115 = !DIDerivedType(tag: DW_TAG_typedef, name: "__SVBool_t", file: !12, baseType: !116)
+  !116 = !DICompositeType(tag: DW_TAG_array_type, baseType: !117, flags: DIFlagVector, elements: !118)
+  !117 = !DIBasicType(name: "unsigned char", size: 8, encoding: DW_ATE_unsigned_char)
+  !118 = !{!119}
+  !119 = !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_constu, 1, DW_OP_bregx, 46, 0, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+  !120 = !DITemplateValueParameter(name: "kKeysPerRow", type: !24, value: i32 6)
+  !121 = !DILocalVariable(name: "this", arg: 1, scope: !122, type: !123, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !122 = distinct !DISubprogram(name: "Sort2", linkageName: "_ZN10TraitsLane5Sort2E4SimdI22Trans_NS_hwy_float16_tLi1ELi0EERu13__SVFloat16_tS4_", scope: !28, file: !12, line: 326, type: !70, scopeLine: 328, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, declaration: !31, retainedNodes: !124, keyInstructions: true)
+  !123 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+  !124 = !{!121, !125, !126, !127, !128, !129, !130, !131, !132}
+  !125 = !DILocalVariable(name: "d", arg: 2, scope: !122, file: !12, line: 326, type: !43)
+  !126 = !DILocalVariable(name: "a", arg: 3, scope: !122, file: !12, line: 327, type: !73)
+  !127 = !DILocalVariable(name: "b", arg: 4, scope: !122, file: !12, line: 328, type: !73)
+  !128 = !DILocalVariable(name: "__trans_tmp_52", scope: !122, file: !12, line: 329, type: !41)
+  !129 = !DILocalVariable(name: "a_copy", scope: !122, file: !12, line: 329, type: !41)
+  !130 = !DILocalVariable(name: "__trans_tmp_45", scope: !122, file: !12, line: 330, type: !41)
+  !131 = !DILocalVariable(name: "__trans_tmp_53", scope: !133, file: !12, line: 334, type: !41)
+  !132 = !DILocalVariable(name: "__trans_tmp_29", scope: !134, file: !12, line: 336, type: !45)
+  !133 = distinct !DILexicalBlock(scope: !122, file: !12, line: 333, column: 5)
+  !134 = distinct !DILexicalBlock(scope: !133, file: !12, line: 335, column: 7)
+  !137 = distinct !DISubprogram(name: "SortPairsDistance1", linkageName: "_ZN10TraitsLane18SortPairsDistance1E4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEu13__SVFloat16_t", scope: !28, file: !12, line: 344, type: !74, scopeLine: 345, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, declaration: !32, retainedNodes: !139, keyInstructions: true)
+  !139 = !{!140, !141, !142, !143}
+  !140 = !DILocalVariable(name: "this", arg: 1, scope: !137, type: !123, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !141 = !DILocalVariable(name: "d", arg: 2, scope: !137, file: !12, line: 344, type: !43)
+  !142 = !DILocalVariable(name: "v", arg: 3, scope: !137, file: !12, line: 345, type: !41)
+  !143 = !DILocalVariable(name: "__trans_tmp_48", scope: !137, file: !12, line: 346, type: !41)
+  !144 = distinct !DISubprogram(name: "Merge16x16<6, SharedTraits<TraitsLane>, __SVFloat16_t>", linkageName: "_Z10Merge16x16ILi6E12SharedTraitsI10TraitsLaneEu13__SVFloat16_tEvT0_RT1_S6_S6_S6_S6_S6_S6_S6_S6_S6_S6_S6_", scope: !12, file: !12, line: 286, type: !146, scopeLine: 288, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !147, retainedNodes: !148, keyInstructions: true)
+  !145 = distinct !DILocation(line: 388, column: 3, scope: !2)
+  !146 = !DISubroutineType(types: !149)
+  !147 = !{!164, !165, !166}
+  !148 = !{!151, !152, !153, !154, !155, !156, !157, !158, !159, !160, !161, !162, !163}
+  !149 = !{null, !22, !150, !150, !150, !150, !150, !150, !150, !150, !150, !150, !150, !150}
+  !150 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !47, size: 64)
+  !151 = !DILocalVariable(name: "st", arg: 1, scope: !144, file: !12, line: 286, type: !22)
+  !152 = !DILocalVariable(name: "v0", arg: 2, scope: !144, file: !12, line: 286, type: !150)
+  !153 = !DILocalVariable(name: "v2", arg: 3, scope: !144, file: !12, line: 286, type: !150)
+  !154 = !DILocalVariable(name: "v5", arg: 4, scope: !144, file: !12, line: 286, type: !150)
+  !155 = !DILocalVariable(name: "v6", arg: 5, scope: !144, file: !12, line: 287, type: !150)
+  !156 = !DILocalVariable(name: "v7", arg: 6, scope: !144, file: !12, line: 287, type: !150)
+  !157 = !DILocalVariable(name: "v9", arg: 7, scope: !144, file: !12, line: 287, type: !150)
+  !158 = !DILocalVariable(name: "va", arg: 8, scope: !144, file: !12, line: 287, type: !150)
+  !159 = !DILocalVariable(name: "vb", arg: 9, scope: !144, file: !12, line: 287, type: !150)
+  !160 = !DILocalVariable(name: "vc", arg: 10, scope: !144, file: !12, line: 288, type: !150)
+  !161 = !DILocalVariable(name: "vd", arg: 11, scope: !144, file: !12, line: 288, type: !150)
+  !162 = !DILocalVariable(name: "ve", arg: 12, scope: !144, file: !12, line: 288, type: !150)
+  !163 = !DILocalVariable(name: "vf", arg: 13, scope: !144, file: !12, line: 288, type: !150)
+  !164 = !DITemplateValueParameter(type: !24, value: i32 6)
+  !165 = !DITemplateTypeParameter(name: "Traits", type: !22)
+  !166 = !DITemplateTypeParameter(name: "V", type: !47)
+  !184 = !DILocalVariable(name: "this", arg: 1, scope: !185, type: !186, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !185 = distinct !DISubprogram(name: "SortPairsDistance2<Simd<Trans_NS_hwy_float16_t, 1, 0> >", linkageName: "_ZN12SharedTraitsI10TraitsLaneE18SortPairsDistance2I4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEEEDTcl4ZerocvT__EEES6_S7_", scope: !22, file: !12, line: 273, type: !187, scopeLine: 273, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !188, declaration: !189, retainedNodes: !190, keyInstructions: true)
+  !186 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+  !187 = !DISubroutineType(types: !191)
+  !188 = !{!193}
+  !189 = !DISubprogram(name: "SortPairsDistance2<Simd<Trans_NS_hwy_float16_t, 1, 0> >", linkageName: "_ZN12SharedTraitsI10TraitsLaneE18SortPairsDistance2I4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEEEDTcl4ZerocvT__EEES6_S7_", scope: !22, file: !12, line: 273, type: !187, scopeLine: 273, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, templateParams: !188)
+  !190 = !{!184, !194, !195, !196, !197}
+  !191 = !{!41, !192, !43, !41}
+  !192 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !193 = !DITemplateTypeParameter(name: "D", type: !43)
+  !194 = !DILocalVariable(name: "d", arg: 2, scope: !185, file: !12, line: 273, type: !43)
+  !195 = !DILocalVariable(name: "v", arg: 3, scope: !185, file: !12, line: 273, type: !41)
+  !196 = !DILocalVariable(name: "base", scope: !185, file: !12, line: 274, type: !28)
+  !197 = !DILocalVariable(name: "swapped", scope: !185, file: !12, line: 275, type: !41)
+  !200 = !DILocation(line: 0, scope: !122, inlinedAt: !201)
+  !201 = distinct !DILocation(line: 358, column: 5, scope: !202, inlinedAt: !203)
+  !202 = distinct !DISubprogram(name: "SortPairsDistance4", linkageName: "_ZN10TraitsLane18SortPairsDistance4E4SimdI22Trans_NS_hwy_float16_tLi1ELi0EEu13__SVFloat16_t", scope: !28, file: !12, line: 352, type: !74, scopeLine: 353, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, declaration: !33, retainedNodes: !204, keyInstructions: true)
+  !203 = distinct !DILocation(line: 298, column: 11, scope: !144, inlinedAt: !145)
+  !204 = !{!205, !206, !207, !208, !209, !210, !211}
+  !205 = !DILocalVariable(name: "this", arg: 1, scope: !202, type: !123, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !206 = !DILocalVariable(name: "d", arg: 2, scope: !202, file: !12, line: 352, type: !43)
+  !207 = !DILocalVariable(name: "v", arg: 3, scope: !202, file: !12, line: 353, type: !41)
+  !208 = !DILocalVariable(name: "__trans_tmp_42", scope: !202, file: !12, line: 354, type: !41)
+  !209 = !DILocalVariable(name: "__trans_tmp_39", scope: !202, file: !12, line: 354, type: !41)
+  !210 = !DILocalVariable(name: "dw", scope: !202, file: !12, line: 355, type: !212)
+  !211 = !DILocalVariable(name: "__trans_tmp_51", scope: !219, file: !12, line: 360, type: !44)
+  !212 = !DIDerivedType(tag: DW_TAG_typedef, name: "RepartitionToWide<Simd<Trans_NS_hwy_float16_t, 1, 0> >", file: !12, line: 103, baseType: !213)
+  !213 = !DIDerivedType(tag: DW_TAG_typedef, name: "Repartition<float, Simd<Trans_NS_hwy_float16_t, 1, 0> >", file: !12, line: 101, baseType: !214)
+  !214 = !DIDerivedType(tag: DW_TAG_typedef, name: "Repartition<float>", scope: !43, file: !12, line: 86, baseType: !215)
+  !215 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Simd<float, 0, 0>", file: !12, line: 83, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !216, identifier: "_ZTS4SimdIfLi0ELi0EE")
+  !216 = !{!217, !218, !54}
+  !217 = !DITemplateTypeParameter(name: "Lane", type: !65)
+  !218 = !DITemplateValueParameter(type: !24, value: i32 0)
+  !219 = distinct !DILexicalBlock(scope: !202, file: !12, line: 359, column: 5)
+  !220 = !DILocalVariable(name: "this", arg: 1, scope: !221, type: !222, flags: DIFlagArtificial | DIFlagObjectPointer)
+  !221 = distinct !DISubprogram(name: "SwapAdjacentPairs", linkageName: "_ZN7KeyLane17SwapAdjacentPairsEu13__SVFloat32_t", scope: !34, file: !12, line: 314, type: !58, scopeLine: 314, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, declaration: !37, retainedNodes: !223, keyInstructions: true)
+  !222 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+  !223 = !{!220, !224}
+  !224 = !DILocalVariable(name: "v", arg: 2, scope: !221, file: !12, line: 314, type: !60)
+  !225 = distinct !DILocation(line: 357, column: 38, scope: !202, inlinedAt: !203)
+  !226 = !DILocalVariable(name: "v", arg: 1, scope: !227, file: !12, line: 264, type: !64)
+  !227 = distinct !DISubprogram(name: "Shuffle1032<__SVFloat32_t>", linkageName: "_Z11Shuffle1032Iu13__SVFloat32_tET_S1_", scope: !12, file: !12, line: 264, type: !228, scopeLine: 264, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !229, retainedNodes: !230, keyInstructions: true)
+  !228 = !DISubroutineType(types: !231)
+  !229 = !{!262}
+  !230 = !{!226, !232, !233, !234}
+  !231 = !{!64, !64}
+  !232 = !DILocalVariable(name: "d", scope: !227, file: !12, line: 265, type: !235)
+  !233 = !DILocalVariable(name: "d8", scope: !227, file: !12, line: 266, type: !252)
+  !234 = !DILocalVariable(name: "v8", scope: !227, file: !12, line: 267, type: !257)
+  !235 = !DIDerivedType(tag: DW_TAG_typedef, name: "DFromV<__SVFloat32_t>", file: !12, line: 108, baseType: !236)
+  !236 = !DIDerivedType(tag: DW_TAG_typedef, name: "type", scope: !237, file: !12, line: 116, baseType: !238)
+  !237 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "DFromV_t<__SVFloat32_t>", file: !12, line: 115, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !239, identifier: "_ZTS8DFromV_tIu13__SVFloat32_tE")
+  !238 = !DIDerivedType(tag: DW_TAG_typedef, name: "ScalableTag<float>", file: !12, line: 95, baseType: !241)
+  !239 = !{!240}
+  !240 = !DITemplateTypeParameter(type: !64)
+  !241 = !DIDerivedType(tag: DW_TAG_typedef, name: "type", scope: !242, file: !12, line: 92, baseType: !243)
+  !242 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "ScalableTagChecker<float>", file: !12, line: 91, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !244, identifier: "_ZTS18ScalableTagCheckerIfE")
+  !243 = !DIDerivedType(tag: DW_TAG_typedef, name: "type", scope: !246, file: !12, line: 89, baseType: !247)
+  !244 = !{!245}
+  !245 = !DITemplateTypeParameter(name: "T", type: !65)
+  !246 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "ClampNAndPow2<float, 64>", file: !12, line: 88, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !248, identifier: "_ZTS13ClampNAndPow2IfLi64EE")
+  !247 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Simd<float, 64, 0>", file: !12, line: 83, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !250, identifier: "_ZTS4SimdIfLi64ELi0EE")
+  !248 = !{!245, !249}
+  !249 = !DITemplateValueParameter(name: "N", type: !24, value: i32 64)
+  !250 = !{!217, !251, !54}
+  !251 = !DITemplateValueParameter(type: !24, value: i32 64)
+  !252 = !DIDerivedType(tag: DW_TAG_typedef, name: "Repartition<unsigned char, Simd<float, 64, 0> >", file: !12, line: 101, baseType: !253)
+  !253 = !DIDerivedType(tag: DW_TAG_typedef, name: "Repartition<unsigned char>", scope: !247, file: !12, line: 86, baseType: !254)
+  !254 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Simd<unsigned char, 0, 0>", file: !12, line: 83, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !255, identifier: "_ZTS4SimdIhLi0ELi0EE")
+  !255 = !{!256, !218, !54}
+  !256 = !DITemplateTypeParameter(name: "Lane", type: !117)
+  !257 = !DIDerivedType(tag: DW_TAG_typedef, name: "svuint8_t", file: !12, line: 22, baseType: !258)
+  !258 = !DIDerivedType(tag: DW_TAG_typedef, name: "__SVUint8_t", file: !12, baseType: !259)
+  !259 = !DICompositeType(tag: DW_TAG_array_type, baseType: !117, flags: DIFlagVector, elements: !260)
+  !260 = !{!261}
+  !261 = !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_constu, 8, DW_OP_bregx, 46, 0, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+  !262 = !DITemplateTypeParameter(name: "V", type: !64)
+  !263 = !DILocalVariable(name: "hi", arg: 1, scope: !264, file: !12, line: 248, type: !259)
+  !264 = distinct !DISubprogram(name: "CombineShiftRightBytes<8, __SVUint8_t>", linkageName: "_Z22CombineShiftRightBytesILi8Eu11__SVUint8_tET0_S1_S1_", scope: !12, file: !12, line: 248, type: !265, scopeLine: 248, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !266, retainedNodes: !267, keyInstructions: true)
+  !265 = !DISubroutineType(types: !268)
+  !266 = !{!283, !284}
+  !267 = !{!263, !269, !270, !271, !272, !273, !274, !275, !276}
+  !268 = !{!259, !259, !259}
+  !269 = !DILocalVariable(name: "lo", arg: 2, scope: !264, file: !12, line: 248, type: !259)
+  !270 = !DILocalVariable(name: "__trans_tmp_33", scope: !264, file: !12, line: 249, type: !257)
+  !271 = !DILocalVariable(name: "__trans_tmp_15", scope: !264, file: !12, line: 249, type: !257)
+  !272 = !DILocalVariable(name: "__trans_tmp_32", scope: !264, file: !12, line: 250, type: !257)
+  !273 = !DILocalVariable(name: "d8", scope: !264, file: !12, line: 251, type: !277)
+  !274 = !DILocalVariable(name: "__trans_tmp_16", scope: !264, file: !12, line: 252, type: !114)
+  !275 = !DILocalVariable(name: "lo_down", scope: !264, file: !12, line: 254, type: !257)
+  !276 = !DILocalVariable(name: "__trans_tmp_34", scope: !264, file: !12, line: 255, type: !114)
+  !277 = !DIDerivedType(tag: DW_TAG_typedef, name: "Repartition<unsigned char, Simd<char, 0, 0> >", file: !12, line: 101, baseType: !278)
+  !278 = !DIDerivedType(tag: DW_TAG_typedef, name: "Repartition<unsigned char>", scope: !279, file: !12, line: 86, baseType: !254)
+  !279 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Simd<char, 0, 0>", file: !12, line: 83, size: 8, flags: DIFlagTypePassByValue, elements: !50, templateParams: !280, identifier: "_ZTS4SimdIcLi0ELi0EE")
+  !280 = !{!281, !218, !54}
+  !281 = !DITemplateTypeParameter(name: "Lane", type: !282)
+  !282 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+  !283 = !DITemplateValueParameter(name: "kBytes", type: !24, value: i32 8)
+  !284 = !DITemplateTypeParameter(name: "V", type: !259)
+  !285 = !DILocalVariable(name: "hi", arg: 1, scope: !286, file: !12, line: 216, type: !257)
+  !286 = distinct !DISubprogram(name: "Ext<8>", linkageName: "_Z3ExtILi8EEu11__SVUint8_tS0_S0_", scope: !12, file: !12, line: 216, type: !287, scopeLine: 216, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !288, retainedNodes: !289, keyInstructions: true)
+  !287 = !DISubroutineType(types: !290)
+  !288 = !{!292}
+  !289 = !{!285, !291}
+  !290 = !{!257, !257, !257}
+  !291 = !DILocalVariable(name: "lo", arg: 2, scope: !286, file: !12, line: 216, type: !257)
+  !292 = !DITemplateValueParameter(name: "kIndex", type: !24, value: i32 8)
+  !293 = !DILocalVariable(name: "a", arg: 1, scope: !294, file: !12, line: 180, type: !47)
+  !294 = distinct !DISubprogram(name: "Min<__SVFloat16_t>", linkageName: "_Z3MinIu13__SVFloat16_tET_S1_S1_", scope: !12, file: !12, line: 180, type: !295, scopeLine: 180, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !3, templateParams: !296, retainedNodes: !297, keyInstructions: true)
+  !295 = !DISubroutineType(types: !298)
+  !296 = !{!166}
+  !297 = !{!293, !299, !300, !301, !302, !303, !304}
+  !298 = !{!47, !47, !47}
+  !299 = !DILocalVariable(name: "b", arg: 2, scope: !294, file: !12, line: 180, type: !47)
+  !300 = !DILocalVariable(name: "__trans_tmp_36", scope: !294, file: !12, line: 181, type: !45)
+  !301 = !DILocalVariable(name: "__trans_tmp_25", scope: !294, file: !12, line: 181, type: !45)
+  !302 = !DILocalVariable(name: "__trans_tmp_27", scope: !294, file: !12, line: 182, type: !114)
+  !303 = !DILocalVariable(name: "__trans_tmp_24", scope: !294, file: !12, line: 183, type: !114)
+  !304 = !DILocalVariable(name: "__trans_tmp_19", scope: !294, file: !12, line: 184, type: !114)
+  !308 = distinct !DILocation(line: 315, column: 12, scope: !221, inlinedAt: !225)
+  !309 = distinct !DILocation(line: 268, column: 21, scope: !227, inlinedAt: !308)
+  !311 = distinct !DILocation(line: 254, column: 18, scope: !264, inlinedAt: !309)
+  !312 = !DILocation(line: 217, column: 10, scope: !286, inlinedAt: !311, atomGroup: 1, atomRank: 2)
+  !313 = !DILocation(line: 257, column: 20, scope: !264, inlinedAt: !309, atomGroup: 5, atomRank: 2)
+  !314 = !DILocation(line: 0, scope: !294, inlinedAt: !315)
+  !315 = distinct !DILocation(line: 331, column: 22, scope: !122, inlinedAt: !201)
+  !316 = !DILocation(line: 185, column: 20, scope: !294, inlinedAt: !315)
+  !317 = !DILocation(line: 403, column: 1, scope: !2, atomGroup: 19449, atomRank: 1)
+
+...
+---
+name:            _Z10Sort16RowsILi6EEv12SharedTraitsI10TraitsLaneEP22Trans_NS_hwy_float16_tiS4_
+body:             |
+  bb.0:
+    liveins: $x1, $z0, $z1, $p0
+
+    $z30 = LDR_ZXI $x1, -14
+    $z31 = LDR_ZXI $x1, -13
+    $z23 = ORR_ZZZ $z30, $z30
+    renamable $z2 = EXT_ZZI_B renamable $z30_z31, 8,  debug-location !312
+    renamable $z7 = SEL_ZPZZ_B renamable $p0, renamable $z0, killed renamable $z1,  debug-location !313
+    DBG_VALUE $z30, $noreg, !129, !DIExpression(),  debug-location !200
+    renamable $p3 = nofpexcept FCMGT_PPzZZ_H renamable $p0, renamable $z0, undef renamable $z1,  debug-location !316
+    DBG_VALUE $z30_z31, $noreg, !129, !DIExpression(),  debug-location !200
+    DBG_VALUE $z30_z31, $noreg, !293, !DIExpression(),  debug-location !314
+    RET undef $lr,  debug-location !317
+...
+


### PR DESCRIPTION
The AArch64 zsub regs are scalable, so defined with a size of -1 (which comes through as 65535). The RegisterSize is only 128, so code to try and find overlapping regs of a z30_z31 in DwarfEmitter can crash on trying to access out of range bits in a BitVector. Hexagon and x86 also contain subregs with unknown sizes.

Ideally most of these would be scalable values but in the meantime add a check that the register are small enough to overlap with the current register size, to prevent us from crashing.

This fixes the issue reported on #153810.