### PR TITLE
[Support] Use std::move in AllocatorHolder's move constructor (NFC)

### DIFF
--- a/llvm/include/llvm/Support/AllocatorBase.h
+++ b/llvm/include/llvm/Support/AllocatorBase.h
@@ -111,7 +111,7 @@ template <typename Alloc> class AllocatorHolder : Alloc {
 public:
   AllocatorHolder() = default;
   AllocatorHolder(const Alloc &A) : Alloc(A) {}
-  AllocatorHolder(Alloc &&A) : Alloc(static_cast<Alloc &&>(A)) {}
+  AllocatorHolder(Alloc &&A) : Alloc(std::move(A)) {}
   Alloc &getAllocator() { return *this; }
   const Alloc &getAllocator() const { return *this; }
 };


### PR DESCRIPTION
std::move is more idiomatic and readable than the equivalent
static_cast.
