### PR TITLE
[ADT] Make ilist_select_iterator_type a type alias (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -51,12 +51,11 @@ class ilist_iterator_w_bits;
 template <class OptionsT> class ilist_sentinel;
 
 // Selector for which iterator type to pick given the iterator-bits node option.
-template <bool use_iterator_bits, typename Opts, bool arg1, bool arg2>
-struct ilist_select_iterator_type {
-  using type = std::conditional_t<use_iterator_bits,
-                                  ilist_iterator_w_bits<Opts, arg1, arg2>,
-                                  ilist_iterator<Opts, arg1, arg2>>;
-};
+template <class OptionsT, bool IsReverse, bool IsConst>
+using ilist_select_iterator_type =
+    std::conditional_t<OptionsT::has_iterator_bits,
+                       ilist_iterator_w_bits<OptionsT, IsReverse, IsConst>,
+                       ilist_iterator<OptionsT, IsReverse, IsConst>>;
 
 /// Implementation for an ilist node.
 ///
@@ -91,18 +90,12 @@ class ilist_node_impl
   friend class ilist_iterator_w_bits<OptionsT, true, true>;
 
 protected:
-  using self_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          false, false>::type;
-  using const_self_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          false, true>::type;
+  using self_iterator = ilist_select_iterator_type<OptionsT, false, false>;
+  using const_self_iterator = ilist_select_iterator_type<OptionsT, false, true>;
   using reverse_self_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          true, false>::type;
+      ilist_select_iterator_type<OptionsT, true, false>;
   using const_reverse_self_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          true, true>::type;
+      ilist_select_iterator_type<OptionsT, true, true>;
 
   ilist_node_impl() = default;
 

--- a/llvm/include/llvm/ADT/simple_ilist.h
+++ b/llvm/include/llvm/ADT/simple_ilist.h
@@ -92,18 +92,11 @@ public:
   using reference = typename OptionsT::reference;
   using const_pointer = typename OptionsT::const_pointer;
   using const_reference = typename OptionsT::const_reference;
-  using iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          false, false>::type;
-  using const_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          false, true>::type;
-  using reverse_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          true, false>::type;
+  using iterator = ilist_select_iterator_type<OptionsT, false, false>;
+  using const_iterator = ilist_select_iterator_type<OptionsT, false, true>;
+  using reverse_iterator = ilist_select_iterator_type<OptionsT, true, false>;
   using const_reverse_iterator =
-      typename ilist_select_iterator_type<OptionsT::has_iterator_bits, OptionsT,
-                                          true, true>::type;
+      ilist_select_iterator_type<OptionsT, true, true>;
   using size_type = size_t;
   using difference_type = ptrdiff_t;
 


### PR DESCRIPTION
Without this patch, we have:

  template <bool use_iterator_bits, typename Opts, bool arg1, bool arg2>
  struct ilist_select_iterator_type {
    using type = ...;
  }

This means that we must reference "type" with somewhat mouthful:

  typename ilist_select_iterator_type<...>::type

This patch simplifies the reference by making
ilist_select_iterator_type a type alias.

Now, we always obtain "bool use_iterator_bit" from
OptionsT::has_iterator_bits, so this patch folds the logic into the
type alias.
