### PR TITLE
[Support] Use list-initialization for returning pairs

### DIFF
--- a/llvm/include/llvm/Support/BinaryStreamRef.h
+++ b/llvm/include/llvm/Support/BinaryStreamRef.h
@@ -209,7 +209,7 @@ struct BinarySubstreamRef {
   BinarySubstreamRef keep_front(uint64_t N) const { return slice(0, N); }
 
   std::pair<BinarySubstreamRef, BinarySubstreamRef> split(uint64_t Off) const {
-    return std::make_pair(keep_front(Off), drop_front(Off));
+    return {keep_front(Off), drop_front(Off)};
   }
 
   uint64_t size() const { return StreamData.getLength(); }

--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -136,7 +136,7 @@ public:
 
   // Return the name and description of the counter with the given ID.
   std::pair<std::string, std::string> getCounterInfo(unsigned ID) const {
-    return std::make_pair(RegisteredCounters[ID], Counters.lookup(ID).Desc);
+    return {RegisteredCounters[ID], Counters.lookup(ID).Desc};
   }
 
   // Iterate through the registered counters

--- a/llvm/include/llvm/Support/FormatProviders.h
+++ b/llvm/include/llvm/Support/FormatProviders.h
@@ -389,7 +389,7 @@ template <typename IterT> class format_provider<llvm::iterator_range<IterT>> {
     StringRef Sep = consumeOneOption(Style, '$', ", ");
     StringRef Args = consumeOneOption(Style, '@', "");
     assert(Style.empty() && "Unexpected text in range option string!");
-    return std::make_pair(Sep, Args);
+    return {Sep, Args};
   }
 
 public:

--- a/llvm/include/llvm/Support/MD5.h
+++ b/llvm/include/llvm/Support/MD5.h
@@ -57,7 +57,7 @@ public:
     }
     std::pair<uint64_t, uint64_t> words() const {
       using namespace support;
-      return std::make_pair(high(), low());
+      return {high(), low()};
     }
   };
 

--- a/llvm/include/llvm/Support/OnDiskHashTable.h
+++ b/llvm/include/llvm/Support/OnDiskHashTable.h
@@ -309,7 +309,7 @@ public:
     offset_type NumEntries =
         endian::readNext<offset_type, llvm::endianness::little, aligned>(
             Buckets);
-    return std::make_pair(NumBuckets, NumEntries);
+    return {NumBuckets, NumEntries};
   }
 
   offset_type getNumBuckets() const { return NumBuckets; }

--- a/llvm/include/llvm/Support/ScaledNumber.h
+++ b/llvm/include/llvm/Support/ScaledNumber.h
@@ -57,8 +57,8 @@ inline std::pair<DigitsT, int16_t> getRounded(DigitsT Digits, int16_t Scale,
   if (ShouldRound)
     if (!++Digits)
       // Overflow.
-      return std::make_pair(DigitsT(1) << (getWidth<DigitsT>() - 1), Scale + 1);
-  return std::make_pair(Digits, Scale);
+      return {DigitsT(1) << (getWidth<DigitsT>() - 1), Scale + 1};
+  return {Digits, Scale};
 }
 
 /// Convenience helper for 32-bit rounding.
@@ -83,7 +83,7 @@ inline std::pair<DigitsT, int16_t> getAdjusted(uint64_t Digits,
 
   const int Width = getWidth<DigitsT>();
   if (Width == 64 || Digits <= std::numeric_limits<DigitsT>::max())
-    return std::make_pair(Digits, Scale);
+    return {Digits, Scale};
 
   // Shift right and round.
   int Shift = llvm::bit_width(Digits) - Width;
@@ -160,9 +160,9 @@ std::pair<DigitsT, int16_t> getQuotient(DigitsT Dividend, DigitsT Divisor) {
 
   // Check for zero.
   if (!Dividend)
-    return std::make_pair(0, 0);
+    return {0, 0};
   if (!Divisor)
-    return std::make_pair(std::numeric_limits<DigitsT>::max(), MaxScale);
+    return {std::numeric_limits<DigitsT>::max(), MaxScale};
 
   if (getWidth<DigitsT>() == 64)
     return divide64(Dividend, Divisor);
@@ -192,7 +192,7 @@ inline std::pair<int32_t, int> getLgImpl(DigitsT Digits, int16_t Scale) {
   static_assert(!std::numeric_limits<DigitsT>::is_signed, "expected unsigned");
 
   if (!Digits)
-    return std::make_pair(INT32_MIN, 0);
+    return {INT32_MIN, 0};
 
   // Get the floor of the lg of Digits.
   static_assert(sizeof(Digits) <= sizeof(uint64_t));
@@ -201,12 +201,12 @@ inline std::pair<int32_t, int> getLgImpl(DigitsT Digits, int16_t Scale) {
   // Get the actual floor.
   int32_t Floor = Scale + LocalFloor;
   if (Digits == UINT64_C(1) << LocalFloor)
-    return std::make_pair(Floor, 0);
+    return {Floor, 0};
 
   // Round based on the next digit.
   assert(LocalFloor >= 1);
   bool Round = Digits & UINT64_C(1) << (LocalFloor - 1);
-  return std::make_pair(Floor + Round, Round ? 1 : -1);
+  return {Floor + Round, Round ? 1 : -1};
 }
 
 /// Get the lg (rounded) of a scaled number.
@@ -348,11 +348,11 @@ std::pair<DigitsT, int16_t> getSum(DigitsT LDigits, int16_t LScale,
   // Compute sum.
   DigitsT Sum = LDigits + RDigits;
   if (Sum >= RDigits)
-    return std::make_pair(Sum, Scale);
+    return {Sum, Scale};
 
   // Adjust sum after arithmetic overflow.
   DigitsT HighBit = DigitsT(1) << (getWidth<DigitsT>() - 1);
-  return std::make_pair(HighBit | Sum >> 1, Scale + 1);
+  return {HighBit | Sum >> 1, Scale + 1};
 }
 
 /// Convenience helper for 32-bit sum.
@@ -384,18 +384,18 @@ std::pair<DigitsT, int16_t> getDifference(DigitsT LDigits, int16_t LScale,
 
   // Compute difference.
   if (LDigits <= RDigits)
-    return std::make_pair(0, 0);
+    return {0, 0};
   if (RDigits || !SavedRDigits)
-    return std::make_pair(LDigits - RDigits, LScale);
+    return {LDigits - RDigits, LScale};
 
   // Check if RDigits just barely lost its last bit.  E.g., for 32-bit:
   //
   //   1*2^32 - 1*2^0 == 0xffffffff != 1*2^32
   const auto RLgFloor = getLgFloor(SavedRDigits, SavedRScale);
   if (!compare(LDigits, LScale, DigitsT(1), RLgFloor + getWidth<DigitsT>()))
-    return std::make_pair(std::numeric_limits<DigitsT>::max(), RLgFloor);
+    return {std::numeric_limits<DigitsT>::max(), RLgFloor};
 
-  return std::make_pair(LDigits, LScale);
+  return {LDigits, LScale};
 }
 
 /// Convenience helper for 32-bit difference.
@@ -435,9 +435,9 @@ public:
 
   static std::pair<uint64_t, bool> splitSigned(int64_t N) {
     if (N >= 0)
-      return std::make_pair(N, false);
+      return {N, false};
     uint64_t Unsigned = N == INT64_MIN ? UINT64_C(1) << 63 : uint64_t(-N);
-    return std::make_pair(Unsigned, true);
+    return {Unsigned, true};
   }
   static int64_t joinSigned(uint64_t U, bool IsNeg) {
     if (U > uint64_t(INT64_MAX))

--- a/llvm/lib/Support/OptimizedStructLayout.cpp
+++ b/llvm/lib/Support/OptimizedStructLayout.cpp
@@ -82,7 +82,7 @@ llvm::performOptimizedStructLayout(MutableArrayRef<Field> Fields) {
 #ifndef NDEBUG
     checkValidLayout(Fields, Size, MaxAlign);
 #endif
-    return std::make_pair(Size, MaxAlign);
+    return {Size, MaxAlign};
   }
 
   // Walk over the flexible-offset fields, tracking MaxAlign and
@@ -164,7 +164,7 @@ llvm::performOptimizedStructLayout(MutableArrayRef<Field> Fields) {
 #ifndef NDEBUG
       checkValidLayout(Fields, LastEnd, MaxAlign);
 #endif
-      return std::make_pair(LastEnd, MaxAlign);
+      return {LastEnd, MaxAlign};
     }
   }
 
@@ -452,5 +452,5 @@ llvm::performOptimizedStructLayout(MutableArrayRef<Field> Fields) {
   checkValidLayout(Fields, LastEnd, MaxAlign);
 #endif
 
-  return std::make_pair(LastEnd, MaxAlign);
+  return {LastEnd, MaxAlign};
 }

--- a/llvm/lib/Support/ScaledNumber.cpp
+++ b/llvm/lib/Support/ScaledNumber.cpp
@@ -41,7 +41,7 @@ std::pair<uint64_t, int16_t> ScaledNumbers::multiply64(uint64_t LHS,
 
   // Check whether the upper digit is empty.
   if (!Upper)
-    return std::make_pair(Lower, 0);
+    return {Lower, 0};
 
   // Shift as little as possible to maximize precision.
   unsigned LeadingZeros = llvm::countl_zero(Upper);
@@ -91,7 +91,7 @@ std::pair<uint64_t, int16_t> ScaledNumbers::divide64(uint64_t Dividend,
 
   // Check for powers of two.
   if (Divisor == 1)
-    return std::make_pair(Dividend, Shift);
+    return {Dividend, Shift};
 
   // Maximize size of dividend.
   if (int Zeros = llvm::countl_zero(Dividend)) {

--- a/llvm/lib/Support/SmallPtrSet.cpp
+++ b/llvm/lib/Support/SmallPtrSet.cpp
@@ -52,7 +52,7 @@ SmallPtrSetImplBase::insert_imp_big(const void *Ptr) {
   // Okay, we know we have space.  Find a hash bucket.
   const void **Bucket = const_cast<const void**>(FindBucketFor(Ptr));
   if (*Bucket == Ptr)
-    return std::make_pair(Bucket, false); // Already inserted, good.
+    return {Bucket, false}; // Already inserted, good.
 
   // Otherwise, insert it!
   if (*Bucket == getTombstoneMarker())
@@ -60,7 +60,7 @@ SmallPtrSetImplBase::insert_imp_big(const void *Ptr) {
   ++NumEntries;
   *Bucket = Ptr;
   incrementEpoch();
-  return std::make_pair(Bucket, true);
+  return {Bucket, true};
 }
 
 const void *const *SmallPtrSetImplBase::doFind(const void *Ptr) const {

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -202,7 +202,7 @@ SourceMgr::getLineAndColumn(SMLoc Loc, unsigned BufferID) const {
   size_t NewlineOffs = StringRef(BufStart, Ptr - BufStart).find_last_of("\n\r");
   if (NewlineOffs == StringRef::npos)
     NewlineOffs = ~(size_t)0;
-  return std::make_pair(LineNo, Ptr - BufStart - NewlineOffs);
+  return {LineNo, Ptr - BufStart - NewlineOffs};
 }
 
 // FIXME: Note that the formatting of source locations is spread between

--- a/llvm/lib/Support/StringExtras.cpp
+++ b/llvm/lib/Support/StringExtras.cpp
@@ -44,7 +44,7 @@ std::pair<StringRef, StringRef> llvm::getToken(StringRef Source,
   // Find the next occurrence of the delimiter.
   StringRef::size_type End = Source.find_first_of(Delimiters, Start);
 
-  return std::make_pair(Source.slice(Start, End), Source.substr(End));
+  return {Source.slice(Start, End), Source.substr(End)};
 }
 
 /// SplitString - Split up the specified string according to the specified


### PR DESCRIPTION
In C++17 and later, "return {A, B};" guarantees copy elision for a
std::pair return type, ensuring the object is constructed directly in
the return slot.  This patch updates those instances under Support/.
