### PR TITLE
[IR] Introduce `llvm.errno.tbaa` metadata for errno alias disambiguation

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -8864,6 +8864,28 @@ For example, the following metadata section contains two library specifiers::
 Each library specifier will be handled independently by the consuming linker.
 The effect of the library specifiers are defined by the consuming linker.
 
+'``llvm.errno.tbaa``' Named Metadata
+====================================
+
+The module-level ``!llvm.errno.tbaa`` metadata specifies the TBAA nodes used
+for accessing ``errno``. These nodes are guaranteed to represent int-compatible
+accesses according to C/C++ strict aliasing rules. This should let LLVM alias
+analyses to reason about aliasing with ``errno`` when calling library functions
+that may set ``errno``, allowing optimizations such as store-to-load forwarding
+across such routines.
+
+For example, the following is a valid metadata specifying the TBAA information
+for an integer access:
+
+    !llvm.errno.tbaa = !{!0}
+    !0 = !{!1, !1, i64 0}
+    !1 = !{!"int", !2, i64 0}
+    !2 = !{!"omnipotent char", !3, i64 0}
+    !3 = !{!"Simple C/C++ TBAA"}
+
+Multiple TBAA operands are allowed to support merging of modules that may use
+different TBAA hierarchies (e.g., when mixing C and C++).
+
 .. _summary:
 
 ThinLTO Summary

--- a/llvm/include/llvm/IR/Verifier.h
+++ b/llvm/include/llvm/IR/Verifier.h
@@ -75,9 +75,9 @@ class TBAAVerifier {
 public:
   TBAAVerifier(VerifierSupport *Diagnostic = nullptr)
       : Diagnostic(Diagnostic) {}
-  /// Visit an instruction and return true if it is valid, return false if an
-  /// invalid TBAA is attached.
-  LLVM_ABI bool visitTBAAMetadata(Instruction &I, const MDNode *MD);
+  /// Visit an instruction, or a TBAA node itself as part of a metadata, and
+  /// return true if it is valid, return false if an invalid TBAA is attached.
+  LLVM_ABI bool visitTBAAMetadata(Instruction *I, const MDNode *MD);
 };
 
 /// Check a function for errors, useful for use when debugging a

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7024,7 +7024,7 @@ Error BitcodeReader::materialize(GlobalValue *GV) {
   if (!MDLoader->isStrippingTBAA()) {
     for (auto &I : instructions(F)) {
       MDNode *TBAA = I.getMetadata(LLVMContext::MD_tbaa);
-      if (!TBAA || TBAAVerifyHelper.visitTBAAMetadata(I, TBAA))
+      if (!TBAA || TBAAVerifyHelper.visitTBAAMetadata(&I, TBAA))
         continue;
       MDLoader->setStripTBAA(true);
       stripTBAA(F->getParent());

--- a/llvm/test/Linker/Inputs/errno-tbaa-cxx-metadata.ll
+++ b/llvm/test/Linker/Inputs/errno-tbaa-cxx-metadata.ll
@@ -1,0 +1,5 @@
+!llvm.errno.tbaa = !{!0}
+!0 = !{!1, !1, i64 0}
+!1 = !{!"int", !2, i64 0}
+!2 = !{!"omnipotent char", !3, i64 0}
+!3 = !{!"Simple C++ TBAA"}

--- a/llvm/test/Linker/Inputs/errno-tbaa-metadata.ll
+++ b/llvm/test/Linker/Inputs/errno-tbaa-metadata.ll
@@ -1,0 +1,5 @@
+!llvm.errno.tbaa = !{!0}
+!0 = !{!1, !1, i64 0}
+!1 = !{!"int", !2, i64 0}
+!2 = !{!"omnipotent char", !3, i64 0}
+!3 = !{!"Simple C/C++ TBAA"}

--- a/llvm/test/Linker/link-errno-tbaa-metadata.ll
+++ b/llvm/test/Linker/link-errno-tbaa-metadata.ll
@@ -1,0 +1,8 @@
+; RUN: llvm-link %S/Inputs/errno-tbaa-metadata.ll %S/Inputs/errno-tbaa-cxx-metadata.ll -S -o - | FileCheck %s --check-prefix=CHECK-MERGE
+; RUN: llvm-link %S/Inputs/errno-tbaa-metadata.ll %S/Inputs/errno-tbaa-metadata.ll -S -o - | FileCheck %s --check-prefix=CHECK-DEDUP
+
+; Ensure merging when linking modules w/ different errno TBAA hierarchies.
+; CHECK-MERGE: !llvm.errno.tbaa = !{![[NODE0:[0-9]+]], ![[NODE1:[0-9]+]]}
+
+; Ensure deduplication when linking modules w/ identical errno TBAA nodes.
+; CHECK-DEDUP: !llvm.errno.tbaa = !{![[NODE:[0-9]+]]}

--- a/llvm/test/Verifier/errno-tbaa-metadata-1.ll
+++ b/llvm/test/Verifier/errno-tbaa-metadata-1.ll
@@ -1,0 +1,5 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: assembly parsed, but does not verify as correct!
+; CHECK-NEXT: llvm.errno.tbaa must have at least one operand
+!llvm.errno.tbaa = !{}

--- a/llvm/test/Verifier/errno-tbaa-metadata-2.ll
+++ b/llvm/test/Verifier/errno-tbaa-metadata-2.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: assembly parsed, but does not verify as correct!
+; CHECK-NEXT: Malformed struct tag metadata: base and access-type should be non-null and point to Metadata nodes
+!llvm.errno.tbaa = !{!0}
+!0 = !{!1, i64 0, !1}
+!1 = !{!"int", !2, i64 0}
+!2 = !{!"omnipotent char", !3, i64 0}
+!3 = !{!"Simple C/C++ TBAA"}


### PR DESCRIPTION
Add a new named module-level frontend-annotated metadata that specifies the TBAA node for an integer access, for which, C/C++ `errno` accesses are guaranteed to use (under strict aliasing). This should allow LLVM to prove the involved memory location/ accesses may not alias `errno`; thus, to perform optimizations around errno-writing libcalls (store-to-load forwarding amongst others).

Clang change: https://github.com/llvm/llvm-project/pull/125258.

Previous discussion: https://discourse.llvm.org/t/rfc-modelling-errno-memory-effects/82972.