### PR TITLE
[AssumptionCache] Don't use ResultElem for assumption list (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/AssumptionCache.h
+++ b/llvm/include/llvm/Analysis/AssumptionCache.h
@@ -65,7 +65,7 @@ private:
 
   /// Vector of weak value handles to calls of the \@llvm.assume
   /// intrinsic.
-  SmallVector<ResultElem, 4> AssumeHandles;
+  SmallVector<WeakVH, 4> AssumeHandles;
 
   class LLVM_ABI AffectedValueCallbackVH final : public CallbackVH {
     AssumptionCache *AC;
@@ -148,7 +148,7 @@ public:
   /// FIXME: We should replace this with pointee_iterator<filter_iterator<...>>
   /// when we can write that to filter out the null values. Then caller code
   /// will become simpler.
-  MutableArrayRef<ResultElem> assumptions() {
+  MutableArrayRef<WeakVH> assumptions() {
     if (!Scanned)
       scanFunction();
     return AssumeHandles;

--- a/llvm/lib/Analysis/AssumptionCache.cpp
+++ b/llvm/lib/Analysis/AssumptionCache.cpp
@@ -172,7 +172,7 @@ void AssumptionCache::scanFunction() {
   for (BasicBlock &B : F)
     for (Instruction &I : B)
       if (isa<AssumeInst>(&I))
-        AssumeHandles.push_back({&I, ExprResultIdx});
+        AssumeHandles.push_back(&I);
 
   // Mark the scan as complete.
   Scanned = true;
@@ -188,7 +188,7 @@ void AssumptionCache::registerAssumption(AssumeInst *CI) {
   if (!Scanned)
     return;
 
-  AssumeHandles.push_back({CI, ExprResultIdx});
+  AssumeHandles.push_back(CI);
 
 #ifndef NDEBUG
   assert(CI->getParent() &&

--- a/llvm/lib/Transforms/Scalar/DropUnnecessaryAssumes.cpp
+++ b/llvm/lib/Transforms/Scalar/DropUnnecessaryAssumes.cpp
@@ -21,7 +21,7 @@ DropUnnecessaryAssumesPass::run(Function &F, FunctionAnalysisManager &FAM) {
   AssumptionCache &AC = FAM.getResult<AssumptionAnalysis>(F);
   bool Changed = false;
 
-  for (WeakVH &Elem : AC.assumptions()) {
+  for (const WeakVH &Elem : AC.assumptions()) {
     auto *Assume = cast_or_null<AssumeInst>(Elem);
     if (!Assume)
       continue;

--- a/llvm/lib/Transforms/Scalar/DropUnnecessaryAssumes.cpp
+++ b/llvm/lib/Transforms/Scalar/DropUnnecessaryAssumes.cpp
@@ -21,8 +21,8 @@ DropUnnecessaryAssumesPass::run(Function &F, FunctionAnalysisManager &FAM) {
   AssumptionCache &AC = FAM.getResult<AssumptionAnalysis>(F);
   bool Changed = false;
 
-  for (AssumptionCache::ResultElem &Elem : AC.assumptions()) {
-    auto *Assume = cast_or_null<AssumeInst>(Elem.Assume);
+  for (WeakVH &Elem : AC.assumptions()) {
+    auto *Assume = cast_or_null<AssumeInst>(Elem);
     if (!Assume)
       continue;
 


### PR DESCRIPTION
ResultElem stores a weak handle of an assume, plus an index for referring to a specific operand bundle. This makes sense for the results of assumptionsFor(), which refers to specific operands of assumes.

However, assumptions() is a plain list of assumes. It does *not* contain separate entries for each operand bundles. The operand bundle index is always ExprResultIdx.

As such, we should be directly using WeakVH for this case, without the additional wrapper.