### PR TITLE
[lld][cmake] install symlinks when built standalone

### DIFF
--- a/lld/cmake/modules/AddLLD.cmake
+++ b/lld/cmake/modules/AddLLD.cmake
@@ -73,6 +73,11 @@ macro(add_lld_tool name)
 endmacro()
 
 macro(add_lld_symlink name dest)
+  # In standalone builds, LLVM_USE_SYMLINKS may not be defined.
+  # In that case, default to using symlinks on Unix platforms.
+  if(NOT DEFINED LLVM_USE_SYMLINKS)
+    set(LLVM_USE_SYMLINKS ${CMAKE_HOST_UNIX})
+  endif()
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)
   if(LLVM_TOOL_LLVM_DRIVER_BUILD
      AND ${dest} IN_LIST LLVM_DRIVER_TOOLS


### PR DESCRIPTION
lld installs symlinks with `llvm_install_symlink`, which relies on the variable `LLVM_USE_SYMLINKS` to determine whether to use symlinks or copies. Since that variable is defined in llvm's `CMakeLists.txt`, it may not be defined when lld is built standalone. In that case, default to using symlinks on Unix platforms. Users can still override this by setting `LLVM_USE_SYMLINKS` manually.

Fixes https://github.com/llvm/llvm-project/issues/151557.
