### PR TITLE
[CMake] Suppress -Wpass-failed warning

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -962,6 +962,13 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
 
   # Enable -Wctad-maybe-unsupported to catch unintended use of CTAD.
   add_flag_if_supported("-Wctad-maybe-unsupported" CTAD_MAYBE_UNSPPORTED_FLAG)
+
+  # Disable -Wno-pass-failed flag, which reports failure to perform
+  # optimizations suggested by pragmas. This warning is not relevant for LLVM
+  # projects and may be injected by pragmas in libstdc++.
+  # FIXME: Reconsider this choice if warnings from STL headers can be reliably
+  # avoided (https://github.com/llvm/llvm-project/issues/157666).
+  add_flag_if_supported("-Wno-pass-failed" NO_PASS_FAILED_FLAG)
 endif (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
 
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT LLVM_ENABLE_WARNINGS)

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -110,12 +110,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   endif()
 endif()
 
-# libstdc++15 makes use of an unroll pragma inside std::find_if(). This
-# produces a warning if clang fails to unroll the loop. As this pragma is
-# outside of our control, suppress the warning.
-check_cxx_compiler_flag("-Wno-pass-failed" CXX_SUPPORTS_WNO_PASS_FAILED)
-append_if(CXX_SUPPORTS_WNO_PASS_FAILED "-Wno-pass-failed" CMAKE_CXX_FLAGS)
-
 # Installing the headers and docs needs to depend on generating any public
 # tablegen'd targets.
 # mlir-generic-headers are dialect-independent.

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -110,6 +110,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   endif()
 endif()
 
+# libstdc++15 makes use of an unroll pragma inside std::find_if(). This
+# produces a warning if clang fails to unroll the loop. As this pragma is
+# outside of our control, suppress the warning.
+check_cxx_compiler_flag("-Wno-pass-failed" CXX_SUPPORTS_WNO_PASS_FAILED)
+append_if(CXX_SUPPORTS_WNO_PASS_FAILED "-Wno-pass-failed" CMAKE_CXX_FLAGS)
+
 # Installing the headers and docs needs to depend on generating any public
 # tablegen'd targets.
 # mlir-generic-headers are dialect-independent.


### PR DESCRIPTION
libstdc++15 makes use of an unroll pragma inside std::find_if(). This produces a warning if clang fails to unroll the loop. As this pragma is outside of our control, suppress the warning. Missed transforms are not something we care about in this context.

Related to https://github.com/llvm/llvm-project/issues/157666.