### PR TITLE
[lit] [test] Fix the shtest-readfile test on Python 3.13 on Windows

### DIFF
--- a/llvm/utils/lit/tests/shtest-readfile.py
+++ b/llvm/utils/lit/tests/shtest-readfile.py
@@ -10,7 +10,7 @@
 
 # CHECK-LABEL: FAIL: shtest-readfile :: file-does-not-exist.txt ({{[^)]*}})
 # CHECK: # executed command: @echo 'echo %{readfile:/file/does/not/exist}'
-# CHECK: # | File specified in readfile substitution does not exist: /file/does/not/exist
+# CHECK: # | File specified in readfile substitution does not exist: {{.*}}/file/does/not/exist
 
 # CHECK-LABEL: FAIL: shtest-readfile :: relative-paths.txt ({{[^)]*}})
 # CHECK: echo hello


### PR DESCRIPTION
Python 3.13 considers "/file/does/not/exist" to not be an absolute path on Windows, so the test runner does os.path.join(cwd, filePath), which can end up with an output path such as "D:/file/does/not/exist".

Accept a potential prefix before the missing path here.

This fixes running the lit tests on Windows with Python 3.13.