### PR TITLE
[clang][bytecode] Don't crash on a null Descriptor

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -3534,6 +3534,9 @@ inline bool AllocCN(InterpState &S, CodePtr OpPC, const Descriptor *ElementDesc,
   if (!CheckDynamicMemoryAllocation(S, OpPC))
     return false;
 
+  if (!ElementDesc)
+    return false;
+
   SizeT NumElements = S.Stk.pop<SizeT>();
   if (!CheckArraySize(S, OpPC, &NumElements, ElementDesc->getSize(),
                       IsNoThrow)) {

--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -1091,6 +1091,19 @@ namespace NewNegSizeNothrow {
   static_assert(test_nothrow_neg_size(), "expected nullptr");
 } // namespace NewNegSizeNothrow
 
+#if __SIZEOF_SIZE_T == 8
+/// We can't allocate the array here as it is too big.
+/// Make sure we're not crashing by assuming an non-null
+/// Descriptor.
+namespace HugeAllocation {
+  void *p;
+  void foo ()
+  {
+    p = new char [256][256][256][256][256];
+  }
+}
+#endif
+
 #else
 /// Make sure we reject this prior to C++20
 constexpr int a() { // both-error {{never produces a constant expression}}


### PR DESCRIPTION
... for dynamic memory allocation. This happens when the requested array size is too large.

Fixes #152951