### PR TITLE
[clang][bytecode] Fix a crash in __builtin_object_size()

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2449,10 +2449,14 @@ static bool interp__builtin_object_size(InterpState &S, CodePtr OpPC,
     if (Ptr.isBaseClass())
       ByteOffset = computePointerOffset(ASTCtx, Ptr.getBase()) -
                    computePointerOffset(ASTCtx, Ptr);
-    else
-      ByteOffset =
-          computePointerOffset(ASTCtx, Ptr) -
-          computePointerOffset(ASTCtx, Ptr.expand().atIndex(0).narrow());
+    else {
+      if (Ptr.inArray())
+        ByteOffset =
+            computePointerOffset(ASTCtx, Ptr) -
+            computePointerOffset(ASTCtx, Ptr.expand().atIndex(0).narrow());
+      else
+        ByteOffset = 0;
+    }
   } else
     ByteOffset = computePointerOffset(ASTCtx, Ptr);
 

--- a/clang/test/AST/ByteCode/builtin-object-size.cpp
+++ b/clang/test/AST/ByteCode/builtin-object-size.cpp
@@ -17,7 +17,8 @@ static_assert(__builtin_object_size(&arrf, 0) == (sizeof(float)*2), "");
 static_assert(__builtin_object_size(&arrf[1], 0) == sizeof(float), "");
 static_assert(__builtin_object_size(&arrf[2], 0) == 0, "");
 
-
+constexpr struct { int a; int b; } F{};
+static_assert(__builtin_object_size(&F.a, 3) == sizeof(int));
 
 struct S {
   int a;


### PR DESCRIPTION
The previous `ByteOffset` computation only makes sense if `Ptr` points into an array.