### PR TITLE
[mlir][IR] Make `RewriterBase::replaceOp` non-virtual

### DIFF
--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -515,12 +515,12 @@ public:
   /// Replace the results of the given (original) operation with the specified
   /// list of values (replacements). The result types of the given op and the
   /// replacements must match. The original op is erased.
-  virtual void replaceOp(Operation *op, ValueRange newValues);
+  void replaceOp(Operation *op, ValueRange newValues);
 
   /// Replace the results of the given (original) operation with the specified
   /// new op (replacement). The result types of the two ops must match. The
   /// original op is erased.
-  virtual void replaceOp(Operation *op, Operation *newOp);
+  void replaceOp(Operation *op, Operation *newOp);
 
   /// Replace the results of the given (original) op with a new op that is
   /// created without verification (replacement). The result values of the two

--- a/mlir/include/mlir/Transforms/DialectConversion.h
+++ b/mlir/include/mlir/Transforms/DialectConversion.h
@@ -900,7 +900,7 @@ public:
   /// RewriterBase APIs, (3) may be removed in the future.
   void replaceAllUsesWith(Value from, ValueRange to);
   void replaceAllUsesWith(Value from, Value to) override {
-    replaceAllUsesWith(from, ValueRange{to});
+    replaceAllUsesWith(from, to ? ValueRange{to} : ValueRange{});
   }
 
   /// Return the converted value of 'key' with a type defined by the type
@@ -922,20 +922,6 @@ public:
   /// Recovery is supported via rollback, allowing for continued processing of
   /// patterns even if a failure is encountered during the rewrite step.
   bool canRecoverFromRewriteFailure() const override { return true; }
-
-  /// Replace the given operation with the new values. The number of op results
-  /// and replacement values must match. The types may differ: the dialect
-  /// conversion driver will reconcile any surviving type mismatches at the end
-  /// of the conversion process with source materializations. The given
-  /// operation is erased.
-  void replaceOp(Operation *op, ValueRange newValues) override;
-
-  /// Replace the given operation with the results of the new op. The number of
-  /// op results must match. The types may differ: the dialect conversion
-  /// driver will reconcile any surviving type mismatches at the end of the
-  /// conversion process with source materializations. The original operation
-  /// is erased.
-  void replaceOp(Operation *op, Operation *newOp) override;
 
   /// Replace the given operation with the new value ranges. The number of op
   /// results and value ranges must match. The given  operation is erased.

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -79,7 +79,7 @@ func.func @remap_call_1_to_1(%arg0: i64) {
 // CHECK-NEXT: notifyOperationInserted: test.return
 
 // The old block is erased.
-// CHECK-NEXT: notifyBlockErased
+// CHECK: notifyBlockErased
 
 // The function op gets a new type attribute.
 // CHECK-NEXT: notifyOperationModified: func.func
@@ -367,31 +367,6 @@ func.func @convert_detached_signature() {
     "test.return"() : () -> ()
   }) : () -> ()
   "test.return"() : () -> ()
-}
-
-// -----
-
-// CHECK: notifyOperationReplaced: test.erase_op
-// CHECK: notifyOperationErased: test.dummy_op_lvl_2
-// CHECK: notifyBlockErased
-// CHECK: notifyOperationErased: test.dummy_op_lvl_1
-// CHECK: notifyBlockErased
-// CHECK: notifyOperationErased: test.erase_op
-// CHECK: notifyOperationInserted: test.valid, was unlinked
-// CHECK: notifyOperationReplaced: test.drop_operands_and_replace_with_valid
-// CHECK: notifyOperationErased: test.drop_operands_and_replace_with_valid
-
-// CHECK-LABEL: func @circular_mapping()
-//  CHECK-NEXT:   "test.valid"() : () -> ()
-func.func @circular_mapping() {
-  // Regression test that used to crash due to circular
-  // unrealized_conversion_cast ops. 
-  %0 = "test.erase_op"() ({
-    "test.dummy_op_lvl_1"() ({
-      "test.dummy_op_lvl_2"() : () -> ()
-    }) : () -> ()
-  }): () -> (i64)
-  "test.drop_operands_and_replace_with_valid"(%0) : (i64) -> ()
 }
 
 // -----


### PR DESCRIPTION
`RewriterBase::replaceOp` used to be virtual, so that `ConversionPatternRewriter` can override the function. This is no longer necessary: both `replaceAllUsesWith` and `eraseOp` are virtual, and `replaceOp` is a combination of these two functions.

Implementation details in the dialect conversion:
* `ReplaceOperationRewrite` is now just a placeholder IRRewrite, which notifies the listener. (It used to be called when erasing an op. This was treated as replacing an op with only null Values.)
* A new `EraseOperationRewrite` was added, which is used when erasing an operation. In rollback mode, an operation can be erased when it still has uses; in that case, source materializations must be created out-of-thin air. This is done with `EraseOperationRewrite::commit`. We used to do this during `ReplaceOperationRewrite::commit`.
* In "no rollback" mode, erasing an operation that still has uses is no longer allowed. That's why the `circular_mapping` test case is moved to a different file. (The conversion rewriter behaves like a regular pattern rewriter here.)
* The `getReplacementValues` helper function is moved into `ConversionPatternRewriterImpl::replaceAllUsesWith`. (The loop is no longer needed.)

RFC: https://discourse.llvm.org/t/making-rewriterbase-replaceop-non-virtual/88405

