### PR TITLE
[SimplifyCFG] Don't perform "redirecting phis between unmergeable BBs and successor BB" optimization when not using jump tables.

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -1159,6 +1159,12 @@ bool llvm::TryToSimplifyUncondBranchFromEmptyBlock(BasicBlock *BB,
   bool BBPhisMergeable = BBKillable || CanRedirectPredsOfEmptyBBToSucc(
                                            BB, Succ, BBPreds, CommonPred);
 
+  // If the function has the "no-jump-tables" attribute, merging phis
+  // can make size worse at -Oz.
+  auto *MF = BB->getParent();
+  if (MF->hasMinSize() && MF->hasFnAttribute("no-jump-tables"))
+    BBPhisMergeable = false;
+
   if ((!BBKillable && !BBPhisMergeable) || introduceTooManyPhiEntries(BB, Succ))
     return false;
 


### PR DESCRIPTION
This optimization works well for most cases but implicitly assumes that the
backend will be able to generate jump tables (see "And lookup table optimization
should convert it into add %arg 1." in PR #67275 description).

When -fno-jump-tables is used however this regresses code size, which is
especially painful in targets like armv7 where there's already high register
pressure.

rdar://157858055