### PR TITLE
[MLIR] Clarify createOrFold as opportunistic eager folding

### DIFF
--- a/mlir/include/mlir/IR/Builders.h
+++ b/mlir/include/mlir/IR/Builders.h
@@ -515,10 +515,10 @@ public:
   /// the results of the operation.
   ///
   /// Note: This performs opportunistic eager folding during IR construction.
-  /// The folders are designed to operate efficiently on canonical IR, which this
-  /// API does not enforce. Complete folding isn't only expected in the context
-  /// of canonicalization which intertwine folders with pattern rewrites until
-  /// fixed-point.
+  /// The folders are designed to operate efficiently on canonical IR, which 
+  /// this API does not enforce. Complete folding isn't only expected in the
+  /// context of canonicalization which intertwine folders with pattern 
+  /// rewrites until fixed-point.
   template <typename OpTy, typename... Args>
   void createOrFold(SmallVectorImpl<Value> &results, Location location,
                     Args &&...args) {

--- a/mlir/include/mlir/IR/Builders.h
+++ b/mlir/include/mlir/IR/Builders.h
@@ -513,6 +513,9 @@ public:
   /// Create an operation of specific op type at the current insertion point,
   /// and immediately try to fold it. This functions populates 'results' with
   /// the results of the operation.
+  ///
+  /// Note: This performs opportunistic eager folding during IR construction,
+  /// attempting optimization only once without iterative refinement.
   template <typename OpTy, typename... Args>
   void createOrFold(SmallVectorImpl<Value> &results, Location location,
                     Args &&...args) {

--- a/mlir/include/mlir/IR/Builders.h
+++ b/mlir/include/mlir/IR/Builders.h
@@ -514,8 +514,11 @@ public:
   /// and immediately try to fold it. This functions populates 'results' with
   /// the results of the operation.
   ///
-  /// Note: This performs opportunistic eager folding during IR construction,
-  /// attempting optimization only once without iterative refinement.
+  /// Note: This performs opportunistic eager folding during IR construction.
+  /// The folders are designed to operate efficiently on canonical IR, which this
+  /// API does not enforce. Complete folding isn't only expected in the context
+  /// of canonicalization which intertwine folders with pattern rewrites until
+  /// fixed-point.
   template <typename OpTy, typename... Args>
   void createOrFold(SmallVectorImpl<Value> &results, Location location,
                     Args &&...args) {


### PR DESCRIPTION
This PR addresses the documentation aspect of #159844 by clarifying the opportunistic nature of `createOrFold`, as discussed with @joker-eph.

This addresses user confusion about createOrFold behavior compared to canonicalization passes.