### PR TITLE
[AIX] Fix AIX failures due to switch to internal shell

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/lds-run-twice-absolute-md.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-run-twice-absolute-md.ll
@@ -1,5 +1,3 @@
-; XFAIL: target={{.*}}-aix{{.*}}
-
 ; RUN: opt -S -mtriple=amdgcn-- -amdgpu-lower-module-lds %s -o %t.ll
 ; RUN: opt -S -mtriple=amdgcn-- -amdgpu-lower-module-lds %t.ll -o %t.second.ll
 ; RUN: diff -ub %t.ll %t.second.ll -I ".*ModuleID.*"

--- a/llvm/test/CodeGen/AMDGPU/lds-run-twice.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-run-twice.ll
@@ -1,5 +1,3 @@
-; XFAIL: target={{.*}}-aix{{.*}}
-
 ; RUN: opt -S -mtriple=amdgcn-- -amdgpu-lower-module-lds %s -o %t.ll
 ; RUN: opt -S -mtriple=amdgcn-- -amdgpu-lower-module-lds %t.ll -o %t.second.ll
 ; RUN: diff -ub %t.ll %t.second.ll -I ".*ModuleID.*"

--- a/llvm/test/tools/llvm-ar/option-X.test
+++ b/llvm/test/tools/llvm-ar/option-X.test
@@ -3,7 +3,6 @@
 ## The option specifies the type of object file llvm-ar will operate on.
 
 # RUN: rm -rf %t && mkdir %t && cd %t
-# RUN: unset OBJECT_MODE
 # RUN: yaml2obj --docnum=1 -DCLASS=ELFCLASS32 %s -o elf32.o
 # RUN: yaml2obj --docnum=1 -DCLASS=ELFCLASS64 %s -o elf64.o
 
@@ -11,7 +10,7 @@
 # RUN: yaml2obj --docnum=2 -DFLAG=0x1F7 %s -o xcoff64.o
 
 ## Test default -X option when creating a new archive.
-# RUN: llvm-ar -q -c archive-default.a xcoff32.o elf32.o xcoff64.o elf64.o  2>&1 | \
+# RUN: env -u OBJECT_MODE llvm-ar -q -c archive-default.a xcoff32.o elf32.o xcoff64.o elf64.o  2>&1 | \
 # RUN:   FileCheck %s --check-prefixes=WARN-XCOFF64,WARN-ELF64
 # RUN: llvm-ar -t -Xany archive-default.a | \
 # RUN:   FileCheck %s --check-prefixes=OBJ32
@@ -74,7 +73,7 @@
 # RUN:   FileCheck %s --check-prefixes=OBJ32_64
 
 ## Test -X option for print operation.
-# RUN: llvm-ar -t archive-any.a | \
+# RUN: env -u OBJECT_MODE llvm-ar -t archive-any.a | \
 # RUN:   FileCheck %s --check-prefixes=OBJ32
 
 # RUN: llvm-ar -t -X32 archive-any.a | \
@@ -115,7 +114,7 @@
 # RUN: cmp elf64.o any/elf64.o
 
 ## Extract a 64-bit object file with option -X32 (or default object mode).
-# RUN: not llvm-ar --output=err64 -x archive-any.a xcoff64.o 2>&1 | \
+# RUN: env -u OBJECT_MODE not llvm-ar --output=err64 -x archive-any.a xcoff64.o 2>&1 | \
 # RUN:   FileCheck %s -DFILE=xcoff64.o --check-prefixes=ERR64
 # RUN: not llvm-ar --output=err64 -x -X32 archive-any.a xcoff64.o 2>&1 | \
 # RUN:   FileCheck %s -DFILE=xcoff64.o --check-prefixes=ERR64
@@ -156,7 +155,7 @@
 ## Without -X64, -X32_64 or -Xany, nothing changed here,
 ## since xcoff.o is a 64-bit object file in command line, but
 ## the xcoff.o member in archive-rep.a is a 32-bit object file.
-# RUN: llvm-ar -r archive-rep.a xcoff.o
+# RUN: env -u OBJECT_MODE llvm-ar -r archive-rep.a xcoff.o
 # RUN: llvm-ar -t -Xany archive-rep.a | \
 # RUN:   FileCheck %s --check-prefixes=REP
 # RUN: llvm-nm -Xany --print-armap archive-rep.a | \
@@ -178,7 +177,7 @@
 ## Test move member.
 # RUN: cp archive-any.a archive.a
 ## Do not move 64-bit object without options -X64, -X32_64, Xany.
-# RUN: llvm-ar -ma elf32.o archive.a xcoff64.o 2>&1 | \
+# RUN: env -u OBJECT_MODE llvm-ar -ma elf32.o archive.a xcoff64.o 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=WARN-XCOFF64
 
 # RUN: llvm-ar -t -Xany archive.a | \
@@ -240,7 +239,7 @@
 # MOVE32-EMPTY:
 
 ## Move after a file with a bitness that doesn't match the object mode.
-# RUN: not llvm-ar -ma xcoff64.o archive-any.a xcoff32.o 2>&1 | \
+# RUN: env -u OBJECT_MODE not llvm-ar -ma xcoff64.o archive-any.a xcoff32.o 2>&1 | \
 # RUN:   FileCheck %s --check-prefixes=ERR-INSERT-POINT
 
 # RUN: not llvm-ar -X32 -ma xcoff64.o archive-any.a xcoff32.o 2>&1 | \
@@ -308,7 +307,7 @@
 # RUN: yaml2obj --docnum=5 %s -o wasm.o
 # RUN: yaml2obj --docnum=6 %s -o coff.o
 
-# RUN: llvm-ar -q -c archive-other32.a coff.o 32.bc 64.bc wasm.o macho32.o macho64.o 2>&1 | \
+# RUN: env -u OBJECT_MODE llvm-ar -q -c archive-other32.a coff.o 32.bc 64.bc wasm.o macho32.o macho64.o 2>&1 | \
 # RUN:   FileCheck %s --check-prefixes=WARN-64
 # RUN: llvm-ar -t -Xany archive-other32.a | \
 # RUN:   FileCheck %s --check-prefixes=OTHER32

--- a/llvm/test/tools/llvm-nm/option-X-AIX.test
+++ b/llvm/test/tools/llvm-nm/option-X-AIX.test
@@ -4,11 +4,10 @@
 # RUN: yaml2obj -DFLAG=0x1DF %s -o %t_xcoff32.o
 # RUN: yaml2obj -DFLAG=0x1F7 %s -o %t_xcoff64.o
 # RUN: rm -rf %t.a
-# RUN: unset OBJECT_MODE
 # RUN: env OBJECT_MODE=any llvm-ar -q -c %t.a %t_xcoff32.o %t_xcoff64.o
 
 ## Test default "-X" option.
-# RUN: llvm-nm --format=just-symbols %t_xcoff32.o %t_xcoff64.o | \
+# RUN: env -u OBJECT_MODE llvm-nm --format=just-symbols %t_xcoff32.o %t_xcoff64.o | \
 # RUN:   FileCheck -DFILE32=%t_xcoff32.o --check-prefixes=XCOFF32 %s --implicit-check-not={{.}}
 
 ## Test environment variable "OBJECT_MODE".

--- a/llvm/test/tools/llvm-ranlib/aix-X-option.test
+++ b/llvm/test/tools/llvm-ranlib/aix-X-option.test
@@ -14,8 +14,7 @@
 # RUN: cp t_all.a t_X32_64.a
 
 ## Test the OBJECT_MODE environment variable when adding symbol table.
-# RUN: unset OBJECT_MODE
-# RUN: llvm-ranlib t_X32.a
+# RUN: env -u OBJECT_MODE llvm-ranlib t_X32.a
 # RUN: llvm-nm --print-armap t_X32.a 2>&1 | FileCheck --check-prefixes=GLOB32 --implicit-check-not="in t64" %s
 # RUN: cp t_all.a t_X32.a
 # RUN: env OBJECT_MODE=32 llvm-ranlib t_X32.a

--- a/llvm/test/tools/llvm-strings/eof.test
+++ b/llvm/test/tools/llvm-strings/eof.test
@@ -1,11 +1,13 @@
 ## Show that llvm-strings prints the last string in the input even if no
 ## unprintable character follows it.
 
-RUN: echo -n abcdefg | llvm-strings - | FileCheck %s --check-prefix=PRINT
+RUN: echo -n abcdefg > %t
+RUN: llvm-strings %t - | FileCheck %s --check-prefix=PRINT
 PRINT: abcdefg
 
 ## Show that llvm-strings does not print the last string in the input if it is
 ## too short and no unprintable character follows it.
 
-RUN: echo -n abc | llvm-strings - | FileCheck --allow-empty %s --check-prefix=NOPRINT
+RUN: echo -n abc > %t
+RUN: llvm-strings %t - | FileCheck --allow-empty %s --check-prefix=NOPRINT
 NOPRINT-NOT: {{.}}

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -1,11 +1,13 @@
 ## Show that llvm-strings can handle stdin input properly.
 
 ## Case 1: output with single string.
-RUN: echo -n "abcdefg" | llvm-strings - | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}
+RUN: echo -n "abcdefg" > %t
+RUN: llvm-strings %t - | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}
 CASE1: abcdefg
 
 ## Case 2: output too short for string.
-RUN: echo -n "abc" | llvm-strings - | FileCheck %s --implicit-check-not={{.}} --allow-empty
+RUN: echo -n "abc" > %t
+RUN: llvm-strings %t - | FileCheck %s --implicit-check-not={{.}} --allow-empty
 
 ## Case 3: output with new line.
 RUN: printf "abcd\nefgh" | llvm-strings - | FileCheck %s --check-prefix=CASE3 --implicit-check-not={{.}}
@@ -19,4 +21,5 @@ CASE4-NEXT: ghij
 CASE4-NEXT: klmn
 
 ## Case 5: no file name specified is equivalent to explicitly requesting stdin.
-RUN: echo -n "abcdefg" | llvm-strings | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}
+RUN: echo -n "abcdefg" > %t
+RUN: llvm-strings %t - | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}

--- a/llvm/test/tools/llvm-strings/whitespace.test
+++ b/llvm/test/tools/llvm-strings/whitespace.test
@@ -1,3 +1,4 @@
 ## Show that the default output format matches GNU strings.
-RUN: echo -n abcd | llvm-strings - | FileCheck %s --strict-whitespace --implicit-check-not={{.}}
+RUN: echo -n abcd > %t
+RUN: llvm-strings %t - | FileCheck %s --strict-whitespace --implicit-check-not={{.}}
 CHECK: {{^}}abcd{{$}}

--- a/llvm/test/tools/yaml2obj/empty-or-invalid-doc.yaml
+++ b/llvm/test/tools/yaml2obj/empty-or-invalid-doc.yaml
@@ -1,5 +1,6 @@
 # RUN: echo "" | not yaml2obj 2>&1 | FileCheck %s
-# RUN: echo -n "" | not yaml2obj 2>&1 | FileCheck %s
+# RUN: echo -n "" > %t
+# RUN: not yaml2obj %t 2>&1 | FileCheck %s
 # RUN: echo " " | not yaml2obj 2>&1 | FileCheck %s
 # RUN: echo "  " | not yaml2obj 2>&1 | FileCheck %s
 # CHECK: yaml2obj: error: unknown document type

--- a/llvm/utils/lit/tests/shtest-readfile-external.py
+++ b/llvm/utils/lit/tests/shtest-readfile-external.py
@@ -11,7 +11,7 @@
 
 # CHECK-LABEL: FAIL: shtest-readfile :: file-does-not-exist.txt ({{[^)]*}})
 # CHECK: echo $(cat /file/does/not/exist) && test -e /file/does/not/exist {{.*}}
-# CHECK: cat: /file/does/not/exist: No such file or directory
+# CHECK: {{.*}}cat{{.*}}/file/does/not/exist{{.*}}
 
 # CHECK-LABEL: FAIL: shtest-readfile :: relative-paths.txt ({{[^)]*}})
 # CHECK: echo $(cat rel_path_test_folder/test_file) && test -e rel_path_test_folder/test_file {{.*}}

--- a/llvm/utils/lit/tests/shtest-ulimit-nondarwin.py
+++ b/llvm/utils/lit/tests/shtest-ulimit-nondarwin.py
@@ -2,7 +2,7 @@
 
 # ulimit does not work on non-POSIX platforms.
 # These tests are specific to options that Darwin does not support.
-# UNSUPPORTED: system-windows, system-darwin
+# UNSUPPORTED: system-windows, system-darwin, system-aix
 
 # RUN: not %{lit} -a -v %{inputs}/shtest-ulimit-nondarwin | FileCheck %s
 


### PR DESCRIPTION
This PR fixes a bunch of failures on AIX that occurred due to the switch to lit internal shell by default. The failures deal with the following:
1. unset not being supported by lit internal shell
2. A bug with echo -n on AIX when there are multiple pipes in the RUN command
3. ulimit test case not supported on AIX due to the -v option
4. platform specific error message for missing file