### PR TITLE
[compiler-rt] [Darwin] libFuzzer tests should use darwin_filter_host_archs

### DIFF
--- a/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+++ b/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
@@ -64,8 +64,7 @@ if ("-fvisibility=hidden" IN_LIST LIBFUZZER_CFLAGS)
 endif()
 
 if(COMPILER_RT_CAN_EXECUTE_TESTS)
-  set(FUZZER_TEST_ARCH ${FUZZER_SUPPORTED_ARCH})
-  if (APPLE)
+  if(APPLE)
     darwin_filter_host_archs(FUZZER_SUPPORTED_ARCH FUZZER_TEST_ARCH)
   else()
     # libFuzzer unit tests are only run on the host machine.
@@ -116,5 +115,5 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
       LINK_FLAGS ${LIBFUZZER_UNITTEST_LINK_FLAGS} ${LIBFUZZER_TEST_RUNTIME_LINK_FLAGS})
     set_target_properties(FuzzedDataProviderUnitTests PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-    endforeach()
+  endforeach()
 endif()

--- a/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+++ b/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
@@ -73,48 +73,48 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   endif()
 
   foreach(arch ${FUZZER_TEST_ARCH})
-  set(LIBFUZZER_TEST_RUNTIME RTFuzzerTest.${arch})
-  if(APPLE)
-    set(LIBFUZZER_TEST_RUNTIME_OBJECTS
-      $<TARGET_OBJECTS:RTfuzzer.osx>)
-  else()
-    set(LIBFUZZER_TEST_RUNTIME_OBJECTS
-      $<TARGET_OBJECTS:RTfuzzer.${arch}>)
-  endif()
-  add_library(${LIBFUZZER_TEST_RUNTIME} STATIC
-    ${LIBFUZZER_TEST_RUNTIME_OBJECTS})
-  set_target_properties(${LIBFUZZER_TEST_RUNTIME} PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    set(LIBFUZZER_TEST_RUNTIME RTFuzzerTest.${arch})
+    if(APPLE)
+      set(LIBFUZZER_TEST_RUNTIME_OBJECTS
+        $<TARGET_OBJECTS:RTfuzzer.osx>)
+    else()
+      set(LIBFUZZER_TEST_RUNTIME_OBJECTS
+        $<TARGET_OBJECTS:RTfuzzer.${arch}>)
+    endif()
+    add_library(${LIBFUZZER_TEST_RUNTIME} STATIC
+      ${LIBFUZZER_TEST_RUNTIME_OBJECTS})
+    set_target_properties(${LIBFUZZER_TEST_RUNTIME} PROPERTIES
+      ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      FOLDER "Compiler-RT/Tests/Runtime")
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-     COMPILER_RT_LIBCXX_PATH AND
-     COMPILER_RT_LIBCXXABI_PATH)
-    file(GLOB libfuzzer_headers ../*.h)
-    set(LIBFUZZER_TEST_RUNTIME_DEPS libcxx_fuzzer_${arch}-install-cmake326-workaround ${libfuzzer_headers})
-    set(LIBFUZZER_TEST_RUNTIME_CFLAGS -isystem ${LIBCXX_${arch}_PREFIX}/include/c++/v1)
-    set(LIBFUZZER_TEST_RUNTIME_LINK_FLAGS ${LIBCXX_${arch}_PREFIX}/lib/libc++.a)
-  endif()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+       COMPILER_RT_LIBCXX_PATH AND
+       COMPILER_RT_LIBCXXABI_PATH)
+      file(GLOB libfuzzer_headers ../*.h)
+      set(LIBFUZZER_TEST_RUNTIME_DEPS libcxx_fuzzer_${arch}-install-cmake326-workaround ${libfuzzer_headers})
+      set(LIBFUZZER_TEST_RUNTIME_CFLAGS -isystem ${LIBCXX_${arch}_PREFIX}/include/c++/v1)
+      set(LIBFUZZER_TEST_RUNTIME_LINK_FLAGS ${LIBCXX_${arch}_PREFIX}/lib/libc++.a)
+    endif()
 
-  set(FuzzerTestObjects)
-  generate_compiler_rt_tests(FuzzerTestObjects
-    FuzzerUnitTests "Fuzzer-${arch}-Test" ${arch}
-    SOURCES FuzzerUnittest.cpp ${COMPILER_RT_GTEST_SOURCE}
-    RUNTIME ${LIBFUZZER_TEST_RUNTIME}
-    DEPS ${LIBFUZZER_TEST_RUNTIME_DEPS}
-    CFLAGS ${LIBFUZZER_UNITTEST_CFLAGS} ${LIBFUZZER_TEST_RUNTIME_CFLAGS}
-    LINK_FLAGS ${LIBFUZZER_UNITTEST_LINK_FLAGS} ${LIBFUZZER_TEST_RUNTIME_LINK_FLAGS})
-  set_target_properties(FuzzerUnitTests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set(FuzzerTestObjects)
+    generate_compiler_rt_tests(FuzzerTestObjects
+      FuzzerUnitTests "Fuzzer-${arch}-Test" ${arch}
+      SOURCES FuzzerUnittest.cpp ${COMPILER_RT_GTEST_SOURCE}
+      RUNTIME ${LIBFUZZER_TEST_RUNTIME}
+      DEPS ${LIBFUZZER_TEST_RUNTIME_DEPS}
+      CFLAGS ${LIBFUZZER_UNITTEST_CFLAGS} ${LIBFUZZER_TEST_RUNTIME_CFLAGS}
+      LINK_FLAGS ${LIBFUZZER_UNITTEST_LINK_FLAGS} ${LIBFUZZER_TEST_RUNTIME_LINK_FLAGS})
+    set_target_properties(FuzzerUnitTests PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-  set(FuzzedDataProviderTestObjects)
-  generate_compiler_rt_tests(FuzzedDataProviderTestObjects
-    FuzzedDataProviderUnitTests "FuzzerUtils-${arch}-Test" ${arch}
-    SOURCES FuzzedDataProviderUnittest.cpp ${COMPILER_RT_GTEST_SOURCE}
-    DEPS ${LIBFUZZER_TEST_RUNTIME_DEPS} ${COMPILER_RT_SOURCE_DIR}/include/fuzzer/FuzzedDataProvider.h
-    CFLAGS ${LIBFUZZER_UNITTEST_CFLAGS} ${LIBFUZZER_TEST_RUNTIME_CFLAGS}
-    LINK_FLAGS ${LIBFUZZER_UNITTEST_LINK_FLAGS} ${LIBFUZZER_TEST_RUNTIME_LINK_FLAGS})
-  set_target_properties(FuzzedDataProviderUnitTests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  endforeach()
+    set(FuzzedDataProviderTestObjects)
+    generate_compiler_rt_tests(FuzzedDataProviderTestObjects
+      FuzzedDataProviderUnitTests "FuzzerUtils-${arch}-Test" ${arch}
+      SOURCES FuzzedDataProviderUnittest.cpp ${COMPILER_RT_GTEST_SOURCE}
+      DEPS ${LIBFUZZER_TEST_RUNTIME_DEPS} ${COMPILER_RT_SOURCE_DIR}/include/fuzzer/FuzzedDataProvider.h
+      CFLAGS ${LIBFUZZER_UNITTEST_CFLAGS} ${LIBFUZZER_TEST_RUNTIME_CFLAGS}
+      LINK_FLAGS ${LIBFUZZER_UNITTEST_LINK_FLAGS} ${LIBFUZZER_TEST_RUNTIME_LINK_FLAGS})
+    set_target_properties(FuzzedDataProviderUnitTests PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endforeach()
 endif()

--- a/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+++ b/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
@@ -63,10 +63,16 @@ if ("-fvisibility=hidden" IN_LIST LIBFUZZER_CFLAGS)
   list(APPEND LIBFUZZER_UNITTEST_CFLAGS "-fvisibility=hidden")
 endif()
 
-if(COMPILER_RT_DEFAULT_TARGET_ARCH IN_LIST FUZZER_SUPPORTED_ARCH)
-  # libFuzzer unit tests are only run on the host machine.
-  set(arch ${COMPILER_RT_DEFAULT_TARGET_ARCH})
+if(COMPILER_RT_CAN_EXECUTE_TESTS)
+  set(FUZZER_TEST_ARCH ${FUZZER_SUPPORTED_ARCH})
+  if (APPLE)
+    darwin_filter_host_archs(FUZZER_SUPPORTED_ARCH FUZZER_TEST_ARCH)
+  else()
+    # libFuzzer unit tests are only run on the host machine.
+    set(FUZZER_TEST_ARCH ${COMPILER_RT_DEFAULT_TARGET_ARCH})
+  endif()
 
+  foreach(arch ${FUZZER_TEST_ARCH})
   set(LIBFUZZER_TEST_RUNTIME RTFuzzerTest.${arch})
   if(APPLE)
     set(LIBFUZZER_TEST_RUNTIME_OBJECTS
@@ -110,4 +116,5 @@ if(COMPILER_RT_DEFAULT_TARGET_ARCH IN_LIST FUZZER_SUPPORTED_ARCH)
     LINK_FLAGS ${LIBFUZZER_UNITTEST_LINK_FLAGS} ${LIBFUZZER_TEST_RUNTIME_LINK_FLAGS})
   set_target_properties(FuzzedDataProviderUnitTests PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  endforeach()
 endif()


### PR DESCRIPTION
Updates the tests in `compiler-rt/lib/fuzzer/tests/` to use `darwin_filter_host_archs` to check which architectures we can run tests for on Darwin, and adds a target for each of them.

This mirrors the code in `compiler-rtlib/asan/tests/` https://github.com/llvm/llvm-project/blob/af82c1a67b3a1dfc05b6149e68caa30103c15ce8/compiler-rt/lib/asan/tests/CMakeLists.txt#L244-L253

The current behavior to run tests on `COMPILER_RT_DEFAULT_TARGET_ARCH` is preserved on non-Apple platforms. 