### PR TITLE
[lldb-dap] bundle lldb-dap extension using esbuild

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -49,13 +49,14 @@
   ],
   "main": "./out/extension",
   "scripts": {
+    "bundle-extension": "npx tsc -p ./ --noEmit && npx esbuild src-ts/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --target=node22 --minify",
     "bundle-symbols-table-view": "npx tsc -p src-ts/webview --noEmit && npx esbuild src-ts/webview/symbols-table-view.ts --bundle --format=iife --outdir=./out/webview",
     "bundle-tabulator": "cp node_modules/tabulator-tables/dist/js/tabulator.min.js ./out/webview/ && cp node_modules/tabulator-tables/dist/css/tabulator_midnight.min.css ./out/webview/ && cp node_modules/tabulator-tables/dist/css/tabulator_simple.min.css ./out/webview/",
     "bundle-webview": "npm run bundle-symbols-table-view && npm run bundle-tabulator",
-    "vscode:prepublish": "npm run bundle-webview && tsc -p ./",
+    "vscode:prepublish": "npm run bundle-webview && npm run bundle-extension",
     "watch": "npm run bundle-webview && tsc -watch -p ./",
     "format": "npx prettier './src-ts/' --write",
-    "package": "rm -rf ./out/lldb-dap.vsix && vsce package --out ./out/lldb-dap.vsix",
+    "package": "rm -rf ./out && vsce package --out ./out/lldb-dap.vsix",
     "publish": "vsce publish",
     "vscode-uninstall": "code --uninstall-extension llvm-vs-code-extensions.lldb-dap",
     "vscode-install": "code --install-extension ./out/lldb-dap.vsix"


### PR DESCRIPTION
The most recent version of the lldb-dap VS Code extension (0.2.17) fails to activate because it's missing the `chokidar` dependency in the `.vsix`. In order to prevent this from happening in the future, this PR adds a `bundle-extension` step to extension packaging in order to bundle the extension into a single `.js` file using esbuild. All dependencies will be included in this bundle so that the `.vscodeignore` doesn't need to be updated.