### PR TITLE
[flang][cuda] Avoid I/O error in block inside a kernel

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -777,7 +777,8 @@ void CUDAChecker::Enter(const parser::AssignmentStmt &x) {
 void CUDAChecker::Enter(const parser::PrintStmt &x) {
   CHECK(context_.location());
   const Scope &scope{context_.FindScope(*context_.location())};
-  if (IsCUDADeviceContext(&scope) || deviceConstructDepth_ > 0) {
+  const Scope &progUnit{GetProgramUnitContaining(scope)};
+  if (IsCUDADeviceContext(&progUnit) || deviceConstructDepth_ > 0) {
     return;
   }
 

--- a/flang/test/Semantics/cuf23.cuf
+++ b/flang/test/Semantics/cuf23.cuf
@@ -32,3 +32,10 @@ attributes(device) subroutine device1()
   real, device :: a(10)
   print*, a ! ok
 end subroutine
+
+attributes(global) subroutine global_with_block()
+  block
+    real, device :: a(10)
+    print*, a ! ok
+  end block
+end subroutine


### PR DESCRIPTION
Make sure we get the program unit to check the device context. The scope would be the block otherwise. 