### PR TITLE
[lit] Allow retries for readfile tests

### DIFF
--- a/llvm/utils/lit/tests/shtest-readfile-external.py
+++ b/llvm/utils/lit/tests/shtest-readfile-external.py
@@ -1,5 +1,8 @@
 ## Tests the readfile substitution.
 
+# TODO(boomanaiden154): This sometimes fails, possibly due to buffers not being flushed.
+# ALLOW_RETRIES: 2
+
 # UNSUPPORTED: system-windows
 # RUN: env LIT_USE_INTERNAL_SHELL=0 not %{lit} -a -v %{inputs}/shtest-readfile | FileCheck -match-full-lines -DTEMP_PATH=%S/Inputs/shtest-readfile/Output %s
 

--- a/llvm/utils/lit/tests/shtest-readfile.py
+++ b/llvm/utils/lit/tests/shtest-readfile.py
@@ -1,5 +1,8 @@
 ## Tests the readfile substitution.
 
+# TODO(boomanaiden154): This sometimes fails, possibly due to buffers not being flushed.
+# ALLOW_RETRIES: 2
+
 # RUN: env LIT_USE_INTERNAL_SHELL=1  not %{lit} -a -v %{inputs}/shtest-readfile | FileCheck -match-full-lines -DTEMP_PATH=%S%{fs-sep}Inputs%{fs-sep}shtest-readfile%{fs-sep}Output %s
 
 # CHECK: -- Testing: 4 tests{{.*}}


### PR DESCRIPTION
This patch allows for two retry attempts for the readfile tests. This is intended as a stop-gap until I have time to do proper investigation into why exactly the tests are failing.