### PR TITLE
[lldb] Support mangled type names in `memory read`

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -459,17 +459,11 @@ protected:
       if (frame)
         search_first = frame->GetSymbolContext(eSymbolContextModule).module_sp;
       TypeQuery query(lookup_type_name.GetStringRef(),
-                      TypeQueryOptions::e_find_one);
+                      TypeQueryOptions::e_find_one |
+                          TypeQueryOptions::e_search_by_mangled_name);
       TypeResults results;
       target->GetImages().FindTypes(search_first.get(), query, results);
       TypeSP type_sp = results.GetFirstType();
-      if (!type_sp) {
-        // Retry, searching for typename as a mangled name.
-        query.SetSearchByMangledName(true);
-        TypeResults results;
-        target->GetImages().FindTypes(search_first.get(), query, results);
-        type_sp = results.GetFirstType();
-      }
 
       if (!type_sp && lookup_type_name.GetCString()) {
         LanguageType language_for_type =

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -463,6 +463,13 @@ protected:
       TypeResults results;
       target->GetImages().FindTypes(search_first.get(), query, results);
       TypeSP type_sp = results.GetFirstType();
+      if (!type_sp) {
+        // Retry, searching for typename as a mangled name.
+        query.SetSearchByMangledName(true);
+        TypeResults results;
+        target->GetImages().FindTypes(search_first.get(), query, results);
+        type_sp = results.GetFirstType();
+      }
 
       if (!type_sp && lookup_type_name.GetCString()) {
         LanguageType language_for_type =

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -147,12 +147,10 @@ IterationAction DWARFIndex::ProcessTypeDIEMatchQuery(
 
   // Since mangled names are unique, we only need to check if the names are
   // the same.
-  if (query.GetSearchByMangledName()) {
-    if (die.GetMangledName(/*substitute_name_allowed=*/false) !=
+  if (query.GetSearchByMangledName())
+    if (die.GetMangledName(/*substitute_name_allowed=*/false) ==
         query.GetTypeBasename().GetStringRef())
-      return IterationAction::Continue;
-    return callback(die);
-  }
+      return callback(die);
 
   std::vector<lldb_private::CompilerContext> die_context;
   if (query.GetModuleSearch())

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2878,7 +2878,7 @@ void SymbolFileDWARF::FindTypes(const TypeQuery &query, TypeResults &results) {
   bool have_index_match = false;
   m_index->GetTypesWithQuery(query_full, [&](DWARFDIE die) {
     if (Type *matching_type = ResolveType(die, true, true)) {
-      if (!query.GetSearchByMangledName() && matching_type->IsTemplateType()) {
+      if (matching_type->IsTemplateType()) {
         // We have to watch out for case where we lookup a type by basename and
         // it matches a template with simple template names. Like looking up
         // "Foo" and if we have simple template names then we will match
@@ -2913,7 +2913,7 @@ void SymbolFileDWARF::FindTypes(const TypeQuery &query, TypeResults &results) {
   // With -gsimple-template-names, a templated type's DW_AT_name will not
   // contain the template parameters. Try again stripping '<' and anything
   // after, filtering out entries with template parameters that don't match.
-  if (!have_index_match && !query.GetSearchByMangledName()) {
+  if (!have_index_match) {
     // Create a type matcher with a compiler context that is tuned for
     // -gsimple-template-names. We will use this for the index lookup and the
     // context matching, but will use the original "match" to insert matches


### PR DESCRIPTION
Changes `memory read` to accept mangled type names with the `--type`/`-t` flag. This is useful for Swift where a typename can sometimes be more readily available, or expressible, using a mangled name.

Example of printing a Swift `String` using its address, and the mangled name for its type (`$sSSD`):

```
(lldb) memory read -t $sSSD 0x24680
(String) 0x24680 = "some string"
```