### PR TITLE
[compiler-rt] Fix coverage-reset.cpp

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/coverage-reset.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage-reset.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib -fPIC %ld_flags_rpath_so
-// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %ld_flags_rpath_exe -o %t.dir/EXE
-// RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t.dir/EXE 2>&1 | tee /tmp/test
+// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %ld_flags_rpath_exe -o %t.dir/coverage-reset
+// RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t.dir/coverage-reset 2>&1 | FileCheck %s
 //
 // UNSUPPORTED: ios
 
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
   bar2();
   __sanitizer_cov_dump();
 // CHECK: RESET
-// CHECK-DAG: SanitizerCoverage: ./coverage-reset.cpp{{.*}}.sancov: 2 PCs written
+// CHECK-DAG: SanitizerCoverage: ./coverage-reset{{.*}}.sancov: 2 PCs written
 // CHECK-DAG: SanitizerCoverage: ./libcoverage-reset.cpp{{.*}}.sancov: 2 PCs written
 
   fprintf(stderr, "RESET\n");
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
   bar1();
   __sanitizer_cov_dump();
 // CHECK: RESET
-// CHECK-DAG: SanitizerCoverage: ./coverage-reset.cpp{{.*}}.sancov: 1 PCs written
+// CHECK-DAG: SanitizerCoverage: ./coverage-reset{{.*}}.sancov: 1 PCs written
 // CHECK-DAG: SanitizerCoverage: ./libcoverage-reset.cpp{{.*}}.sancov: 1 PCs written
 
   fprintf(stderr, "RESET\n");
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
   foo2();
   __sanitizer_cov_dump();
 // CHECK: RESET
-// CHECK: SanitizerCoverage: ./coverage-reset.cpp{{.*}}.sancov: 2 PCs written
+// CHECK: SanitizerCoverage: ./coverage-reset{{.*}}.sancov: 2 PCs written
 
   fprintf(stderr, "RESET\n");
   __sanitizer_cov_reset();


### PR DESCRIPTION
When relanding a previous patch I had accidentally left this patched to tee output into a file rather than run FileCheck. This patch fixes that so the test actually tests what it is supposed to.