### PR TITLE
[libc++][test] Guard non-guaranteed implicit-lifetime-ness cases with `_LIBCPP_VERSION`

### DIFF
--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_implicit_lifetime.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_implicit_lifetime.pass.cpp
@@ -17,9 +17,12 @@
 
 #include <cassert>
 #include <cstddef>
+#include <expected>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 #include "test_macros.h"
 #include "type_algorithms.h"
@@ -216,8 +219,17 @@ constexpr bool test() {
 
   // C++ standard library types
 
+  // These types are guaranteed to be implicit-lifetime.
+  test_is_implicit_lifetime<std::expected<int, float>>();
+  test_is_implicit_lifetime<std::optional<float>>();
+  test_is_implicit_lifetime<std::variant<float, int>>();
+
+#ifdef _LIBCPP_VERSION
+  // These types should be implicit-lifetime, but they are not guaranteed to be so.
+  // Especially, MSVC STL has not made them implicit-lifetime yet. See https://github.com/microsoft/STL/issues/5667.
   test_is_implicit_lifetime<std::pair<int, float>>();
   test_is_implicit_lifetime<std::tuple<int, float>>();
+#endif
 
   // Standard C23 types
 

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_implicit_lifetime.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_implicit_lifetime.pass.cpp
@@ -226,7 +226,6 @@ constexpr bool test() {
 
 #ifdef _LIBCPP_VERSION
   // These types should be implicit-lifetime, but they are not guaranteed to be so.
-  // Especially, MSVC STL has not made them implicit-lifetime yet. See https://github.com/microsoft/STL/issues/5667.
   test_is_implicit_lifetime<std::pair<int, float>>();
   test_is_implicit_lifetime<std::tuple<int, float>>();
 #endif


### PR DESCRIPTION
And add some guaranteed cases (namely, for `expected`, `optional`, and `variant`) to `is_implicit_lifetime.pass.cpp`.

It's somehow unfortunate that `pair` and `tuple` are not guaranteed to propagate triviality of copy/move constructors, and MSVC STL fails to do so due to ABI compatibility. This affects the implicit-lifetime property.