### PR TITLE
[runtimes] Fix duplicate BUILTINS_CMAKE_ARGS/RUNTIMES_CMAKE_ARGS

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -94,7 +94,6 @@ function(builtin_default_target compiler_rt_path)
                                       -DCMAKE_CXX_COMPILER_WORKS=ON
                                       -DCMAKE_ASM_COMPILER_WORKS=ON
                                       ${COMMON_CMAKE_ARGS}
-                                      ${BUILTINS_CMAKE_ARGS}
                            PASSTHROUGH_PREFIXES COMPILER_RT
                                                 DARWIN
                                                 SANITIZER
@@ -275,7 +274,6 @@ function(runtime_default_target)
                                       -DCMAKE_Fortran_COMPILER_WORKS=ON
                                       -DCMAKE_ASM_COMPILER_WORKS=ON
                                       ${COMMON_CMAKE_ARGS}
-                                      ${RUNTIMES_CMAKE_ARGS}
                                       ${ARG_CMAKE_ARGS}
                            PASSTHROUGH_PREFIXES LLVM_ENABLE_RUNTIMES
                                                 LLVM_USE_LINKER


### PR DESCRIPTION
`llvm_ExternalProject_Add` already prepends the `RUNTIMES_CMAKE_ARGS` and `BUILTINS_CMAKE_ARGS` to the cmake invocation via `${nameCanon}_CMAKE_ARGS`.

https://github.com/llvm/llvm-project/blob/3e6ec475b756559560cba4a16c2bc755aa8caee5/llvm/cmake/modules/LLVMExternalProjectUtils.cmake#L389-L395

Therefore, we do not need to append them a second time in our call to `llvm_ExternalProject_Add` for the default runtimes target and default builtins target.