### PR TITLE
[Docs] Add missing closing brace

### DIFF
--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl01.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl01.rst
@@ -105,6 +105,7 @@ from standard input. Its definition starts as:
       // Skip any whitespace.
       while (isspace(LastChar))
         LastChar = getchar();
+    }
 
 ``gettok`` works by calling the C ``getchar()`` function to read
 characters one at a time from standard input. It eats them as it


### PR DESCRIPTION
Fixed a typo in the Kaleidoscope docs. Added the missing closing brace in the function.