### PR TITLE
[ADT] Simplify IsSizeLessThanThreshold (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -90,13 +90,12 @@ protected:
   template <typename T> struct AdjustedParamTBase {
     static_assert(!std::is_reference<T>::value,
                   "references should be handled by template specialization");
-    template <typename U>
-    using IsSizeLessThanThresholdT =
-        std::bool_constant<sizeof(U) <= 2 * sizeof(void *)>;
+    static constexpr bool IsSizeLessThanThreshold =
+        sizeof(T) <= 2 * sizeof(void *);
     using type =
         std::conditional_t<std::is_trivially_copy_constructible<T>::value &&
                                std::is_trivially_move_constructible<T>::value &&
-                               IsSizeLessThanThresholdT<T>::value,
+                               IsSizeLessThanThreshold,
                            T, T &>;
   };
 


### PR DESCRIPTION
IsSizeLessThanThreshold is used only in AdjustedParamTBase, just a few
lines below the declaration.  This patch simplifies
IsSizeLessThanThreshold by substituting U with T, stripping away the
template, and switching to "static constexpr bool.
