### PR TITLE
[LangRef][VP] Clarify 'ff' mnemonic in vp.load.ff: 'first-fault'

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24468,7 +24468,7 @@ Overview:
 
 The '``llvm.vp.load.ff.*``' intrinsic is similar to
 '``llvm.vp.load.*``', but will not trap if there are not ``evl`` readable
-lanes at the pointer. '``ff``' stands for fault-first or fault-only-first.
+lanes at the pointer. '``ff``' stands for first-fault or fault-only-first.
 
 Arguments:
 """"""""""


### PR DESCRIPTION
The LangRef for llvm.vp.load.ff.* stated that 'ff' stands for 'fault-first or fault-only-first.' This patch corrects this to 'first-fault or fault-only-first.' to match established terminology.

- ARM SVE uses "first-fault" [1]
- RISC-V V uses "fault-only-first" [2]

[1] https://arxiv.org/abs/1803.06185
[2] https://github.com/riscvarchive/riscv-v-spec/blob/master/v-spec.adoc