### PR TITLE
[Flang] Add -ffast-real-mod and direct code for MOD on REAL types

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2750,6 +2750,7 @@ def fno_unsafe_math_optimizations : Flag<["-"], "fno-unsafe-math-optimizations">
   Group<f_Group>;
 def fassociative_math : Flag<["-"], "fassociative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
 def fno_associative_math : Flag<["-"], "fno-associative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
+def ffast_real_mod : Flag<["-"], "ffast-real-mod">, Visibility<[FlangOption, FC1Option]>, Group<f_Group>;
 defm reciprocal_math : BoolFOption<"reciprocal-math",
   LangOpts<"AllowRecip">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option, FC1Option, FlangOption],
@@ -7373,7 +7374,6 @@ def emit_mlir : Flag<["-"], "emit-mlir">, Alias<emit_fir>;
 
 def emit_hlfir : Flag<["-"], "emit-hlfir">, Group<Action_Group>,
   HelpText<"Build the parse tree, then lower it to HLFIR">;
-
 } // let Visibility = [FC1Option]
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2750,8 +2750,9 @@ def fno_unsafe_math_optimizations : Flag<["-"], "fno-unsafe-math-optimizations">
   Group<f_Group>;
 def fassociative_math : Flag<["-"], "fassociative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
 def fno_associative_math : Flag<["-"], "fno-associative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
-def ffast_real_mod : Flag<["-"], "ffast-real-mod">, Visibility<[FlangOption, FC1Option]>, Group<f_Group>;
-def fno_fast_real_mod : Flag<["-"], "fno-fast-real-mod">, Visibility<[FlangOption, FC1Option]>, Group<f_Group>;
+def fno_fast_real_mod : Flag<["-"], "fno-fast-real-mod">,
+  Group<f_Group>, Visibility<[FlangOption, FC1Option]>,
+  HelpText<"Disable optimization of MOD for REAL types in presence of -ffast-math">;
 defm reciprocal_math : BoolFOption<"reciprocal-math",
   LangOpts<"AllowRecip">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option, FC1Option, FlangOption],

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2751,6 +2751,7 @@ def fno_unsafe_math_optimizations : Flag<["-"], "fno-unsafe-math-optimizations">
 def fassociative_math : Flag<["-"], "fassociative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
 def fno_associative_math : Flag<["-"], "fno-associative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
 def ffast_real_mod : Flag<["-"], "ffast-real-mod">, Visibility<[FlangOption, FC1Option]>, Group<f_Group>;
+def fno_fast_real_mod : Flag<["-"], "fno-fast-real-mod">, Visibility<[FlangOption, FC1Option]>, Group<f_Group>;
 defm reciprocal_math : BoolFOption<"reciprocal-math",
   LangOpts<"AllowRecip">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option, FC1Option, FlangOption],

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7374,6 +7374,7 @@ def emit_mlir : Flag<["-"], "emit-mlir">, Alias<emit_fir>;
 
 def emit_hlfir : Flag<["-"], "emit-hlfir">, Group<Action_Group>,
   HelpText<"Build the parse tree, then lower it to HLFIR">;
+
 } // let Visibility = [FC1Option]
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -767,10 +767,8 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
   if (ReciprocalMath)
     CmdArgs.push_back("-freciprocal-math");
 
-  if (Args.hasArg(options::OPT_ffast_real_mod)) {
-    fprintf(stderr, "##> -ffast-real-mod: %d\n", options::OPT_ffast_real_mod);
+  if (Args.hasArg(options::OPT_ffast_real_mod))
     CmdArgs.push_back("-ffast-real-mod");
-  }
 }
 
 static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -766,6 +766,11 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
 
   if (ReciprocalMath)
     CmdArgs.push_back("-freciprocal-math");
+
+  if (Args.hasArg(options::OPT_ffast_real_mod)) {
+    fprintf(stderr, "##> -ffast-real-mod: %d\n", options::OPT_ffast_real_mod);
+    CmdArgs.push_back("-ffast-real-mod");
+  }
 }
 
 static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -739,6 +739,9 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
                                          complexRangeKindToStr(Range)));
   }
 
+  if (Args.hasArg(options::OPT_fno_fast_real_mod))
+    CmdArgs.push_back("-fno-fast-real-mod");
+
   if (!HonorINFs && !HonorNaNs && AssociativeMath && ReciprocalMath &&
       ApproxFunc && !SignedZeros &&
       (FPContract == "fast" || FPContract.empty())) {
@@ -766,11 +769,6 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
 
   if (ReciprocalMath)
     CmdArgs.push_back("-freciprocal-math");
-
-  if (Args.hasArg(options::OPT_ffast_real_mod))
-    CmdArgs.push_back("-ffast-real-mod");
-  if (Args.hasArg(options::OPT_fno_fast_real_mod))
-    CmdArgs.push_back("-fno-fast-real-mod");
 }
 
 static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -769,6 +769,8 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
 
   if (Args.hasArg(options::OPT_ffast_real_mod))
     CmdArgs.push_back("-ffast-real-mod");
+  if (Args.hasArg(options::OPT_fno_fast_real_mod))
+    CmdArgs.push_back("-fno-fast-real-mod");
 }
 
 static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,

--- a/flang/include/flang/Support/LangOptions.def
+++ b/flang/include/flang/Support/LangOptions.def
@@ -60,7 +60,8 @@ LANGOPT(OpenMPNoThreadState, 1, 0)
 LANGOPT(OpenMPNoNestedParallelism, 1, 0)
 /// Use SIMD only OpenMP support.
 LANGOPT(OpenMPSimd, 1, false)
-
+/// Enable fast MOD operations for REAL
+LANGOPT(FastRealMod, 1, false)
 LANGOPT(VScaleMin, 32, 0)  ///< Minimum vscale range value
 LANGOPT(VScaleMax, 32, 0)  ///< Maximum vscale range value
 

--- a/flang/include/flang/Support/LangOptions.def
+++ b/flang/include/flang/Support/LangOptions.def
@@ -61,7 +61,7 @@ LANGOPT(OpenMPNoNestedParallelism, 1, 0)
 /// Use SIMD only OpenMP support.
 LANGOPT(OpenMPSimd, 1, false)
 /// Enable fast MOD operations for REAL
-LANGOPT(FastRealMod, 1, false)
+LANGOPT(NoFastRealMod, 1, false)
 LANGOPT(VScaleMin, 32, 0)  ///< Minimum vscale range value
 LANGOPT(VScaleMax, 32, 0)  ///< Maximum vscale range value
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1425,9 +1425,7 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
   }
 
   if (args.hasArg(clang::driver::options::OPT_ffast_real_mod)) {
-    fprintf(stderr, "$$> FC1: -ffast-real-mod: %d\n", (int) opts.FastRealMod);
     opts.FastRealMod = true;
-    fprintf(stderr, "$$> FC1: -ffast-real-mod: %d\n", (int) opts.FastRealMod);
   }
 
   return true;

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1424,6 +1424,12 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
     opts.setFPContractMode(Fortran::common::LangOptions::FPM_Fast);
   }
 
+  if (args.hasArg(clang::driver::options::OPT_ffast_real_mod)) {
+    fprintf(stderr, "$$> FC1: -ffast-real-mod: %d\n", (int) opts.FastRealMod);
+    opts.FastRealMod = true;
+    fprintf(stderr, "$$> FC1: -ffast-real-mod: %d\n", (int) opts.FastRealMod);
+  }
+
   return true;
 }
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1424,10 +1424,8 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
     opts.setFPContractMode(Fortran::common::LangOptions::FPM_Fast);
   }
 
-  if (args.hasArg(clang::driver::options::OPT_ffast_real_mod))
-    opts.FastRealMod = true;
   if (args.hasArg(clang::driver::options::OPT_fno_fast_real_mod))
-    opts.FastRealMod = false;
+    opts.NoFastRealMod = true;
 
   return true;
 }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1426,6 +1426,8 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
 
   if (args.hasArg(clang::driver::options::OPT_ffast_real_mod))
     opts.FastRealMod = true;
+  if (args.hasArg(clang::driver::options::OPT_fno_fast_real_mod))
+    opts.FastRealMod = false;
 
   return true;
 }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1424,9 +1424,8 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
     opts.setFPContractMode(Fortran::common::LangOptions::FPM_Fast);
   }
 
-  if (args.hasArg(clang::driver::options::OPT_ffast_real_mod)) {
+  if (args.hasArg(clang::driver::options::OPT_ffast_real_mod))
     opts.FastRealMod = true;
-  }
 
   return true;
 }

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -277,6 +277,13 @@ bool CodeGenAction::beginSourceFileAction() {
                               ci.getInvocation().getLangOpts().OpenMPVersion);
   }
 
+  if (ci.getInvocation().getLangOpts().FastRealMod) {
+    fprintf(stderr, "YAY!!!!\n");
+    auto mod = lb.getModule();
+    mod.getOperation()->setAttr(mlir::StringAttr::get(mod.getContext(), llvm::Twine{"fir.fast_real_mod"}),
+      mlir::BoolAttr::get(mod.getContext(), true));
+  }
+
   // Create a parse tree and lower it to FIR
   parseAndLowerTree(ci, lb);
 

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -278,10 +278,11 @@ bool CodeGenAction::beginSourceFileAction() {
   }
 
   if (ci.getInvocation().getLangOpts().FastRealMod) {
-    fprintf(stderr, "YAY!!!!\n");
     auto mod = lb.getModule();
-    mod.getOperation()->setAttr(mlir::StringAttr::get(mod.getContext(), llvm::Twine{"fir.fast_real_mod"}),
-      mlir::BoolAttr::get(mod.getContext(), true));
+    mod.getOperation()->setAttr(
+        mlir::StringAttr::get(mod.getContext(),
+                              llvm::Twine{"fir.fast_real_mod"}),
+        mlir::BoolAttr::get(mod.getContext(), true));
   }
 
   // Create a parse tree and lower it to FIR

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -277,11 +277,11 @@ bool CodeGenAction::beginSourceFileAction() {
                               ci.getInvocation().getLangOpts().OpenMPVersion);
   }
 
-  if (ci.getInvocation().getLangOpts().FastRealMod) {
+  if (ci.getInvocation().getLangOpts().NoFastRealMod) {
     mlir::ModuleOp mod = lb.getModule();
     mod.getOperation()->setAttr(
         mlir::StringAttr::get(mod.getContext(),
-                              llvm::Twine{"fir.fast_real_mod"}),
+                              llvm::Twine{"fir.no_fast_real_mod"}),
         mlir::BoolAttr::get(mod.getContext(), true));
   }
 

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -278,7 +278,7 @@ bool CodeGenAction::beginSourceFileAction() {
   }
 
   if (ci.getInvocation().getLangOpts().FastRealMod) {
-    auto mod = lb.getModule();
+    mlir::ModuleOp mod = lb.getModule();
     mod.getOperation()->setAttr(
         mlir::StringAttr::get(mod.getContext(),
                               llvm::Twine{"fir.fast_real_mod"}),

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -7027,12 +7027,16 @@ static mlir::Value genFastMod(fir::FirOpBuilder &builder, mlir::Location loc,
 
 mlir::Value IntrinsicLibrary::genMod(mlir::Type resultType,
                                      llvm::ArrayRef<mlir::Value> args) {
-  bool useFastRealMod = true;
   auto mod = builder.getModule();
-  if (auto attr = mod->getAttrOfType<mlir::omp::VersionAttr>("omp.version"))
-      fprintf(stderr, "omp version: %d\n", attr.getVersion());
-
+  bool useFastRealMod = false;
+  if (auto attr = mod->getAttrOfType<mlir::BoolAttr>("fir.fast_real_mod")) {
+    fprintf(stderr, "fir.fast_real_mod present: %d\n", (int) attr.getValue());
+    useFastRealMod = attr.getValue();
+  } else {
+    fprintf(stderr, "fir.fast_real_mod not present\n");
+  }
   fprintf(stderr, "--> -ffast-real-mod: %d\n", (int) useFastRealMod);
+
   assert(args.size() == 2);
   if (resultType.isUnsignedInteger()) {
     mlir::Type signlessType = mlir::IntegerType::get(

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -7045,11 +7045,9 @@ mlir::Value IntrinsicLibrary::genMod(mlir::Type resultType,
   if (mlir::isa<mlir::IntegerType>(resultType))
     return mlir::arith::RemSIOp::create(builder, loc, args[0], args[1]);
 
-  if (useFastRealMod) {
+  if (useFastRealMod && resultType.isFloat()) {
     // If fast MOD for REAL has been requested, generate less precise,
     // but faster code directly.
-    assert(resultType.isFloat() &&
-           "non floating-point type hit for fast real MOD");
     return builder.createConvert(loc, resultType,
                                  genFastMod(builder, loc, args[0], args[1]));
   } else {

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -46,7 +46,6 @@
 #include "flang/Optimizer/Support/Utils.h"
 #include "flang/Runtime/entry-names.h"
 #include "flang/Runtime/iostat-consts.h"
-#include "flang/Support/LangOptions.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -7014,7 +7014,8 @@ static mlir::Value genFastMod(fir::FirOpBuilder &builder, mlir::Location loc,
   auto fastmathFlags = mlir::arith::FastMathFlags::contract;
   auto fastmathAttr =
       mlir::arith::FastMathFlagsAttr::get(builder.getContext(), fastmathFlags);
-  mlir::Value divResult = mlir::arith::DivFOp::create(builder, loc, a, p, fastmathAttr);
+  mlir::Value divResult =
+      mlir::arith::DivFOp::create(builder, loc, a, p, fastmathAttr);
   mlir::Type intType = builder.getIntegerType(
       a.getType().getIntOrFloatBitWidth(), /*signed=*/true);
   mlir::Value intResult = builder.createConvert(loc, intType, divResult);

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -7012,15 +7012,18 @@ mlir::Value IntrinsicLibrary::genMergeBits(mlir::Type resultType,
 // MOD
 static mlir::Value genFastMod(fir::FirOpBuilder &builder, mlir::Location loc,
                               mlir::Value a, mlir::Value p) {
-  mlir::Value divResult = mlir::arith::DivFOp::create(builder, loc, a, p);
+  auto fastmathFlags = mlir::arith::FastMathFlags::contract;
+  auto fastmathAttr =
+      mlir::arith::FastMathFlagsAttr::get(builder.getContext(), fastmathFlags);
+  mlir::Value divResult = mlir::arith::DivFOp::create(builder, loc, a, p, fastmathAttr);
   mlir::Type intType = builder.getIntegerType(
       a.getType().getIntOrFloatBitWidth(), /*signed=*/true);
   mlir::Value intResult = builder.createConvert(loc, intType, divResult);
   mlir::Value cnvResult = builder.createConvert(loc, a.getType(), intResult);
   mlir::Value mulResult =
-      mlir::arith::MulFOp::create(builder, loc, cnvResult, p);
+      mlir::arith::MulFOp::create(builder, loc, cnvResult, p, fastmathAttr);
   mlir::Value subResult =
-      mlir::arith::SubFOp::create(builder, loc, a, mulResult);
+      mlir::arith::SubFOp::create(builder, loc, a, mulResult, fastmathAttr);
   return subResult;
 }
 

--- a/flang/test/Driver/fast-real-mod.f90
+++ b/flang/test/Driver/fast-real-mod.f90
@@ -1,7 +1,5 @@
-! RUN: %flang -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
 ! RUN: %flang -fno-fast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-NO-FAST-REAL-MOD
 
-! CHECK-FAST-REAL-MOD: "-ffast-real-mod"
 ! CHECK-NO-FAST-REAL-MOD: "-fno-fast-real-mod"
 
 program test

--- a/flang/test/Driver/fast-real-mod.f90
+++ b/flang/test/Driver/fast-real-mod.f90
@@ -1,0 +1,9 @@
+! RUN: %flang -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
+! RUN: %flang -fno-fast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-NO-FAST-REAL-MOD
+
+! CHECK-FAST-REAL-MOD: "-ffast-real-mod"
+! CHECK-NO-FAST-REAL-MOD: "-fno-fast-real-mod"
+
+program test
+    ! nothing to be done in here
+end program test

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s
+! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK: module attributes {{{.*}}fir.fast_real_mod = true{{.*}}}
 
@@ -42,16 +42,34 @@ end subroutine mod_real8
 subroutine mod_real10(r, a, p)
     implicit none
     real(kind=10) :: r, a, p
-! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
-! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
-! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
-! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
-! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f80
-! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
-! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
-! CHECK: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f80
-! CHECK: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f80
-! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
+! CHECK-KIND10: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK-KIND10: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK-KIND10: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK-KIND10: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK-KIND10: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK-KIND10: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f80
+! CHECK-KIND10: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
+! CHECK-KIND10: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
+! CHECK-KIND10: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f80
+! CHECK-KIND10: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f80
+! CHECK-KIND10: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
     r = mod(a, p)
 end subroutine mod_real10
+
+! CHECK-LABEL: @_QPmod_real16
+subroutine mod_real16(r, a, p)
+    implicit none
+    real(kind=16) :: r, a, p
+! CHECK-KIND16: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK-KIND16: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK-KIND16: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK-KIND16: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK-KIND16: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK-KIND16: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f128
+! CHECK-KIND16: %[[CV1:.*]] = fir.convert %[[DIV]] : (f128) -> si128
+! CHECK-KIND16: %[[CV2:.*]] = fir.convert %[[CV1]] : (si128) -> f128
+! CHECK-KIND16: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f128
+! CHECK-KIND16: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f128
+! CHECK-KIND16: fir.store %[[SUB]] to %[[R]] : !fir.ref<f128>
+    r = mod(a, p)
+end subroutine mod_real16

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -1,0 +1,57 @@
+! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s
+
+! CHECK: module attributes {{{.*}}fir.fast_real_mod = true{{.*}}}
+
+! CHECK-LABEL: @_QPmod_real4
+subroutine mod_real4(r, a, p)
+    implicit none
+    real(kind=4) :: r, a, p
+! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f32
+! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f32) -> si32
+! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si32) -> f32
+! CHECK: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f32
+! CHECK: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f32
+! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f32>
+    r = mod(a, p)
+end subroutine mod_real4
+
+! CHECK-LABEL: @_QPmod_real8
+subroutine mod_real8(r, a, p)
+    implicit none
+    real(kind=8) :: r, a, p
+! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f64
+! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f64) -> si64
+! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si64) -> f64
+! CHECK: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f64
+! CHECK: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f64
+! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f64>
+    r = mod(a, p)
+end subroutine mod_real8
+
+! CHECK-LABEL: @_QPmod_real10
+subroutine mod_real10(r, a, p)
+    implicit none
+    real(kind=10) :: r, a, p
+! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f80
+! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
+! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
+! CHECK: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f80
+! CHECK: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f80
+! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
+    r = mod(a, p)
+end subroutine mod_real10

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -1,6 +1,8 @@
-! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
+! RUN: %flang_fc1 -ffast-math -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
+! RUN: %flang_fc1 -ffast-math -fno-fast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK-NFRM%if target=x86_64{{.*}} %{,CHECK-NFRM-KIND10%}%if flang-supports-f128-math %{,CHECK-NFRM-KIND16%}
 
-! CHECK: module attributes {{{.*}}fir.fast_real_mod = true{{.*}}}
+! TODO: check line that fir.fast_real_mod is not there
+! CHECK-NFRM: module attributes {{{.*}}fir.no_fast_real_mod = true{{.*}}}
 
 ! CHECK-LABEL: @_QPmod_real4
 subroutine mod_real4(r, a, p)
@@ -11,12 +13,13 @@ subroutine mod_real4(r, a, p)
 ! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
 ! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
 ! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f32
+! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f32
 ! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f32) -> si32
 ! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si32) -> f32
-! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f32
-! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f32
+! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f32
+! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f32
 ! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f32>
+! CHECK-NFRM: fir.call @_FortranAModReal4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f32, f32, !fir.ref<i8>, i32) -> f32
     r = mod(a, p)
 end subroutine mod_real4
 
@@ -29,12 +32,13 @@ subroutine mod_real8(r, a, p)
 ! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
 ! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
 ! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f64
+! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f64
 ! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f64) -> si64
 ! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si64) -> f64
-! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f64
-! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f64
+! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f64
+! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f64
 ! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f64>
+! CHECK-NFRM: fir.call @_FortranAModReal8(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f64, f64, !fir.ref<i8>, i32) -> f64
     r = mod(a, p)
 end subroutine mod_real8
 
@@ -48,12 +52,13 @@ subroutine mod_real10(r, a, p)
 ! CHECK-KIND10: %[[R:.*]] = fir.declare{{.*}}r"
 ! CHECK-KIND10: %[[A_LOAD:.*]] = fir.load %[[A]]
 ! CHECK-KIND10: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK-KIND10: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f80
+! CHECK-KIND10: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f80
 ! CHECK-KIND10: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
 ! CHECK-KIND10: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
-! CHECK-KIND10: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f80
-! CHECK-KIND10: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f80
+! CHECK-KIND10: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f80
+! CHECK-KIND10: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f80
 ! CHECK-KIND10: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
+! CHECK-NFRM-KIND10: fir.call @_FortranAModReal10(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f80, f80, !fir.ref<i8>, i32) -> f80
     r = mod(a, p)
 end subroutine mod_real10
 
@@ -67,11 +72,12 @@ subroutine mod_real16(r, a, p)
 ! CHECK-KIND16: %[[R:.*]] = fir.declare{{.*}}r"
 ! CHECK-KIND16: %[[A_LOAD:.*]] = fir.load %[[A]]
 ! CHECK-KIND16: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK-KIND16: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f128
+! CHECK-KIND16: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f128
 ! CHECK-KIND16: %[[CV1:.*]] = fir.convert %[[DIV]] : (f128) -> si128
 ! CHECK-KIND16: %[[CV2:.*]] = fir.convert %[[CV1]] : (si128) -> f128
-! CHECK-KIND16: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f128
-! CHECK-KIND16: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f128
+! CHECK-KIND16: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f128
+! CHECK-KIND16: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f128
 ! CHECK-KIND16: fir.store %[[SUB]] to %[[R]] : !fir.ref<f128>
+! CHECK-NFRM-KIND16: fir.call @_FortranAModReal16(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f128, f128, !fir.ref<i8>, i32) -> f128
     r = mod(a, p)
 end subroutine mod_real16

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -1,4 +1,7 @@
+! RUN: %flang -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
 ! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
+
+! CHECK-FAST-REAL-MOD: "-ffast-real-mod"
 
 ! CHECK: module attributes {{{.*}}fir.fast_real_mod = true{{.*}}}
 

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -41,7 +41,8 @@ end subroutine mod_real8
 ! CHECK-LABEL: @_QPmod_real10
 subroutine mod_real10(r, a, p)
     implicit none
-    real(kind=10) :: r, a, p
+    integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+    real(kind=kind10) :: r, a, p
 ! CHECK-KIND10: %[[A:.*]] = fir.declare{{.*}}a"
 ! CHECK-KIND10: %[[P:.*]] = fir.declare{{.*}}p"
 ! CHECK-KIND10: %[[R:.*]] = fir.declare{{.*}}r"
@@ -59,7 +60,8 @@ end subroutine mod_real10
 ! CHECK-LABEL: @_QPmod_real16
 subroutine mod_real16(r, a, p)
     implicit none
-    real(kind=16) :: r, a, p
+    integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+    real(kind=kind16) :: r, a, p
 ! CHECK-KIND16: %[[A:.*]] = fir.declare{{.*}}a"
 ! CHECK-KIND16: %[[P:.*]] = fir.declare{{.*}}p"
 ! CHECK-KIND16: %[[R:.*]] = fir.declare{{.*}}r"

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -14,8 +14,8 @@ subroutine mod_real4(r, a, p)
 ! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f32
 ! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f32) -> si32
 ! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si32) -> f32
-! CHECK: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f32
-! CHECK: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f32
+! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f32
+! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f32
 ! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f32>
     r = mod(a, p)
 end subroutine mod_real4
@@ -32,8 +32,8 @@ subroutine mod_real8(r, a, p)
 ! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f64
 ! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f64) -> si64
 ! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si64) -> f64
-! CHECK: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f64
-! CHECK: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f64
+! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f64
+! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f64
 ! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f64>
     r = mod(a, p)
 end subroutine mod_real8
@@ -50,8 +50,8 @@ subroutine mod_real10(r, a, p)
 ! CHECK-KIND10: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f80
 ! CHECK-KIND10: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
 ! CHECK-KIND10: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
-! CHECK-KIND10: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f80
-! CHECK-KIND10: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f80
+! CHECK-KIND10: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f80
+! CHECK-KIND10: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f80
 ! CHECK-KIND10: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
     r = mod(a, p)
 end subroutine mod_real10
@@ -68,8 +68,8 @@ subroutine mod_real16(r, a, p)
 ! CHECK-KIND16: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<contract> : f128
 ! CHECK-KIND16: %[[CV1:.*]] = fir.convert %[[DIV]] : (f128) -> si128
 ! CHECK-KIND16: %[[CV2:.*]] = fir.convert %[[CV1]] : (si128) -> f128
-! CHECK-KIND16: %[[MUL:.*]] = arith.mulf %8, %5 fastmath<contract> : f128
-! CHECK-KIND16: %[[SUB:.*]] = arith.subf %4, %9 fastmath<contract> : f128
+! CHECK-KIND16: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<contract> : f128
+! CHECK-KIND16: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<contract> : f128
 ! CHECK-KIND16: fir.store %[[SUB]] to %[[R]] : !fir.ref<f128>
     r = mod(a, p)
 end subroutine mod_real16

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -1,7 +1,4 @@
-! RUN: %flang -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
 ! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
-
-! CHECK-FAST-REAL-MOD: "-ffast-real-mod"
 
 ! CHECK: module attributes {{{.*}}fir.fast_real_mod = true{{.*}}}
 

--- a/flang/test/Lower/Intrinsics/mod.f90
+++ b/flang/test/Lower/Intrinsics/mod.f90
@@ -1,5 +1,4 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
-! RUN: %flang_fc1 -ffast-real-mod -fno-fast-real-mod -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: func @_QPmod_testr4(
 subroutine mod_testr4(r, a, p)

--- a/flang/test/Lower/Intrinsics/mod.f90
+++ b/flang/test/Lower/Intrinsics/mod.f90
@@ -1,4 +1,5 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
+! RUN: %flang_fc1 -ffast-real-mod -fno-fast-real-mod -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: func @_QPmod_testr4(
 subroutine mod_testr4(r, a, p)


### PR DESCRIPTION
This patch adds direct code-gen support for a faster MOD intrinsic for REAL types.  Flang has maintained and keeps maintaining a high-precision implementation of the MOD intrinsic as part of the Fortran runtime.  With the -ffast-real-mod flag, users can opt to avoid calling into the Fortran runtime, but instead trigger code-gen that produces faster code by avoiding the runtime call, at the expense of potentially risking bit cancelation by having the compiler use the MOD formula a specified by ISO Fortran.