### PR TITLE
[lldb][test] Make Linux cpuinfo check more robust

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/cpu_feature.py
+++ b/lldb/packages/Python/lldbsuite/test/cpu_feature.py
@@ -40,13 +40,10 @@ class CPUFeature:
             return output, False
 
         # Assume that every processor presents the same features.
-        # Look for the first "Features: ...." line.
-        for line in output.splitlines():
-            line = line.strip()
-            if line.startswith("Features"):
-                # Feature names are space separated.
-                features = line.split(":")[1].strip().split()
-                return None, (self.cpu_info_flag in features)
+        # Look for the first "Features: ...." line. Features are space separated.
+        if m := re.search(r"Features\s*: (.*)\n", output):
+            features = m.group(1).split()
+            return None, (self.cpu_info_flag in features)
 
         return f'No "Features:" line found in /proc/cpuinfo', False
 

--- a/lldb/packages/Python/lldbsuite/test/cpu_feature.py
+++ b/lldb/packages/Python/lldbsuite/test/cpu_feature.py
@@ -39,9 +39,16 @@ class CPUFeature:
         if err.Fail() or retcode != 0:
             return output, False
 
-        # FIXME: simple substring match, e.g., test for 'sme' will be true if
-        # 'sme2' or 'smefa64' is present
-        return None, (self.cpu_info_flag in output)
+        # Assume that every processor presents the same features.
+        # Look for the first "Features: ...." line.
+        for line in output.splitlines():
+            line = line.strip()
+            if line.startswith("Features"):
+                # Feature names are space separated.
+                features = line.split(":")[1].strip().split()
+                return None, (self.cpu_info_flag in features)
+
+        return f'No "Features:" line found in /proc/cpuinfo', False
 
     def _is_supported_darwin(self, cmd_runner):
         if not self.sysctl_key:

--- a/lldb/packages/Python/lldbsuite/test/cpu_feature.py
+++ b/lldb/packages/Python/lldbsuite/test/cpu_feature.py
@@ -45,7 +45,7 @@ class CPUFeature:
             features = m.group(1).split()
             return None, (self.cpu_info_flag in features)
 
-        return f'No "Features:" line found in /proc/cpuinfo', False
+        return 'No "Features:" line found in /proc/cpuinfo', False
 
     def _is_supported_darwin(self, cmd_runner):
         if not self.sysctl_key:


### PR DESCRIPTION
We were looking for any mention of the feature name in cpuinfo, which could have hit anything including features with common prefixes like sme, sme2, smefa64.

Luckily this was not a problem but I'm changing this to find the features line and split the features into a list. Then we are only looking for exact matches.

Here's the information for one core as an example:
```
processor	: 7
BogoMIPS	: 200.00
Features	: fp asimd evtstrm crc32 atomics fphp asimdhp cpuid <...>
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd0f
CPU revision	: 0
```
(and to avoid any doubt, this is from a CPU simulated in Arm's FVP, it's not real)

Note that the layout of the label, colon, values is sometimes aligned but not always. So I trim whitespace a few times to normalise that.

This repeats once for each core so we only need to find one features line.