### PR TITLE
[libc++] Use _BitInt and __builtin_popcountg in bitset::count()

### DIFF
--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -867,7 +867,16 @@ bitset<_Size>::to_string(char __zero, char __one) const {
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 size_t bitset<_Size>::count() const _NOEXCEPT {
-  return static_cast<size_t>(std::count(__base::__make_iter(0), __base::__make_iter(_Size), true));
+#  if defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(_LIBCPP_CXX03_LANG)
+  if constexpr (_Size == 0) {
+    return 0;
+  } else if constexpr (_Size <= __base::__bits_per_word) {
+    return __builtin_popcountg(static_cast<unsigned _BitInt(_Size)>(__base::__first_));
+  } else
+#  endif
+  {
+    return static_cast<size_t>(std::count(__base::__make_iter(0), __base::__make_iter(_Size), true));
+  }
 }
 
 template <size_t _Size>


### PR DESCRIPTION
This has multiple benefits:
1) The compiler has to do way less work to figure out things fold into a simple `popcount`, improving compile times quite a bit
2) The compiler inlines better, since the compile doesn't have to do complicated optimizations to get to the same point. Looking at the pipeline, it seems that without this, LLVM has to go all the way to GVN to get to the same code as there is after the first InstCombine pass with this change.

Currently this applies only to `bitset`s with at most 64 bits, but that is by far the most common case.