### PR TITLE
[compiler-rt] Fix test ifdefs and XFAILs

### DIFF
--- a/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
@@ -1,12 +1,11 @@
-// XFAIL: target=aarch64-{{.*}}-windows-{{.*}}
 // RUN: %clang_builtins %s %librt -o %t && %run %t
 // REQUIRES: librt_has_fixunstfdi
 
 #include <stdio.h>
 
-#if defined(CRT_HAS_TF_MODE)
-
 #include "int_lib.h"
+
+#if defined(CRT_HAS_TF_MODE)
 
 // Returns: convert a to a unsigned long long, rounding toward zero.
 //          Negative values all become zero.

--- a/compiler-rt/test/builtins/Unit/multc3_test.c
+++ b/compiler-rt/test/builtins/Unit/multc3_test.c
@@ -1,12 +1,12 @@
-// XFAIL: target=aarch64-{{.*}}-windows-{{.*}}
 // RUN: %clang_builtins %s %librt -o %t && %run %t
 // REQUIRES: librt_has_multc3
 
 #include <stdio.h>
 
+#include "int_lib.h"
+
 #if defined(CRT_HAS_128BIT) && defined(CRT_HAS_F128)
 
-#include "int_lib.h"
 #include <math.h>
 #include <complex.h>
 


### PR DESCRIPTION
This fixes the ifdefs added in
e9e166e54354330c474457711a8e7a7ca2efd731; we need to include int_lib.h first before we can expect these defines to be set.

Also remove the XFAILs for aarch64 windows. As this test now became a no-op on platforms that lack CRT_HAS_128BIT or CRT_HAS_F128 (aarch64 windows lacks the latter), it no longer fails.