### PR TITLE
[clang][DebugInfo][NFC] Simplify CollectRecordLambdaFields

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -397,6 +397,7 @@ private:
   void CollectRecordFields(const RecordDecl *Decl, llvm::DIFile *F,
                            SmallVectorImpl<llvm::Metadata *> &E,
                            llvm::DICompositeType *RecordTy);
+  llvm::StringRef GetLambdaCaptureName(const LambdaCapture &Capture);
 
   /// If the C++ class has vtable info then insert appropriate debug
   /// info entry in EltTys vector.


### PR DESCRIPTION
This patch creates a helper to retrieve the name from a lambda capture and only calls `createFieldType` once.

This will simplify reviewing some upcoming changes in this function.