### PR TITLE
[ARM] Mark function calls as possibly changing FPSCR

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -22004,6 +22004,11 @@ bool ARMTargetLowering::isComplexDeinterleavingOperationSupported(
           ScalarTy->isIntegerTy(32));
 }
 
+ArrayRef<MCPhysReg> ARMTargetLowering::getRoundingControlRegisters() const {
+  static const MCPhysReg RCRegs[] = {ARM::FPSCR};
+  return RCRegs;
+}
+
 Value *ARMTargetLowering::createComplexDeinterleavingIR(
     IRBuilderBase &B, ComplexDeinterleavingOperation OperationType,
     ComplexDeinterleavingRotation Rotation, Value *InputA, Value *InputB,

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -22005,7 +22005,7 @@ bool ARMTargetLowering::isComplexDeinterleavingOperationSupported(
 }
 
 ArrayRef<MCPhysReg> ARMTargetLowering::getRoundingControlRegisters() const {
-  static const MCPhysReg RCRegs[] = {ARM::FPSCR};
+  static const MCPhysReg RCRegs[] = {ARM::FPSCR_RM};
   return RCRegs;
 }
 

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -1005,6 +1005,8 @@ class VectorType;
 
     bool isUnsupportedFloatingType(EVT VT) const;
 
+    ArrayRef<MCPhysReg> getRoundingControlRegisters() const override;
+
     SDValue getCMOV(const SDLoc &dl, EVT VT, SDValue FalseVal, SDValue TrueVal,
                     SDValue ARMcc, SDValue Flags, SelectionDAG &DAG) const;
     SDValue getARMCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC,

--- a/llvm/test/CodeGen/ARM/strict-fp-func.ll
+++ b/llvm/test/CodeGen/ARM/strict-fp-func.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple aarch64-none-linux-gnu -stop-after=finalize-isel %s -o - | FileCheck %s
+
+define float @func_02(float %x, float %y) strictfp nounwind {
+  %call = call float @func_01(float %x) strictfp
+  %res = call float @llvm.experimental.constrained.fadd.f32(float %call, float %y, metadata !"round.dynamic", metadata !"fpexcept.ignore") strictfp
+  ret float %res
+}
+; CHECK-LABEL: name: func_02
+; CHECK:       BL @func_01, {{.*}}, implicit-def $fpcr
+
+
+declare float @func_01(float)
+declare float @llvm.experimental.constrained.fadd.f32(float, float, metadata, metadata)

--- a/llvm/test/CodeGen/ARM/strict-fp-func.ll
+++ b/llvm/test/CodeGen/ARM/strict-fp-func.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple aarch64-none-linux-gnu -stop-after=finalize-isel %s -o - | FileCheck %s
+; RUN: llc -mtriple arm-none-eabi -stop-after=finalize-isel %s -o - | FileCheck %s
 
 define float @func_02(float %x, float %y) strictfp nounwind {
   %call = call float @func_01(float %x) strictfp
@@ -6,7 +6,7 @@ define float @func_02(float %x, float %y) strictfp nounwind {
   ret float %res
 }
 ; CHECK-LABEL: name: func_02
-; CHECK:       BL @func_01, {{.*}}, implicit-def $fpcr
+; CHECK:       BL @func_01, {{.*}}, implicit-def $fpscr_rm
 
 
 declare float @func_01(float)


### PR DESCRIPTION
This patch does the same changes as D143001 for AArch64.

This PR is part of the work on adding strict FP support in ARM, which was previously discussed in #137101.