### PR TITLE
[CodeGen] Adjust global-split remat heuristic to match LICM

### DIFF
--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -67,7 +67,8 @@ bool TargetRegisterInfo::shouldRegionSplitForVirtReg(
   const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
   const MachineRegisterInfo &MRI = MF.getRegInfo();
   MachineInstr *MI = MRI.getUniqueVRegDef(VirtReg.reg());
-  if (MI && TII->isReMaterializable(*MI) && VirtReg.size() > HugeSizeForSplit)
+  if (MI && TII->isTriviallyReMaterializable(*MI) &&
+      VirtReg.size() > HugeSizeForSplit)
     return false;
   return true;
 }


### PR DESCRIPTION
This heuristic was originally added in 40c4aa with the stated purpose of avoiding global split on live long ranges created by MachineLICM hoisting trivially rematerializable instructions.  In the meantime, various backends have introduced non-trivial rematerialization cases, MachineLICM gained an explicitly triviality check, and we've reworked our APIs to match naming wise.  Let's move this heuristic back to truely trivial remat only.

This is a functional change, though somewhat hard to hit.  This change will cause non-trivially rematerializable instructions to be globally split more often.  This is likely a good thing since non-trivial remat may not be legal at all possible points in the live interval, but may cost slightly more compile time.

I don't have a motivating example; I found it when reviewing the callers of isRemMaterializable(MI).