### PR TITLE
[MLIR][MLIRToLLVM] Fix zero fp value to array translation

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -647,7 +647,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
           llvm::ElementCount::get(numElements, /*Scalable=*/isScalable), child);
     if (llvmType->isArrayTy()) {
       auto *arrayType = llvm::ArrayType::get(elementType, numElements);
-      if (child->isZeroValue()) {
+      if (child->isZeroValue() && !elementType->isFPOrFPVectorTy()) {
         return llvm::ConstantAggregateZero::get(arrayType);
       } else {
         if (llvm::ConstantDataSequential::isElementTypeCompatible(

--- a/mlir/test/Target/LLVMIR/global_float_array.mlir
+++ b/mlir/test/Target/LLVMIR/global_float_array.mlir
@@ -1,0 +1,4 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// CHECK: @test = internal global [1 x float] [float -0.000000e+00]
+llvm.mlir.global internal @test(dense<-0.000000e+00> : tensor<1xf32>) {addr_space = 0 : i32} : !llvm.array<1 x f32>


### PR DESCRIPTION
The translator should not generate zeroinitilizer on fp all zero values,
since it may affect signedness of zeroes

Fixes #160437
