### PR TITLE
[clang-format] Fix qualifier ordering for lines after PP directives

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -571,7 +571,7 @@ void LeftRightQualifierAlignmentFixer::fixQualifierAlignment(
 
     for (const auto *Tok = First; Tok && Tok != Last && Tok->Next;
          Tok = Tok->Next) {
-      if (Tok->MustBreakBefore)
+      if (Tok->MustBreakBefore && Tok != First)
         break;
       if (Tok->is(tok::comment))
         continue;

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -1195,6 +1195,41 @@ TEST_F(QualifierFixerTest, QualifiersBrokenUpByPPDirectives) {
                Style);
 }
 
+TEST_F(QualifierFixerTest, QualifierOrderingAfterPreprocessorDirectives) {
+  auto Style = getLLVMStyle();
+  Style.QualifierAlignment = FormatStyle::QAS_Custom;
+  Style.QualifierOrder = {"static", "inline", "const", "type"};
+
+  verifyFormat("#if 1\n"
+               "void foo(const int par);\n"
+               "const int var1;\n"
+               "#endif\n"
+               "\n"
+               "const int var2;\n"
+               "const int var3;\n",
+               "#if 1\n"
+               "void foo(int const par);\n"
+               "int const var1;\n"
+               "#endif\n"
+               "\n"
+               "int const var2;\n"
+               "int const var3;\n",
+               Style);
+  verifyFormat("#if defined(FOO)\n"
+               "static const int x = 1;\n"
+               "#else\n"
+               "static const int x = 2;\n"
+               "#endif\n"
+               "static const int y = 3;",
+               "#if defined(FOO)\n"
+               "const static int x = 1;\n"
+               "#else\n"
+               "const static int x = 2;\n"
+               "#endif\n"
+               "const static int y = 3;",
+               Style);
+}
+
 TEST_F(QualifierFixerTest, UnsignedQualifier) {
 
   FormatStyle Style = getLLVMStyle();

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -1206,14 +1206,14 @@ TEST_F(QualifierFixerTest, QualifierOrderingAfterPreprocessorDirectives) {
                "#endif\n"
                "\n"
                "const int var2;\n"
-               "const int var3;\n",
+               "const int var3;",
                "#if 1\n"
                "void foo(int const par);\n"
                "int const var1;\n"
                "#endif\n"
                "\n"
                "int const var2;\n"
-               "int const var3;\n",
+               "int const var3;",
                Style);
   verifyFormat("#if defined(FOO)\n"
                "static const int x = 1;\n"


### PR DESCRIPTION
Lines appearing after preprocessor conditional blocks (like `#endif`) were not having their qualifiers reordered by `QualifierOrder`, while lines inside the conditional blocks were processed correctly.

The issue was that tokens on lines following preprocessor directives have `MustBreakBefore` = `true`. The qualifier alignment logic was breaking immediately upon encountering any token with `MustBreakBefore` = `true`, preventing analysis of the entire line.

The fix allows processing to continue when `MustBreakBefore` = `true` on the first token of a line, since this is expected behavior (the token legitimately starts a new line). Only tokens with `MustBreakBefore` = `true` that appear mid-line will cause the analysis loop to break.

Fixes https://github.com/llvm/llvm-project/issues/160487.

CC @owenca.
