### PR TITLE
[AMDGPU] Avoid constraining RC based on folded into operand (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -717,10 +717,10 @@ bool SIFoldOperandsImpl::updateOperand(FoldCandidate &Fold) const {
     if (New->getSubReg()) {
       ConstrainRC =
           TRI->getMatchingSuperRegClass(NewRC, OpRC, New->getSubReg());
-    }
 
-    if (!ConstrainRC)
-      return false;
+      if (!ConstrainRC)
+        return false;
+    }
 
     if (!MRI->constrainRegClass(New->getReg(), ConstrainRC)) {
       LLVM_DEBUG(dbgs() << "Cannot constrain " << printReg(New->getReg(), TRI)

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -712,8 +712,13 @@ bool SIFoldOperandsImpl::updateOperand(FoldCandidate &Fold) const {
           TII->getRegClass(MI->getDesc(), Fold.UseOpNo, TRI)) {
     const TargetRegisterClass *NewRC =
         TRI->getRegClassForReg(*MRI, New->getReg());
-    const TargetRegisterClass *ConstrainRC =
-        TRI->findCommonRegClass(OpRC, Old.getSubReg(), NewRC, New->getSubReg());
+
+    const TargetRegisterClass *ConstrainRC = OpRC;
+    if (New->getSubReg()) {
+      ConstrainRC =
+          TRI->getMatchingSuperRegClass(NewRC, OpRC, New->getSubReg());
+    }
+
     if (!ConstrainRC)
       return false;
 


### PR DESCRIPTION
The RC of the folded operand does not need to be constrained based on the RC of the current operand we are folding into.

The purpose of this PR is to facilitate this PR: https://github.com/llvm/llvm-project/pull/151033