### PR TITLE
[ARM] Generate build-attributes more correctly in the presence of intrinsic declarations.

### DIFF
--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -610,20 +610,23 @@ void ARMAsmPrinter::emitEndOfAsmFile(Module &M) {
 // to appear in the .ARM.attributes section in ELF.
 // Instead of subclassing the MCELFStreamer, we do the work here.
 
- // Returns true if all functions have the same function attribute value.
- // It also returns true when the module has no functions.
+// Returns true if all function definitions have the same function attribute
+// value. It also returns true when the module has no functions.
 static bool checkFunctionsAttributeConsistency(const Module &M, StringRef Attr,
                                                StringRef Value) {
-   return !any_of(M, [&](const Function &F) {
-       return F.getFnAttribute(Attr).getValueAsString() != Value;
-   });
+  return !any_of(M, [&](const Function &F) {
+    if (F.isDeclaration())
+      return false;
+    return F.getFnAttribute(Attr).getValueAsString() != Value;
+  });
 }
-// Returns true if all functions have the same denormal mode.
+// Returns true if all functions definitions have the same denormal mode.
 // It also returns true when the module has no functions.
-static bool checkDenormalAttributeConsistency(const Module &M,
-                                              StringRef Attr,
+static bool checkDenormalAttributeConsistency(const Module &M, StringRef Attr,
                                               DenormalMode Value) {
   return !any_of(M, [&](const Function &F) {
+    if (F.isDeclaration())
+      return false;
     StringRef AttrVal = F.getFnAttribute(Attr).getValueAsString();
     return parseDenormalFPAttribute(AttrVal) != Value;
   });

--- a/llvm/test/CodeGen/ARM/build-attributes-fn-attr3.ll
+++ b/llvm/test/CodeGen/ARM/build-attributes-fn-attr3.ll
@@ -11,7 +11,10 @@
 
 define i32 @foo() local_unnamed_addr #0 {
 entry:
+  %a = call float @llvm.fma.f32(float 0.0, float 0.0, float 0.0)
   ret i32 42
 }
+
+declare float @llvm.fma.f32(float, float, float)
 
 attributes #0 = { minsize norecurse nounwind optsize readnone "no-trapping-math"="true" "denormal-fp-math"="ieee"}

--- a/llvm/test/CodeGen/ARM/build-attributes-fn-attr4.ll
+++ b/llvm/test/CodeGen/ARM/build-attributes-fn-attr4.ll
@@ -10,7 +10,10 @@
 
 define i32 @foo1() local_unnamed_addr #0 {
 entry:
+  %a = call float @llvm.fma.f32(float 0.0, float 0.0, float 0.0)
   ret i32 42
 }
+
+declare float @llvm.fma.f32(float, float, float)
 
 attributes #0 = { minsize norecurse nounwind optsize readnone "denormal-fp-math"="positive-zero,positive-zero" }

--- a/llvm/test/CodeGen/ARM/build-attributes-fn-attr5.ll
+++ b/llvm/test/CodeGen/ARM/build-attributes-fn-attr5.ll
@@ -10,7 +10,10 @@
 
 define i32 @foo1() local_unnamed_addr #0 {
 entry:
+  %a = call float @llvm.fma.f32(float 0.0, float 0.0, float 0.0)
   ret i32 42
 }
+
+declare float @llvm.fma.f32(float, float, float)
 
 attributes #0 = { minsize norecurse nounwind optsize readnone "denormal-fp-math"="preserve-sign,preserve-sign"}

--- a/llvm/test/CodeGen/ARM/build-attributes-fn-attr6.ll
+++ b/llvm/test/CodeGen/ARM/build-attributes-fn-attr6.ll
@@ -11,6 +11,7 @@
 
 define i32 @foo1() local_unnamed_addr #0 {
 entry:
+  %a = call float @llvm.fma.f32(float 0.0, float 0.0, float 0.0)
   ret i32 42
 }
 
@@ -18,6 +19,8 @@ define i32 @foo2() local_unnamed_addr #1 {
 entry:
   ret i32 42
 }
+
+declare float @llvm.fma.f32(float, float, float)
 
 attributes #0 = { minsize norecurse nounwind optsize readnone "denormal-fp-math"="preserve-sign,preserve-sign"}
 attributes #1 = { minsize norecurse nounwind optsize readnone "denormal-fp-math"="positive-zero,positive-zero"}


### PR DESCRIPTION
This code doesn't work very well, but this makes it work when intrinsic definitions are present. It now discounts functions declarations from the set of attributes it looks at.

The code would have worked better before 0ab5b5b8581d9f2951575f7245824e6e4fc57dec when module-level attributes could provide the information used to construct build-attributes.