### PR TITLE
✨[AArch64] Do not try to fold if getSwappedCondition(CC) has no swapped condition

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -25985,9 +25985,12 @@ static SDValue reassociateCSELOperandsForCSE(SDNode *N, SelectionDAG &DAG) {
     // Try again with the operands of the SUBS instruction and the condition
     // swapped. Due to canonicalization, this only helps for non-constant
     // operands of the SUBS instruction.
-    std::swap(CmpOpToMatch, CmpOpOther);
-    if (SDValue R = Fold(getSwappedCondition(CC), CmpOpToMatch, CmpOpToMatch))
-      return R;
+    auto NewCC = getSwappedCondition(CC);
+    if (NewCC != AArch64CC::AL) {
+      std::swap(CmpOpToMatch, CmpOpOther);
+      if (SDValue R = Fold(NewCC, CmpOpToMatch, CmpOpToMatch))
+        return R;
+    }
     return SDValue();
   }
 


### PR DESCRIPTION
NFC for now, but if we simplify nodes where we can remove a compare with 0 and we are stuck with condition codes MI or PL, we are in trouble, as you cannot swap that.