### PR TITLE
[RegAlloc] Add printer and dump for VNInfo [nfc]

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveInterval.h
+++ b/llvm/include/llvm/CodeGen/LiveInterval.h
@@ -83,7 +83,15 @@ namespace llvm {
 
     /// Mark this value as unused.
     void markUnused() { def = SlotIndex(); }
+
+    LLVM_ABI void print(raw_ostream &OS) const;
+    LLVM_ABI void dump() const;
   };
+
+  inline raw_ostream &operator<<(raw_ostream &OS, const VNInfo &VNI) {
+    VNI.print(OS);
+    return OS;
+  }
 
   /// Result of a LiveRange query. This class hides the implementation details
   /// of live ranges, and it should be used as the primary interface for

--- a/llvm/lib/CodeGen/LiveInterval.cpp
+++ b/llvm/lib/CodeGen/LiveInterval.cpp
@@ -1024,7 +1024,8 @@ void LiveRange::print(raw_ostream &OS) const {
     for (const_vni_iterator i = vni_begin(), e = vni_end(); i != e;
          ++i, ++vnum) {
       const VNInfo *vni = *i;
-      if (vnum) OS << ' ';
+      if (vnum)
+        OS << ' ';
       OS << *vni;
       assert(vnum == vni->id && "Bad VNInfo");
     }
@@ -1046,13 +1047,9 @@ void LiveInterval::print(raw_ostream &OS) const {
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-LLVM_DUMP_METHOD void VNInfo::dump() const {
-  dbgs() << *this << '\n';
-}
+LLVM_DUMP_METHOD void VNInfo::dump() const { dbgs() << *this << '\n'; }
 
-LLVM_DUMP_METHOD void LiveRange::dump() const {
-  dbgs() << *this << '\n';
-}
+LLVM_DUMP_METHOD void LiveRange::dump() const { dbgs() << *this << '\n'; }
 
 LLVM_DUMP_METHOD void LiveInterval::SubRange::dump() const {
   dbgs() << *this << '\n';

--- a/llvm/lib/CodeGen/LiveInterval.cpp
+++ b/llvm/lib/CodeGen/LiveInterval.cpp
@@ -996,6 +996,17 @@ LLVM_DUMP_METHOD void LiveRange::Segment::dump() const {
 }
 #endif
 
+void VNInfo::print(raw_ostream &OS) const {
+  OS << id << '@';
+  if (isUnused()) {
+    OS << 'x';
+  } else {
+    OS << def;
+    if (isPHIDef())
+      OS << "-phi";
+  }
+}
+
 void LiveRange::print(raw_ostream &OS) const {
   if (empty())
     OS << "EMPTY";
@@ -1014,14 +1025,8 @@ void LiveRange::print(raw_ostream &OS) const {
          ++i, ++vnum) {
       const VNInfo *vni = *i;
       if (vnum) OS << ' ';
-      OS << vnum << '@';
-      if (vni->isUnused()) {
-        OS << 'x';
-      } else {
-        OS << vni->def;
-        if (vni->isPHIDef())
-          OS << "-phi";
-      }
+      OS << *vni;
+      assert(vnum == vni->id && "Bad VNInfo");
     }
   }
 }
@@ -1041,6 +1046,10 @@ void LiveInterval::print(raw_ostream &OS) const {
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void VNInfo::dump() const {
+  dbgs() << *this << '\n';
+}
+
 LLVM_DUMP_METHOD void LiveRange::dump() const {
   dbgs() << *this << '\n';
 }


### PR DESCRIPTION
Uses the existing format of the LiveRange printer, and just factors it out so that you can do vni->dump() when debugging, or log a vni in a debug print statement.