### PR TITLE
[RegAlloc] Strengthen asserts in LiveRangeEdit::scanRemattable [nfc]

### DIFF
--- a/llvm/lib/CodeGen/LiveRangeEdit.cpp
+++ b/llvm/lib/CodeGen/LiveRangeEdit.cpp
@@ -75,11 +75,11 @@ void LiveRangeEdit::scanRemattable() {
     Register Original = VRM->getOriginal(getReg());
     LiveInterval &OrigLI = LIS.getInterval(Original);
     VNInfo *OrigVNI = OrigLI.getVNInfoAt(VNI->def);
-    if (!OrigVNI)
+    assert(OrigVNI && "Corrupt interval mapping?");
+    if (OrigVNI->isPHIDef())
       continue;
     MachineInstr *DefMI = LIS.getInstructionFromIndex(OrigVNI->def);
-    if (!DefMI)
-      continue;
+    assert(DefMI && "Missing instruction for def slot");
     if (TII.isReMaterializable(*DefMI))
       Remattable.insert(OrigVNI);
   }


### PR DESCRIPTION
We should always be able to find the VNInfo in the original live interval which corresponds to the subset we're trying to spill, and the only cases where we have a VNInfo without a definition instruction are if the vni is unused, or corresponds to a phi. Adjust the code structure to explicitly check for PHIDef, and assert the stronger conditions.