### PR TITLE
[lldb] Turn off AdbClientTest on windows to fix build breakage

### DIFF
--- a/lldb/unittests/Platform/Android/AdbClientTest.cpp
+++ b/lldb/unittests/Platform/Android/AdbClientTest.cpp
@@ -108,6 +108,9 @@ static uint16_t FindUnusedPort() {
   return port;
 }
 
+#ifndef _WIN32
+// This test is disabled on Windows due to platform-specific socket behavior
+// that causes assertion failures in TCPSocket::Listen()
 TEST_F(AdbClientTest, RealTcpConnection) {
   uint16_t unused_port = FindUnusedPort();
   ASSERT_NE(unused_port, 0) << "Failed to find an unused port";
@@ -137,3 +140,4 @@ TEST_F(AdbClientTest, RealTcpConnection) {
       << "Connection should succeed when server is listening on port "
       << unused_port;
 }
+#endif // _WIN32


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/159676 was recently landed. After it was landed, additional tests were ran, where I saw an assertion error on windows only. I am not able to test on windows, and the test is a new test to mock an adb server. The mock server fails to start on windows, so I am disabling to fix the breakage on main. This is not an issue with the main code, only a test issue.

Relevant error output:
```
Step 8 (test-check-lldb-unit) failure: Test just built components: check-lldb-unit completed (failure)
******************** TEST 'lldb-unit :: Platform/Android/./AdbClientTests.exe/7/20' FAILED ********************
Script(shard):
--
GTEST_OUTPUT=json:C:\buildbot\as-builder-10\lldb-x86-64\build\tools\lldb\unittests\Platform\Android\.\AdbClientTests.exe-lldb-unit-30696-7-20.json GTEST_SHUFFLE=0 GTEST_TOTAL_SHARDS=20 GTEST_SHARD_INDEX=7 C:\buildbot\as-builder-10\lldb-x86-64\build\tools\lldb\unittests\Platform\Android\.\AdbClientTests.exe
--

Note: This is test shard 8 of 20.

[==========] Running 1 test from 1 test suite.

[----------] Global test environment set-up.

[----------] 1 test from AdbClientTest

[ RUN      ] AdbClientTest.RealTcpConnection

Assertion failed: error.Fail(), file C:\buildbot\as-builder-10\lldb-x86-64\llvm-project\lldb\source\Host\common\TCPSocket.cpp, line 254
```