### PR TITLE
[cmake] External projects don't need llvm-config when cross-compiling

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -364,6 +364,7 @@ function(llvm_ExternalProject_Add name source_dir)
     endif()
   else()
     set(llvm_config_path "$<TARGET_FILE:llvm-config>")
+    list(APPEND ARG_DEPENDS llvm-config)
     set(cmake_args ${ARG_CMAKE_ARGS})
   endif()
 
@@ -379,7 +380,7 @@ function(llvm_ExternalProject_Add name source_dir)
   endif()
 
   ExternalProject_Add(${name}
-    DEPENDS ${ARG_DEPENDS} llvm-config
+    DEPENDS ${ARG_DEPENDS}
     ${name}-clobber
     PREFIX ${CMAKE_BINARY_DIR}/projects/${name}
     SOURCE_DIR ${source_dir}


### PR DESCRIPTION
`llvm-config` is currently a dependency when building compiler-rt via `LLVM_ENABLE_RUNTIMES`. This is also true of any other project that gets built via `llvm_ExternalProject_Add`. However, this dependency does not make sense when cross-compiling, since `llvm-config` would not be executable on the host. 

Currently, the path to the built `llvm-config` is passed as `LLVM_CONFIG_PATH`, but not when cross-compiling: https://github.com/llvm/llvm-project/blob/7b28fcd2b182ba2c9d2d71c386be92fc0ee3cc9d/llvm/cmake/modules/LLVMExternalProjectUtils.cmake#L365-L368

When cross-compiling, the existing value of `LLVM_CONFIG_PATH` is forwarded to the external build: https://github.com/llvm/llvm-project/blob/7b28fcd2b182ba2c9d2d71c386be92fc0ee3cc9d/llvm/cmake/modules/LLVMExternalProjectUtils.cmake#L332

Since the path to the built  `llvm-config` is not used when cross-compiling, we should also not require it as a dependency when cross-compiling.

Note that as of 23c665371a98c7a16765d12bf2db19b0626b7181, compiler-rt now uses `find_package` instead of relying on `LLVM_CONFIG_PATH`. A future commit should convert this code from `LLVM_CONFIG_PATH` to `LLVM_CMAKE_PATH` since `LLVM_CONFIG_PATH` is deprecated: https://github.com/llvm/llvm-project/blob/7b28fcd2b182ba2c9d2d71c386be92fc0ee3cc9d/compiler-rt/cmake/Modules/CompilerRTUtils.cmake#L288-L298