### PR TITLE
[llvm][clang] Use the VFS in `FileCollector`

### DIFF
--- a/clang/include/clang/Frontend/Utils.h
+++ b/clang/include/clang/Frontend/Utils.h
@@ -143,8 +143,9 @@ class ModuleDependencyCollector : public DependencyCollector {
   std::error_code copyToRoot(StringRef Src, StringRef Dst = {});
 
 public:
-  ModuleDependencyCollector(std::string DestDir)
-      : DestDir(std::move(DestDir)) {}
+  ModuleDependencyCollector(std::string DestDir,
+                            IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS)
+      : DestDir(std::move(DestDir)), Canonicalizer(std::move(VFS)) {}
   ~ModuleDependencyCollector() override { writeFileMap(); }
 
   StringRef getDest() { return DestDir; }

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -503,7 +503,7 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   // then we're the top level compiler instance and need to create one.
   if (!ModuleDepCollector && !DepOpts.ModuleDependencyOutputDir.empty()) {
     ModuleDepCollector = std::make_shared<ModuleDependencyCollector>(
-        DepOpts.ModuleDependencyOutputDir);
+        DepOpts.ModuleDependencyOutputDir, getVirtualFileSystemPtr());
   }
 
   // If there is a module dep collector, register with other dep collectors

--- a/lldb/source/Plugins/ExpressionParser/Clang/ModuleDependencyCollector.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ModuleDependencyCollector.h
@@ -19,8 +19,8 @@ class ModuleDependencyCollectorAdaptor
 public:
   ModuleDependencyCollectorAdaptor(
       std::shared_ptr<llvm::FileCollectorBase> file_collector)
-      : clang::ModuleDependencyCollector(""), m_file_collector(file_collector) {
-  }
+      : clang::ModuleDependencyCollector("", llvm::vfs::getRealFileSystem()),
+        m_file_collector(file_collector) {}
 
   void addFile(llvm::StringRef Filename,
                llvm::StringRef FileDst = {}) override {

--- a/llvm/include/llvm/Support/FileCollector.h
+++ b/llvm/include/llvm/Support/FileCollector.h
@@ -81,11 +81,16 @@ public:
     /// Canonicalize a pair of virtual and real paths.
     LLVM_ABI PathStorage canonicalize(StringRef SrcPath);
 
+    explicit PathCanonicalizer(IntrusiveRefCntPtr<vfs::FileSystem> VFS)
+        : VFS(std::move(VFS)) {}
+
   private:
     /// Replace with a (mostly) real path, or don't modify. Resolves symlinks
     /// in the directory, using \a CachedDirs to avoid redundant lookups, but
     /// leaves the filename as a possible symlink.
     void updateWithRealPath(SmallVectorImpl<char> &Path);
+
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS;
 
     StringMap<std::string> CachedDirs;
   };
@@ -93,7 +98,8 @@ public:
   /// \p Root is the directory where collected files are will be stored.
   /// \p OverlayRoot is VFS mapping root.
   /// \p Root directory gets created in copyFiles unless it already exists.
-  FileCollector(std::string Root, std::string OverlayRoot);
+  FileCollector(std::string Root, std::string OverlayRoot,
+                IntrusiveRefCntPtr<vfs::FileSystem> VFS);
 
   /// Write the yaml mapping (for the VFS) to the given file.
   std::error_code writeMapping(StringRef MappingFile);

--- a/llvm/tools/dsymutil/Reproducer.cpp
+++ b/llvm/tools/dsymutil/Reproducer.cpp
@@ -37,9 +37,10 @@ ReproducerGenerate::ReproducerGenerate(std::error_code &EC, int Argc,
                                        char **Argv, bool GenerateOnExit)
     : Root(createReproducerDir(EC)), GenerateOnExit(GenerateOnExit) {
   llvm::append_range(Args, ArrayRef(Argv, Argc));
+  auto RealFS = vfs::getRealFileSystem();
   if (!Root.empty())
-    FC = std::make_shared<FileCollector>(Root, Root);
-  VFS = FileCollector::createCollectorVFS(vfs::getRealFileSystem(), FC);
+    FC = std::make_shared<FileCollector>(Root, Root, RealFS);
+  VFS = FileCollector::createCollectorVFS(std::move(RealFS), FC);
 }
 
 ReproducerGenerate::~ReproducerGenerate() {

--- a/llvm/unittests/Support/FileCollectorTest.cpp
+++ b/llvm/unittests/Support/FileCollectorTest.cpp
@@ -43,7 +43,8 @@ public:
 TEST(FileCollectorTest, addFile) {
   TempDir root("add_file_root", /*Unique*/ true);
   std::string root_fs(root.path());
-  TestingFileCollector FileCollector(root_fs, root_fs);
+  TestingFileCollector FileCollector(root_fs, root_fs,
+                                     vfs::getRealFileSystem());
 
   FileCollector.addFile("/path/to/a");
   FileCollector.addFile("/path/to/b");
@@ -77,7 +78,8 @@ TEST(FileCollectorTest, addDirectory) {
   TempFile c(ccc.str());
 
   std::string root_fs(file_root.path());
-  TestingFileCollector FileCollector(root_fs, root_fs);
+  TestingFileCollector FileCollector(root_fs, root_fs,
+                                     vfs::getRealFileSystem());
 
   FileCollector.addDirectory(file_root.path());
 
@@ -105,7 +107,8 @@ TEST(FileCollectorTest, copyFiles) {
   // Create file collector and add files.
   TempDir root("copy_files_root", /*Unique*/ true);
   std::string root_fs(root.path());
-  TestingFileCollector FileCollector(root_fs, root_fs);
+  TestingFileCollector FileCollector(root_fs, root_fs,
+                                     vfs::getRealFileSystem());
   FileCollector.addFile(a.path());
   FileCollector.addFile(b.path());
   FileCollector.addFile(c.path());
@@ -133,7 +136,8 @@ TEST(FileCollectorTest, recordAndConstructDirectory) {
   // Create file collector and add files.
   TempDir root("copy_files_root", /*Unique*/ true);
   std::string root_fs(root.path());
-  TestingFileCollector FileCollector(root_fs, root_fs);
+  TestingFileCollector FileCollector(root_fs, root_fs,
+                                     vfs::getRealFileSystem());
   FileCollector.addFile(a.path());
 
   // The empty directory isn't seen until we add it.
@@ -169,7 +173,8 @@ TEST(FileCollectorTest, recordVFSAccesses) {
   // Create file collector and add files.
   TempDir root("copy_files_root", /*Unique*/ true);
   std::string root_fs(root.path());
-  auto Collector = std::make_shared<TestingFileCollector>(root_fs, root_fs);
+  auto Collector = std::make_shared<TestingFileCollector>(
+      root_fs, root_fs, vfs::getRealFileSystem());
   auto VFS =
       FileCollector::createCollectorVFS(vfs::getRealFileSystem(), Collector);
   VFS->status(a.path());
@@ -216,7 +221,8 @@ TEST(FileCollectorTest, Symlinks) {
   // Root where files are copied to.
   TempDir reproducer_root("reproducer_root", /*Unique*/ true);
   std::string root_fs(reproducer_root.path());
-  TestingFileCollector FileCollector(root_fs, root_fs);
+  TestingFileCollector FileCollector(root_fs, root_fs,
+                                     vfs::getRealFileSystem());
 
   // Add all the files to the collector.
   FileCollector.addFile(a.path());
@@ -264,7 +270,8 @@ TEST(FileCollectorTest, recordVFSSymlinkAccesses) {
   // Create file collector and add files.
   TempDir root("copy_files_root", true);
   std::string root_fs(root.path());
-  auto Collector = std::make_shared<TestingFileCollector>(root_fs, root_fs);
+  auto Collector = std::make_shared<TestingFileCollector>(
+      root_fs, root_fs, vfs::getRealFileSystem());
   auto VFS =
       FileCollector::createCollectorVFS(vfs::getRealFileSystem(), Collector);
   SmallString<256> Output;


### PR DESCRIPTION
This PR changes `llvm::FileCollector` to use the `llvm::vfs::FileSystem` API for making file paths absolute instead of using `llvm::sys::fs::make_absolute()` directly. This matches the behavior of the compiler on most other input files.