### PR TITLE
[llvm-remarkutil] filter: Fix curses.h namespace pollution

### DIFF
--- a/llvm/tools/llvm-remarkutil/RemarkFilter.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkFilter.cpp
@@ -20,6 +20,10 @@ using namespace llvm;
 using namespace remarks;
 using namespace llvm::remarkutil;
 
+// Note: Avoid using the identifier "filter" in this file, as it is prone to
+// namespace collision with headers that might get included e.g.
+// curses.h.
+
 static cl::SubCommand FilterSub("filter",
                                 "Filter remarks based on specified criteria.");
 

--- a/llvm/tools/llvm-remarkutil/RemarkFilter.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkFilter.cpp
@@ -20,8 +20,6 @@ using namespace llvm;
 using namespace remarks;
 using namespace llvm::remarkutil;
 
-namespace filter {
-
 static cl::SubCommand FilterSub("filter",
                                 "Filter remarks based on specified criteria.");
 
@@ -80,5 +78,3 @@ static Error tryFilter() {
 }
 
 static CommandRegistration FilterReg(&FilterSub, tryFilter);
-
-} // namespace filter


### PR DESCRIPTION
Remove the filter namespace, because `filter` is used by `curses.h`,
causing some external build failures
(https://github.com/llvm/llvm-project/pull/159784#discussion_r2380574036).

We don't really need the namespace here anyways, because everything is
static. This was just following what some of the other commands in
llvm-remarkutil are doing.
