### PR TITLE
[ADT] Apply Rule of Five to StringTable::Iterator

### DIFF
--- a/llvm/include/llvm/ADT/StringTable.h
+++ b/llvm/include/llvm/ADT/StringTable.h
@@ -118,12 +118,8 @@ public:
     constexpr Iterator(const Iterator &RHS) = default;
     constexpr Iterator(Iterator &&RHS) = default;
 
-    Iterator &operator=(const Iterator &RHS) {
-      Table = RHS.Table;
-      O = RHS.O;
-      S = RHS.S;
-      return *this;
-    }
+    constexpr Iterator &operator=(const Iterator &RHS) = default;
+    constexpr Iterator &operator=(Iterator &&RHS) = default;
 
     bool operator==(const Iterator &RHS) const {
       assert(Table == RHS.Table && "Compared iterators for unrelated tables!");


### PR DESCRIPTION
StringTable::Iterator has a user-defined copy assignment operator, a
defaulted copy constructor, and a defaulted move constructor.

This patch makes the copy assignment operator defaulted and adds a
defaulted move assignment operator to adhere to the Rule of Five while
making the operators constexpr.
