### PR TITLE
[X86] Set default rounding mode round to nearest for llvm.set.rounding

### DIFF
--- a/llvm/lib/Target/X86/GISel/X86LegalizerInfo.cpp
+++ b/llvm/lib/Target/X86/GISel/X86LegalizerInfo.cpp
@@ -905,6 +905,7 @@ bool X86LegalizerInfo::legalizeSETROUNDING(MachineInstr &MI,
     int FieldVal = X86::getRoundingModeX86(RM);
 
     if (FieldVal == X86::rmInvalid) {
+      FieldVal = X86::rmToNearest;
       LLVMContext &C = MF.getFunction().getContext();
       C.diagnose(DiagnosticInfoUnsupported(
           MF.getFunction(), "rounding mode is not supported by X86 hardware",

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -28714,11 +28714,11 @@ SDValue X86TargetLowering::LowerSET_ROUNDING(SDValue Op,
     int FieldVal = X86::getRoundingModeX86(RM);
 
     if (FieldVal == X86::rmInvalid) {
+      FieldVal = X86::rmToNearest;
       LLVMContext &C = MF.getFunction().getContext();
       C.diagnose(DiagnosticInfoUnsupported(
           MF.getFunction(), "rounding mode is not supported by X86 hardware",
           DiagnosticLocation(DL.getDebugLoc()), DS_Error));
-      return {};
     }
     RMBits = DAG.getConstant(FieldVal, DL, MVT::i16);
   } else {


### PR DESCRIPTION
- Fix https://github.com/llvm/llvm-project/pull/156591#issuecomment-3335218842
- As per https://cdrdv2.intel.com/v1/dl/getContent/671200 default rounding mode is **round to nearest**. 