### PR TITLE
clang/AMDGPU: Report some missing OpenCL 2.0 feature macros

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -319,9 +319,12 @@ public:
       Opts["__opencl_c_images"] = true;
       Opts["__opencl_c_3d_image_writes"] = true;
       Opts["cl_khr_3d_image_writes"] = true;
+      Opts["__opencl_c_program_scope_global_variables"] = true;
 
-      Opts["__opencl_c_generic_address_space"] =
-          GPUKind >= llvm::AMDGPU::GK_GFX700;
+      if (GPUKind >= llvm::AMDGPU::GK_GFX700) {
+        Opts["__opencl_c_generic_address_space"] = true;
+        Opts["__opencl_c_device_enqueue"] = true;
+      }
     }
   }
 

--- a/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
+++ b/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
@@ -171,7 +171,7 @@
     #endif
   #else
     #ifdef __opencl_c_generic_address_space
-      #error "Incorrect __opencl_c_atomic_scope_all_devices define"
+      #error "Incorrect __opencl_c_generic_address_space define"
     #endif
   #endif
 #endif

--- a/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
+++ b/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
@@ -8,6 +8,9 @@
 // RUN: %clang_cc1 -x cl -cl-std=CL1.2 %s -verify -triple amdgcn-unknown-unknown -Wpedantic-core-features -DTEST_CORE_FEATURES
 // RUN: %clang_cc1 -x cl -cl-std=CL2.0 %s -verify -triple amdgcn-unknown-unknown -Wpedantic-core-features -DTEST_CORE_FEATURES
 
+// RUN: %clang_cc1 -x cl -cl-std=CL3.0 %s -verify -triple amdgcn-unknown-unknown -Wpedantic-core-features -DTEST_CORE_FEATURES
+// RUN: %clang_cc1 -x cl -cl-std=CL3.0 %s -verify -triple amdgcn-unknown-unknown -target-cpu gfx700 -Wpedantic-core-features -DTEST_CORE_FEATURES -DFLAT_SUPPORT
+
 // Extensions in all versions
 #ifndef cl_clang_storage_class_specifiers
 #error "Missing cl_clang_storage_class_specifiers define"
@@ -156,10 +159,31 @@
 #pragma OPENCL EXTENSION cl_amd_media_ops2: enable
 
 #if (__OPENCL_C_VERSION__ >= 300)
-#ifndef __opencl_c_generic_address_space
-#error "Missing __opencl_c_generic_address_space define"
-#else
-#error "Incorrect __opencl_c_generic_address_space define"
+  #ifndef __opencl_c_program_scope_global_variables
+    #error "Missing __opencl_c_program_scope_global_variables define"
+  #endif
 #endif
-#pragma OPENCL EXTENSION __opencl_c_generic_address_space: enable
+
+#if (__OPENCL_C_VERSION__ >= 300)
+  #ifdef FLAT_SUPPORT
+    #ifndef __opencl_c_generic_address_space
+      #error "Missing __opencl_c_generic_address_space define"
+    #endif
+  #else
+    #ifdef __opencl_c_generic_address_space
+      #error "Incorrect __opencl_c_atomic_scope_all_devices define"
+    #endif
+  #endif
+#endif
+
+#if (__OPENCL_C_VERSION__ >= 300)
+  #ifdef FLAT_SUPPORT
+    #ifndef __opencl_c_device_enqueue
+      #error "Missing __opencl_c_device_enqueue define"
+    #endif
+  #else
+    #ifdef __opencl_c_device_enqueue
+      #error "Incorrect __opencl_c_device_enqueue define"
+    #endif
+  #endif
 #endif


### PR DESCRIPTION
Report __opencl_c_program_scope_global_variables and
__opencl_c_device_enqueue as supported. These 2.0 features are
supported but were missing from the extension map.

__opencl_c_atomic_scope_all_devices should also be reported, but
that seems to not just work by adding it to the map for some
reason.

The existing test for these macros was also broken, since it was
missing CL3.0 run lines, so add those.