### PR TITLE
[lldb][test] Fix elf-no-shdrs-pt-notes.yaml on Windows

### DIFF
--- a/lldb/test/Shell/ObjectFile/ELF/elf-no-shdrs-pt-notes.yaml
+++ b/lldb/test/Shell/ObjectFile/ELF/elf-no-shdrs-pt-notes.yaml
@@ -10,8 +10,8 @@
 # RUN:   -o "image list" \
 # RUN:   | FileCheck %s
 
-# CHECK: Current executable set to '{{.*/tools/lldb/test/Shell/ObjectFile/ELF/Output/elf-no-shdrs-pt-notes.yaml.tmp}}' (x86_64).
-# CHECK: [  0] 7F1F56D6-7DBB-17BA-C9A3-4417DB52F097-2548414F 0x0000000000000000 {{.*/tools/lldb/test/Shell/ObjectFile/ELF/Output/elf-no-shdrs-pt-notes.yaml.tmp}}
+# CHECK: Current executable set to '{{.*}}elf-no-shdrs-pt-notes.yaml.tmp' (x86_64).
+# CHECK: [  0] 7F1F56D6-7DBB-17BA-C9A3-4417DB52F097-2548414F 0x0000000000000000 {{.*}}elf-no-shdrs-pt-notes.yaml.tmp
 
 --- !ELF
 FileHeader:


### PR DESCRIPTION
Windows paths have different slashes, but I don't think we care about the exact paths there anyway so I've just checked for the final filename.

Fixes #160652