### PR TITLE
[MLIR][TBLGen] Added compound assignment operator for any BitEnum

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -1649,6 +1649,15 @@ inline constexpr MyBitEnum operator&(MyBitEnum a, MyBitEnum b) {
 inline constexpr MyBitEnum operator^(MyBitEnum a, MyBitEnum b) {
   return static_cast<MyBitEnum>(static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
 }
+inline constexpr MyBitEnum &operator|=(MyBitEnum &a, MyBitEnum b) {
+  return a = a | b;
+}
+inline constexpr MyBitEnum &operator&=(MyBitEnum &a, MyBitEnum b) {
+  return a = a & b;
+}
+inline constexpr MyBitEnum &operator^=(MyBitEnum &a, MyBitEnum b) {
+  return a = a ^ b;
+}
 inline constexpr MyBitEnum operator~(MyBitEnum bits) {
   // Ensure only bits that can be present in the enum are set
   return static_cast<MyBitEnum>(~static_cast<uint32_t>(bits) & static_cast<uint32_t>(15u));

--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
@@ -512,7 +512,7 @@ calculateMemoryRequirements(Value accessedPtr, bool isNontemporal,
   if (!sizeInBytes.has_value())
     return failure();
 
-  memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;
+  memoryAccess |= spirv::MemoryAccess::Aligned;
   auto memAccessAttr = spirv::MemoryAccessAttr::get(ctx, memoryAccess);
   auto alignmentValue = preferredAlignment ? preferredAlignment : *sizeInBytes;
   auto alignment = IntegerAttr::get(IntegerType::get(ctx, 32), alignmentValue);

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -753,7 +753,7 @@ struct VectorLoadOpConverter final
     spirv::MemoryAccessAttr memoryAccessAttr;
     IntegerAttr alignmentAttr;
     if (alignment.has_value()) {
-      memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;
+      memoryAccess |= spirv::MemoryAccess::Aligned;
       memoryAccessAttr =
           spirv::MemoryAccessAttr::get(rewriter.getContext(), memoryAccess);
       alignmentAttr = rewriter.getI32IntegerAttr(alignment.value());
@@ -822,7 +822,7 @@ struct VectorStoreOpConverter final
     spirv::MemoryAccessAttr memoryAccessAttr;
     IntegerAttr alignmentAttr;
     if (alignment.has_value()) {
-      memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;
+      memoryAccess |= spirv::MemoryAccess::Aligned;
       memoryAccessAttr =
           spirv::MemoryAccessAttr::get(rewriter.getContext(), memoryAccess);
       alignmentAttr = rewriter.getI32IntegerAttr(alignment.value());

--- a/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
@@ -77,7 +77,7 @@ static void addScopeToFunction(LLVM::LLVMFuncOp llvmFunc,
   auto subprogramFlags = LLVM::DISubprogramFlags::Optimized;
   if (!llvmFunc.isExternal()) {
     id = DistinctAttr::create(UnitAttr::get(context));
-    subprogramFlags = subprogramFlags | LLVM::DISubprogramFlags::Definition;
+    subprogramFlags |= LLVM::DISubprogramFlags::Definition;
   } else {
     compileUnitAttr = {};
   }

--- a/mlir/tools/mlir-tblgen/EnumsGen.cpp
+++ b/mlir/tools/mlir-tblgen/EnumsGen.cpp
@@ -364,6 +364,9 @@ getAllBitsUnsetCase(llvm::ArrayRef<EnumCase> cases) {
 // inline constexpr <enum-type> operator|(<enum-type> a, <enum-type> b);
 // inline constexpr <enum-type> operator&(<enum-type> a, <enum-type> b);
 // inline constexpr <enum-type> operator^(<enum-type> a, <enum-type> b);
+// inline constexpr <enum-type> &operator|=(<enum-type> &a, <enum-type> b);
+// inline constexpr <enum-type> &operator&=(<enum-type> &a, <enum-type> b);
+// inline constexpr <enum-type> &operator^=(<enum-type> &a, <enum-type> b);
 // inline constexpr <enum-type> operator~(<enum-type> bits);
 // inline constexpr bool bitEnumContainsAll(<enum-type> bits, <enum-type> bit);
 // inline constexpr bool bitEnumContainsAny(<enum-type> bits, <enum-type> bit);
@@ -384,6 +387,15 @@ inline constexpr {0} operator&({0} a, {0} b) {{
 }
 inline constexpr {0} operator^({0} a, {0} b) {{
   return static_cast<{0}>(static_cast<{1}>(a) ^ static_cast<{1}>(b));
+}
+inline constexpr {0} &operator|=({0} &a, {0} b) {{
+    return a = a | b;
+}
+inline constexpr {0} &operator&=({0} &a, {0} b) {{
+    return a = a & b;
+}
+inline constexpr {0} &operator^=({0} &a, {0} b) {{
+    return a = a ^ b;
 }
 inline constexpr {0} operator~({0} bits) {{
   // Ensure only bits that can be present in the enum are set


### PR DESCRIPTION
## Details:
- Added missing compound assignment operators `|=`, `&=`, `^=` to `mlir-tblgen`
- Replaced the arithmetic operators with added assignment operators for `BitEnum` in the transformations
- Updated related documentation


## Tickets:
- Closes https://github.com/llvm/llvm-project/issues/158098
