### PR TITLE
[clang][bytecode] Remove Program include from InterpFrame.h

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.h
+++ b/clang/lib/AST/ByteCode/EvalEmitter.h
@@ -16,6 +16,7 @@
 #include "EvaluationResult.h"
 #include "InterpState.h"
 #include "PrimType.h"
+#include "Record.h"
 #include "Source.h"
 
 namespace clang {

--- a/clang/lib/AST/ByteCode/InterpBlock.h
+++ b/clang/lib/AST/ByteCode/InterpBlock.h
@@ -115,9 +115,10 @@ public:
     return reinterpret_cast<const std::byte *>(this) + sizeof(Block);
   }
 
-  template <typename T> T deref() const {
+  template <typename T> const T &deref() const {
     return *reinterpret_cast<const T *>(data());
   }
+  template <typename T> T &deref() { return *reinterpret_cast<T *>(data()); }
 
   /// Invokes the constructor.
   void invokeCtor() {

--- a/clang/lib/AST/ByteCode/InterpFrame.h
+++ b/clang/lib/AST/ByteCode/InterpFrame.h
@@ -14,7 +14,8 @@
 #define LLVM_CLANG_AST_INTERP_INTERPFRAME_H
 
 #include "Frame.h"
-#include "Program.h"
+#include "InterpBlock.h"
+#include "Pointer.h"
 
 namespace clang {
 namespace interp {
@@ -93,7 +94,7 @@ public:
     auto Pt = Params.find(Offset);
     if (Pt == Params.end())
       return stackRef<T>(Offset);
-    return Pointer(reinterpret_cast<Block *>(Pt->second.get())).deref<T>();
+    return reinterpret_cast<const Block *>(Pt->second.get())->deref<T>();
   }
 
   /// Mutates a local copy of a parameter.
@@ -151,7 +152,7 @@ private:
 
   /// Returns an offset to a local.
   template <typename T> T &localRef(unsigned Offset) const {
-    return getLocalPointer(Offset).deref<T>();
+    return localBlock(Offset)->deref<T>();
   }
 
   /// Returns a pointer to a local's block.


### PR DESCRIPTION
Program itself is unused in that file, so just include the needed headers.