### PR TITLE
[BOLT][AArch64] Fix BUILD_SHARED_LIBS after #158738

### DIFF
--- a/bolt/lib/Target/AArch64/CMakeLists.txt
+++ b/bolt/lib/Target/AArch64/CMakeLists.txt
@@ -28,7 +28,7 @@ add_llvm_library(LLVMBOLTTargetAArch64
   AArch64CommonTableGen
   )
 
-target_link_libraries(LLVMBOLTTargetAArch64 PRIVATE LLVMBOLTCore)
+target_link_libraries(LLVMBOLTTargetAArch64 PRIVATE LLVMBOLTCore LLVMBOLTUtils)
 
 include_directories(
   ${LLVM_MAIN_SRC_DIR}/lib/Target/AArch64


### PR DESCRIPTION
Link BOLTUtils against the AArch64 target to support the new option
that enables instrumentation without LSE (see #158738)

This fixes shared library builds, eg:
https://lab.llvm.org/staging/#/builders/220/builds/1537

Note: the link points to a collapsing builder.