### PR TITLE
[Offload] Prevent by default passing CMAKE_CXX_FLAGS to GPU build

### DIFF
--- a/offload/cmake/caches/Offload.cmake
+++ b/offload/cmake/caches/Offload.cmake
@@ -7,3 +7,9 @@ set(RUNTIMES_nvptx64-nvidia-cuda_CACHE_FILES "${CMAKE_SOURCE_DIR}/../libcxx/cmak
 set(RUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES "${CMAKE_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake" CACHE STRING "")
 set(RUNTIMES_nvptx64-nvidia-cuda_LLVM_ENABLE_RUNTIMES "compiler-rt;libc;openmp;libcxx;libcxxabi" CACHE STRING "")
 set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES "compiler-rt;libc;openmp;libcxx;libcxxabi" CACHE STRING "")
+
+# Prevent people mistakenly sending CPU flags to the GPU build.
+set(RUNTIMES_nvptx64-nvidia-cuda_CMAKE_CXX_FLAGS "" CACHE STRING "")
+set(RUNTIMES_amdgcn-amd-amdhsa_CMAKE_CXX_FLAGS "" CACHE STRING "")
+set(RUNTIMES_nvptx64-nvidia-cuda_CMAKE_C_FLAGS "" CACHE STRING "")
+set(RUNTIMES_amdgcn-amd-amdhsa_CMAKE_C_FLAGS "" CACHE STRING "")


### PR DESCRIPTION
Summary:
People will use this to pass incompatible flags. The default behavior is
to inherit the top level options for all the runtimes. Some of these
aren't compatible. The cache file should put users in a most-useful
state, and this also serves as documentation. Just override it so users
need to explicit if they want a non-standard flag on their GPU build.
