### PR TITLE
[Clang] only convert dependency filename to native form when MS-compatible

### DIFF
--- a/clang/include/clang/Frontend/Utils.h
+++ b/clang/include/clang/Frontend/Utils.h
@@ -118,6 +118,9 @@ protected:
   void outputDependencyFile(llvm::raw_ostream &OS);
 
 private:
+  void outputDependencyFilename(llvm::raw_ostream &OS,
+                                StringRef Filename) const;
+
   void outputDependencyFile(DiagnosticsEngine &Diags);
 
   std::string OutputFile;
@@ -128,6 +131,7 @@ private:
   bool SeenMissingHeader;
   bool IncludeModuleFiles;
   DependencyOutputFormat OutputFormat;
+  bool MSCompatible;
   unsigned InputFileIndex;
 };
 

--- a/clang/test/Frontend/dependency-gen-posix-ms-compatible.c
+++ b/clang/test/Frontend/dependency-gen-posix-ms-compatible.c
@@ -1,0 +1,17 @@
+// REQUIRES: !system-windows
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir/include/foo
+// RUN: echo > %t.dir/include/foo/bar.h
+// RUN: echo > %t.dir/include/foo\\bar.h
+
+// RUN: %clang -MD -MF - %s -fsyntax-only -fms-compatibility -I %t.dir/include | FileCheck -check-prefix=CHECK-ONE %s
+// CHECK-ONE: foo/bar.h
+// CHECK-ONE-NOT: foo\bar.h
+// CHECK-ONE-NOT: foo\\bar.h
+
+// RUN: %clang -MD -MF - %s -fsyntax-only -fno-ms-compatibility -I %t.dir/include | FileCheck -check-prefix=CHECK-TWO %s
+// CHECK-TWO: foo\bar.h
+// CHECK-TWO-NOT: foo/bar.h
+// CHECK-TWO-NOT: foo\\bar.h
+
+#include "foo\bar.h"


### PR DESCRIPTION
Currently, `llvm::sys::path::native` is called unconditionally when generating dependency filenames. This is correct on Windows, where backslashes are valid path separators, but can be incorrect on non-Windows platforms when the Clang invocation is not MS-compatible (`-fno-ms-compatibility`), because in that case backslashes in the filename are converted by `llvm::sys::path::native` to forward slashes, while they should be treated as ordinary characters.

This fixes the following inconsistency on non-Windows platforms (notice how the dependency output always converts the backslash to a forward slash, assuming it's a path separator, while the actual include directive treats it as an ordinary character when `-fno-ms-compatibility` is set):

```console
$ tree
.
└── foo
    ├── a
    │   └── b.h
    └── a\b.h

3 directories, 2 files

$ cat foo/a/b.h
#warning a/b.h
$ cat foo/a\\b.h
#warning a\\b.h

$ echo '#include "foo/a\\b.h"' | clang -c -xc - -fms-compatibility -o /dev/null
In file included from <stdin>:1:
./foo/a/b.h:1:2: warning: a/b.h [-W#warnings]
    1 | #warning a/b.h
      |  ^
1 warning generated.
$ echo '#include "foo/a\\b.h"' | clang -xc - -fms-compatibility -M -MG
-.o: foo/a/b.h

$ echo '#include "foo/a\\b.h"' | clang -c -xc - -fno-ms-compatibility -o /dev/null
In file included from <stdin>:1:
./foo/a\b.h:1:2: warning: a\\b.h [-W#warnings]
    1 | #warning a\\b.h
      |  ^
1 warning generated.
$ echo '#include "foo/a\\b.h"' | clang -xc - -fno-ms-compatibility -M -MG
-.o: foo/a/b.h
```

See also:

- https://github.com/llvm/llvm-project/pull/160834
- https://github.com/llvm/llvm-project/pull/160927

If these PRs are accepted then I'll try to extract the logic into a new `llvm/support` helper class. These changes are presented as separate PRs because each of them change the behavior slightly differently.
