### PR TITLE
[Clang][ASTImporter] Implement AST import for CXXParenListInitExpr, SubstNonTypeTemplateParmPackExpr, PseudoObjectExpr

### DIFF
--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3323,13 +3323,10 @@ TEST_P(ImportExpr, ImportCXXParenListInitExpr) {
       int val;
       double d;
     };
-    template <int N> struct Container {
-      Node* create() { return new Node(N, 3.14); }
-    };
-    using declToImport = Container<42>;
+    Node* declToImport() { return new Node(2, 3.14); }
   )";
   testImport(Code, Lang_CXX20, "", Lang_CXX20, Verifier,
-             typedefNameDecl(hasName("declToImport")));
+             functionDecl(hasName("declToImport")));
 }
 
 TEST_P(ImportExpr, ImportPseudoObjectExpr) {

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3316,6 +3316,23 @@ TEST_P(ImportExpr, ImportSubstNonTypeTemplateParmPackExpr) {
              typedefNameDecl(hasName("declToImport")));
 }
 
+
+TEST_P(ImportExpr, ImportCXXParenListInitExpr) {
+  MatchVerifier<Decl> Verifier;
+  const char *Code = R"(
+    struct Node {
+      int val;
+      double d;
+    };
+    template <int N> struct Container {
+      Node* create() { return new Node(N, 3.14); }
+    };
+    using declToImport = Container<42>;
+  )";
+  testImport(Code, Lang_CXX20, "", Lang_CXX20, Verifier,
+             typedefNameDecl(hasName("declToImport")));
+}
+
 class ImportImplicitMethods : public ASTImporterOptionSpecificTestBase {
 public:
   static constexpr auto DefaultCode = R"(

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3300,6 +3300,22 @@ TEST_P(ImportExpr, ConceptNestedNonInstantiationDependentRequirement) {
              conceptDecl(has(requiresExpr(has(requiresExprBodyDecl())))));
 }
 
+TEST_P(ImportExpr, ImportSubstNonTypeTemplateParmPackExpr) {
+  MatchVerifier<Decl> Verifier;
+  const char *Code = R"(
+    template<auto ...> struct X {};
+    template<typename ...> struct Z {};
+
+    template<int ...N> struct E {
+      template<int ...M> using B = Z<X<N, M>...>;
+      template<int M1, int M2> E(B<M1, M2>);
+    };
+    using declToImport = E<1, 3>;
+  )";
+  testImport(Code, Lang_CXX20, "", Lang_CXX20, Verifier,
+             typedefNameDecl(hasName("declToImport")));
+}
+
 class ImportImplicitMethods : public ASTImporterOptionSpecificTestBase {
 public:
   static constexpr auto DefaultCode = R"(


### PR DESCRIPTION
Add new visit functions to ASTImporter for CXXParenListInitExpr, SubstNonTypeTemplateParmPackExpr and PseudoObjectExpr.
On CTU analysis there are lot of "cannot import unsupported AST node" for CXXParenListInitExpr, SubstNonTypeTemplateParmPackExpr and PseudoObjectExpr. Problem occurred after full support of Concepts in importer.