### PR TITLE
[lld][ELF] Only convert dependency filename to native form on Windows

### DIFF
--- a/lld/test/ELF/dependency-file-backslash-as-normal-char.s
+++ b/lld/test/ELF/dependency-file-backslash-as-normal-char.s
@@ -1,0 +1,13 @@
+# REQUIRES: x86, !system-windows
+# RUN: mkdir -p %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o "%t/back\\slash.o"
+# RUN: ld.lld -o %t/foo.exe "%t/back\\slash.o" --dependency-file=%t/foo.d
+# RUN: FileCheck --match-full-lines -DFILE=%t %s < %t/foo.d
+
+# CHECK:      [[FILE]]/foo.exe: \
+# CHECK-NEXT:   [[FILE]]/back\slash.o
+# CHECK-EMPTY:
+# CHECK-NEXT: [[FILE]]/back\slash.o:
+
+.global _start
+_start:

--- a/lld/test/ELF/dependency-file-backslash-as-normal-char.s
+++ b/lld/test/ELF/dependency-file-backslash-as-normal-char.s
@@ -2,12 +2,12 @@
 # RUN: mkdir -p %t
 # RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o "%t/back\\slash.o"
 # RUN: ld.lld -o %t/foo.exe "%t/back\\slash.o" --dependency-file=%t/foo.d
-# RUN: FileCheck --match-full-lines -DFILE=%t %s < %t/foo.d
+# RUN: FileCheck --match-full-lines --strict-whitespace -DFILE=%t %s < %t/foo.d
 
-# CHECK:      [[FILE]]/foo.exe: \
-# CHECK-NEXT:   [[FILE]]/back\slash.o
+#       CHECK:[[FILE]]/foo.exe: \
+#  CHECK-NEXT:  [[FILE]]/back\slash.o
 # CHECK-EMPTY:
-# CHECK-NEXT: [[FILE]]/back\slash.o:
+#  CHECK-NEXT:[[FILE]]/back\slash.o:
 
 .global _start
 _start:

--- a/lld/test/ELF/dependency-file-backslash-as-path-separator.s
+++ b/lld/test/ELF/dependency-file-backslash-as-path-separator.s
@@ -1,0 +1,13 @@
+# REQUIRES: x86, system-windows
+# RUN: mkdir -p %t/back
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o "%t/back\\slash.o"
+# RUN: ld.lld -o %t/foo.exe "%t/back\\slash.o" --dependency-file=%t/foo.d
+# RUN: FileCheck --match-full-lines -DFILE=%t %s < %t/foo.d
+
+# CHECK:      [[FILE]]\foo.exe: \
+# CHECK-NEXT:   [[FILE]]\back\slash.o
+# CHECK-EMPTY:
+# CHECK-NEXT: [[FILE]]\back\slash.o:
+
+.global _start
+_start:

--- a/lld/test/ELF/dependency-file-backslash-as-path-separator.s
+++ b/lld/test/ELF/dependency-file-backslash-as-path-separator.s
@@ -2,12 +2,12 @@
 # RUN: mkdir -p %t/back
 # RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o "%t/back\\slash.o"
 # RUN: ld.lld -o %t/foo.exe "%t/back\\slash.o" --dependency-file=%t/foo.d
-# RUN: FileCheck --match-full-lines -DFILE=%t %s < %t/foo.d
+# RUN: FileCheck --match-full-lines --strict-whitespace -DFILE=%t %s < %t/foo.d
 
-# CHECK:      [[FILE]]\foo.exe: \
-# CHECK-NEXT:   [[FILE]]\back\slash.o
+#       CHECK:[[FILE]]\foo.exe: \
+#  CHECK-NEXT:  [[FILE]]\back\slash.o
 # CHECK-EMPTY:
-# CHECK-NEXT: [[FILE]]\back\slash.o:
+#  CHECK-NEXT:[[FILE]]\back\slash.o:
 
 .global _start
 _start:

--- a/lld/test/ELF/dependency-file.s
+++ b/lld/test/ELF/dependency-file.s
@@ -4,18 +4,18 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64 /dev/null -o "%t/bar baz.o"
 # RUN: llvm-mc -filetype=obj -triple=x86_64 /dev/null -o "%t/#quux$.o"
 # RUN: ld.lld -o %t/foo.exe %t/foo.o %t/"bar baz.o" "%t/#quux$.o" --dependency-file=%t/foo.d
-# RUN: FileCheck --match-full-lines -DFILE=%t %s < %t/foo.d
+# RUN: FileCheck --match-full-lines --strict-whitespace -DFILE=%t %s < %t/foo.d
 
-# CHECK:      [[FILE]]{{/|(\\)+}}foo.exe: \
-# CHECK-NEXT:   [[FILE]]{{/|(\\)+}}foo.o \
-# CHECK-NEXT:   [[FILE]]{{/|(\\)+}}bar\ baz.o \
-# CHECK-NEXT:   [[FILE]]{{/|(\\)+}}\#quux$$.o
+#       CHECK:[[FILE]]{{/|(\\)+}}foo.exe: \
+#  CHECK-NEXT:  [[FILE]]{{/|(\\)+}}foo.o \
+#  CHECK-NEXT:  [[FILE]]{{/|(\\)+}}bar\ baz.o \
+#  CHECK-NEXT:  [[FILE]]{{/|(\\)+}}\#quux$$.o
 # CHECK-EMPTY:
-# CHECK-NEXT: [[FILE]]{{/|(\\)+}}foo.o:
+#  CHECK-NEXT:[[FILE]]{{/|(\\)+}}foo.o:
 # CHECK-EMPTY:
-# CHECK-NEXT: [[FILE]]{{/|(\\)+}}bar\ baz.o:
+#  CHECK-NEXT:[[FILE]]{{/|(\\)+}}bar\ baz.o:
 # CHECK-EMPTY:
-# CHECK-NEXT: [[FILE]]{{/|(\\)+}}\#quux$$.o:
+#  CHECK-NEXT:[[FILE]]{{/|(\\)+}}\#quux$$.o:
 
 .global _start
 _start:


### PR DESCRIPTION
Currently, `llvm::sys::path::native` is used unconditionally when generating dependency filenames. This is correct on Windows, where backslashes are valid path separators, but can be incorrect on non-Windows platforms, because in that case backslashes in the filenames are converted to forward slashes, while they should be treated as ordinary characters.

This fixes the following inconsistency between `ld.lld` and `ld.bfd`:

```console
$ cat test.s
.globl _start
_start:
$ cc -c test.s -o "back\\slash.o"
$ ld.lld -o test "back\\slash.o" --dependency-file=/dev/stdout
test: \
 back/slash.o

back/slash.o:
$ ld.bfd -o test "back\\slash.o" --dependency-file=/dev/stdout
test: \
  back\slash.o

back\slash.o:
```

In addition, while we're here, use 2-space indentation when printing out dependency filenames (consistent with Clang and `ld.bfd`), and escape the target filename too.

See also:

- https://github.com/llvm/llvm-project/pull/160834
- https://github.com/llvm/llvm-project/pull/160903

If these PRs are accepted then I'll try to extract the logic into a new `llvm/support` helper class. These changes are presented as separate PRs because each of them change the behavior slightly differently.
