### PR TITLE
[LLDB] Handle i686 mingw32 mangling prefix

### DIFF
--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -63,6 +63,10 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
   if (name.starts_with("_Z"))
     return Mangled::eManglingSchemeItanium;
 
+  // __Z is used on i686 mingw32
+  if (name.starts_with("__Z"))
+    return Mangled::eManglingSchemeItanium;
+
   // ___Z is a clang extension of block invocations
   if (name.starts_with("___Z"))
     return Mangled::eManglingSchemeItanium;

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -114,6 +114,23 @@ TEST(MangledTest, SameForInvalidDLangPrefixedName) {
   EXPECT_STREQ("_DDD", the_demangled.GetCString());
 }
 
+TEST(MangledTest, ResultForValidMingw32Name) {
+  ConstString mangled_name("__Z7recursei");
+  Mangled the_mangled(mangled_name);
+  ConstString the_demangled = the_mangled.GetDemangledName();
+
+  ConstString expected_result("recurse(int)");
+  EXPECT_STREQ(expected_result.GetCString(), the_demangled.GetCString());
+}
+
+TEST(MangledTest, EmptyForInvalidMingw32Name) {
+  ConstString mangled_name("__Zzrecursei");
+  Mangled the_mangled(mangled_name);
+  ConstString the_demangled = the_mangled.GetDemangledName();
+
+  EXPECT_STREQ("", the_demangled.GetCString());
+}
+
 TEST(MangledTest, RecognizeSwiftMangledNames) {
   llvm::StringRef valid_swift_mangled_names[] = {
       "_TtC4main7MyClass",   // Mangled objc class name


### PR DESCRIPTION
On i686 mingw32, `__Z` is used instead of `_Z`. `Mangled` didn't handle this and assumed the given string is not mangled.

Found in https://github.com/llvm/llvm-project/pull/149701#issuecomment-3333291102.