### PR TITLE
Revert "[compiler-rt] Fix some tests to work with lit internal shell."

### DIFF
--- a/compiler-rt/test/fuzzer/fork-sigusr.test
+++ b/compiler-rt/test/fuzzer/fork-sigusr.test
@@ -1,16 +1,14 @@
 # Check that libFuzzer honors SIGUSR1/SIGUSR2
 # Disabled on Windows which does not have SIGUSR1/SIGUSR2.
+REQUIRES: shell
 UNSUPPORTED: darwin, target={{.*windows.*}}, target=aarch64{{.*}}
 RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %cpp_compiler %S/SleepOneSecondTest.cpp -o %t/ForkSIGUSR
 
-# The line below needs the " | env" at the end, in order to make the
-# script continue executing, rather than waiting (forever) for the
-# 'nohup run...' command to finish.
-RUN: bash -c "nohup %run %t/ForkSIGUSR -fork=3 -ignore_crashes=1 2>%t/log & echo -n $! > %t2" | env
+RUN: %run %t/ForkSIGUSR -fork=3 -ignore_crashes=1 2>%t/log & export PID=$!
 RUN: sleep 3
-RUN: kill -SIGUSR2 %{readfile:%t2}
+RUN: kill -SIGUSR2 $PID
 RUN: sleep 6
 RUN: cat %t/log | FileCheck %s --dump-input=fail
 

--- a/compiler-rt/test/fuzzer/sigint.test
+++ b/compiler-rt/test/fuzzer/sigint.test
@@ -1,4 +1,4 @@
-REQUIRES: msan
+REQUIRES: shell, msan
 UNSUPPORTED: target=arm{{.*}}
 
 # Check that libFuzzer exits gracefully under SIGINT with MSan.
@@ -6,12 +6,9 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %msan_compiler %S/SleepOneSecondTest.cpp -o %t/LFSIGINT
 
-# The line below needs the " | env" at the end, in order to make the
-# script continue executing, rather than waiting (forever) for the
-# 'nohup run...' command to finish.
-RUN: bash -c "nohup %run %t/LFSIGINT 2> %t/log & echo -n $! > %t2" | env
+RUN: %run %t/LFSIGINT 2> %t/log & export PID=$!
 RUN: sleep 2
-RUN: kill -SIGINT %{readfile:%t2}
+RUN: kill -SIGINT $PID
 RUN: sleep 3
 RUN: cat %t/log | FileCheck %s
 

--- a/compiler-rt/test/fuzzer/sigusr.test
+++ b/compiler-rt/test/fuzzer/sigusr.test
@@ -1,17 +1,15 @@
 # FIXME: Disabled on Windows for now because of reliance on posix only features
 # (eg: export, "&", pkill).
+REQUIRES: shell
 UNSUPPORTED: darwin, target={{.*windows.*}}
 # Check that libFuzzer honors SIGUSR1/SIGUSR2
 RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %cpp_compiler %S/SleepOneSecondTest.cpp -o %t/LFSIGUSR
 
-# The line below needs the " | env" at the end, in order to make the
-# script continue executing, rather than waiting (forever) for the
-# 'nohup run...' command to finish.
-RUN: bash -c "nohup %run %t/LFSIGUSR 2> %t/log & echo -n $! > %t2"| env
+RUN: %run %t/LFSIGUSR 2> %t/log & export PID=$!
 RUN: sleep 2
-RUN: kill -SIGUSR1 %{readfile:%t2}
+RUN: kill -SIGUSR1 $PID
 RUN: sleep 3
 RUN: cat %t/log | FileCheck %s
 

--- a/compiler-rt/test/msan/allocator_mapping.cpp
+++ b/compiler-rt/test/msan/allocator_mapping.cpp
@@ -3,8 +3,7 @@
 // mapping the heap early, in __msan_init.
 //
 // RUN: %clangxx_msan -O0 %s -o %t_1
-// RUN: %run %t_1 > %t_3
-// RUN: %clangxx_msan -O0 -DHEAP_ADDRESS=%{readfile:%t_3} %s -o %t_2 && %run %t_2
+// RUN: %clangxx_msan -O0 -DHEAP_ADDRESS=$(%run %t_1) %s -o %t_2 && %run %t_2
 //
 // This test only makes sense for the 64-bit allocator. The 32-bit allocator
 // does not have a fixed mapping. Exclude platforms that use the 32-bit

--- a/compiler-rt/test/nsan/Posix/allocator_mapping.cpp
+++ b/compiler-rt/test/nsan/Posix/allocator_mapping.cpp
@@ -2,8 +2,7 @@
 /// Test that a module constructor can not map memory over the NSan heap
 /// (without MAP_FIXED, of course).
 // RUN: %clangxx_nsan -O0 %s -o %t_1
-// RUN: %run %t_1 > %t_3
-// RUN: %clangxx_nsan -O0 -DHEAP_ADDRESS=%{readfile:%t_3} %s -o %t_2 && %run %t_2
+// RUN: %clangxx_nsan -O0 -DHEAP_ADDRESS=$(%run %t_1) %s -o %t_2 && %run %t_2
 
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
Reverts llvm/llvm-project#160728

That appeared to be causing a buildbot failure; reverting this change while I investigate.

https://lab.llvm.org/buildbot/#/builders/174/builds/25130