### PR TITLE
[debugserver] Support for `qMemTags` packet

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/cpu_feature.py
+++ b/lldb/packages/Python/lldbsuite/test/cpu_feature.py
@@ -62,7 +62,7 @@ class CPUFeature:
 class AArch64:
     FPMR = CPUFeature("fpmr")
     GCS = CPUFeature("gcs")
-    MTE = CPUFeature("mte")
+    MTE = CPUFeature("mte", "hw.optional.arm.FEAT_MTE4")
     MTE_STORE_ONLY = CPUFeature("mtestoreonly")
     PTR_AUTH = CPUFeature("paca", "hw.optional.arm.FEAT_PAuth2")
     SME = CPUFeature("sme", "hw.optional.arm.FEAT_SME")

--- a/lldb/test/API/macosx/mte/Makefile
+++ b/lldb/test/API/macosx/mte/Makefile
@@ -1,0 +1,12 @@
+C_SOURCES := main.c
+
+EXE := uaf_mte
+
+all: uaf_mte sign
+
+include Makefile.rules
+
+sign: mte-entitlements.plist uaf_mte
+ifeq ($(OS),Darwin)
+	codesign -s - -f --entitlements $^
+endif

--- a/lldb/test/API/macosx/mte/TestDarwinMTE.py
+++ b/lldb/test/API/macosx/mte/TestDarwinMTE.py
@@ -33,6 +33,23 @@ class TestDarwinMTE(TestBase):
         )
 
     @skipUnlessFeature(cpu_feature.AArch64.MTE)
+    def test_memory_region(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// before free", lldb.SBFileSpec("main.c"), exe_name=exe_name
+        )
+
+        # (lldb) memory region ptr
+        # [0x00000001005ec000-0x00000001009ec000) rw-
+        # memory tagging: enabled
+        # Modified memory (dirty) page list provided, 2 entries.
+        # Dirty pages: 0x1005ec000, 0x1005fc000.
+        self.expect(
+            "memory region ptr",
+            substrs=[") rw-", "memory tagging: enabled"]
+        )
+
+    @skipUnlessFeature(cpu_feature.AArch64.MTE)
     def test_memory_read_with_tags(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/macosx/mte/TestDarwinMTE.py
+++ b/lldb/test/API/macosx/mte/TestDarwinMTE.py
@@ -44,10 +44,7 @@ class TestDarwinMTE(TestBase):
         # memory tagging: enabled
         # Modified memory (dirty) page list provided, 2 entries.
         # Dirty pages: 0x1005ec000, 0x1005fc000.
-        self.expect(
-            "memory region ptr",
-            substrs=[") rw-", "memory tagging: enabled"]
-        )
+        self.expect("memory region ptr", substrs=["memory tagging: enabled"])
 
     @skipUnlessFeature(cpu_feature.AArch64.MTE)
     def test_memory_read_with_tags(self):

--- a/lldb/test/API/macosx/mte/TestDarwinMTE.py
+++ b/lldb/test/API/macosx/mte/TestDarwinMTE.py
@@ -1,0 +1,90 @@
+"""Test MTE Memory Tagging on Apple platforms"""
+
+import lldb
+import re
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+import lldbsuite.test.cpu_feature as cpu_feature
+
+exe_name = "uaf_mte"  # Must match Makefile
+
+
+class TestDarwinMTE(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipUnlessFeature(cpu_feature.AArch64.MTE)
+    def test_tag_fault(self):
+        self.build()
+        exe = self.getBuildArtifact(exe_name)
+
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        process = target.LaunchSimple(None, None, None)
+        self.assertState(process.GetState(), lldb.eStateStopped, PROCESS_STOPPED)
+
+        self.expect(
+            "thread info",
+            substrs=["stop reason = EXC_ARM_MTE_TAG_FAULT", "MTE tag mismatch detected"],
+        )
+
+    @skipUnlessFeature(cpu_feature.AArch64.MTE)
+    def test_memory_read_with_tags(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// before free", lldb.SBFileSpec("main.c"), exe_name=exe_name
+        )
+
+        # (lldb) memory read ptr-16 ptr+48 --show-tags
+        # 0x7d2c00930: 00 00 00 00 00 00 00 00 d0 e3 a5 0a 02 00 00 00  ................ (tag: 0x3)
+        # 0x7d2c00940: 48 65 6c 6c 6f 00 00 00 00 00 00 00 00 00 00 00  Hello........... (tag: 0xb)
+        # 0x7d2c00950: 57 6f 72 6c 64 00 00 00 00 00 00 00 00 00 00 00  World........... (tag: 0xb)
+        # 0x7d2c00960: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................ (tag: 0x9)
+        self.expect(
+            "memory read ptr-16 ptr+48 --show-tags",
+            substrs=[" Hello...........", " World..........."],
+            patterns=[r"(.*\(tag: 0x[0-9a-f]\)\n){4}"])
+
+    def _parse_pointer_tag(self):
+        return re.search(r"Logical tag: (0x[0-9a-f])", self.res.GetOutput()).group(1)
+
+    def _parse_memory_tags(self, expected_tag_count):
+        tags = re.findall(r"\): (0x[0-9a-f])", self.res.GetOutput())
+        self.assertEqual(len(tags), expected_tag_count)
+        return tags
+
+    @skipUnlessFeature(cpu_feature.AArch64.MTE)
+    def test_memory_tag_read(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// before free", lldb.SBFileSpec("main.c"), exe_name=exe_name
+        )
+
+        # (lldb) memory tag read ptr-1 ptr+33
+        # Logical tag: 0x5
+        # Allocation tags:
+        # [0x100a65a40, 0x100a65a50): 0xf (mismatch)
+        # [0x100a65a50, 0x100a65a60): 0x5
+        # [0x100a65a60, 0x100a65a70): 0x5
+        # [0x100a65a70, 0x100a65a80): 0x2 (mismatch)
+        self.expect(
+            "memory tag read ptr-1 ptr+33",
+            substrs=["Logical tag: 0x", "Allocation tags:", "(mismatch)"],
+            patterns=[r"(\[.*\): 0x[0-9a-f].*\n){4}"]
+        )
+        self.assertEqual(self.res.GetOutput().count("(mismatch)"), 2)
+        ptr_tag = self._parse_pointer_tag()
+        tags = self._parse_memory_tags(4)
+        self.assertEqual(tags[1], ptr_tag)
+        self.assertEqual(tags[2], ptr_tag)
+        self.assertNotEqual(tags[0], ptr_tag)
+        self.assertNotEqual(tags[3], ptr_tag)
+
+        # Continue running until MTE fault
+        self.runCmd("process continue")
+
+        self.runCmd("memory tag read ptr-1 ptr+33")
+        self.assertEqual(self.res.GetOutput().count("(mismatch)"), 4)
+        tags = self._parse_memory_tags(4)
+        self.assertTrue(all(t != ptr_tag for t in tags))

--- a/lldb/test/API/macosx/mte/TestDarwinMTE.py
+++ b/lldb/test/API/macosx/mte/TestDarwinMTE.py
@@ -26,7 +26,10 @@ class TestDarwinMTE(TestBase):
 
         self.expect(
             "thread info",
-            substrs=["stop reason = EXC_ARM_MTE_TAG_FAULT", "MTE tag mismatch detected"],
+            substrs=[
+                "stop reason = EXC_ARM_MTE_TAG_FAULT",
+                "MTE tag mismatch detected",
+            ],
         )
 
     @skipUnlessFeature(cpu_feature.AArch64.MTE)
@@ -44,7 +47,8 @@ class TestDarwinMTE(TestBase):
         self.expect(
             "memory read ptr-16 ptr+48 --show-tags",
             substrs=[" Hello...........", " World..........."],
-            patterns=[r"(.*\(tag: 0x[0-9a-f]\)\n){4}"])
+            patterns=[r"(.*\(tag: 0x[0-9a-f]\)\n){4}"],
+        )
 
     def _parse_pointer_tag(self):
         return re.search(r"Logical tag: (0x[0-9a-f])", self.res.GetOutput()).group(1)
@@ -71,7 +75,7 @@ class TestDarwinMTE(TestBase):
         self.expect(
             "memory tag read ptr-1 ptr+33",
             substrs=["Logical tag: 0x", "Allocation tags:", "(mismatch)"],
-            patterns=[r"(\[.*\): 0x[0-9a-f].*\n){4}"]
+            patterns=[r"(\[.*\): 0x[0-9a-f].*\n){4}"],
         )
         self.assertEqual(self.res.GetOutput().count("(mismatch)"), 2)
         ptr_tag = self._parse_pointer_tag()

--- a/lldb/test/API/macosx/mte/main.c
+++ b/lldb/test/API/macosx/mte/main.c
@@ -5,21 +5,20 @@
 
 // Produce some names on the trace
 const size_t tag_granule = 16;
-uint8_t *my_malloc(void) { return malloc(2 * tag_granule); }
-uint8_t *allocate(void) { return my_malloc(); }
+static uint8_t *my_malloc(void) { return malloc(2 * tag_granule); }
+static uint8_t *allocate(void) { return my_malloc(); }
 
-void my_free(void *ptr) { free(ptr); }
-void deallocate(void *ptr) { my_free(ptr); }
+static void my_free(void *ptr) { free(ptr); }
+static void deallocate(void *ptr) { my_free(ptr); }
 
-void touch_memory(uint8_t *ptr) { ptr[7] = 1; } // invalid access
-void modify(uint8_t *ptr) { touch_memory(ptr); }
+static void touch_memory(uint8_t *ptr) { ptr[7] = 1; } // invalid access
+static void modify(uint8_t *ptr) { touch_memory(ptr); }
 
 int main() {
   uint8_t *ptr = allocate();
-  printf("ptr: %p\n", ptr);
 
-  strcpy((char *)ptr, "Hello");
-  strcpy((char *)ptr + 16, "World");
+  strncpy((char *)ptr, "Hello", 16);
+  strncpy((char *)ptr + 16, "World", 16);
 
   deallocate(ptr); // before free
 

--- a/lldb/test/API/macosx/mte/main.c
+++ b/lldb/test/API/macosx/mte/main.c
@@ -11,7 +11,7 @@ uint8_t *allocate(void) { return my_malloc(); }
 void my_free(void *ptr) { free(ptr); }
 void deallocate(void *ptr) { my_free(ptr); }
 
-void touch_memory(uint8_t *ptr) { ptr[7] = 1; }  // invalid access
+void touch_memory(uint8_t *ptr) { ptr[7] = 1; } // invalid access
 void modify(uint8_t *ptr) { touch_memory(ptr); }
 
 int main() {
@@ -19,11 +19,11 @@ int main() {
   printf("ptr: %p\n", ptr);
 
   strcpy((char *)ptr, "Hello");
-  strcpy((char *)ptr+16, "World");
+  strcpy((char *)ptr + 16, "World");
 
-  deallocate(ptr);  // before free
+  deallocate(ptr); // before free
 
-  modify(ptr);  // use-after-free
+  modify(ptr); // use-after-free
 
   return 0;
 }

--- a/lldb/test/API/macosx/mte/main.c
+++ b/lldb/test/API/macosx/mte/main.c
@@ -1,0 +1,29 @@
+#include <malloc/malloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Produce some names on the trace
+const size_t tag_granule = 16;
+uint8_t *my_malloc(void) { return malloc(2 * tag_granule); }
+uint8_t *allocate(void) { return my_malloc(); }
+
+void my_free(void *ptr) { free(ptr); }
+void deallocate(void *ptr) { my_free(ptr); }
+
+void touch_memory(uint8_t *ptr) { ptr[7] = 1; }  // invalid access
+void modify(uint8_t *ptr) { touch_memory(ptr); }
+
+int main() {
+  uint8_t *ptr = allocate();
+  printf("ptr: %p\n", ptr);
+
+  strcpy((char *)ptr, "Hello");
+  strcpy((char *)ptr+16, "World");
+
+  deallocate(ptr);  // before free
+
+  modify(ptr);  // use-after-free
+
+  return 0;
+}

--- a/lldb/test/API/macosx/mte/mte-entitlements.plist
+++ b/lldb/test/API/macosx/mte/mte-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hardened-process</key>
+    <true/>
+    <key>com.apple.security.hardened-process.checked-allocations</key>
+    <true/>
+</dict>
+</plist>

--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1386,6 +1386,16 @@ int DNBProcessMemoryRegionInfo(nub_process_t pid, nub_addr_t addr,
   return -1;
 }
 
+nub_bool_t DNBProcessGetMemoryTags(nub_process_t pid, nub_addr_t addr,
+                                   nub_size_t size,
+                                   std::vector<uint8_t> &tags) {
+  MachProcessSP procSP;
+  if (GetProcessSP(pid, procSP))
+    return procSP->Task().GetMemoryTags(addr, size, tags);
+
+  return false;
+}
+
 std::string DNBProcessGetProfileData(nub_process_t pid,
                                      DNBProfileDataScanType scanType) {
   MachProcessSP procSP;

--- a/lldb/tools/debugserver/source/DNB.h
+++ b/lldb/tools/debugserver/source/DNB.h
@@ -105,6 +105,9 @@ nub_bool_t DNBProcessMemoryDeallocate(nub_process_t pid,
                                       nub_addr_t addr) DNB_EXPORT;
 int DNBProcessMemoryRegionInfo(nub_process_t pid, nub_addr_t addr,
                                DNBRegionInfo *region_info) DNB_EXPORT;
+nub_bool_t DNBProcessGetMemoryTags(nub_process_t pid, nub_addr_t addr,
+                                   nub_size_t size,
+                                   std::vector<uint8_t> &tags) DNB_EXPORT;
 std::string
 DNBProcessGetProfileData(nub_process_t pid,
                          DNBProfileDataScanType scanType) DNB_EXPORT;

--- a/lldb/tools/debugserver/source/DNBDefs.h
+++ b/lldb/tools/debugserver/source/DNBDefs.h
@@ -358,10 +358,11 @@ struct DNBExecutableImageInfo {
 struct DNBRegionInfo {
 public:
   DNBRegionInfo()
-      : addr(0), size(0), permissions(0), dirty_pages(), vm_types() {}
+      : addr(0), size(0), permissions(0), flags(), dirty_pages(), vm_types() {}
   nub_addr_t addr;
   nub_addr_t size;
   uint32_t permissions;
+  std::vector<std::string> flags;
   std::vector<nub_addr_t> dirty_pages;
   std::vector<std::string> vm_types;
 };

--- a/lldb/tools/debugserver/source/MacOSX/MachTask.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.h
@@ -56,6 +56,8 @@ public:
   nub_size_t ReadMemory(nub_addr_t addr, nub_size_t size, void *buf);
   nub_size_t WriteMemory(nub_addr_t addr, nub_size_t size, const void *buf);
   int GetMemoryRegionInfo(nub_addr_t addr, DNBRegionInfo *region_info);
+  nub_bool_t GetMemoryTags(nub_addr_t addr, nub_size_t size,
+                           std::vector<uint8_t> &tags);
   std::string GetProfileData(DNBProfileDataScanType scanType);
 
   nub_addr_t AllocateMemory(nub_size_t size, uint32_t permissions);

--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -213,7 +213,7 @@ nub_size_t MachTask::WriteMemory(nub_addr_t addr, nub_size_t size,
 }
 
 //----------------------------------------------------------------------
-// MachTask::GetMemoryRegionInfo
+// MachTask::MemoryRegionInfo
 //----------------------------------------------------------------------
 int MachTask::GetMemoryRegionInfo(nub_addr_t addr, DNBRegionInfo *region_info) {
   task_t task = TaskPort();
@@ -221,7 +221,7 @@ int MachTask::GetMemoryRegionInfo(nub_addr_t addr, DNBRegionInfo *region_info) {
     return -1;
 
   int ret = m_vm_memory.GetMemoryRegionInfo(task, addr, region_info);
-  DNBLogThreadedIf(LOG_MEMORY, "MachTask::GetMemoryRegionInfo ( addr = 0x%8.8llx "
+  DNBLogThreadedIf(LOG_MEMORY, "MachTask::MemoryRegionInfo ( addr = 0x%8.8llx "
                                ") => %i  (start = 0x%8.8llx, size = 0x%8.8llx, "
                                "permissions = %u)",
                    (uint64_t)addr, ret, (uint64_t)region_info->addr,

--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -213,7 +213,7 @@ nub_size_t MachTask::WriteMemory(nub_addr_t addr, nub_size_t size,
 }
 
 //----------------------------------------------------------------------
-// MachTask::MemoryRegionInfo
+// MachTask::GetMemoryRegionInfo
 //----------------------------------------------------------------------
 int MachTask::GetMemoryRegionInfo(nub_addr_t addr, DNBRegionInfo *region_info) {
   task_t task = TaskPort();
@@ -221,12 +221,29 @@ int MachTask::GetMemoryRegionInfo(nub_addr_t addr, DNBRegionInfo *region_info) {
     return -1;
 
   int ret = m_vm_memory.GetMemoryRegionInfo(task, addr, region_info);
-  DNBLogThreadedIf(LOG_MEMORY, "MachTask::MemoryRegionInfo ( addr = 0x%8.8llx "
+  DNBLogThreadedIf(LOG_MEMORY, "MachTask::GetMemoryRegionInfo ( addr = 0x%8.8llx "
                                ") => %i  (start = 0x%8.8llx, size = 0x%8.8llx, "
                                "permissions = %u)",
                    (uint64_t)addr, ret, (uint64_t)region_info->addr,
                    (uint64_t)region_info->size, region_info->permissions);
   return ret;
+}
+
+//----------------------------------------------------------------------
+// MachTask::GetMemoryTags
+//----------------------------------------------------------------------
+nub_bool_t MachTask::GetMemoryTags(nub_addr_t addr, nub_size_t size,
+                                   std::vector<uint8_t> &tags) {
+  task_t task = TaskPort();
+  if (task == TASK_NULL)
+    return false;
+
+  bool ok = m_vm_memory.GetMemoryTags(task, addr, size, tags);
+  DNBLogThreadedIf(LOG_MEMORY, "MachTask::GetMemoryTags ( addr = 0x%8.8llx, "
+                               "size = 0x%8.8llx ) => %s ( tag count = %llu)",
+                  (uint64_t)addr, (uint64_t)size, (ok ? "ok" : "err"),
+                  (uint64_t)tags.size());
+  return ok;
 }
 
 #define TIME_VALUE_TO_TIMEVAL(a, r)                                            \

--- a/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
@@ -173,11 +173,11 @@ nub_bool_t MachVMMemory::GetMemoryTags(task_t task, nub_addr_t address,
           RTLD_DEFAULT, "mach_vm_update_pointers_with_remote_tags");
   assert(mach_vm_update_pointers_with_remote_tags);
 
-  // Max batch size supported by mach_vm_update_pointers_with_remote_tags()
+  // Max batch size supported by mach_vm_update_pointers_with_remote_tags.
   constexpr uint32_t max_ptr_count = VM_OFFSET_LIST_MAX;
   constexpr uint32_t tag_shift = 56;
   constexpr nub_addr_t tag_mask =
-      ((nub_addr_t)0x0f << tag_shift); // Lower half of top byte
+      ((nub_addr_t)0x0f << tag_shift); // Lower half of top byte.
   constexpr uint32_t tag_granule = 16;
 
   mach_msg_type_number_t ptr_count =

--- a/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
@@ -172,10 +172,9 @@ nub_bool_t MachVMMemory::GetMemoryTags(task_t task, nub_addr_t address,
       (size / tag_granule) + ((size % tag_granule > 0) ? 1 : 0);
   ptr_count = std::min(ptr_count, max_ptr_count);
 
-  auto ptr_arr = std::make_unique<nub_addr_t[]>(ptr_count);
-  for (size_t i = 0; i < ptr_count; i++) {
+  auto ptr_arr = std::make_unique<mach_vm_offset_t[]>(ptr_count);
+  for (size_t i = 0; i < ptr_count; i++)
     ptr_arr[i] = (address + i * tag_granule);
-  }
 
   mach_msg_type_number_t ptr_count_out = ptr_count;
   m_err = ::mach_vm_update_pointers_with_remote_tags(

--- a/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
@@ -151,6 +151,53 @@ nub_bool_t MachVMMemory::GetMemoryRegionInfo(task_t task, nub_addr_t address,
   return true;
 }
 
+// API availability:
+//  mach_vm_update_pointers_with_remote_tags() - 26.0
+//  VM_OFFSET_LIST_MAX macro - 26.1
+#ifndef VM_OFFSET_LIST_MAX
+#define VM_OFFSET_LIST_MAX 512
+#endif
+nub_bool_t MachVMMemory::GetMemoryTags(task_t task, nub_addr_t address,
+                                       nub_size_t size,
+                                       std::vector<uint8_t> &tags) {
+  // Max batch size supported by mach_vm_update_pointers_with_remote_tags()
+  constexpr uint32_t max_ptr_count = VM_OFFSET_LIST_MAX;
+
+  constexpr uint32_t tag_shift = 56;
+  constexpr nub_addr_t tag_mask =
+      ((nub_addr_t)0x0f << tag_shift); // Lower half of top byte
+  constexpr uint32_t tag_granule = 16;
+
+  mach_msg_type_number_t ptr_count =
+      (size / tag_granule) + ((size % tag_granule > 0) ? 1 : 0);
+  ptr_count = std::min(ptr_count, max_ptr_count);
+
+  auto ptr_arr = std::make_unique<nub_addr_t[]>(ptr_count);
+  for (size_t i = 0; i < ptr_count; i++) {
+    ptr_arr[i] = (address + i * tag_granule);
+  }
+
+  mach_msg_type_number_t ptr_count_out = ptr_count;
+  m_err = ::mach_vm_update_pointers_with_remote_tags(
+      task, ptr_arr.get(), ptr_count, ptr_arr.get(), &ptr_count_out);
+
+  const bool failed = (m_err.Fail() || (ptr_count != ptr_count_out));
+  if (failed || DNBLogCheckLogBit(LOG_MEMORY))
+    m_err.LogThreaded("::mach_vm_update_pointers_with_remote_tags ( task = "
+                      "0x%4.4x, ptr_count = %d ) => %i ( ptr_count_out = %d)",
+                      task, ptr_count, m_err.Status(), ptr_count_out);
+  if (failed)
+    return false;
+
+  tags.reserve(ptr_count);
+  for (size_t i = 0; i < ptr_count; i++) {
+    nub_addr_t tag = (ptr_arr[i] & tag_mask) >> tag_shift;
+    tags.push_back(tag);
+  }
+
+  return true;
+}
+
 static uint64_t GetPhysicalMemory() {
   // This doesn't change often at all. No need to poll each time.
   static uint64_t physical_memory = 0;

--- a/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp
@@ -123,6 +123,7 @@ nub_bool_t MachVMMemory::GetMemoryRegionInfo(task_t task, nub_addr_t address,
     region_info->addr = vmRegion.StartAddress();
     region_info->size = vmRegion.GetByteSize();
     region_info->permissions = vmRegion.GetDNBPermissions();
+    region_info->flags = vmRegion.GetFlags();
     region_info->dirty_pages =
         get_dirty_pages(task, vmRegion.StartAddress(), vmRegion.GetByteSize());
     region_info->vm_types = vmRegion.GetMemoryTypes();

--- a/lldb/tools/debugserver/source/MacOSX/MachVMMemory.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMMemory.h
@@ -28,6 +28,8 @@ public:
   nub_size_t PageSize(task_t task);
   nub_bool_t GetMemoryRegionInfo(task_t task, nub_addr_t address,
                                  DNBRegionInfo *region_info);
+  nub_bool_t GetMemoryTags(task_t task, nub_addr_t address, nub_size_t size,
+                           std::vector<uint8_t> &tags);
   nub_bool_t GetMemoryProfile(DNBProfileDataScanType scanType, task_t task,
                               struct task_basic_info ti, cpu_type_t cputype,
                               nub_process_t pid, vm_statistics64_data_t &vminfo,

--- a/lldb/tools/debugserver/source/MacOSX/MachVMRegion.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMRegion.cpp
@@ -152,12 +152,13 @@ bool MachVMRegion::GetRegionForAddress(nub_addr_t addr) {
                    "is_submap = %d, "
                    "behavior = %d, "
                    "object_id = 0x%8.8x, "
-                   "user_wired_count = 0x%4.4x }",
+                   "user_wired_count = 0x%4.4x, "
+                   "flags = %d }",
                    m_data.protection, m_data.max_protection, m_data.inheritance,
                    (uint64_t)m_data.offset, m_data.user_tag, m_data.ref_count,
                    m_data.shadow_depth, m_data.external_pager,
                    m_data.share_mode, m_data.is_submap, m_data.behavior,
-                   m_data.object_id, m_data.user_wired_count);
+                   m_data.object_id, m_data.user_wired_count, m_data.flags);
   }
   m_curr_protection = m_data.protection;
 
@@ -181,6 +182,20 @@ uint32_t MachVMRegion::GetDNBPermissions() const {
   if ((m_data.protection & VM_PROT_EXECUTE) == VM_PROT_EXECUTE)
     dnb_permissions |= eMemoryPermissionsExecutable;
   return dnb_permissions;
+}
+
+#ifndef VM_REGION_FLAG_MTE_ENABLED
+#define VM_REGION_FLAG_MTE_ENABLED 0x4
+#endif
+std::vector<std::string> MachVMRegion::GetFlags() const {
+  std::vector<std::string> flags;
+  if (m_data.flags & VM_REGION_FLAG_JIT_ENABLED)
+    flags.push_back("jit");
+  if (m_data.flags & VM_REGION_FLAG_TPRO_ENABLED)
+    flags.push_back("tpro");
+  if (m_data.flags & VM_REGION_FLAG_MTE_ENABLED)
+    flags.push_back("mt");
+  return flags;
 }
 
 std::vector<std::string> MachVMRegion::GetMemoryTypes() const {

--- a/lldb/tools/debugserver/source/MacOSX/MachVMRegion.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMRegion.cpp
@@ -114,6 +114,11 @@ bool MachVMRegion::RestoreProtections() {
   return false;
 }
 
+#ifdef VM_REGION_FLAG_JIT_ENABLED
+#define VM_REGION_HAS_FLAGS 1
+#else
+#define VM_REGION_HAS_FLAGS 0
+#endif
 bool MachVMRegion::GetRegionForAddress(nub_addr_t addr) {
   // Restore any original protections and clear our vars
   Clear();
@@ -140,6 +145,7 @@ bool MachVMRegion::GetRegionForAddress(nub_addr_t addr) {
   if (failed)
     return false;
   if (log_protections) {
+#if VM_REGION_HAS_FLAGS
     DNBLogThreaded("info = { prot = %u, "
                    "max_prot = %u, "
                    "inheritance = 0x%8.8x, "
@@ -159,6 +165,29 @@ bool MachVMRegion::GetRegionForAddress(nub_addr_t addr) {
                    m_data.shadow_depth, m_data.external_pager,
                    m_data.share_mode, m_data.is_submap, m_data.behavior,
                    m_data.object_id, m_data.user_wired_count, m_data.flags);
+#else
+    // Duplicate log call instead of #if-defing printing of flags to avoid
+    // compiler warning: 'embedding a directive within macro arguments has
+    // undefined behavior'
+    DNBLogThreaded("info = { prot = %u, "
+                   "max_prot = %u, "
+                   "inheritance = 0x%8.8x, "
+                   "offset = 0x%8.8llx, "
+                   "user_tag = 0x%8.8x, "
+                   "ref_count = %u, "
+                   "shadow_depth = %u, "
+                   "ext_pager = %u, "
+                   "share_mode = %u, "
+                   "is_submap = %d, "
+                   "behavior = %d, "
+                   "object_id = 0x%8.8x, "
+                   "user_wired_count = 0x%4.4x }",
+                   m_data.protection, m_data.max_protection, m_data.inheritance,
+                   (uint64_t)m_data.offset, m_data.user_tag, m_data.ref_count,
+                   m_data.shadow_depth, m_data.external_pager,
+                   m_data.share_mode, m_data.is_submap, m_data.behavior,
+                   m_data.object_id, m_data.user_wired_count);
+#endif
   }
   m_curr_protection = m_data.protection;
 
@@ -189,12 +218,14 @@ uint32_t MachVMRegion::GetDNBPermissions() const {
 #endif
 std::vector<std::string> MachVMRegion::GetFlags() const {
   std::vector<std::string> flags;
+#if VM_REGION_HAS_FLAGS
   if (m_data.flags & VM_REGION_FLAG_JIT_ENABLED)
     flags.push_back("jit");
   if (m_data.flags & VM_REGION_FLAG_TPRO_ENABLED)
     flags.push_back("tpro");
   if (m_data.flags & VM_REGION_FLAG_MTE_ENABLED)
     flags.push_back("mt");
+#endif
   return flags;
 }
 

--- a/lldb/tools/debugserver/source/MacOSX/MachVMRegion.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachVMRegion.h
@@ -40,9 +40,10 @@ public:
                       vm_prot_t prot);
   bool RestoreProtections();
   bool GetRegionForAddress(nub_addr_t addr);
-  std::vector<std::string> GetMemoryTypes() const;
 
   uint32_t GetDNBPermissions() const;
+  std::vector<std::string> GetFlags() const;
+  std::vector<std::string> GetMemoryTypes() const;
 
   const DNBError &GetError() { return m_err; }
 

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -4326,7 +4326,7 @@ rnb_err_t RNBRemote::HandlePacket_MemoryRegionInfo(const char *p) {
       ostrm << "flags:";
       for (size_t i = 0; i < region_info.flags.size(); i++) {
         if (i != 0)
-          ostrm << " ";  // Separator is whitespace
+          ostrm << " "; // Separator is whitespace
         ostrm << region_info.flags[i];
       }
       ostrm << ";";

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -22,7 +22,7 @@
 #include <mach/mach_vm.h>
 #include <mach/task_info.h>
 #include <memory>
-#if __has_include(<os/security_config.h>) // macOS 26.1
+#if __has_include(<os/security_config.h>)
 #include <os/security_config.h>
 #endif
 #include <pwd.h>
@@ -6247,18 +6247,8 @@ GetCPUTypesFromHost(nub_process_t pid) {
   return {cputype, cpusubtype};
 }
 
-#if !__has_include(<os/security_config.h>) // macOS 26.1
-extern "C" {
-using os_security_config_t = uint64_t;
-#define OS_SECURITY_CONFIG_MTE 0x4
-
-API_AVAILABLE(macos(26.0), ios(26.0), tvos(26.0), watchos(26.0), visionos(26.0),
-              driverkit(25.0))
-OS_EXPORT OS_NOTHROW OS_NONNULL_ALL int
-os_security_config_get_for_proc(pid_t pid, os_security_config_t *config);
-}
-#endif
 static bool ProcessRunningWithMemoryTagging(pid_t pid) {
+#if __has_include(<os/security_config.h>)
   if (__builtin_available(macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0,
                           visionOS 26.0, driverkit 25.0, *)) {
     os_security_config_t config;
@@ -6268,6 +6258,7 @@ static bool ProcessRunningWithMemoryTagging(pid_t pid) {
 
     return (config & OS_SECURITY_CONFIG_MTE);
   }
+#endif
   return false;
 }
 

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -4251,7 +4251,6 @@ rnb_err_t RNBRemote::HandlePacket_MemoryRegionInfo(const char *p) {
      is in unmapped memory
          Region lookup cannot be performed on this platform or process is not
      yet launched
-         This packet isn't implemented
 
      Examples of use:
         qMemoryRegionInfo:3a55140
@@ -4302,6 +4301,16 @@ rnb_err_t RNBRemote::HandlePacket_MemoryRegionInfo(const char *p) {
     if (region_info.permissions & eMemoryPermissionsExecutable)
       ostrm << 'x';
     ostrm << ';';
+
+    if (!region_info.flags.empty()) {
+      ostrm << "flags:";
+      for (size_t i = 0; i < region_info.flags.size(); i++) {
+        if (i != 0)
+          ostrm << " ";  // Separator is whitespace
+        ostrm << region_info.flags[i];
+      }
+      ostrm << ";";
+    }
 
     ostrm << "dirty-pages:";
     if (region_info.dirty_pages.size() > 0) {

--- a/lldb/tools/debugserver/source/RNBRemote.h
+++ b/lldb/tools/debugserver/source/RNBRemote.h
@@ -121,6 +121,7 @@ public:
     set_list_threads_in_stop_reply,     // 'QListThreadsInStopReply:'
     sync_thread_state,                  // 'QSyncThreadState:'
     memory_region_info,                 // 'qMemoryRegionInfo:'
+    get_memory_tags,                    // 'qMemTags:'
     get_profile_data,                   // 'qGetProfileData'
     set_enable_profiling,               // 'QSetEnableAsyncProfiling'
     enable_compression,                 // 'QEnableCompression:'
@@ -237,6 +238,7 @@ public:
   rnb_err_t HandlePacket_SaveRegisterState(const char *p);
   rnb_err_t HandlePacket_RestoreRegisterState(const char *p);
   rnb_err_t HandlePacket_MemoryRegionInfo(const char *p);
+  rnb_err_t HandlePacket_qMemTags(const char *p);
   rnb_err_t HandlePacket_GetProfileData(const char *p);
   rnb_err_t HandlePacket_SetEnableAsyncProfiling(const char *p);
   rnb_err_t HandlePacket_QEnableCompression(const char *p);


### PR DESCRIPTION
Support for `qMemTags` packet in debugserver which allows usage of LLDB's `memory tag read` on Darwin.