### PR TITLE
[clang-tidy] Add IgnoredRegex to 'bugprone-suspicious-include'

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
@@ -31,7 +31,7 @@ public:
 
   FileExtensionsSet HeaderFileExtensions;
   FileExtensionsSet ImplementationFileExtensions;
-  std::optional<StringRef> IgnoredRegexString;
+  StringRef IgnoredRegexString;
   llvm::Regex IgnoredRegex;
 };
 

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
@@ -31,7 +31,8 @@ public:
 
   FileExtensionsSet HeaderFileExtensions;
   FileExtensionsSet ImplementationFileExtensions;
-  std::optional<StringRef> IgnoredRegex;
+  std::optional<StringRef> IgnoredRegexString;
+  llvm::Regex IgnoredRegex;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
@@ -10,7 +10,6 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_SUSPICIOUSINCLUDECHECK_H
 
 #include "../ClangTidyCheck.h"
-#include "../utils/FileExtensionsUtils.h"
 
 namespace clang::tidy::bugprone {
 
@@ -28,9 +27,11 @@ public:
   SuspiciousIncludeCheck(StringRef Name, ClangTidyContext *Context);
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 
   FileExtensionsSet HeaderFileExtensions;
   FileExtensionsSet ImplementationFileExtensions;
+  std::optional<StringRef> IgnoredRegex;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -259,6 +259,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/sizeof-expression>` check by fixing
   a crash on ``sizeof`` of an array of dependent type.
 
+- Improved :doc:`bugprone-suspicious-include
+  <clang-tidy/checks/bugprone/suspicious-include>` check by adding
+  `IgnoredRegex` option.
+
 - Improved :doc:`bugprone-tagged-union-member-count
   <clang-tidy/checks/bugprone/tagged-union-member-count>` by fixing a false
   positive when enums or unions from system header files or the ``std``
@@ -363,10 +367,6 @@ Changes in existing checks
 - Improved :doc:`readability-uppercase-literal-suffix
   <clang-tidy/checks/readability/uppercase-literal-suffix>` check to recognize
   literal suffixes added in C++23 and C23.
-
-- Improved :doc:`bugprone-suspicious-include
-  <clang-tidy/checks/bugprone/suspicious-include>` check by adding
-  ``IgnoredRegex`` option.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -364,6 +364,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/uppercase-literal-suffix>` check to recognize
   literal suffixes added in C++23 and C23.
 
+- Improved :doc:`bugprone-suspicious-include
+  <clang-tidy/checks/bugprone/suspicious-include>` check by adding
+  ``IgnoredRegex`` option.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
@@ -21,5 +21,5 @@ Options
 .. option::  IgnoredRegex
 
    A regular expression for the file name to be ignored by the check. Default
-   is no regular expression.
+   is empty string.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
@@ -22,4 +22,3 @@ Options
 
    A regular expression for the file name to be ignored by the check. Default
    is empty string.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
@@ -14,3 +14,12 @@ Examples:
   #include "Pterodactyl.h"    // OK, .h files tend not to have definitions.
   #include "Velociraptor.cpp" // Warning, filename is suspicious.
   #include_next <stdio.c>     // Warning, filename is suspicious.
+
+Options
+-------
+
+.. option::  IgnoredRegex
+
+   A regular expression for the file name to be ignored by the check. Default
+   is empty.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
@@ -21,5 +21,5 @@ Options
 .. option::  IgnoredRegex
 
    A regular expression for the file name to be ignored by the check. Default
-   is empty.
+   is no regular expression.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-include.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-include.cpp
@@ -1,4 +1,6 @@
-// RUN: %check_clang_tidy %s bugprone-suspicious-include %t -- -config="{CheckOptions: {bugprone-suspicious-include.IgnoredRegex: 'moc_.*'}"} -- -isystem %clang_tidy_headers -fmodules
+// RUN: %check_clang_tidy %s bugprone-suspicious-include %t -- \
+// RUN:   -config="{CheckOptions: {bugprone-suspicious-include.IgnoredRegex: 'moc_.*'}"} -- \
+// RUN:   -isystem %clang_tidy_headers -fmodules
 
 // clang-format off
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-include.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-include.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-suspicious-include %t -- -- -isystem %clang_tidy_headers -fmodules
+// RUN: %check_clang_tidy %s bugprone-suspicious-include %t -- -config="{CheckOptions: {bugprone-suspicious-include.IgnoredRegex: 'moc_.*'}"} -- -isystem %clang_tidy_headers -fmodules
 
 // clang-format off
 
@@ -22,3 +22,6 @@
 
 // CHECK-MESSAGES: [[@LINE+1]]:14: warning: suspicious #include of file with '.cxx' extension
 #  include  <c.cxx>
+
+// CHECK-MESSAGES-NOT: warning:
+#include "moc_foo.cpp"


### PR DESCRIPTION
The use case is shown in the test: Qt's moc output not to trigger a warning.