### PR TITLE
[WebAssembly] Define llvm-internal WasmEH tags in compiler-rt

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -816,14 +816,15 @@ set(s390x_SOURCES
   ${GENERIC_TF_SOURCES}
 )
 
-set(wasm32_SOURCES
+
+set(wasm_SOURCES
+  wasm/__c_longjmp.S
+  wasm/__cpp_exceptions.S
   ${GENERIC_TF_SOURCES}
   ${GENERIC_SOURCES}
 )
-set(wasm64_SOURCES
-  ${GENERIC_TF_SOURCES}
-  ${GENERIC_SOURCES}
-)
+set(wasm32_SOURCES ${wasm_SOURCES})
+set(wasm64_SOURCES ${wasm_SOURCES})
 
 set(ve_SOURCES
   ve/grow_stack.S

--- a/compiler-rt/lib/builtins/wasm/__c_longjmp.S
+++ b/compiler-rt/lib/builtins/wasm/__c_longjmp.S
@@ -1,0 +1,26 @@
+//===-- __c_longjmp.S - Implement __c_longjmp -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __c_longjmp which LLVM uses to implenmet setjmp/longjmp
+// when Wasm EH is enabled.
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __wasm_exception_handling__
+
+#ifdef __wasm64__
+#define PTR i64
+#else
+#define PTR i32
+#endif
+
+.globl __c_longjmp
+.tagtype __c_longjmp PTR
+__c_longjmp:
+
+#endif // !__wasm_exception_handling__

--- a/compiler-rt/lib/builtins/wasm/__cpp_exception.S
+++ b/compiler-rt/lib/builtins/wasm/__cpp_exception.S
@@ -1,0 +1,26 @@
+//===-- __cpp_exception.S - Implement __cpp_exception ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __cpp_exception which LLVM uses to implement exception
+// handling when Wasm EH is enabled.
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __wasm_exception_handling__
+
+#ifdef __wasm64__
+#define PTR i64
+#else
+#define PTR i32
+#endif
+
+.globl __cpp_exception
+.tagtype __cpp_exception PTR
+__cpp_exception:
+
+#endif // !__wasm_exception_handling__


### PR DESCRIPTION
The `__c_longjmp` and `__cpp_exceptions` tags are used internally by llvm to implement setjmp/longjmp and C++ exception handling respectively.

These symbols were previously defined weakly in each object file but were recently converted to external references in #159143.  They now need to be defined somewhere in the runtime libraries.  I think compiler-rt is likely the most sensible place for them.