### PR TITLE
[clang-tidy][NFC] Do less unnecessary work in `modernize-deprecated-headers`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
@@ -147,8 +147,7 @@ IncludeModernizePPCallbacks::IncludeModernizePPCallbacks(
       {"string.h", "cstring"}, {"time.h", "ctime"},
       {"wchar.h", "cwchar"},   {"wctype.h", "cwctype"},
   };
-  for (const auto &KeyValue : CXX98Headers)
-    CStyledHeaderToCxx.insert(KeyValue);
+  CStyledHeaderToCxx.insert(std::begin(CXX98Headers), std::end(CXX98Headers));
 
   static constexpr std::pair<StringRef, StringRef> CXX11Headers[] = {
       {"fenv.h", "cfenv"},         {"stdint.h", "cstdint"},
@@ -156,13 +155,11 @@ IncludeModernizePPCallbacks::IncludeModernizePPCallbacks(
       {"uchar.h", "cuchar"},
   };
   if (LangOpts.CPlusPlus11)
-    for (const auto &KeyValue : CXX11Headers)
-      CStyledHeaderToCxx.insert(KeyValue);
+    CStyledHeaderToCxx.insert(std::begin(CXX11Headers), std::end(CXX11Headers));
 
   static constexpr StringRef HeadersToDelete[] = {"stdalign.h", "stdbool.h",
                                                   "iso646.h"};
-  for (const auto &Key : HeadersToDelete)
-    DeleteHeaders.insert(Key);
+  DeleteHeaders.insert_range(HeadersToDelete);
 }
 
 void IncludeModernizePPCallbacks::InclusionDirective(

--- a/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.h
@@ -44,7 +44,7 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
   struct IncludeMarker {
-    std::string Replacement;
+    StringRef Replacement;
     StringRef FileName;
     SourceRange ReplacementRange;
     SourceLocation DiagLoc;


### PR DESCRIPTION
- `IncludeModernizePPCallbacks` creates temporary vectors when all it needs is constant arrays
- The header replacement strings are `std::string` when they can just be `StringRef`
- `IncludeModernizePPCallbacks`'s constructor
  1. Takes `LangOptions` by value (the thing is 832 bytes)
  2. Stores it, but none of `IncludeModernizePPCallbacks`'s member functions use it