### PR TITLE
[clang] Fix a use-after free in ASTContext::getSubstBuiltinTemplatePack

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5877,9 +5877,9 @@ ASTContext::getSubstBuiltinTemplatePack(const TemplateArgument &ArgPack) {
     Canon = getSubstBuiltinTemplatePack(CanonArgPack);
     // Refresh InsertPos, in case the recursive call above caused rehashing,
     // which would invalidate the bucket pointer.
-    if (auto *T =
-            SubstBuiltinTemplatePackTypes.FindNodeOrInsertPos(ID, InsertPos))
-      return QualType(T, 0);
+    [[maybe_unused]] const auto *Nothing =
+        SubstBuiltinTemplatePackTypes.FindNodeOrInsertPos(ID, InsertPos);
+    assert(!Nothing);
   }
 
   auto *PackType = new (*this, alignof(SubstBuiltinTemplatePackType))


### PR DESCRIPTION
ASTContext::getSubstBuiltinTemplatePack finds InsertPos and then calls itself
recursively, which may lead to rehashing and invalidation of all pointers to
buckets. The function then proceeds with using the potentially invalid
InsertPos, leading to use-after-free.

The issue goes back to https://github.com/llvm/llvm-project/pull/157662.

I didn't manage to produce a reasonably-sized test case yet.
