### PR TITLE
[MLIR][LivenessAnalysis] Add custom visitCallOperation

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/LivenessAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/LivenessAnalysis.h
@@ -82,6 +82,11 @@ public:
   LogicalResult visitOperation(Operation *op, ArrayRef<Liveness *> operands,
                                ArrayRef<const Liveness *> results) override;
 
+  LogicalResult
+  visitCallOperation(CallOpInterface call,
+                     ArrayRef<Liveness *> operandLattices,
+                     ArrayRef<const Liveness *> resultLattices) override;
+
   void visitBranchOperand(OpOperand &operand) override;
 
   void visitCallOperand(OpOperand &operand) override;

--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -464,6 +464,21 @@ protected:
   visitCallableOperation(Operation *op, CallableOpInterface callable,
                          ArrayRef<AbstractSparseLattice *> operandLattices);
 
+  /// Visits a call operation. Given the result lattices, set the operand lattices.
+  //  Performs interprocedural data flow as follows: if the call
+  /// operation targets an external function, or if the solver is not
+  /// interprocedural, attempts to infer the results from the call arguments
+  /// using the user-provided `visitExternalCallImpl`. Otherwise, computes the
+  /// result lattices from the return sites if all return sites are known;
+  /// otherwise, conservatively marks the result lattices as having reached
+  /// their pessimistic fixpoints.
+  /// This method can be overridden to, for example, be less conservative and
+  /// propagate the information even if some return sites are unknown.
+  virtual LogicalResult
+  visitCallOperation(CallOpInterface call,
+                     ArrayRef<AbstractSparseLattice *> operandLattices,
+                     ArrayRef<const AbstractSparseLattice *> resultLattices);
+
 private:
   /// Recursively initialize the analysis on nested operations and blocks.
   LogicalResult initializeRecursively(Operation *op);

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -495,42 +495,7 @@ AbstractSparseBackwardDataFlowAnalysis::visitOperation(Operation *op) {
   // For function calls, connect the arguments of the entry blocks to the
   // operands of the call op that are forwarded to these arguments.
   if (auto call = dyn_cast<CallOpInterface>(op)) {
-    LDBG() << "Processing CallOpInterface operation";
-    Operation *callableOp = call.resolveCallableInTable(&symbolTable);
-    if (auto callable = dyn_cast_or_null<CallableOpInterface>(callableOp)) {
-      // Not all operands of a call op forward to arguments. Such operands are
-      // stored in `unaccounted`.
-      BitVector unaccounted(op->getNumOperands(), true);
-
-      // If the call invokes an external function (or a function treated as
-      // external due to config), defer to the corresponding extension hook.
-      // By default, it just does `visitCallOperand` for all operands.
-      OperandRange argOperands = call.getArgOperands();
-      MutableArrayRef<OpOperand> argOpOperands =
-          operandsToOpOperands(argOperands);
-      Region *region = callable.getCallableRegion();
-      if (!region || region->empty() ||
-          !getSolverConfig().isInterprocedural()) {
-        visitExternalCallImpl(call, operandLattices, resultLattices);
-        return success();
-      }
-
-      // Otherwise, propagate information from the entry point of the function
-      // back to operands whenever possible.
-      Block &block = region->front();
-      for (auto [blockArg, argOpOperand] :
-           llvm::zip(block.getArguments(), argOpOperands)) {
-        meet(getLatticeElement(argOpOperand.get()),
-             *getLatticeElementFor(getProgramPointAfter(op), blockArg));
-        unaccounted.reset(argOpOperand.getOperandNumber());
-      }
-
-      // Handle the operands of the call op that aren't forwarded to any
-      // arguments.
-      for (int index : unaccounted.set_bits()) {
-        OpOperand &opOperand = op->getOpOperand(index);
-        visitCallOperand(opOperand);
-      }
+    if (visitCallOperation(call, operandLattices, resultLattices).succeeded()) {
       return success();
     }
   }
@@ -586,6 +551,56 @@ LogicalResult AbstractSparseBackwardDataFlowAnalysis::visitCallableOperation(
     setAllToExitStates(operandLattices);
   }
   return success();
+}
+
+LogicalResult AbstractSparseBackwardDataFlowAnalysis::visitCallOperation(
+    CallOpInterface call,
+    ArrayRef<AbstractSparseLattice *> operandLattices,
+    ArrayRef<const AbstractSparseLattice *> resultLattices) {
+    LDBG() << "Processing CallOpInterface operation";
+
+    //  Treat any function as external due to config.
+    if (!getSolverConfig().isInterprocedural()) {
+        visitExternalCallImpl(call, operandLattices, resultLattices);
+        return success();
+    }
+
+    Operation *callableOp = call.resolveCallableInTable(&symbolTable);
+    if (auto callable = dyn_cast_or_null<CallableOpInterface>(callableOp)) {
+      // Not all operands of a call op forward to arguments. Such operands are
+      // stored in `unaccounted`.
+      BitVector unaccounted(call->getNumOperands(), true);
+
+      // If the call invokes an external function, defer to the corresponding extension hook.
+      // By default, it just does `visitCallOperand` for all operands.
+      OperandRange argOperands = call.getArgOperands();
+      MutableArrayRef<OpOperand> argOpOperands =
+          operandsToOpOperands(argOperands);
+      Region *region = callable.getCallableRegion();
+
+      if (!region || region->empty()) {
+        visitExternalCallImpl(call, operandLattices, resultLattices);
+        return success();
+      }
+      // Otherwise, propagate information from the entry point of the function
+      // back to operands whenever possible.
+      Block &block = region->front();
+      for (auto [blockArg, argOpOperand] :
+           llvm::zip(block.getArguments(), argOpOperands)) {
+        meet(getLatticeElement(argOpOperand.get()),
+             *getLatticeElementFor(getProgramPointAfter(call), blockArg));
+        unaccounted.reset(argOpOperand.getOperandNumber());
+      }
+
+      // Handle the operands of the call op that aren't forwarded to any
+      // arguments.
+      for (int index : unaccounted.set_bits()) {
+        OpOperand &opOperand = call->getOpOperand(index);
+        visitCallOperand(opOperand);
+      }
+      return success();
+    }
+    return failure();
 }
 
 void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(


### PR DESCRIPTION
This diff add virtual function visitCallOperation to SparseBackwardDataFlowAnalysis. This allows Liveness Analysis hook custom logic for the public function. 