### PR TITLE
[alpha.webkit.RetainPtrCtorAdoptChecker] Allow leakRef in copy methods

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RetainPtrCtorAdoptChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RetainPtrCtorAdoptChecker.cpp
@@ -385,6 +385,10 @@ public:
       if (RTC.isUnretained(RetValue->getType()))
         return;
     }
+    if (retainsRet && *retainsRet) {
+      CreateOrCopyFnCall.insert(RetValue);
+      return;
+    }
     if (auto *CE = dyn_cast<CallExpr>(RetValue)) {
       auto *Callee = CE->getDirectCallee();
       if (!Callee || !isCreateOrCopyFunction(Callee))

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
@@ -104,6 +104,14 @@ void basic_correct_arc() {
   _number = value;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  auto copy = adoptNS([(SomeObj *)[SomeObj allocWithZone:zone] init]);
+  [copy setValue:_number];
+  [copy setNext:_next];
+  [copy setOther:_other];
+  return copy.leakRef();
+}
+
 @end;
 
 RetainPtr<CVPixelBufferRef> cf_out_argument() {
@@ -151,7 +159,7 @@ NSArray *makeArray() NS_RETURNS_RETAINED {
 
 extern Class (*getNSArrayClass)();
 NSArray *allocArrayInstance() NS_RETURNS_RETAINED {
-  return [[getNSArrayClass() alloc] init];
+  return adoptNS([[getNSArrayClass() alloc] init]).leakRef();
 }
 
 extern int (*GetObj)(CF_RETURNS_RETAINED CFTypeRef* objOut);
@@ -294,7 +302,7 @@ RetainPtr<CFArrayRef> adopt_make_array() {
 }
 
 -(NSString *)make_string {
-  return [[NSString alloc] initWithUTF8String:"hello"];
+  return adoptNS([[NSString alloc] initWithUTF8String:"hello"]).leakRef();
 }
 
 -(void)local_leak_string {


### PR DESCRIPTION
Allow leakRef() in the return statement of an Objective-C copy method and other methods which return +1.