### PR TITLE
[InstCombine] Transform `vector.reduce.add` and `splat` into multiplication

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3774,7 +3774,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         assert(Arg->getType()->isVectorTy() &&
                "The vector.reduce.add intrinsic's argument must be a vector!");
         ElementCount ReducedVectorElementCount =
-            static_cast<VectorType *>(Arg->getType())->getElementCount();
+            cast<VectorType>(Arg->getType())->getElementCount();
         if (ReducedVectorElementCount.isFixed()) {
           unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
           Type *SplatType = Splat->getType();

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3768,7 +3768,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       // %0, i64 0 %3 = shufflevector <4 x i32> %2, poison, <4 x i32>
       // zeroinitializer %4 = tail call i32 @llvm.vector.reduce.add.v4i32(%3)
       // =>
-      // %2 = shl i32 %0, 2
+      // %2 = mul i32 %0, 4
       if (Value *Splat = getSplatValue(Arg)) {
         // It is only a multiplication if we add the same element over and over.
         assert(Arg->getType()->isVectorTy() &&
@@ -3778,10 +3778,8 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         if (ReducedVectorElementCount.isFixed()) {
           unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
           Type *SplatType = Splat->getType();
-          unsigned SplatTypeWidth = SplatType->getIntegerBitWidth();
-          Value *Res = Builder.CreateMul(
-              Splat, Constant::getIntegerValue(
-                         SplatType, APInt(SplatTypeWidth, VectorSize)));
+          Value *Res =
+              Builder.CreateMul(Splat, ConstantInt::get(SplatType, VectorSize));
           return replaceInstUsesWith(CI, Res);
         }
       }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3778,9 +3778,8 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         if (ReducedVectorElementCount.isFixed()) {
           unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
           Type *SplatType = Splat->getType();
-          Value *Res =
-              Builder.CreateMul(Splat, ConstantInt::get(SplatType, VectorSize));
-          return replaceInstUsesWith(CI, Res);
+          return BinaryOperator::CreateMul(
+              Splat, ConstantInt::get(SplatType, VectorSize));
         }
       }
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3763,18 +3763,16 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
           }
       }
 
-      // Handle the case where a value is multiplied by a power of two.
-      // For example:
-      // %2 = insertelement <4 x i32> poison, i32 %0, i64 0
-      // %3 = shufflevector <4 x i32> %2, poison, <4 x i32> zeroinitializer
-      // %4 = tail call i32 @llvm.vector.reduce.add.v4i32(%3)
+      // Handle the case where a splat is summarized. In that case we have a
+      // multpilication. For example: %2 = insertelement <4 x i32> poison, i32
+      // %0, i64 0 %3 = shufflevector <4 x i32> %2, poison, <4 x i32>
+      // zeroinitializer %4 = tail call i32 @llvm.vector.reduce.add.v4i32(%3)
       // =>
       // %2 = shl i32 %0, 2
-      assert(Arg->getType()->isVectorTy() &&
-             "The vector.reduce.add intrinsic's argument must be a vector!");
-
       if (Value *Splat = getSplatValue(Arg)) {
         // It is only a multiplication if we add the same element over and over.
+        assert(Arg->getType()->isVectorTy() &&
+               "The vector.reduce.add intrinsic's argument must be a vector!");
         ElementCount ReducedVectorElementCount =
             static_cast<VectorType *>(Arg->getType())->getElementCount();
         if (ReducedVectorElementCount.isFixed()) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3779,17 +3779,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
           unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
           Type *SplatType = Splat->getType();
           unsigned SplatTypeWidth = SplatType->getIntegerBitWidth();
-          Value *Res;
-          // Power of two is a special case. We can just use a left shif here.
-          if (isPowerOf2_32(VectorSize)) {
-            unsigned Pow2 = Log2_32(VectorSize);
-            Res = Builder.CreateShl(
-                Splat, Constant::getIntegerValue(SplatType,
-                                                 APInt(SplatTypeWidth, Pow2)));
-            return replaceInstUsesWith(CI, Res);
-          }
-          // Otherwise just multiply.
-          Res = Builder.CreateMul(
+          Value *Res = Builder.CreateMul(
               Splat, Constant::getIntegerValue(
                          SplatType, APInt(SplatTypeWidth, VectorSize)));
           return replaceInstUsesWith(CI, Res);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3769,7 +3769,8 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
             cast<VectorType>(Arg->getType())->getElementCount();
         if (ReducedVectorElementCount.isFixed()) {
           unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
-          return BinaryOperator::CreateMul(Splat, ConstantInt::get(Splat->getType(), VectorSize));
+          return BinaryOperator::CreateMul(
+              Splat, ConstantInt::get(Splat->getType(), VectorSize));
         }
       }
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3765,10 +3765,10 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
 
       // vector.reduce.add.vNiM(splat(%x)) -> mul(%x, N)
       if (Value *Splat = getSplatValue(Arg)) {
-        ElementCount ReducedVectorElementCount =
+        ElementCount VecToReduceCount =
             cast<VectorType>(Arg->getType())->getElementCount();
-        if (ReducedVectorElementCount.isFixed()) {
-          unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
+        if (VecToReduceCount.isFixed()) {
+          unsigned VectorSize = VecToReduceCount.getFixedValue();
           return BinaryOperator::CreateMul(
               Splat, ConstantInt::get(Splat->getType(), VectorSize));
         }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3771,8 +3771,6 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       // %2 = mul i32 %0, 4
       if (Value *Splat = getSplatValue(Arg)) {
         // It is only a multiplication if we add the same element over and over.
-        assert(Arg->getType()->isVectorTy() &&
-               "The vector.reduce.add intrinsic's argument must be a vector!");
         ElementCount ReducedVectorElementCount =
             cast<VectorType>(Arg->getType())->getElementCount();
         if (ReducedVectorElementCount.isFixed()) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3779,15 +3779,22 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
             static_cast<VectorType *>(Arg->getType())->getElementCount();
         if (ReducedVectorElementCount.isFixed()) {
           unsigned VectorSize = ReducedVectorElementCount.getFixedValue();
+          Type *SplatType = Splat->getType();
+          unsigned SplatTypeWidth = SplatType->getIntegerBitWidth();
+          Value *Res;
+          // Power of two is a special case. We can just use a left shif here.
           if (isPowerOf2_32(VectorSize)) {
             unsigned Pow2 = Log2_32(VectorSize);
-            Value *Res = Builder.CreateShl(
-                Splat,
-                Constant::getIntegerValue(
-                    Splat->getType(),
-                    APInt(Splat->getType()->getIntegerBitWidth(), Pow2)));
+            Res = Builder.CreateShl(
+                Splat, Constant::getIntegerValue(SplatType,
+                                                 APInt(SplatTypeWidth, Pow2)));
             return replaceInstUsesWith(CI, Res);
           }
+          // Otherwise just multiply.
+          Res = Builder.CreateMul(
+              Splat, Constant::getIntegerValue(
+                         SplatType, APInt(SplatTypeWidth, VectorSize)));
+          return replaceInstUsesWith(CI, Res);
         }
       }
     }

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -320,6 +320,17 @@ define i32 @constant_multiplied_4xi32(i32 %0) {
   ret i32 %4
 }
 
+define i32 @constant_multiplied_3xi32(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_3xi32(
+; CHECK-NEXT:    [[TMP2:%.*]] = mul i32 [[TMP0:%.*]], 3
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %2 = insertelement <3 x i32> poison, i32 %0, i64 0
+  %3 = shufflevector <3 x i32> %2, <3 x i32> poison, <3 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.v3i32(<3 x i32> %3)
+  ret i32 %4
+}
+
 define i64 @constant_multiplied_4xi64(i64 %0) {
 ; CHECK-LABEL: @constant_multiplied_4xi64(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i64 [[TMP0:%.*]], 2
@@ -421,5 +432,37 @@ define i2 @constant_multiplied_4xi2(i2 %0) {
   %2 = insertelement <4 x i2> poison, i2 %0, i32 0
   %3 = shufflevector <4 x i2> %2, <4 x i2> poison, <4 x i32> zeroinitializer
   %4 = tail call i2 @llvm.vector.reduce.add.v4i2(<4 x i2> %3)
+  ret i2 %4
+}
+
+define i2 @constant_multiplied_5xi2(i2 %0) {
+; CHECK-LABEL: @constant_multiplied_5xi2(
+; CHECK-NEXT:    ret i2 [[TMP0:%.*]]
+;
+  %2 = insertelement <5 x i2> poison, i2 %0, i64 0
+  %3 = shufflevector <5 x i2> %2, <5 x i2> poison, <5 x i32> zeroinitializer
+  %4 = tail call i2 @llvm.vector.reduce.add.v5i2(<5 x i2> %3)
+  ret i2 %4
+}
+
+define i2 @constant_multiplied_6xi2(i2 %0) {
+; CHECK-LABEL: @constant_multiplied_6xi2(
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i2 [[TMP0:%.*]], 1
+; CHECK-NEXT:    ret i2 [[TMP2]]
+;
+  %2 = insertelement <6 x i2> poison, i2 %0, i64 0
+  %3 = shufflevector <6 x i2> %2, <6 x i2> poison, <6 x i32> zeroinitializer
+  %4 = tail call i2 @llvm.vector.reduce.add.v6i2(<6 x i2> %3)
+  ret i2 %4
+}
+
+define i2 @constant_multiplied_7xi2(i2 %0) {
+; CHECK-LABEL: @constant_multiplied_7xi2(
+; CHECK-NEXT:    [[TMP2:%.*]] = sub i2 0, [[TMP0:%.*]]
+; CHECK-NEXT:    ret i2 [[TMP2]]
+;
+  %2 = insertelement <7 x i2> poison, i2 %0, i64 0
+  %3 = shufflevector <7 x i2> %2, <7 x i2> poison, <7 x i32> zeroinitializer
+  %4 = tail call i2 @llvm.vector.reduce.add.v7i2(<7 x i2> %3)
   ret i2 %4
 }

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -398,3 +398,18 @@ define i64 @constant_multiplied_non_power_of_2_i64(i64 %0) {
   %4 = tail call i64 @llvm.vector.reduce.add.v6i64(<6 x i64> %3)
   ret i64 %4
 }
+
+define i1 @constant_multiplied_non_power_of_2_i1(i1 %0) {
+; CHECK-LABEL: @constant_multiplied_non_power_of_2_i1(
+; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <8 x i1> poison, i1 [[TMP0:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <8 x i1> [[TMP6]], <8 x i1> poison, <8 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i1> [[TMP3]] to i8
+; CHECK-NEXT:    [[TMP5:%.*]] = call range(i8 0, 9) i8 @llvm.ctpop.i8(i8 [[TMP4]])
+; CHECK-NEXT:    [[TMP2:%.*]] = trunc i8 [[TMP5]] to i1
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  %2 = insertelement <8 x i1> poison, i1 %0, i32 0
+  %3 = shufflevector <8 x i1> %2, <8 x i1> poison, <8 x i32> zeroinitializer
+  %4 = tail call i1 @llvm.vector.reduce.add.v6i1(<8 x i1> %3)
+  ret i1 %4
+}

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -309,8 +309,8 @@ define i32 @diff_of_sums_type_mismatch2(<8 x i32> %v0, <4 x i32> %v1) {
   ret i32 %r
 }
 
-define i32 @constant_multiplied_at_0(i32 %0) {
-; CHECK-LABEL: @constant_multiplied_at_0(
+define i32 @constant_multiplied_4xi32(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_4xi32(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 2
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
@@ -320,8 +320,8 @@ define i32 @constant_multiplied_at_0(i32 %0) {
   ret i32 %4
 }
 
-define i64 @constant_multiplied_at_0_64bits(i64 %0) {
-; CHECK-LABEL: @constant_multiplied_at_0_64bits(
+define i64 @constant_multiplied_4xi64(i64 %0) {
+; CHECK-LABEL: @constant_multiplied_4xi64(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i64 [[TMP0:%.*]], 2
 ; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
@@ -331,8 +331,8 @@ define i64 @constant_multiplied_at_0_64bits(i64 %0) {
   ret i64 %4
 }
 
-define i32 @constant_multiplied_at_0_two_pow8(i32 %0) {
-; CHECK-LABEL: @constant_multiplied_at_0_two_pow8(
+define i32 @constant_multiplied_8xi32(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_8xi32(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 3
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
@@ -343,8 +343,8 @@ define i32 @constant_multiplied_at_0_two_pow8(i32 %0) {
 }
 
 
-define i32 @constant_multiplied_at_0_two_pow16(i32 %0) {
-; CHECK-LABEL: @constant_multiplied_at_0_two_pow16(
+define i32 @constant_multiplied_16xi32(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_16xi32(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 4
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
@@ -355,8 +355,8 @@ define i32 @constant_multiplied_at_0_two_pow16(i32 %0) {
 }
 
 
-define i32 @constant_multiplied_at_1(i32 %0) {
-; CHECK-LABEL: @constant_multiplied_at_1(
+define i32 @constant_multiplied_4xi32_at_idx1(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_4xi32_at_idx1(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 2
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
@@ -367,8 +367,8 @@ define i32 @constant_multiplied_at_1(i32 %0) {
   ret i32 %4
 }
 
-define i32 @negative_constant_multiplied_at_1(i32 %0) {
-; CHECK-LABEL: @negative_constant_multiplied_at_1(
+define i32 @negative_constant_multiplied_4xi32(i32 %0) {
+; CHECK-LABEL: @negative_constant_multiplied_4xi32(
 ; CHECK-NEXT:    ret i32 poison
 ;
   %2 = insertelement <4 x i32> poison, i32 %0, i64 1
@@ -377,8 +377,8 @@ define i32 @negative_constant_multiplied_at_1(i32 %0) {
   ret i32 %4
 }
 
-define i32 @constant_multiplied_non_power_of_2(i32 %0) {
-; CHECK-LABEL: @constant_multiplied_non_power_of_2(
+define i32 @constant_multiplied_6xi32(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_6xi32(
 ; CHECK-NEXT:    [[TMP2:%.*]] = mul i32 [[TMP0:%.*]], 6
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
@@ -388,8 +388,8 @@ define i32 @constant_multiplied_non_power_of_2(i32 %0) {
   ret i32 %4
 }
 
-define i64 @constant_multiplied_non_power_of_2_i64(i64 %0) {
-; CHECK-LABEL: @constant_multiplied_non_power_of_2_i64(
+define i64 @constant_multiplied_6xi64(i64 %0) {
+; CHECK-LABEL: @constant_multiplied_6xi64(
 ; CHECK-NEXT:    [[TMP2:%.*]] = mul i64 [[TMP0:%.*]], 6
 ; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
@@ -399,14 +399,14 @@ define i64 @constant_multiplied_non_power_of_2_i64(i64 %0) {
   ret i64 %4
 }
 
-define i1 @constant_multiplied_non_power_of_2_i1(i1 %0) {
-; CHECK-LABEL: @constant_multiplied_non_power_of_2_i1(
-; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <8 x i1> poison, i1 [[TMP0:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <8 x i1> [[TMP6]], <8 x i1> poison, <8 x i32> zeroinitializer
+define i1 @constant_multiplied_8xi1(i1 %0) {
+; CHECK-LABEL: @constant_multiplied_8xi1(
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <8 x i1> poison, i1 [[TMP0:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <8 x i1> [[TMP2]], <8 x i1> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i1> [[TMP3]] to i8
 ; CHECK-NEXT:    [[TMP5:%.*]] = call range(i8 0, 9) i8 @llvm.ctpop.i8(i8 [[TMP4]])
-; CHECK-NEXT:    [[TMP2:%.*]] = trunc i8 [[TMP5]] to i1
-; CHECK-NEXT:    ret i1 [[TMP2]]
+; CHECK-NEXT:    [[TMP6:%.*]] = trunc i8 [[TMP5]] to i1
+; CHECK-NEXT:    ret i1 [[TMP6]]
 ;
   %2 = insertelement <8 x i1> poison, i1 %0, i32 0
   %3 = shufflevector <8 x i1> %2, <8 x i1> poison, <8 x i32> zeroinitializer
@@ -414,8 +414,8 @@ define i1 @constant_multiplied_non_power_of_2_i1(i1 %0) {
   ret i1 %4
 }
 
-define i2 @constant_multiplied_non_power_of_2_i2x4(i2 %0) {
-; CHECK-LABEL: @constant_multiplied_non_power_of_2_i2x4(
+define i2 @constant_multiplied_4xi2(i2 %0) {
+; CHECK-LABEL: @constant_multiplied_4xi2(
 ; CHECK-NEXT:    ret i2 0
 ;
   %2 = insertelement <4 x i2> poison, i2 %0, i32 0

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -410,6 +410,46 @@ define i1 @constant_multiplied_non_power_of_2_i1(i1 %0) {
 ;
   %2 = insertelement <8 x i1> poison, i1 %0, i32 0
   %3 = shufflevector <8 x i1> %2, <8 x i1> poison, <8 x i32> zeroinitializer
-  %4 = tail call i1 @llvm.vector.reduce.add.v6i1(<8 x i1> %3)
+  %4 = tail call i1 @llvm.vector.reduce.add.v8i1(<8 x i1> %3)
   ret i1 %4
+}
+
+define i1 @constant_multiplied_non_power_of_2_i1x4(i1 %0) {
+; CHECK-LABEL: @constant_multiplied_non_power_of_2_i1x4(
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i1> poison, i1 [[TMP0:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x i1> [[TMP2]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i1> [[TMP3]] to i4
+; CHECK-NEXT:    [[TMP5:%.*]] = call range(i4 0, 5) i4 @llvm.ctpop.i4(i4 [[TMP4]])
+; CHECK-NEXT:    [[TMP6:%.*]] = trunc i4 [[TMP5]] to i1
+; CHECK-NEXT:    ret i1 [[TMP6]]
+;
+  %2 = insertelement <4 x i1> poison, i1 %0, i32 0
+  %3 = shufflevector <4 x i1> %2, <4 x i1> poison, <4 x i32> zeroinitializer
+  %4 = tail call i1 @llvm.vector.reduce.add.v4i1(<4 x i1> %3)
+  ret i1 %4
+}
+
+define i1 @constant_multiplied_non_power_of_2_i1x2(i1 %0) {
+; CHECK-LABEL: @constant_multiplied_non_power_of_2_i1x2(
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x i1> poison, i1 [[TMP0:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <2 x i1> [[TMP2]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i1> [[TMP3]] to i2
+; CHECK-NEXT:    [[TMP5:%.*]] = call range(i2 0, -1) i2 @llvm.ctpop.i2(i2 [[TMP4]])
+; CHECK-NEXT:    [[TMP6:%.*]] = trunc i2 [[TMP5]] to i1
+; CHECK-NEXT:    ret i1 [[TMP6]]
+;
+  %2 = insertelement <2 x i1> poison, i1 %0, i32 0
+  %3 = shufflevector <2 x i1> %2, <2 x i1> poison, <2 x i32> zeroinitializer
+  %4 = tail call i1 @llvm.vector.reduce.add.v2i1(<2 x i1> %3)
+  ret i1 %4
+}
+
+define i2 @constant_multiplied_non_power_of_2_i2x4(i2 %0) {
+; CHECK-LABEL: @constant_multiplied_non_power_of_2_i2x4(
+; CHECK-NEXT:    ret i2 0
+;
+  %2 = insertelement <4 x i2> poison, i2 %0, i32 0
+  %3 = shufflevector <4 x i2> %2, <4 x i2> poison, <4 x i32> zeroinitializer
+  %4 = tail call i2 @llvm.vector.reduce.add.v4i2(<4 x i2> %3)
+  ret i2 %4
 }

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -414,36 +414,6 @@ define i1 @constant_multiplied_non_power_of_2_i1(i1 %0) {
   ret i1 %4
 }
 
-define i1 @constant_multiplied_non_power_of_2_i1x4(i1 %0) {
-; CHECK-LABEL: @constant_multiplied_non_power_of_2_i1x4(
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i1> poison, i1 [[TMP0:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x i1> [[TMP2]], <4 x i1> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i1> [[TMP3]] to i4
-; CHECK-NEXT:    [[TMP5:%.*]] = call range(i4 0, 5) i4 @llvm.ctpop.i4(i4 [[TMP4]])
-; CHECK-NEXT:    [[TMP6:%.*]] = trunc i4 [[TMP5]] to i1
-; CHECK-NEXT:    ret i1 [[TMP6]]
-;
-  %2 = insertelement <4 x i1> poison, i1 %0, i32 0
-  %3 = shufflevector <4 x i1> %2, <4 x i1> poison, <4 x i32> zeroinitializer
-  %4 = tail call i1 @llvm.vector.reduce.add.v4i1(<4 x i1> %3)
-  ret i1 %4
-}
-
-define i1 @constant_multiplied_non_power_of_2_i1x2(i1 %0) {
-; CHECK-LABEL: @constant_multiplied_non_power_of_2_i1x2(
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x i1> poison, i1 [[TMP0:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <2 x i1> [[TMP2]], <2 x i1> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i1> [[TMP3]] to i2
-; CHECK-NEXT:    [[TMP5:%.*]] = call range(i2 0, -1) i2 @llvm.ctpop.i2(i2 [[TMP4]])
-; CHECK-NEXT:    [[TMP6:%.*]] = trunc i2 [[TMP5]] to i1
-; CHECK-NEXT:    ret i1 [[TMP6]]
-;
-  %2 = insertelement <2 x i1> poison, i1 %0, i32 0
-  %3 = shufflevector <2 x i1> %2, <2 x i1> poison, <2 x i32> zeroinitializer
-  %4 = tail call i1 @llvm.vector.reduce.add.v2i1(<2 x i1> %3)
-  ret i1 %4
-}
-
 define i2 @constant_multiplied_non_power_of_2_i2x4(i2 %0) {
 ; CHECK-LABEL: @constant_multiplied_non_power_of_2_i2x4(
 ; CHECK-NEXT:    ret i2 0

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -466,3 +466,16 @@ define i2 @constant_multiplied_7xi2(i2 %0) {
   %4 = tail call i2 @llvm.vector.reduce.add.v7i2(<7 x i2> %3)
   ret i2 %4
 }
+
+define i32 @negative_scalable_vector(i32 %0) {
+; CHECK-LABEL: @negative_scalable_vector(
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[TMP0:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <vscale x 4 x i32> [[TMP2]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.vector.reduce.add.nxv4i32(<vscale x 4 x i32> [[TMP3]])
+; CHECK-NEXT:    ret i32 [[TMP4]]
+;
+  %2 = insertelement <vscale x 4 x i32> poison, i32 %0, i64 0
+  %3 = shufflevector <vscale x 4 x i32> %2, <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.nxv4i32(<vscale x 4 x i32> %3)
+  ret i32 %4
+}

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -377,15 +377,24 @@ define i32 @negative_constant_multiplied_at_1(i32 %0) {
   ret i32 %4
 }
 
-define i32 @negative_constant_multiplied_non_power_of_2(i32 %0) {
-; CHECK-LABEL: @negative_constant_multiplied_non_power_of_2(
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i32> poison, i32 [[TMP0:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x i32> [[TMP2]], <4 x i32> poison, <6 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.vector.reduce.add.v6i32(<6 x i32> [[TMP3]])
-; CHECK-NEXT:    ret i32 [[TMP4]]
+define i32 @constant_multiplied_non_power_of_2(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_non_power_of_2(
+; CHECK-NEXT:    [[TMP2:%.*]] = mul i32 [[TMP0:%.*]], 6
+; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %2 = insertelement <4 x i32> poison, i32 %0, i64 0
   %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <6 x i32> zeroinitializer
   %4 = tail call i32 @llvm.vector.reduce.add.v6i32(<6 x i32> %3)
   ret i32 %4
+}
+
+define i64 @constant_multiplied_non_power_of_2_i64(i64 %0) {
+; CHECK-LABEL: @constant_multiplied_non_power_of_2_i64(
+; CHECK-NEXT:    [[TMP2:%.*]] = mul i64 [[TMP0:%.*]], 6
+; CHECK-NEXT:    ret i64 [[TMP2]]
+;
+  %2 = insertelement <4 x i64> poison, i64 %0, i64 0
+  %3 = shufflevector <4 x i64> %2, <4 x i64> poison, <6 x i32> zeroinitializer
+  %4 = tail call i64 @llvm.vector.reduce.add.v6i64(<6 x i64> %3)
+  ret i64 %4
 }

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -308,3 +308,73 @@ define i32 @diff_of_sums_type_mismatch2(<8 x i32> %v0, <4 x i32> %v1) {
   %r = sub i32 %r0, %r1
   ret i32 %r
 }
+
+define i32 @constant_multiplied_at_0(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_at_0(
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 2
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %2 = insertelement <4 x i32> poison, i32 %0, i64 0
+  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <4 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %3)
+  ret i32 %4
+}
+
+define i32 @constant_multiplied_at_0_two_pow8(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_at_0_two_pow8(
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 3
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %2 = insertelement <4 x i32> poison, i32 %0, i64 0
+  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <8 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %3)
+  ret i32 %4
+}
+
+
+define i32 @constant_multiplied_at_0_two_pow16(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_at_0_two_pow16(
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 4
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %2 = insertelement <4 x i32> poison, i32 %0, i64 0
+  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <16 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %3)
+  ret i32 %4
+}
+
+
+define i32 @constant_multiplied_at_1(i32 %0) {
+; CHECK-LABEL: @constant_multiplied_at_1(
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 2
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %2 = insertelement <4 x i32> poison, i32 %0, i64 1
+  %3 = shufflevector <4 x i32> %2, <4 x i32> poison,
+  <4 x i32> <i32 1, i32 1, i32 1, i32 1>
+  %4 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %3)
+  ret i32 %4
+}
+
+define i32 @negative_constant_multiplied_at_1(i32 %0) {
+; CHECK-LABEL: @negative_constant_multiplied_at_1(
+; CHECK-NEXT:    ret i32 poison
+;
+  %2 = insertelement <4 x i32> poison, i32 %0, i64 1
+  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <4 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %3)
+  ret i32 %4
+}
+
+define i32 @negative_constant_multiplied_non_power_of_2(i32 %0) {
+; CHECK-LABEL: @negative_constant_multiplied_non_power_of_2(
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i32> poison, i32 [[TMP0:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x i32> [[TMP2]], <4 x i32> poison, <6 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.vector.reduce.add.v6i32(<6 x i32> [[TMP3]])
+; CHECK-NEXT:    ret i32 [[TMP4]]
+;
+  %2 = insertelement <4 x i32> poison, i32 %0, i64 0
+  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <6 x i32> zeroinitializer
+  %4 = tail call i32 @llvm.vector.reduce.add.v6i32(<6 x i32> %3)
+  ret i32 %4
+}

--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -320,6 +320,17 @@ define i32 @constant_multiplied_at_0(i32 %0) {
   ret i32 %4
 }
 
+define i64 @constant_multiplied_at_0_64bits(i64 %0) {
+; CHECK-LABEL: @constant_multiplied_at_0_64bits(
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i64 [[TMP0:%.*]], 2
+; CHECK-NEXT:    ret i64 [[TMP2]]
+;
+  %2 = insertelement <4 x i64> poison, i64 %0, i64 0
+  %3 = shufflevector <4 x i64> %2, <4 x i64> poison, <4 x i32> zeroinitializer
+  %4 = tail call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> %3)
+  ret i64 %4
+}
+
 define i32 @constant_multiplied_at_0_two_pow8(i32 %0) {
 ; CHECK-LABEL: @constant_multiplied_at_0_two_pow8(
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP0:%.*]], 3


### PR DESCRIPTION
Fixes #160066

Whenever we have a vector with all the same elemnts, created with `insertelement` and `shufflevector`  and we sum the vector, we have a multiplication.