### PR TITLE
[GitHub][docker] Add python3 venv package to CI container

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && \
     # Having a symlink from python to python3 enables code sharing between
     # the Linux and Windows pipelines.
     python3-pip \
+    python3-venv \
     file \
     tzdata \
     python-is-python3 && \


### PR DESCRIPTION
I'm trying to make `pr-code-format.yml` job run natively on `ci-ubuntu-24.04` container.
As it appears, `ci-ubuntu-24.04` already [has](https://github.com/llvm/llvm-project/blob/41a2dfc0d77d9ad977d1d36358f979abb3a0928f/.github/workflows/containers/github-action-ci/Dockerfile#L35) latest `clang-format`, `python3.12` installed, but `python3.12` needs `venv` to work properly, and Ubuntu asks for `python3-venv` package to be installed to create a venv.

FYI I hacked it with `--break-system-packages` to test and clang-format job runs a lot faster https://github.com/llvm/llvm-project/actions/runs/18064896361/job/51406365488#logs (skipping 1min long `clang-format` installation). Just don't look at "Initialize containers" taking 6min, it usually takes 15-20sec