### PR TITLE
[clang-tidy] Fix typoed option name in `bugprone-signed-char-misuse`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SignedCharMisuseCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SignedCharMisuseCheck.cpp
@@ -21,12 +21,12 @@ static constexpr int UnsignedASCIIUpperBound = 127;
 SignedCharMisuseCheck::SignedCharMisuseCheck(StringRef Name,
                                              ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      CharTypdefsToIgnoreList(Options.get("CharTypdefsToIgnore", "")),
+      CharTypedefsToIgnoreList(Options.get("CharTypedefsToIgnore", "")),
       DiagnoseSignedUnsignedCharComparisons(
           Options.get("DiagnoseSignedUnsignedCharComparisons", true)) {}
 
 void SignedCharMisuseCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "CharTypdefsToIgnore", CharTypdefsToIgnoreList);
+  Options.store(Opts, "CharTypedefsToIgnore", CharTypedefsToIgnoreList);
   Options.store(Opts, "DiagnoseSignedUnsignedCharComparisons",
                 DiagnoseSignedUnsignedCharComparisons);
 }
@@ -39,7 +39,7 @@ BindableMatcher<clang::Stmt> SignedCharMisuseCheck::charCastExpression(
   // (e.g. typedef char sal_Int8). In this case, we don't need to
   // worry about the misinterpretation of char values.
   const auto IntTypedef = qualType(hasDeclaration(typedefDecl(
-      hasAnyName(utils::options::parseStringList(CharTypdefsToIgnoreList)))));
+      hasAnyName(utils::options::parseStringList(CharTypedefsToIgnoreList)))));
 
   auto CharTypeExpr = expr();
   if (IsSigned) {

--- a/clang-tools-extra/clang-tidy/bugprone/SignedCharMisuseCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SignedCharMisuseCheck.h
@@ -35,7 +35,7 @@ private:
       const ast_matchers::internal::Matcher<clang::QualType> &IntegerType,
       const std::string &CastBindName) const;
 
-  const StringRef CharTypdefsToIgnoreList;
+  const StringRef CharTypedefsToIgnoreList;
   const bool DiagnoseSignedUnsignedCharComparisons;
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -58,8 +58,11 @@ Potentially Breaking Changes
   :doc:`bugprone-easily-swappable-parameters
   <clang-tidy/checks/bugprone/easily-swappable-parameters>` from
   ``NamePrefixSuffixSilenceDissimilarityTreshold`` to
-  ``NamePrefixSuffixSilenceDissimilarityThreshold``,
-  correcting a spelling mistake.
+  ``NamePrefixSuffixSilenceDissimilarityThreshold`` and of check
+  :doc:`bugprone-signed-char-misuse
+  <clang-tidy/checks/bugprone/signed-char-misuse>` from
+  ``CharTypdefsToIgnore`` to ``CharTypedefsToIgnore``,
+  correcting spelling mistakes.
 
 Improvements to clangd
 ----------------------

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -57,12 +57,12 @@ Potentially Breaking Changes
 - Renamed a few :program:`clang-tidy` check options, as they
   were misspelled:
 
-  - `NamePrefixSuffixSilenceDissimilarityTreshold` →
+  - `NamePrefixSuffixSilenceDissimilarityTreshold` to
     `NamePrefixSuffixSilenceDissimilarityThreshold` in
     :doc:`bugprone-easily-swappable-parameters
     <clang-tidy/checks/bugprone/easily-swappable-parameters>`
 
-  - `CharTypdefsToIgnore` → `CharTypedefsToIgnore` in
+  - `CharTypdefsToIgnore` to `CharTypedefsToIgnore` in
     :doc:`bugprone-signed-char-misuse
     <clang-tidy/checks/bugprone/signed-char-misuse>`
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -54,15 +54,17 @@ Potentially Breaking Changes
   :program:`clang-tidy-20`. Users should use the check-specific options of the
   same name instead.
 
-- Renamed :program:`clang-tidy`'s option name of check
-  :doc:`bugprone-easily-swappable-parameters
-  <clang-tidy/checks/bugprone/easily-swappable-parameters>` from
-  ``NamePrefixSuffixSilenceDissimilarityTreshold`` to
-  ``NamePrefixSuffixSilenceDissimilarityThreshold`` and of check
-  :doc:`bugprone-signed-char-misuse
-  <clang-tidy/checks/bugprone/signed-char-misuse>` from
-  ``CharTypdefsToIgnore`` to ``CharTypedefsToIgnore``,
-  correcting spelling mistakes.
+- Renamed a few :program:`clang-tidy` check options, as they
+  were misspelled:
+
+  - `NamePrefixSuffixSilenceDissimilarityTreshold` →
+    `NamePrefixSuffixSilenceDissimilarityThreshold` in
+    :doc:`bugprone-easily-swappable-parameters
+    <clang-tidy/checks/bugprone/easily-swappable-parameters>`
+
+  - `CharTypdefsToIgnore` → `CharTypedefsToIgnore` in
+    :doc:`bugprone-signed-char-misuse
+    <clang-tidy/checks/bugprone/signed-char-misuse>`
 
 Improvements to clangd
 ----------------------

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
@@ -107,7 +107,7 @@ so both arguments will have the same type.
 Options
 -------
 
-.. option:: CharTypdefsToIgnore
+.. option:: CharTypedefsToIgnore
 
   A semicolon-separated list of typedef names. In this list, we can list
   typedefs for ``char`` or ``signed char``, which will be ignored by the

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/signed-char-misuse-with-option.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/signed-char-misuse-with-option.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s bugprone-signed-char-misuse %t \
 // RUN: -config='{CheckOptions: \
-// RUN:  {bugprone-signed-char-misuse.CharTypdefsToIgnore: "sal_Int8;int8_t"}}' \
+// RUN:  {bugprone-signed-char-misuse.CharTypedefsToIgnore: "sal_Int8;int8_t"}}' \
 // RUN: --
 
 ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Following the example of #158282.