### PR TITLE
[AMDGPU] Regenerate checks for test/CodeGen/AMDGPU/bf16.ll

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/bf16.ll
@@ -10908,12 +10908,13 @@ define <2 x bfloat> @v_fadd_v2bf16(<2 x bfloat> %a, <2 x bfloat> %b) {
 ; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11FAKE16-NEXT:    v_perm_b32 v0, v0, v1, 0x7060302
 ; GFX11FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GFX1250-LABEL: v_fadd_v2bf16:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:   s_wait_loadcnt_dscnt 0x0
-; GFX1250-NEXT:   s_wait_kmcnt 0x0
-; GFX1250-NEXT:   v_pk_add_bf16 v0, v0, v1
-; GFX1250-NEXT:   s_set_pc_i64 s[30:31]
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_add_bf16 v0, v0, v1
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %op = fadd <2 x bfloat> %a, %b
   ret <2 x bfloat> %op
 }
@@ -11446,13 +11447,14 @@ define <4 x bfloat> @v_fadd_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b) {
 ; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11FAKE16-NEXT:    v_perm_b32 v1, v1, v4, 0x7060302
 ; GFX11FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GFX1250-LABEL: v_fadd_v4bf16:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:   s_wait_loadcnt_dscnt 0x0
-; GFX1250-NEXT:   s_wait_kmcnt 0x0
-; GFX1250-NEXT:   v_pk_add_bf16 v0, v0, v2
-; GFX1250-NEXT:   v_pk_add_bf16 v1, v1, v3
-; GFX1250-NEXT:   s_set_pc_i64 s[30:31]
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_add_bf16 v0, v0, v2
+; GFX1250-NEXT:    v_pk_add_bf16 v1, v1, v3
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %op = fadd <4 x bfloat> %a, %b
   ret <4 x bfloat> %op
 }
@@ -49991,6 +49993,622 @@ define <4 x bfloat> @v_fma_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b, <4 x bfloat>
   ret <4 x bfloat> %op
 }
 
+define <8 x bfloat> @v_fma_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c) {
+; GCN-LABEL: v_fma_v8bf16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v7, 1.0, v7
+; GCN-NEXT:    v_mul_f32_e32 v15, 1.0, v15
+; GCN-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GCN-NEXT:    v_mul_f32_e32 v6, 1.0, v6
+; GCN-NEXT:    v_mul_f32_e32 v14, 1.0, v14
+; GCN-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GCN-NEXT:    v_mul_f32_e32 v5, 1.0, v5
+; GCN-NEXT:    v_mul_f32_e32 v13, 1.0, v13
+; GCN-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GCN-NEXT:    v_mul_f32_e32 v4, 1.0, v4
+; GCN-NEXT:    v_mul_f32_e32 v12, 1.0, v12
+; GCN-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GCN-NEXT:    v_mul_f32_e32 v3, 1.0, v3
+; GCN-NEXT:    v_mul_f32_e32 v11, 1.0, v11
+; GCN-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GCN-NEXT:    v_mul_f32_e32 v2, 1.0, v2
+; GCN-NEXT:    v_mul_f32_e32 v10, 1.0, v10
+; GCN-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GCN-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GCN-NEXT:    v_mul_f32_e32 v8, 1.0, v8
+; GCN-NEXT:    v_mul_f32_e32 v16, 1.0, v16
+; GCN-NEXT:    v_mul_f32_e32 v1, 1.0, v1
+; GCN-NEXT:    v_mul_f32_e32 v9, 1.0, v9
+; GCN-NEXT:    v_mul_f32_e32 v17, 1.0, v17
+; GCN-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GCN-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GCN-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GCN-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GCN-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GCN-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GCN-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GCN-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GCN-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GCN-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GCN-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GCN-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GCN-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GCN-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GCN-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GCN-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GCN-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GCN-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GCN-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GCN-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GCN-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GCN-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GCN-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GCN-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GCN-NEXT:    v_fma_f32 v7, v7, v15, v23
+; GCN-NEXT:    v_fma_f32 v6, v6, v14, v22
+; GCN-NEXT:    v_fma_f32 v5, v5, v13, v21
+; GCN-NEXT:    v_fma_f32 v4, v4, v12, v20
+; GCN-NEXT:    v_fma_f32 v3, v3, v11, v19
+; GCN-NEXT:    v_fma_f32 v2, v2, v10, v18
+; GCN-NEXT:    v_fma_f32 v1, v1, v9, v17
+; GCN-NEXT:    v_fma_f32 v0, v0, v8, v16
+; GCN-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GCN-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GCN-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GCN-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GCN-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GCN-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GCN-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GCN-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: v_fma_v8bf16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v7, 1.0, v7
+; GFX7-NEXT:    v_mul_f32_e32 v15, 1.0, v15
+; GFX7-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GFX7-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX7-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX7-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX7-NEXT:    v_fma_f32 v7, v7, v15, v23
+; GFX7-NEXT:    v_mul_f32_e32 v6, 1.0, v6
+; GFX7-NEXT:    v_mul_f32_e32 v14, 1.0, v14
+; GFX7-NEXT:    v_mul_f32_e32 v15, 1.0, v22
+; GFX7-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX7-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX7-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX7-NEXT:    v_fma_f32 v6, v6, v14, v15
+; GFX7-NEXT:    v_mul_f32_e32 v5, 1.0, v5
+; GFX7-NEXT:    v_mul_f32_e32 v13, 1.0, v13
+; GFX7-NEXT:    v_mul_f32_e32 v14, 1.0, v21
+; GFX7-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX7-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX7-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX7-NEXT:    v_fma_f32 v5, v5, v13, v14
+; GFX7-NEXT:    v_mul_f32_e32 v4, 1.0, v4
+; GFX7-NEXT:    v_mul_f32_e32 v12, 1.0, v12
+; GFX7-NEXT:    v_mul_f32_e32 v13, 1.0, v20
+; GFX7-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX7-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX7-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX7-NEXT:    v_fma_f32 v4, v4, v12, v13
+; GFX7-NEXT:    v_mul_f32_e32 v3, 1.0, v3
+; GFX7-NEXT:    v_mul_f32_e32 v11, 1.0, v11
+; GFX7-NEXT:    v_mul_f32_e32 v12, 1.0, v19
+; GFX7-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX7-NEXT:    v_fma_f32 v3, v3, v11, v12
+; GFX7-NEXT:    v_mul_f32_e32 v2, 1.0, v2
+; GFX7-NEXT:    v_mul_f32_e32 v10, 1.0, v10
+; GFX7-NEXT:    v_mul_f32_e32 v11, 1.0, v18
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX7-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX7-NEXT:    v_fma_f32 v2, v2, v10, v11
+; GFX7-NEXT:    v_mul_f32_e32 v1, 1.0, v1
+; GFX7-NEXT:    v_mul_f32_e32 v9, 1.0, v9
+; GFX7-NEXT:    v_mul_f32_e32 v11, 1.0, v17
+; GFX7-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GFX7-NEXT:    v_mul_f32_e32 v8, 1.0, v8
+; GFX7-NEXT:    v_mul_f32_e32 v10, 1.0, v16
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX7-NEXT:    v_fma_f32 v1, v1, v9, v11
+; GFX7-NEXT:    v_and_b32_e32 v9, 0xffff0000, v10
+; GFX7-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX7-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX7-NEXT:    v_fma_f32 v0, v0, v8, v9
+; GFX7-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX7-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX7-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX7-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX7-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX7-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX7-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_fma_v8bf16:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v12, 16, v11
+; GFX8-NEXT:    v_lshlrev_b32_e32 v13, 16, v7
+; GFX8-NEXT:    v_lshlrev_b32_e32 v14, 16, v3
+; GFX8-NEXT:    v_fma_f32 v12, v14, v13, v12
+; GFX8-NEXT:    v_bfe_u32 v13, v12, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v13, vcc, v13, v12
+; GFX8-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX8-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX8-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX8-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX8-NEXT:    v_add_u32_e32 v13, vcc, s4, v13
+; GFX8-NEXT:    v_fma_f32 v3, v3, v7, v11
+; GFX8-NEXT:    v_or_b32_e32 v14, 0x400000, v12
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v12, v12
+; GFX8-NEXT:    v_bfe_u32 v7, v3, 16, 1
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, v13, v14, vcc
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v7, v3
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, s4, v7
+; GFX8-NEXT:    v_or_b32_e32 v11, 0x400000, v3
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v3, v3
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v11, vcc
+; GFX8-NEXT:    v_lshlrev_b32_e32 v7, 16, v10
+; GFX8-NEXT:    v_lshlrev_b32_e32 v11, 16, v6
+; GFX8-NEXT:    v_lshlrev_b32_e32 v13, 16, v2
+; GFX8-NEXT:    v_fma_f32 v7, v13, v11, v7
+; GFX8-NEXT:    v_bfe_u32 v11, v7, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v11, vcc, v11, v7
+; GFX8-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX8-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX8-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX8-NEXT:    v_add_u32_e32 v11, vcc, s4, v11
+; GFX8-NEXT:    v_fma_f32 v2, v2, v6, v10
+; GFX8-NEXT:    v_or_b32_e32 v13, 0x400000, v7
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v7, v7
+; GFX8-NEXT:    v_bfe_u32 v6, v2, 16, 1
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v2
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, s4, v6
+; GFX8-NEXT:    v_or_b32_e32 v10, 0x400000, v2
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v2, v2
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v6, v10, vcc
+; GFX8-NEXT:    v_lshlrev_b32_e32 v6, 16, v9
+; GFX8-NEXT:    v_lshlrev_b32_e32 v10, 16, v5
+; GFX8-NEXT:    v_lshlrev_b32_e32 v11, 16, v1
+; GFX8-NEXT:    v_fma_f32 v6, v11, v10, v6
+; GFX8-NEXT:    v_bfe_u32 v10, v6, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v10, v6
+; GFX8-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX8-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX8-NEXT:    v_add_u32_e32 v10, vcc, s4, v10
+; GFX8-NEXT:    v_fma_f32 v1, v1, v5, v9
+; GFX8-NEXT:    v_or_b32_e32 v11, 0x400000, v6
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v6, v6
+; GFX8-NEXT:    v_bfe_u32 v5, v1, 16, 1
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v10, v11, vcc
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v1
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, s4, v5
+; GFX8-NEXT:    v_or_b32_e32 v9, 0x400000, v1
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v1, v1
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v9, vcc
+; GFX8-NEXT:    v_lshlrev_b32_e32 v5, 16, v8
+; GFX8-NEXT:    v_lshlrev_b32_e32 v9, 16, v4
+; GFX8-NEXT:    v_lshlrev_b32_e32 v10, 16, v0
+; GFX8-NEXT:    v_fma_f32 v5, v10, v9, v5
+; GFX8-NEXT:    v_bfe_u32 v9, v5, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v9, vcc, v9, v5
+; GFX8-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX8-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX8-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX8-NEXT:    v_add_u32_e32 v9, vcc, s4, v9
+; GFX8-NEXT:    v_fma_f32 v0, v0, v4, v8
+; GFX8-NEXT:    v_or_b32_e32 v10, 0x400000, v5
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v5, v5
+; GFX8-NEXT:    v_bfe_u32 v4, v0, 16, 1
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v9, v10, vcc
+; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v0
+; GFX8-NEXT:    v_add_u32_e32 v4, vcc, 0x7fff, v4
+; GFX8-NEXT:    v_or_b32_e32 v8, 0x400000, v0
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v8, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX8-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX8-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX8-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GFX8-NEXT:    v_alignbit_b32 v0, v0, v5, 16
+; GFX8-NEXT:    v_alignbit_b32 v1, v1, v6, 16
+; GFX8-NEXT:    v_alignbit_b32 v2, v2, v7, 16
+; GFX8-NEXT:    v_alignbit_b32 v3, v3, v12, 16
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_fma_v8bf16:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v12, 16, v11
+; GFX900-NEXT:    v_lshlrev_b32_e32 v13, 16, v7
+; GFX900-NEXT:    v_lshlrev_b32_e32 v14, 16, v3
+; GFX900-NEXT:    v_fma_f32 v12, v14, v13, v12
+; GFX900-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX900-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX900-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX900-NEXT:    v_bfe_u32 v13, v12, 16, 1
+; GFX900-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX900-NEXT:    v_fma_f32 v3, v3, v7, v11
+; GFX900-NEXT:    v_add3_u32 v13, v13, v12, s4
+; GFX900-NEXT:    v_or_b32_e32 v14, 0x400000, v12
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v12, v12
+; GFX900-NEXT:    v_bfe_u32 v7, v3, 16, 1
+; GFX900-NEXT:    v_cndmask_b32_e32 v12, v13, v14, vcc
+; GFX900-NEXT:    v_add3_u32 v7, v7, v3, s4
+; GFX900-NEXT:    v_or_b32_e32 v11, 0x400000, v3
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v3, v3
+; GFX900-NEXT:    v_cndmask_b32_e32 v3, v7, v11, vcc
+; GFX900-NEXT:    v_lshlrev_b32_e32 v7, 16, v10
+; GFX900-NEXT:    v_lshlrev_b32_e32 v11, 16, v6
+; GFX900-NEXT:    v_lshlrev_b32_e32 v13, 16, v2
+; GFX900-NEXT:    v_fma_f32 v7, v13, v11, v7
+; GFX900-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX900-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX900-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX900-NEXT:    v_bfe_u32 v11, v7, 16, 1
+; GFX900-NEXT:    v_fma_f32 v2, v2, v6, v10
+; GFX900-NEXT:    v_add3_u32 v11, v11, v7, s4
+; GFX900-NEXT:    v_or_b32_e32 v13, 0x400000, v7
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v7, v7
+; GFX900-NEXT:    v_bfe_u32 v6, v2, 16, 1
+; GFX900-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
+; GFX900-NEXT:    v_add3_u32 v6, v6, v2, s4
+; GFX900-NEXT:    v_or_b32_e32 v10, 0x400000, v2
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v2, v2
+; GFX900-NEXT:    v_cndmask_b32_e32 v2, v6, v10, vcc
+; GFX900-NEXT:    v_lshlrev_b32_e32 v6, 16, v9
+; GFX900-NEXT:    v_lshlrev_b32_e32 v10, 16, v5
+; GFX900-NEXT:    v_lshlrev_b32_e32 v11, 16, v1
+; GFX900-NEXT:    v_fma_f32 v6, v11, v10, v6
+; GFX900-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX900-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX900-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX900-NEXT:    v_bfe_u32 v10, v6, 16, 1
+; GFX900-NEXT:    v_fma_f32 v1, v1, v5, v9
+; GFX900-NEXT:    v_add3_u32 v10, v10, v6, s4
+; GFX900-NEXT:    v_or_b32_e32 v11, 0x400000, v6
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v6, v6
+; GFX900-NEXT:    v_bfe_u32 v5, v1, 16, 1
+; GFX900-NEXT:    v_cndmask_b32_e32 v6, v10, v11, vcc
+; GFX900-NEXT:    v_add3_u32 v5, v5, v1, s4
+; GFX900-NEXT:    v_or_b32_e32 v9, 0x400000, v1
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v1, v1
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v9, vcc
+; GFX900-NEXT:    v_lshlrev_b32_e32 v5, 16, v8
+; GFX900-NEXT:    v_lshlrev_b32_e32 v9, 16, v4
+; GFX900-NEXT:    v_lshlrev_b32_e32 v10, 16, v0
+; GFX900-NEXT:    v_fma_f32 v5, v10, v9, v5
+; GFX900-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX900-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX900-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX900-NEXT:    v_bfe_u32 v9, v5, 16, 1
+; GFX900-NEXT:    v_fma_f32 v0, v0, v4, v8
+; GFX900-NEXT:    v_add3_u32 v9, v9, v5, s4
+; GFX900-NEXT:    v_or_b32_e32 v10, 0x400000, v5
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v5, v5
+; GFX900-NEXT:    v_bfe_u32 v4, v0, 16, 1
+; GFX900-NEXT:    v_cndmask_b32_e32 v5, v9, v10, vcc
+; GFX900-NEXT:    v_add3_u32 v4, v4, v0, s4
+; GFX900-NEXT:    v_or_b32_e32 v8, 0x400000, v0
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, v4, v8, vcc
+; GFX900-NEXT:    s_mov_b32 s4, 0x7060302
+; GFX900-NEXT:    v_perm_b32 v0, v0, v5, s4
+; GFX900-NEXT:    v_perm_b32 v1, v1, v6, s4
+; GFX900-NEXT:    v_perm_b32 v2, v2, v7, s4
+; GFX900-NEXT:    v_perm_b32 v3, v3, v12, s4
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX950-LABEL: v_fma_v8bf16:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_and_b32_e32 v12, 0xffff0000, v11
+; GFX950-NEXT:    v_and_b32_e32 v13, 0xffff0000, v7
+; GFX950-NEXT:    v_and_b32_e32 v14, 0xffff0000, v3
+; GFX950-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX950-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX950-NEXT:    v_fmac_f32_e32 v12, v14, v13
+; GFX950-NEXT:    v_fmac_f32_e32 v11, v3, v7
+; GFX950-NEXT:    v_and_b32_e32 v3, 0xffff0000, v10
+; GFX950-NEXT:    v_and_b32_e32 v7, 0xffff0000, v6
+; GFX950-NEXT:    v_and_b32_e32 v13, 0xffff0000, v2
+; GFX950-NEXT:    v_fmac_f32_e32 v3, v13, v7
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 16, v10
+; GFX950-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX950-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX950-NEXT:    v_fmac_f32_e32 v7, v2, v6
+; GFX950-NEXT:    v_and_b32_e32 v2, 0xffff0000, v9
+; GFX950-NEXT:    v_and_b32_e32 v6, 0xffff0000, v5
+; GFX950-NEXT:    v_and_b32_e32 v10, 0xffff0000, v1
+; GFX950-NEXT:    v_fmac_f32_e32 v2, v10, v6
+; GFX950-NEXT:    v_lshlrev_b32_e32 v6, 16, v9
+; GFX950-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX950-NEXT:    v_fmac_f32_e32 v6, v1, v5
+; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff0000, v8
+; GFX950-NEXT:    v_and_b32_e32 v5, 0xffff0000, v4
+; GFX950-NEXT:    v_and_b32_e32 v9, 0xffff0000, v0
+; GFX950-NEXT:    v_fmac_f32_e32 v1, v9, v5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v5, 16, v8
+; GFX950-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX950-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX950-NEXT:    v_fmac_f32_e32 v5, v0, v4
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v0, v5, v1
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v1, v6, v2
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v2, v7, v3
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v3, v11, v12
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX10-LABEL: v_fma_v8bf16:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v12, 16, v11
+; GFX10-NEXT:    v_lshlrev_b32_e32 v13, 16, v7
+; GFX10-NEXT:    v_lshlrev_b32_e32 v14, 16, v3
+; GFX10-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX10-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX10-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX10-NEXT:    v_lshlrev_b32_e32 v18, 16, v0
+; GFX10-NEXT:    v_fmac_f32_e32 v12, v14, v13
+; GFX10-NEXT:    v_lshlrev_b32_e32 v14, 16, v2
+; GFX10-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX10-NEXT:    v_fmac_f32_e32 v11, v3, v7
+; GFX10-NEXT:    v_lshlrev_b32_e32 v3, 16, v10
+; GFX10-NEXT:    v_bfe_u32 v13, v12, 16, 1
+; GFX10-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX10-NEXT:    v_or_b32_e32 v15, 0x400000, v12
+; GFX10-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v12, v12
+; GFX10-NEXT:    v_add3_u32 v13, v13, v12, 0x7fff
+; GFX10-NEXT:    v_fmac_f32_e32 v3, v14, v7
+; GFX10-NEXT:    v_and_b32_e32 v7, 0xffff0000, v10
+; GFX10-NEXT:    v_bfe_u32 v16, v11, 16, 1
+; GFX10-NEXT:    v_lshlrev_b32_e32 v14, 16, v1
+; GFX10-NEXT:    v_cndmask_b32_e32 v10, v13, v15, vcc_lo
+; GFX10-NEXT:    v_bfe_u32 v13, v3, 16, 1
+; GFX10-NEXT:    v_fmac_f32_e32 v7, v2, v6
+; GFX10-NEXT:    v_add3_u32 v12, v16, v11, 0x7fff
+; GFX10-NEXT:    v_lshlrev_b32_e32 v2, 16, v9
+; GFX10-NEXT:    v_lshlrev_b32_e32 v6, 16, v5
+; GFX10-NEXT:    v_add3_u32 v13, v13, v3, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v15, 0x400000, v3
+; GFX10-NEXT:    v_bfe_u32 v16, v7, 16, 1
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v3, v3
+; GFX10-NEXT:    v_fmac_f32_e32 v2, v14, v6
+; GFX10-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX10-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX10-NEXT:    v_add3_u32 v6, v16, v7, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, v13, v15, vcc_lo
+; GFX10-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX10-NEXT:    v_lshlrev_b32_e32 v15, 16, v8
+; GFX10-NEXT:    v_lshlrev_b32_e32 v16, 16, v4
+; GFX10-NEXT:    v_or_b32_e32 v13, 0x400000, v7
+; GFX10-NEXT:    v_bfe_u32 v14, v2, 16, 1
+; GFX10-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX10-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v7, v7
+; GFX10-NEXT:    v_fmac_f32_e32 v9, v1, v5
+; GFX10-NEXT:    v_fmac_f32_e32 v15, v18, v16
+; GFX10-NEXT:    v_or_b32_e32 v1, 0x400000, v2
+; GFX10-NEXT:    v_fmac_f32_e32 v8, v0, v4
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, v6, v13, vcc_lo
+; GFX10-NEXT:    v_add3_u32 v0, v14, v2, 0x7fff
+; GFX10-NEXT:    v_bfe_u32 v4, v9, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v5, v15, 16, 1
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v2, v2
+; GFX10-NEXT:    v_bfe_u32 v7, v8, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v13, 0x400000, v9
+; GFX10-NEXT:    v_or_b32_e32 v17, 0x400000, v11
+; GFX10-NEXT:    v_add3_u32 v2, v5, v15, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, v0, v1, vcc_lo
+; GFX10-NEXT:    v_add3_u32 v0, v4, v9, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v4, 0x400000, v15
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v15, v15
+; GFX10-NEXT:    v_add3_u32 v5, v7, v8, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v7, 0x400000, v8
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v8, v8
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, v5, v7, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v9, v9
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, v0, v13, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v11, v11
+; GFX10-NEXT:    v_perm_b32 v0, v4, v2, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v2, v6, v3, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v1, v5, v1, 0x7060302
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, v12, v17, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v3, v7, v10, 0x7060302
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11TRUE16-LABEL: v_fma_v8bf16:
+; GFX11TRUE16:       ; %bb.0:
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v12, 0xffff0000, v11
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v13, 0xffff0000, v7
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v15, 0xffff0000, v6
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v16, 0xffff0000, v2
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v14, 0xffff0000, v3
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v11, v3, v7
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v10
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v7, v2, v6
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v12, v14, v13
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v6, 0x400000, v11
+; GFX11TRUE16-NEXT:    v_bfe_u32 v13, v12, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v17, 0x400000, v12
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v12, v12
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11TRUE16-NEXT:    v_add3_u32 v13, v13, v12, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v3, v13, v17, vcc_lo
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v17, 0xffff0000, v1
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v14, 0xffff0000, v10
+; GFX11TRUE16-NEXT:    v_bfe_u32 v10, v11, 16, 1
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v11, v11
+; GFX11TRUE16-NEXT:    v_bfe_u32 v13, v7, 16, 1
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v14, v16, v15
+; GFX11TRUE16-NEXT:    v_add3_u32 v2, v10, v11, 0x7fff
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v16, 0xffff0000, v5
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v11, 0x400000, v7
+; GFX11TRUE16-NEXT:    v_bfe_u32 v15, v14, 16, 1
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v6, v2, v6, vcc_lo
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11TRUE16-NEXT:    v_add3_u32 v10, v15, v14, 0x7fff
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v15, 0xffff0000, v9
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v12, 0x400000, v14
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v14, v14
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v14, 16, v4
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v3.l, v6.h
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v9, v1, v5
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff0000, v4
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v2, v10, v12, vcc_lo
+; GFX11TRUE16-NEXT:    v_add3_u32 v10, v13, v7, 0x7fff
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v7, v7
+; GFX11TRUE16-NEXT:    v_bfe_u32 v7, v9, 16, 1
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v13, 16, v8
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_dual_cndmask_b32 v4, v10, v11 :: v_dual_and_b32 v5, 0xffff0000, v8
+; GFX11TRUE16-NEXT:    v_add3_u32 v7, v7, v9, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v10, 0x400000, v9
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v9, v9
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v2.l, v4.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v7, v7, v10, vcc_lo
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v15, v17, v16
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v16, 16, v0
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_bfe_u32 v12, v15, 16, 1
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v13, v16, v14
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v5, v0, v1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v1, 0x400000, v15
+; GFX11TRUE16-NEXT:    v_add3_u32 v8, v12, v15, 0x7fff
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_bfe_u32 v0, v13, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v11, v5, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v12, 0x400000, v13
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v13, v13
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v10, 0x400000, v5
+; GFX11TRUE16-NEXT:    v_add3_u32 v0, v0, v13, 0x7fff
+; GFX11TRUE16-NEXT:    v_add3_u32 v9, v11, v5, 0x7fff
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v11, v0, v12, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v15, v15
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v5, v5
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v1.l, v7.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v0, v9, v10, vcc_lo
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v0.l, v11.h
+; GFX11TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11FAKE16-LABEL: v_fma_v8bf16:
+; GFX11FAKE16:       ; %bb.0:
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v12, 16, v11
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v13, 16, v7
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v14, 16, v3
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v18, 16, v0
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v12, v14, v13 :: v_dual_and_b32 v3, 0xffff0000, v3
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v14, 16, v2
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11FAKE16-NEXT:    v_bfe_u32 v13, v12, 16, 1
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v11, v3, v7
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v15, 0x400000, v12
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v12, v12
+; GFX11FAKE16-NEXT:    v_add3_u32 v13, v13, v12, 0x7fff
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v10
+; GFX11FAKE16-NEXT:    v_bfe_u32 v16, v11, 16, 1
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v17, 0x400000, v11
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v3, v14, v7
+; GFX11FAKE16-NEXT:    v_dual_cndmask_b32 v10, v13, v15 :: v_dual_and_b32 v7, 0xffff0000, v10
+; GFX11FAKE16-NEXT:    v_add3_u32 v12, v16, v11, 0x7fff
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v14, 16, v1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v13, v3, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v15, 0x400000, v3
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v3, v3
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11FAKE16-NEXT:    v_add3_u32 v13, v13, v3, 0x7fff
+; GFX11FAKE16-NEXT:    v_dual_cndmask_b32 v3, v13, v15 :: v_dual_and_b32 v2, 0xffff0000, v2
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v7, v2, v6 :: v_dual_lshlrev_b32 v6, 16, v5
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v15, 16, v8
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v9
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX11FAKE16-NEXT:    v_bfe_u32 v16, v7, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v13, 0x400000, v7
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v2, v14, v6 :: v_dual_and_b32 v5, 0xffff0000, v5
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v7, v7
+; GFX11FAKE16-NEXT:    v_add3_u32 v6, v16, v7, 0x7fff
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v9, v1, v5 :: v_dual_and_b32 v8, 0xffff0000, v8
+; GFX11FAKE16-NEXT:    v_bfe_u32 v14, v2, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v1, 0x400000, v2
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v6, v6, v13, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v2, v2
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v16, 16, v4
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v13, 0x400000, v9
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v8, v0, v4
+; GFX11FAKE16-NEXT:    v_add3_u32 v0, v14, v2, 0x7fff
+; GFX11FAKE16-NEXT:    v_bfe_u32 v4, v9, 16, 1
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11FAKE16-NEXT:    v_bfe_u32 v7, v8, 16, 1
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v1, v0, v1, vcc_lo
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v15, v18, v16
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_add3_u32 v0, v4, v9, 0x7fff
+; GFX11FAKE16-NEXT:    v_bfe_u32 v5, v15, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v4, 0x400000, v15
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v15, v15
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX11FAKE16-NEXT:    v_add3_u32 v2, v5, v15, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v5, v7, v8, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v7, 0x400000, v8
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v8, v8
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v4, v5, v7, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v9, v9
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v5, v0, v13, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v11, v11
+; GFX11FAKE16-NEXT:    v_perm_b32 v0, v4, v2, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v2, v6, v3, 0x7060302
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11FAKE16-NEXT:    v_perm_b32 v1, v5, v1, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v7, v12, v17, vcc_lo
+; GFX11FAKE16-NEXT:    v_perm_b32 v3, v7, v10, 0x7060302
+; GFX11FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GFX1250-LABEL: v_fma_v8bf16:
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
@@ -50000,11 +50618,1239 @@ define <4 x bfloat> @v_fma_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b, <4 x bfloat>
 ; GFX1250-NEXT:    v_pk_fma_bf16 v2, v2, v6, v10
 ; GFX1250-NEXT:    v_pk_fma_bf16 v3, v3, v7, v11
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
-define <8 x bfloat> @v_fma_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c) {
   %op = call <8 x bfloat> @llvm.fma.v8bf16(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c)
   ret <8 x bfloat> %op
 }
 
+define <16 x bfloat> @v_fma_v16bf16(<16 x bfloat> %a, <16 x bfloat> %b, <16 x bfloat> %c) {
+; GCN-LABEL: v_fma_v16bf16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    buffer_load_dword v31, off, s[0:3], s32
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GCN-NEXT:    v_mul_f32_e32 v15, 1.0, v15
+; GCN-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v31, 1.0, v31
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GCN-NEXT:    v_fma_f32 v15, v15, v31, v32
+; GCN-NEXT:    v_mul_f32_e32 v14, 1.0, v14
+; GCN-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
+; GCN-NEXT:    v_mul_f32_e32 v30, 1.0, v30
+; GCN-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GCN-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v31, 1.0, v31
+; GCN-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GCN-NEXT:    v_fma_f32 v14, v14, v30, v31
+; GCN-NEXT:    v_mul_f32_e32 v13, 1.0, v13
+; GCN-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:56
+; GCN-NEXT:    v_mul_f32_e32 v29, 1.0, v29
+; GCN-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GCN-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v30, 1.0, v30
+; GCN-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GCN-NEXT:    v_fma_f32 v13, v13, v29, v30
+; GCN-NEXT:    v_mul_f32_e32 v12, 1.0, v12
+; GCN-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:52
+; GCN-NEXT:    v_mul_f32_e32 v28, 1.0, v28
+; GCN-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GCN-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v29, 1.0, v29
+; GCN-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GCN-NEXT:    v_fma_f32 v12, v12, v28, v29
+; GCN-NEXT:    v_mul_f32_e32 v11, 1.0, v11
+; GCN-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:48
+; GCN-NEXT:    v_mul_f32_e32 v27, 1.0, v27
+; GCN-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GCN-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v28, 1.0, v28
+; GCN-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GCN-NEXT:    v_fma_f32 v11, v11, v27, v28
+; GCN-NEXT:    v_mul_f32_e32 v10, 1.0, v10
+; GCN-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:44
+; GCN-NEXT:    v_mul_f32_e32 v26, 1.0, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GCN-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v27, 1.0, v27
+; GCN-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GCN-NEXT:    v_fma_f32 v10, v10, v26, v27
+; GCN-NEXT:    v_mul_f32_e32 v9, 1.0, v9
+; GCN-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:40
+; GCN-NEXT:    v_mul_f32_e32 v25, 1.0, v25
+; GCN-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GCN-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v26, 1.0, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GCN-NEXT:    v_fma_f32 v9, v9, v25, v26
+; GCN-NEXT:    v_mul_f32_e32 v8, 1.0, v8
+; GCN-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:36
+; GCN-NEXT:    v_mul_f32_e32 v24, 1.0, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GCN-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v25, 1.0, v25
+; GCN-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GCN-NEXT:    v_fma_f32 v8, v8, v24, v25
+; GCN-NEXT:    v_mul_f32_e32 v7, 1.0, v7
+; GCN-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:32
+; GCN-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GCN-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GCN-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v24, 1.0, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GCN-NEXT:    v_fma_f32 v7, v7, v23, v24
+; GCN-NEXT:    v_mul_f32_e32 v6, 1.0, v6
+; GCN-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:28
+; GCN-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GCN-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GCN-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GCN-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GCN-NEXT:    v_fma_f32 v6, v6, v22, v23
+; GCN-NEXT:    v_mul_f32_e32 v5, 1.0, v5
+; GCN-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:24
+; GCN-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GCN-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GCN-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GCN-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GCN-NEXT:    v_fma_f32 v5, v5, v21, v22
+; GCN-NEXT:    v_mul_f32_e32 v4, 1.0, v4
+; GCN-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:20
+; GCN-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GCN-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GCN-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GCN-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GCN-NEXT:    v_fma_f32 v4, v4, v20, v21
+; GCN-NEXT:    v_mul_f32_e32 v3, 1.0, v3
+; GCN-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:16
+; GCN-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GCN-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GCN-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GCN-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GCN-NEXT:    v_fma_f32 v3, v3, v19, v20
+; GCN-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:12
+; GCN-NEXT:    v_mul_f32_e32 v2, 1.0, v2
+; GCN-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GCN-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; GCN-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GCN-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GCN-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GCN-NEXT:    v_fma_f32 v2, v2, v18, v19
+; GCN-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:8
+; GCN-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GCN-NEXT:    v_mul_f32_e32 v16, 1.0, v16
+; GCN-NEXT:    v_mul_f32_e32 v1, 1.0, v1
+; GCN-NEXT:    v_mul_f32_e32 v17, 1.0, v17
+; GCN-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GCN-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GCN-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GCN-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v19, 1.0, v20
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GCN-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GCN-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GCN-NEXT:    v_fma_f32 v1, v1, v17, v18
+; GCN-NEXT:    v_fma_f32 v0, v0, v16, v19
+; GCN-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GCN-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GCN-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GCN-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GCN-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GCN-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GCN-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GCN-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GCN-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GCN-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GCN-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GCN-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GCN-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GCN-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GCN-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GCN-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: v_fma_v16bf16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GFX7-NEXT:    v_mul_f32_e32 v15, 1.0, v15
+; GFX7-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX7-NEXT:    v_mul_f32_e32 v14, 1.0, v14
+; GFX7-NEXT:    v_mul_f32_e32 v30, 1.0, v30
+; GFX7-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX7-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX7-NEXT:    v_mul_f32_e32 v13, 1.0, v13
+; GFX7-NEXT:    v_mul_f32_e32 v29, 1.0, v29
+; GFX7-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX7-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX7-NEXT:    v_mul_f32_e32 v12, 1.0, v12
+; GFX7-NEXT:    v_mul_f32_e32 v28, 1.0, v28
+; GFX7-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX7-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX7-NEXT:    v_mul_f32_e32 v11, 1.0, v11
+; GFX7-NEXT:    v_mul_f32_e32 v27, 1.0, v27
+; GFX7-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    v_mul_f32_e32 v10, 1.0, v10
+; GFX7-NEXT:    v_mul_f32_e32 v26, 1.0, v26
+; GFX7-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GFX7-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX7-NEXT:    v_mul_f32_e32 v9, 1.0, v9
+; GFX7-NEXT:    v_mul_f32_e32 v25, 1.0, v25
+; GFX7-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX7-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX7-NEXT:    v_mul_f32_e32 v8, 1.0, v8
+; GFX7-NEXT:    v_mul_f32_e32 v24, 1.0, v24
+; GFX7-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX7-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX7-NEXT:    v_mul_f32_e32 v7, 1.0, v7
+; GFX7-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GFX7-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX7-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX7-NEXT:    v_mul_f32_e32 v6, 1.0, v6
+; GFX7-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GFX7-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX7-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX7-NEXT:    v_mul_f32_e32 v5, 1.0, v5
+; GFX7-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GFX7-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX7-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX7-NEXT:    v_mul_f32_e32 v4, 1.0, v4
+; GFX7-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GFX7-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX7-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX7-NEXT:    v_mul_f32_e32 v3, 1.0, v3
+; GFX7-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GFX7-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX7-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX7-NEXT:    v_mul_f32_e32 v2, 1.0, v2
+; GFX7-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GFX7-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX7-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX7-NEXT:    v_mul_f32_e32 v1, 1.0, v1
+; GFX7-NEXT:    v_mul_f32_e32 v17, 1.0, v17
+; GFX7-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GFX7-NEXT:    v_mul_f32_e32 v16, 1.0, v16
+; GFX7-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX7-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX7-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v31, 1.0, v31
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GFX7-NEXT:    v_fma_f32 v15, v15, v31, v32
+; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
+; GFX7-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v31, 1.0, v31
+; GFX7-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GFX7-NEXT:    v_fma_f32 v14, v14, v30, v31
+; GFX7-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:56
+; GFX7-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v30, 1.0, v30
+; GFX7-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX7-NEXT:    v_fma_f32 v13, v13, v29, v30
+; GFX7-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:52
+; GFX7-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v29, 1.0, v29
+; GFX7-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX7-NEXT:    v_fma_f32 v12, v12, v28, v29
+; GFX7-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:48
+; GFX7-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v28, 1.0, v28
+; GFX7-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX7-NEXT:    v_fma_f32 v11, v11, v27, v28
+; GFX7-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:44
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v27, 1.0, v27
+; GFX7-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX7-NEXT:    v_fma_f32 v10, v10, v26, v27
+; GFX7-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:40
+; GFX7-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v26, 1.0, v26
+; GFX7-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GFX7-NEXT:    v_fma_f32 v9, v9, v25, v26
+; GFX7-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:36
+; GFX7-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v25, 1.0, v25
+; GFX7-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX7-NEXT:    v_fma_f32 v8, v8, v24, v25
+; GFX7-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:32
+; GFX7-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v24, 1.0, v24
+; GFX7-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX7-NEXT:    v_fma_f32 v7, v7, v23, v24
+; GFX7-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:28
+; GFX7-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GFX7-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX7-NEXT:    v_fma_f32 v6, v6, v22, v23
+; GFX7-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:24
+; GFX7-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GFX7-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX7-NEXT:    v_fma_f32 v5, v5, v21, v22
+; GFX7-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:20
+; GFX7-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GFX7-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX7-NEXT:    v_fma_f32 v4, v4, v20, v21
+; GFX7-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:16
+; GFX7-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GFX7-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX7-NEXT:    v_fma_f32 v3, v3, v19, v20
+; GFX7-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:12
+; GFX7-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; GFX7-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GFX7-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX7-NEXT:    v_fma_f32 v2, v2, v18, v19
+; GFX7-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:8
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v19, 1.0, v20
+; GFX7-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GFX7-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX7-NEXT:    v_fma_f32 v1, v1, v17, v18
+; GFX7-NEXT:    v_and_b32_e32 v17, 0xffff0000, v19
+; GFX7-NEXT:    v_fma_f32 v0, v0, v16, v17
+; GFX7-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_fma_v16bf16:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v24, 16, v23
+; GFX8-NEXT:    v_lshlrev_b32_e32 v25, 16, v15
+; GFX8-NEXT:    v_lshlrev_b32_e32 v26, 16, v7
+; GFX8-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX8-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX8-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX8-NEXT:    v_fma_f32 v24, v26, v25, v24
+; GFX8-NEXT:    v_fma_f32 v7, v7, v15, v23
+; GFX8-NEXT:    v_lshlrev_b32_e32 v15, 16, v22
+; GFX8-NEXT:    v_lshlrev_b32_e32 v23, 16, v14
+; GFX8-NEXT:    v_lshlrev_b32_e32 v25, 16, v6
+; GFX8-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX8-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX8-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX8-NEXT:    v_fma_f32 v15, v25, v23, v15
+; GFX8-NEXT:    v_fma_f32 v6, v6, v14, v22
+; GFX8-NEXT:    v_lshlrev_b32_e32 v14, 16, v21
+; GFX8-NEXT:    v_lshlrev_b32_e32 v22, 16, v13
+; GFX8-NEXT:    v_lshlrev_b32_e32 v23, 16, v5
+; GFX8-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX8-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX8-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX8-NEXT:    v_fma_f32 v14, v23, v22, v14
+; GFX8-NEXT:    v_fma_f32 v5, v5, v13, v21
+; GFX8-NEXT:    v_lshlrev_b32_e32 v13, 16, v20
+; GFX8-NEXT:    v_lshlrev_b32_e32 v21, 16, v12
+; GFX8-NEXT:    v_lshlrev_b32_e32 v22, 16, v4
+; GFX8-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX8-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX8-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX8-NEXT:    v_fma_f32 v13, v22, v21, v13
+; GFX8-NEXT:    v_fma_f32 v4, v4, v12, v20
+; GFX8-NEXT:    v_lshlrev_b32_e32 v12, 16, v19
+; GFX8-NEXT:    v_lshlrev_b32_e32 v20, 16, v11
+; GFX8-NEXT:    v_lshlrev_b32_e32 v21, 16, v3
+; GFX8-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX8-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX8-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX8-NEXT:    v_fma_f32 v12, v21, v20, v12
+; GFX8-NEXT:    v_fma_f32 v3, v3, v11, v19
+; GFX8-NEXT:    v_lshlrev_b32_e32 v11, 16, v18
+; GFX8-NEXT:    v_lshlrev_b32_e32 v19, 16, v10
+; GFX8-NEXT:    v_lshlrev_b32_e32 v20, 16, v2
+; GFX8-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX8-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX8-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX8-NEXT:    v_fma_f32 v11, v20, v19, v11
+; GFX8-NEXT:    v_fma_f32 v2, v2, v10, v18
+; GFX8-NEXT:    v_lshlrev_b32_e32 v10, 16, v17
+; GFX8-NEXT:    v_lshlrev_b32_e32 v18, 16, v9
+; GFX8-NEXT:    v_lshlrev_b32_e32 v19, 16, v1
+; GFX8-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX8-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX8-NEXT:    v_fma_f32 v10, v19, v18, v10
+; GFX8-NEXT:    v_fma_f32 v1, v1, v9, v17
+; GFX8-NEXT:    v_lshlrev_b32_e32 v9, 16, v16
+; GFX8-NEXT:    v_lshlrev_b32_e32 v17, 16, v8
+; GFX8-NEXT:    v_lshlrev_b32_e32 v18, 16, v0
+; GFX8-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX8-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX8-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX8-NEXT:    v_fma_f32 v0, v0, v8, v16
+; GFX8-NEXT:    v_bfe_u32 v8, v24, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v8, vcc, v8, v24
+; GFX8-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX8-NEXT:    v_add_u32_e32 v8, vcc, s4, v8
+; GFX8-NEXT:    v_or_b32_e32 v16, 0x400000, v24
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v24, v24
+; GFX8-NEXT:    v_cndmask_b32_e32 v8, v8, v16, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v7, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v7
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_fma_f32 v9, v18, v17, v9
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v7
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v7, v7
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v15, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v15
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v15
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v15, v15
+; GFX8-NEXT:    v_cndmask_b32_e32 v15, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v6, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v6
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v6
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v6, v6
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v14, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v14
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v14
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v14, v14
+; GFX8-NEXT:    v_cndmask_b32_e32 v14, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v5, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v5
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v5
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v5, v5
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v13, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v13
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v13
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v13, v13
+; GFX8-NEXT:    v_cndmask_b32_e32 v13, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v4, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v4
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v4
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v4, v4
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v12, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v12
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v12
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v12, v12
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v3, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v3
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v3
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v3, v3
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v11, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v11
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v11
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v11, v11
+; GFX8-NEXT:    v_cndmask_b32_e32 v11, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v2, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v2
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v2
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v2, v2
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v10, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v10
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v10
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v10, v10
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v1, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v1
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v1, v1
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v9, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v9
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v9
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v9, v9
+; GFX8-NEXT:    v_cndmask_b32_e32 v9, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v16, v0, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v0
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v0
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v16, v17, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GFX8-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX8-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX8-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
+; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
+; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
+; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX8-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX8-NEXT:    v_alignbit_b32 v0, v0, v9, 16
+; GFX8-NEXT:    v_alignbit_b32 v1, v1, v10, 16
+; GFX8-NEXT:    v_alignbit_b32 v2, v2, v11, 16
+; GFX8-NEXT:    v_alignbit_b32 v3, v3, v12, 16
+; GFX8-NEXT:    v_alignbit_b32 v4, v4, v13, 16
+; GFX8-NEXT:    v_alignbit_b32 v5, v5, v14, 16
+; GFX8-NEXT:    v_alignbit_b32 v6, v6, v15, 16
+; GFX8-NEXT:    v_alignbit_b32 v7, v7, v8, 16
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_fma_v16bf16:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v24, 16, v23
+; GFX900-NEXT:    v_lshlrev_b32_e32 v25, 16, v15
+; GFX900-NEXT:    v_lshlrev_b32_e32 v26, 16, v7
+; GFX900-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX900-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX900-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX900-NEXT:    v_fma_f32 v24, v26, v25, v24
+; GFX900-NEXT:    v_fma_f32 v7, v7, v15, v23
+; GFX900-NEXT:    v_lshlrev_b32_e32 v15, 16, v22
+; GFX900-NEXT:    v_lshlrev_b32_e32 v23, 16, v14
+; GFX900-NEXT:    v_lshlrev_b32_e32 v25, 16, v6
+; GFX900-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX900-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX900-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX900-NEXT:    v_fma_f32 v15, v25, v23, v15
+; GFX900-NEXT:    v_fma_f32 v6, v6, v14, v22
+; GFX900-NEXT:    v_lshlrev_b32_e32 v14, 16, v21
+; GFX900-NEXT:    v_lshlrev_b32_e32 v22, 16, v13
+; GFX900-NEXT:    v_lshlrev_b32_e32 v23, 16, v5
+; GFX900-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX900-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX900-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX900-NEXT:    v_fma_f32 v14, v23, v22, v14
+; GFX900-NEXT:    v_fma_f32 v5, v5, v13, v21
+; GFX900-NEXT:    v_lshlrev_b32_e32 v13, 16, v20
+; GFX900-NEXT:    v_lshlrev_b32_e32 v21, 16, v12
+; GFX900-NEXT:    v_lshlrev_b32_e32 v22, 16, v4
+; GFX900-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX900-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX900-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX900-NEXT:    v_fma_f32 v13, v22, v21, v13
+; GFX900-NEXT:    v_fma_f32 v4, v4, v12, v20
+; GFX900-NEXT:    v_lshlrev_b32_e32 v12, 16, v19
+; GFX900-NEXT:    v_lshlrev_b32_e32 v20, 16, v11
+; GFX900-NEXT:    v_lshlrev_b32_e32 v21, 16, v3
+; GFX900-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX900-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX900-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX900-NEXT:    v_fma_f32 v12, v21, v20, v12
+; GFX900-NEXT:    v_fma_f32 v3, v3, v11, v19
+; GFX900-NEXT:    v_lshlrev_b32_e32 v11, 16, v18
+; GFX900-NEXT:    v_lshlrev_b32_e32 v19, 16, v10
+; GFX900-NEXT:    v_lshlrev_b32_e32 v20, 16, v2
+; GFX900-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX900-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX900-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX900-NEXT:    v_fma_f32 v11, v20, v19, v11
+; GFX900-NEXT:    v_fma_f32 v2, v2, v10, v18
+; GFX900-NEXT:    v_lshlrev_b32_e32 v10, 16, v17
+; GFX900-NEXT:    v_lshlrev_b32_e32 v18, 16, v9
+; GFX900-NEXT:    v_lshlrev_b32_e32 v19, 16, v1
+; GFX900-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX900-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX900-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX900-NEXT:    v_fma_f32 v10, v19, v18, v10
+; GFX900-NEXT:    v_fma_f32 v1, v1, v9, v17
+; GFX900-NEXT:    v_lshlrev_b32_e32 v9, 16, v16
+; GFX900-NEXT:    v_lshlrev_b32_e32 v17, 16, v8
+; GFX900-NEXT:    v_lshlrev_b32_e32 v18, 16, v0
+; GFX900-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX900-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX900-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX900-NEXT:    v_fma_f32 v0, v0, v8, v16
+; GFX900-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX900-NEXT:    v_bfe_u32 v8, v24, 16, 1
+; GFX900-NEXT:    v_add3_u32 v8, v8, v24, s4
+; GFX900-NEXT:    v_or_b32_e32 v16, 0x400000, v24
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v24, v24
+; GFX900-NEXT:    v_cndmask_b32_e32 v8, v8, v16, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v7, 16, 1
+; GFX900-NEXT:    v_fma_f32 v9, v18, v17, v9
+; GFX900-NEXT:    v_add3_u32 v16, v16, v7, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v7
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v7, v7
+; GFX900-NEXT:    v_cndmask_b32_e32 v7, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v15, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v15, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v15
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v15, v15
+; GFX900-NEXT:    v_cndmask_b32_e32 v15, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v6, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v6, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v6
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v6, v6
+; GFX900-NEXT:    v_cndmask_b32_e32 v6, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v14, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v14, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v14
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v14, v14
+; GFX900-NEXT:    v_cndmask_b32_e32 v14, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v5, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v5, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v5
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v5, v5
+; GFX900-NEXT:    v_cndmask_b32_e32 v5, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v13, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v13, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v13
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v13, v13
+; GFX900-NEXT:    v_cndmask_b32_e32 v13, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v4, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v4, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v4, v4
+; GFX900-NEXT:    v_cndmask_b32_e32 v4, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v12, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v12, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v12
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v12, v12
+; GFX900-NEXT:    v_cndmask_b32_e32 v12, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v3, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v3, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v3
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v3, v3
+; GFX900-NEXT:    v_cndmask_b32_e32 v3, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v11, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v11, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v11
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v11, v11
+; GFX900-NEXT:    v_cndmask_b32_e32 v11, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v2, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v2, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v2
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v2, v2
+; GFX900-NEXT:    v_cndmask_b32_e32 v2, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v10, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v10, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v10
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v10, v10
+; GFX900-NEXT:    v_cndmask_b32_e32 v10, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v1, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v1, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v1
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v1, v1
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v9, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v9, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v9
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v9, v9
+; GFX900-NEXT:    v_cndmask_b32_e32 v9, v16, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v16, v0, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v0, s4
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v0
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, v16, v17, vcc
+; GFX900-NEXT:    s_mov_b32 s4, 0x7060302
+; GFX900-NEXT:    v_perm_b32 v0, v0, v9, s4
+; GFX900-NEXT:    v_perm_b32 v1, v1, v10, s4
+; GFX900-NEXT:    v_perm_b32 v2, v2, v11, s4
+; GFX900-NEXT:    v_perm_b32 v3, v3, v12, s4
+; GFX900-NEXT:    v_perm_b32 v4, v4, v13, s4
+; GFX900-NEXT:    v_perm_b32 v5, v5, v14, s4
+; GFX900-NEXT:    v_perm_b32 v6, v6, v15, s4
+; GFX900-NEXT:    v_perm_b32 v7, v7, v8, s4
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX950-LABEL: v_fma_v16bf16:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_and_b32_e32 v24, 0xffff0000, v23
+; GFX950-NEXT:    v_and_b32_e32 v25, 0xffff0000, v15
+; GFX950-NEXT:    v_and_b32_e32 v26, 0xffff0000, v7
+; GFX950-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
+; GFX950-NEXT:    v_lshlrev_b32_e32 v15, 16, v15
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX950-NEXT:    v_fmac_f32_e32 v24, v26, v25
+; GFX950-NEXT:    v_fmac_f32_e32 v23, v7, v15
+; GFX950-NEXT:    v_and_b32_e32 v7, 0xffff0000, v22
+; GFX950-NEXT:    v_and_b32_e32 v15, 0xffff0000, v14
+; GFX950-NEXT:    v_and_b32_e32 v25, 0xffff0000, v6
+; GFX950-NEXT:    v_fmac_f32_e32 v7, v25, v15
+; GFX950-NEXT:    v_lshlrev_b32_e32 v15, 16, v22
+; GFX950-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
+; GFX950-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX950-NEXT:    v_fmac_f32_e32 v15, v6, v14
+; GFX950-NEXT:    v_and_b32_e32 v6, 0xffff0000, v21
+; GFX950-NEXT:    v_and_b32_e32 v14, 0xffff0000, v13
+; GFX950-NEXT:    v_and_b32_e32 v22, 0xffff0000, v5
+; GFX950-NEXT:    v_fmac_f32_e32 v6, v22, v14
+; GFX950-NEXT:    v_lshlrev_b32_e32 v14, 16, v21
+; GFX950-NEXT:    v_lshlrev_b32_e32 v13, 16, v13
+; GFX950-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX950-NEXT:    v_fmac_f32_e32 v14, v5, v13
+; GFX950-NEXT:    v_and_b32_e32 v5, 0xffff0000, v20
+; GFX950-NEXT:    v_and_b32_e32 v13, 0xffff0000, v12
+; GFX950-NEXT:    v_and_b32_e32 v21, 0xffff0000, v4
+; GFX950-NEXT:    v_fmac_f32_e32 v5, v21, v13
+; GFX950-NEXT:    v_lshlrev_b32_e32 v13, 16, v20
+; GFX950-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
+; GFX950-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX950-NEXT:    v_fmac_f32_e32 v13, v4, v12
+; GFX950-NEXT:    v_and_b32_e32 v4, 0xffff0000, v19
+; GFX950-NEXT:    v_and_b32_e32 v12, 0xffff0000, v11
+; GFX950-NEXT:    v_and_b32_e32 v20, 0xffff0000, v3
+; GFX950-NEXT:    v_fmac_f32_e32 v4, v20, v12
+; GFX950-NEXT:    v_lshlrev_b32_e32 v12, 16, v19
+; GFX950-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; GFX950-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX950-NEXT:    v_fmac_f32_e32 v12, v3, v11
+; GFX950-NEXT:    v_and_b32_e32 v3, 0xffff0000, v18
+; GFX950-NEXT:    v_and_b32_e32 v11, 0xffff0000, v10
+; GFX950-NEXT:    v_and_b32_e32 v19, 0xffff0000, v2
+; GFX950-NEXT:    v_fmac_f32_e32 v3, v19, v11
+; GFX950-NEXT:    v_lshlrev_b32_e32 v11, 16, v18
+; GFX950-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
+; GFX950-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX950-NEXT:    v_fmac_f32_e32 v11, v2, v10
+; GFX950-NEXT:    v_and_b32_e32 v2, 0xffff0000, v17
+; GFX950-NEXT:    v_and_b32_e32 v10, 0xffff0000, v9
+; GFX950-NEXT:    v_and_b32_e32 v18, 0xffff0000, v1
+; GFX950-NEXT:    v_fmac_f32_e32 v2, v18, v10
+; GFX950-NEXT:    v_lshlrev_b32_e32 v10, 16, v17
+; GFX950-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
+; GFX950-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX950-NEXT:    v_fmac_f32_e32 v10, v1, v9
+; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff0000, v16
+; GFX950-NEXT:    v_and_b32_e32 v9, 0xffff0000, v8
+; GFX950-NEXT:    v_and_b32_e32 v17, 0xffff0000, v0
+; GFX950-NEXT:    v_fmac_f32_e32 v1, v17, v9
+; GFX950-NEXT:    v_lshlrev_b32_e32 v9, 16, v16
+; GFX950-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
+; GFX950-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX950-NEXT:    v_fmac_f32_e32 v9, v0, v8
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v0, v9, v1
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v1, v10, v2
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v2, v11, v3
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v3, v12, v4
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v4, v13, v5
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v5, v14, v6
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v6, v15, v7
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v7, v23, v24
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX10-LABEL: v_fma_v16bf16:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v24, 16, v23
+; GFX10-NEXT:    v_lshlrev_b32_e32 v25, 16, v15
+; GFX10-NEXT:    v_lshlrev_b32_e32 v26, 16, v7
+; GFX10-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX10-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX10-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX10-NEXT:    v_fmac_f32_e32 v24, v26, v25
+; GFX10-NEXT:    v_lshlrev_b32_e32 v26, 16, v6
+; GFX10-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX10-NEXT:    v_fmac_f32_e32 v23, v7, v15
+; GFX10-NEXT:    v_lshlrev_b32_e32 v7, 16, v22
+; GFX10-NEXT:    v_bfe_u32 v25, v24, 16, 1
+; GFX10-NEXT:    v_lshlrev_b32_e32 v15, 16, v14
+; GFX10-NEXT:    v_or_b32_e32 v27, 0x400000, v24
+; GFX10-NEXT:    v_bfe_u32 v28, v23, 16, 1
+; GFX10-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX10-NEXT:    v_add3_u32 v25, v25, v24, 0x7fff
+; GFX10-NEXT:    v_fmac_f32_e32 v7, v26, v15
+; GFX10-NEXT:    v_and_b32_e32 v15, 0xffff0000, v22
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX10-NEXT:    v_add3_u32 v24, v28, v23, 0x7fff
+; GFX10-NEXT:    v_bfe_u32 v26, v7, 16, 1
+; GFX10-NEXT:    v_fmac_f32_e32 v15, v6, v14
+; GFX10-NEXT:    v_cndmask_b32_e32 v22, v25, v27, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v25, 0x400000, v23
+; GFX10-NEXT:    v_lshlrev_b32_e32 v6, 16, v21
+; GFX10-NEXT:    v_lshlrev_b32_e32 v14, 16, v13
+; GFX10-NEXT:    v_lshlrev_b32_e32 v27, 16, v5
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v23, v23
+; GFX10-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX10-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX10-NEXT:    v_fmac_f32_e32 v6, v27, v14
+; GFX10-NEXT:    v_cndmask_b32_e32 v23, v24, v25, vcc_lo
+; GFX10-NEXT:    v_add3_u32 v24, v26, v7, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v25, 0x400000, v7
+; GFX10-NEXT:    v_bfe_u32 v26, v15, 16, 1
+; GFX10-NEXT:    v_and_b32_e32 v14, 0xffff0000, v21
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v7, v7
+; GFX10-NEXT:    v_add3_u32 v21, v26, v15, 0x7fff
+; GFX10-NEXT:    v_fmac_f32_e32 v14, v5, v13
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, v24, v25, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v24, 0x400000, v15
+; GFX10-NEXT:    v_bfe_u32 v25, v6, 16, 1
+; GFX10-NEXT:    v_lshlrev_b32_e32 v5, 16, v20
+; GFX10-NEXT:    v_lshlrev_b32_e32 v13, 16, v12
+; GFX10-NEXT:    v_lshlrev_b32_e32 v26, 16, v4
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v15, v15
+; GFX10-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX10-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX10-NEXT:    v_fmac_f32_e32 v5, v26, v13
+; GFX10-NEXT:    v_cndmask_b32_e32 v15, v21, v24, vcc_lo
+; GFX10-NEXT:    v_add3_u32 v21, v25, v6, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v24, 0x400000, v6
+; GFX10-NEXT:    v_bfe_u32 v25, v14, 16, 1
+; GFX10-NEXT:    v_and_b32_e32 v13, 0xffff0000, v20
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v6, v6
+; GFX10-NEXT:    v_lshlrev_b32_e32 v26, 16, v2
+; GFX10-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX10-NEXT:    v_add3_u32 v20, v25, v14, 0x7fff
+; GFX10-NEXT:    v_fmac_f32_e32 v13, v4, v12
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, v21, v24, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v21, 0x400000, v14
+; GFX10-NEXT:    v_bfe_u32 v24, v5, 16, 1
+; GFX10-NEXT:    v_lshlrev_b32_e32 v4, 16, v19
+; GFX10-NEXT:    v_lshlrev_b32_e32 v12, 16, v11
+; GFX10-NEXT:    v_lshlrev_b32_e32 v25, 16, v3
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v14, v14
+; GFX10-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX10-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX10-NEXT:    v_fmac_f32_e32 v4, v25, v12
+; GFX10-NEXT:    v_cndmask_b32_e32 v14, v20, v21, vcc_lo
+; GFX10-NEXT:    v_add3_u32 v20, v24, v5, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v21, 0x400000, v5
+; GFX10-NEXT:    v_and_b32_e32 v12, 0xffff0000, v19
+; GFX10-NEXT:    v_lshlrev_b32_e32 v19, 16, v18
+; GFX10-NEXT:    v_lshlrev_b32_e32 v25, 16, v10
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v5, v5
+; GFX10-NEXT:    v_bfe_u32 v24, v13, 16, 1
+; GFX10-NEXT:    v_fmac_f32_e32 v12, v3, v11
+; GFX10-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX10-NEXT:    v_fmac_f32_e32 v19, v26, v25
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, v20, v21, vcc_lo
+; GFX10-NEXT:    v_bfe_u32 v20, v4, 16, 1
+; GFX10-NEXT:    v_add3_u32 v21, v24, v13, 0x7fff
+; GFX10-NEXT:    v_bfe_u32 v24, v12, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v25, v19, 16, 1
+; GFX10-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX10-NEXT:    v_add3_u32 v11, v20, v4, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v20, 0x400000, v4
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v4, v4
+; GFX10-NEXT:    v_or_b32_e32 v26, 0x400000, v19
+; GFX10-NEXT:    v_fmac_f32_e32 v18, v2, v10
+; GFX10-NEXT:    v_lshlrev_b32_e32 v2, 16, v17
+; GFX10-NEXT:    v_lshlrev_b32_e32 v10, 16, v9
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, v11, v20, vcc_lo
+; GFX10-NEXT:    v_add3_u32 v11, v24, v12, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v20, 0x400000, v12
+; GFX10-NEXT:    v_add3_u32 v24, v25, v19, 0x7fff
+; GFX10-NEXT:    v_lshlrev_b32_e32 v25, 16, v1
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v12, v12
+; GFX10-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX10-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX10-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX10-NEXT:    v_fmac_f32_e32 v2, v25, v10
+; GFX10-NEXT:    v_cndmask_b32_e32 v11, v11, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v19, v19
+; GFX10-NEXT:    v_lshlrev_b32_e32 v25, 16, v8
+; GFX10-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX10-NEXT:    v_bfe_u32 v20, v2, 16, 1
+; GFX10-NEXT:    v_fmac_f32_e32 v17, v1, v9
+; GFX10-NEXT:    v_cndmask_b32_e32 v10, v24, v26, vcc_lo
+; GFX10-NEXT:    v_lshlrev_b32_e32 v24, 16, v16
+; GFX10-NEXT:    v_lshlrev_b32_e32 v26, 16, v0
+; GFX10-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX10-NEXT:    v_add3_u32 v1, v20, v2, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v9, 0x400000, v2
+; GFX10-NEXT:    v_fmac_f32_e32 v24, v26, v25
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v2, v2
+; GFX10-NEXT:    v_fmac_f32_e32 v16, v0, v8
+; GFX10-NEXT:    v_bfe_u32 v0, v17, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v27, v18, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v8, v24, 16, 1
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v9, 0x400000, v17
+; GFX10-NEXT:    v_add3_u32 v0, v0, v17, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v17, v17
+; GFX10-NEXT:    v_bfe_u32 v2, v16, 16, 1
+; GFX10-NEXT:    v_add3_u32 v8, v8, v24, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v20, 0x400000, v24
+; GFX10-NEXT:    v_or_b32_e32 v25, 0x400000, v16
+; GFX10-NEXT:    v_cndmask_b32_e32 v9, v0, v9, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX10-NEXT:    v_add3_u32 v2, v2, v16, 0x7fff
+; GFX10-NEXT:    v_add3_u32 v12, v27, v18, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v19, 0x400000, v18
+; GFX10-NEXT:    v_or_b32_e32 v3, 0x400000, v13
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, v8, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v16, v16
+; GFX10-NEXT:    v_perm_b32 v1, v9, v1, 0x7060302
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, v2, v25, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v18, v18
+; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x7060302
+; GFX10-NEXT:    v_cndmask_b32_e32 v8, v12, v19, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v13, v13
+; GFX10-NEXT:    v_perm_b32 v2, v8, v10, 0x7060302
+; GFX10-NEXT:    v_cndmask_b32_e32 v12, v21, v3, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v3, v11, v4, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v4, v12, v5, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v5, v14, v6, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v6, v15, v7, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v7, v23, v22, 0x7060302
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11TRUE16-LABEL: v_fma_v16bf16:
+; GFX11TRUE16:       ; %bb.0:
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v24, 0xffff0000, v23
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v26, 0xffff0000, v7
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v27, 0xffff0000, v14
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v28, 0xffff0000, v6
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v25, 0xffff0000, v15
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v24, v26, v25 :: v_dual_lshlrev_b32 v7, 16, v7
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v26, 0xffff0000, v22
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v22, 16, v22
+; GFX11TRUE16-NEXT:    v_bfe_u32 v25, v24, 16, 1
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v26, v28, v27
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v22, v6, v14
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v14, 0xffff0000, v21
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v28, 0xffff0000, v13
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v15, 16, v15
+; GFX11TRUE16-NEXT:    v_add3_u32 v25, v25, v24, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v29, 0x400000, v24
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v13, 16, v13
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v23, v7, v15
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v7, v25, v29, vcc_lo
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v29, 0xffff0000, v5
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_bfe_u32 v15, v23, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v24, v26, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v25, 0x400000, v23
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v23, v23
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v27, 0x400000, v26
+; GFX11TRUE16-NEXT:    v_add3_u32 v15, v15, v23, 0x7fff
+; GFX11TRUE16-NEXT:    v_add3_u32 v24, v24, v26, 0x7fff
+; GFX11TRUE16-NEXT:    v_bfe_u32 v23, v22, 16, 1
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v14, v29, v28 :: v_dual_cndmask_b32 v15, v15, v25
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v26, v26
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v25, 0xffff0000, v12
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v26, 0xffff0000, v4
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v6, v24, v27, vcc_lo
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v24, 0xffff0000, v20
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
+; GFX11TRUE16-NEXT:    v_add3_u32 v23, v23, v22, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v27, 0x400000, v22
+; GFX11TRUE16-NEXT:    v_bfe_u32 v28, v14, 16, 1
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v22, v22
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v20, v4, v12
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v12, 0xffff0000, v19
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff0000, v11
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v24, v26, v25
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v22, 0x400000, v14
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v7.l, v15.h
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v21, v5, v13
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v13, v23, v27, vcc_lo
+; GFX11TRUE16-NEXT:    v_add3_u32 v5, v28, v14, 0x7fff
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v14, v14
+; GFX11TRUE16-NEXT:    v_bfe_u32 v25, v24, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v23, v21, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v27, v20, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v26, 0x400000, v24
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v5, v5, v22, vcc_lo
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v22, 0x400000, v21
+; GFX11TRUE16-NEXT:    v_add3_u32 v14, v23, v21, 0x7fff
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v21, v21
+; GFX11TRUE16-NEXT:    v_add3_u32 v23, v25, v24, 0x7fff
+; GFX11TRUE16-NEXT:    v_add3_u32 v21, v27, v20, 0x7fff
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v6.l, v13.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v14, v14, v22, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v22, 0x400000, v20
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v25, 0xffff0000, v3
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v24, 0xffff0000, v18
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v5.l, v14.h
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v12, v25, v4
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v4, v23, v26, vcc_lo
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v25, 0xffff0000, v10
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v26, 0xffff0000, v2
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
+; GFX11TRUE16-NEXT:    v_bfe_u32 v23, v12, 16, 1
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v20, v20
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v24, v26, v25
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX11TRUE16-NEXT:    v_dual_cndmask_b32 v20, v21, v22 :: v_dual_and_b32 v25, 0xffff0000, v1
+; GFX11TRUE16-NEXT:    v_add3_u32 v21, v23, v12, 0x7fff
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_bfe_u32 v23, v24, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v22, 0x400000, v12
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v12, v12
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v4.l, v20.h
+; GFX11TRUE16-NEXT:    v_add3_u32 v12, v23, v24, 0x7fff
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v23, 0xffff0000, v9
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v19, v3, v11
+; GFX11TRUE16-NEXT:    v_dual_cndmask_b32 v3, v21, v22 :: v_dual_and_b32 v22, 0xffff0000, v17
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v11, 16, v18
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v17, 16, v17
+; GFX11TRUE16-NEXT:    v_bfe_u32 v18, v19, 16, 1
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v19, v19
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v22, v25, v23 :: v_dual_fmac_f32 v11, v2, v10
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v10, 0x400000, v19
+; GFX11TRUE16-NEXT:    v_add3_u32 v2, v18, v19, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v18, 0x400000, v24
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v23, 16, v8
+; GFX11TRUE16-NEXT:    v_bfe_u32 v21, v11, 16, 1
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v17, v1, v9 :: v_dual_cndmask_b32 v10, v2, v10
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v24, 16, v0
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v9, 0xffff0000, v16
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff0000, v8
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v2, v12, v18, vcc_lo
+; GFX11TRUE16-NEXT:    v_add3_u32 v12, v21, v11, 0x7fff
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v21, 16, v16
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v18, 0x400000, v11
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v11, v11
+; GFX11TRUE16-NEXT:    v_bfe_u32 v11, v17, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v19, v22, 16, 1
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v21, v24, v23
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v9, v0, v1
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v8, v12, v18, vcc_lo
+; GFX11TRUE16-NEXT:    v_add3_u32 v11, v11, v17, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v16, 0x400000, v17
+; GFX11TRUE16-NEXT:    v_bfe_u32 v0, v21, 16, 1
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v17, v17
+; GFX11TRUE16-NEXT:    v_add3_u32 v12, v19, v22, 0x7fff
+; GFX11TRUE16-NEXT:    v_bfe_u32 v18, v9, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v19, 0x400000, v21
+; GFX11TRUE16-NEXT:    v_add3_u32 v0, v0, v21, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v11, v11, v16, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v21, v21
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v1, 0x400000, v22
+; GFX11TRUE16-NEXT:    v_add3_u32 v16, v18, v9, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v17, 0x400000, v9
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v18, v0, v19, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v22, v22
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v3.l, v10.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v1, v12, v1, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v9, v9
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v1.l, v11.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v0, v16, v17, vcc_lo
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v0.l, v18.h
+; GFX11TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11FAKE16-LABEL: v_fma_v16bf16:
+; GFX11FAKE16:       ; %bb.0:
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v24, 16, v23
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v25, 16, v15
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v26, 16, v7
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v24, v26, v25 :: v_dual_and_b32 v23, 0xffff0000, v23
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v23, v7, v15 :: v_dual_lshlrev_b32 v26, 16, v6
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v15, 16, v14
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11FAKE16-NEXT:    v_bfe_u32 v25, v24, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v27, 0x400000, v24
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX11FAKE16-NEXT:    v_bfe_u32 v28, v23, 16, 1
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX11FAKE16-NEXT:    v_add3_u32 v25, v25, v24, 0x7fff
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v22
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_add3_u32 v24, v28, v23, 0x7fff
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v7, v26, v15
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_cndmask_b32 v22, v25, v27 :: v_dual_and_b32 v15, 0xffff0000, v22
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v25, 0x400000, v23
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v23, v23
+; GFX11FAKE16-NEXT:    v_bfe_u32 v26, v7, 16, 1
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v27, 16, v5
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v23, v24, v25, vcc_lo
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_add3_u32 v24, v26, v7, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v25, 0x400000, v7
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v7, v7
+; GFX11FAKE16-NEXT:    v_dual_cndmask_b32 v7, v24, v25 :: v_dual_and_b32 v6, 0xffff0000, v6
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v15, v6, v14 :: v_dual_lshlrev_b32 v14, 16, v13
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v24, 0x400000, v15
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v15, v15
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v6, 16, v21
+; GFX11FAKE16-NEXT:    v_bfe_u32 v26, v15, 16, 1
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v6, v27, v14
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v14, 0xffff0000, v21
+; GFX11FAKE16-NEXT:    v_add3_u32 v21, v26, v15, 0x7fff
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v26, 16, v4
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_bfe_u32 v25, v6, 16, 1
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v14, v5, v13 :: v_dual_lshlrev_b32 v5, 16, v20
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v13, 16, v12
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v15, v21, v24, vcc_lo
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_add3_u32 v21, v25, v6, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v24, 0x400000, v6
+; GFX11FAKE16-NEXT:    v_bfe_u32 v25, v14, 16, 1
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v5, v26, v13 :: v_dual_and_b32 v12, 0xffff0000, v12
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v13, 0xffff0000, v20
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v6, v6
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v26, 16, v2
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX11FAKE16-NEXT:    v_add3_u32 v20, v25, v14, 0x7fff
+; GFX11FAKE16-NEXT:    v_dual_cndmask_b32 v6, v21, v24 :: v_dual_lshlrev_b32 v25, 16, v3
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v21, 0x400000, v14
+; GFX11FAKE16-NEXT:    v_bfe_u32 v24, v5, 16, 1
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v13, v4, v12 :: v_dual_lshlrev_b32 v4, 16, v19
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v12, 16, v11
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v14, v14
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v4, v25, v12
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v14, v20, v21, vcc_lo
+; GFX11FAKE16-NEXT:    v_add3_u32 v20, v24, v5, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v21, 0x400000, v5
+; GFX11FAKE16-NEXT:    v_bfe_u32 v24, v13, 16, 1
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v12, 0xffff0000, v19
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v5, v5
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v25, 16, v10
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v12, v3, v11 :: v_dual_cndmask_b32 v5, v20, v21
+; GFX11FAKE16-NEXT:    v_add3_u32 v21, v24, v13, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v3, 0x400000, v13
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v19, 16, v18
+; GFX11FAKE16-NEXT:    v_bfe_u32 v20, v4, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v24, v12, 16, 1
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v4, v4
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v19, v26, v25
+; GFX11FAKE16-NEXT:    v_add3_u32 v11, v20, v4, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v20, 0x400000, v4
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v18, v2, v10
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v17
+; GFX11FAKE16-NEXT:    v_bfe_u32 v25, v19, 16, 1
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v10, 16, v9
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v4, v11, v20, vcc_lo
+; GFX11FAKE16-NEXT:    v_add3_u32 v11, v24, v12, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v20, 0x400000, v12
+; GFX11FAKE16-NEXT:    v_add3_u32 v24, v25, v19, 0x7fff
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v25, 16, v1
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v12, v12
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v26, 0x400000, v19
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v2, v25, v10 :: v_dual_and_b32 v9, 0xffff0000, v9
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v11, v11, v20, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v19, v19
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v25, 16, v8
+; GFX11FAKE16-NEXT:    v_bfe_u32 v20, v2, 16, 1
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v10, v24, v26, vcc_lo
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v24, 16, v16
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v26, 16, v0
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v17, v1, v9 :: v_dual_and_b32 v0, 0xffff0000, v0
+; GFX11FAKE16-NEXT:    v_add3_u32 v1, v20, v2, 0x7fff
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v24, v26, v25
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v9, 0x400000, v2
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v16, v0, v8
+; GFX11FAKE16-NEXT:    v_bfe_u32 v0, v17, 16, 1
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v2, v2
+; GFX11FAKE16-NEXT:    v_bfe_u32 v8, v24, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v20, 0x400000, v24
+; GFX11FAKE16-NEXT:    v_bfe_u32 v2, v16, 16, 1
+; GFX11FAKE16-NEXT:    v_add3_u32 v0, v0, v17, 0x7fff
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v9, 0x400000, v17
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v17, v17
+; GFX11FAKE16-NEXT:    v_add3_u32 v8, v8, v24, 0x7fff
+; GFX11FAKE16-NEXT:    v_bfe_u32 v27, v18, 16, 1
+; GFX11FAKE16-NEXT:    v_add3_u32 v2, v2, v16, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v25, 0x400000, v16
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v9, v0, v9, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v24, v24
+; GFX11FAKE16-NEXT:    v_add3_u32 v12, v27, v18, 0x7fff
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v19, 0x400000, v18
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v1, v9, v1, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v0, v8, v20, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v16, v16
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v2, v2, v25, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v18, v18
+; GFX11FAKE16-NEXT:    v_perm_b32 v0, v2, v0, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v8, v12, v19, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v13, v13
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v2, v8, v10, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v12, v21, v3, vcc_lo
+; GFX11FAKE16-NEXT:    v_perm_b32 v3, v11, v4, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v4, v12, v5, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v5, v14, v6, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v6, v15, v7, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v7, v23, v22, 0x7060302
+; GFX11FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GFX1250-LABEL: v_fma_v16bf16:
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
@@ -50018,67 +51864,2797 @@ define <8 x bfloat> @v_fma_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat>
 ; GFX1250-NEXT:    v_pk_fma_bf16 v6, v6, v14, v22
 ; GFX1250-NEXT:    v_pk_fma_bf16 v7, v7, v15, v23
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
-define <16 x bfloat> @v_fma_v16bf16(<16 x bfloat> %a, <16 x bfloat> %b, <16 x bfloat> %c) {
   %op = call <16 x bfloat> @llvm.fma.v16bf16(<16 x bfloat> %a, <16 x bfloat> %b, <16 x bfloat> %c)
   ret <16 x bfloat> %op
 }
 
+define <32 x bfloat> @v_fma_v32bf16(<32 x bfloat> %a, <32 x bfloat> %b, <32 x bfloat> %c) {
+; GCN-LABEL: v_fma_v32bf16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    buffer_load_dword v31, off, s[0:3], s32
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:128
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:256
+; GCN-NEXT:    s_waitcnt vmcnt(2)
+; GCN-NEXT:    v_mul_f32_e32 v31, 1.0, v31
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GCN-NEXT:    v_fma_f32 v31, v31, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:252
+; GCN-NEXT:    v_mul_f32_e32 v30, 1.0, v30
+; GCN-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v30, v30, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:248
+; GCN-NEXT:    v_mul_f32_e32 v29, 1.0, v29
+; GCN-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v29, v29, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:116
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:244
+; GCN-NEXT:    v_mul_f32_e32 v28, 1.0, v28
+; GCN-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v28, v28, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:240
+; GCN-NEXT:    v_mul_f32_e32 v27, 1.0, v27
+; GCN-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v27, v27, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:108
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:236
+; GCN-NEXT:    v_mul_f32_e32 v26, 1.0, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v26, v26, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:232
+; GCN-NEXT:    v_mul_f32_e32 v25, 1.0, v25
+; GCN-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v25, v25, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:100
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:228
+; GCN-NEXT:    v_mul_f32_e32 v24, 1.0, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v24, v24, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:224
+; GCN-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GCN-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v23, v23, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:92
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:220
+; GCN-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GCN-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v22, v22, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:216
+; GCN-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GCN-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v21, v21, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:84
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:212
+; GCN-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GCN-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v20, v20, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:208
+; GCN-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GCN-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v19, v19, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:76
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:204
+; GCN-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GCN-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v18, v18, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:200
+; GCN-NEXT:    v_mul_f32_e32 v17, 1.0, v17
+; GCN-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v17, v17, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:68
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:196
+; GCN-NEXT:    v_mul_f32_e32 v16, 1.0, v16
+; GCN-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v16, v16, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:192
+; GCN-NEXT:    v_mul_f32_e32 v15, 1.0, v15
+; GCN-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v15, v15, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:60
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:188
+; GCN-NEXT:    v_mul_f32_e32 v14, 1.0, v14
+; GCN-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v14, v14, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:184
+; GCN-NEXT:    v_mul_f32_e32 v13, 1.0, v13
+; GCN-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v13, v13, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:52
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:180
+; GCN-NEXT:    v_mul_f32_e32 v12, 1.0, v12
+; GCN-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v12, v12, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:176
+; GCN-NEXT:    v_mul_f32_e32 v11, 1.0, v11
+; GCN-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v11, v11, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:44
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:172
+; GCN-NEXT:    v_mul_f32_e32 v10, 1.0, v10
+; GCN-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v10, v10, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:168
+; GCN-NEXT:    v_mul_f32_e32 v9, 1.0, v9
+; GCN-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v9, v9, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:36
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:164
+; GCN-NEXT:    v_mul_f32_e32 v8, 1.0, v8
+; GCN-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v8, v8, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:160
+; GCN-NEXT:    v_mul_f32_e32 v7, 1.0, v7
+; GCN-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v7, v7, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:28
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:156
+; GCN-NEXT:    v_mul_f32_e32 v6, 1.0, v6
+; GCN-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v6, v6, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:152
+; GCN-NEXT:    v_mul_f32_e32 v5, 1.0, v5
+; GCN-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v5, v5, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:20
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:148
+; GCN-NEXT:    v_mul_f32_e32 v4, 1.0, v4
+; GCN-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v4, v4, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:144
+; GCN-NEXT:    v_mul_f32_e32 v3, 1.0, v3
+; GCN-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v3, v3, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:12
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:140
+; GCN-NEXT:    v_mul_f32_e32 v2, 1.0, v2
+; GCN-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v2, v2, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:136
+; GCN-NEXT:    v_mul_f32_e32 v1, 1.0, v1
+; GCN-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v1, v1, v32, v33
+; GCN-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:4
+; GCN-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:132
+; GCN-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GCN-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GCN-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GCN-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GCN-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GCN-NEXT:    v_fma_f32 v0, v0, v32, v33
+; GCN-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GCN-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GCN-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GCN-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GCN-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GCN-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GCN-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GCN-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GCN-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GCN-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GCN-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GCN-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GCN-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GCN-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GCN-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GCN-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GCN-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GCN-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GCN-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GCN-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GCN-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GCN-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GCN-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GCN-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GCN-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GCN-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GCN-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GCN-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GCN-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GCN-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GCN-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: v_fma_v32bf16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:128
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:256
+; GFX7-NEXT:    v_mul_f32_e32 v30, 1.0, v30
+; GFX7-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX7-NEXT:    v_mul_f32_e32 v29, 1.0, v29
+; GFX7-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX7-NEXT:    v_mul_f32_e32 v28, 1.0, v28
+; GFX7-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX7-NEXT:    v_mul_f32_e32 v27, 1.0, v27
+; GFX7-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX7-NEXT:    v_mul_f32_e32 v26, 1.0, v26
+; GFX7-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GFX7-NEXT:    v_mul_f32_e32 v25, 1.0, v25
+; GFX7-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX7-NEXT:    v_mul_f32_e32 v24, 1.0, v24
+; GFX7-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX7-NEXT:    v_mul_f32_e32 v23, 1.0, v23
+; GFX7-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX7-NEXT:    v_mul_f32_e32 v22, 1.0, v22
+; GFX7-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX7-NEXT:    v_mul_f32_e32 v21, 1.0, v21
+; GFX7-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX7-NEXT:    v_mul_f32_e32 v20, 1.0, v20
+; GFX7-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX7-NEXT:    v_mul_f32_e32 v19, 1.0, v19
+; GFX7-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX7-NEXT:    v_mul_f32_e32 v18, 1.0, v18
+; GFX7-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX7-NEXT:    v_mul_f32_e32 v17, 1.0, v17
+; GFX7-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX7-NEXT:    v_mul_f32_e32 v16, 1.0, v16
+; GFX7-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX7-NEXT:    v_mul_f32_e32 v15, 1.0, v15
+; GFX7-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX7-NEXT:    v_mul_f32_e32 v14, 1.0, v14
+; GFX7-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX7-NEXT:    v_mul_f32_e32 v13, 1.0, v13
+; GFX7-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX7-NEXT:    v_mul_f32_e32 v12, 1.0, v12
+; GFX7-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX7-NEXT:    v_mul_f32_e32 v11, 1.0, v11
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    v_mul_f32_e32 v10, 1.0, v10
+; GFX7-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX7-NEXT:    v_mul_f32_e32 v9, 1.0, v9
+; GFX7-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX7-NEXT:    v_mul_f32_e32 v8, 1.0, v8
+; GFX7-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX7-NEXT:    v_mul_f32_e32 v7, 1.0, v7
+; GFX7-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX7-NEXT:    v_mul_f32_e32 v6, 1.0, v6
+; GFX7-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX7-NEXT:    v_mul_f32_e32 v5, 1.0, v5
+; GFX7-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX7-NEXT:    v_mul_f32_e32 v4, 1.0, v4
+; GFX7-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX7-NEXT:    v_mul_f32_e32 v3, 1.0, v3
+; GFX7-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX7-NEXT:    v_mul_f32_e32 v2, 1.0, v2
+; GFX7-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX7-NEXT:    v_mul_f32_e32 v1, 1.0, v1
+; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX7-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GFX7-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX7-NEXT:    s_waitcnt vmcnt(2)
+; GFX7-NEXT:    v_mul_f32_e32 v31, 1.0, v31
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GFX7-NEXT:    v_fma_f32 v31, v31, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:252
+; GFX7-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v30, v30, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:248
+; GFX7-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v29, v29, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:116
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:244
+; GFX7-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v28, v28, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:240
+; GFX7-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v27, v27, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:108
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:236
+; GFX7-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v26, v26, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:232
+; GFX7-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v25, v25, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:100
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:228
+; GFX7-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v24, v24, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:224
+; GFX7-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v23, v23, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:92
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:220
+; GFX7-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v22, v22, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:216
+; GFX7-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v21, v21, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:84
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:212
+; GFX7-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v20, v20, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:208
+; GFX7-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v19, v19, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:76
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:204
+; GFX7-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v18, v18, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:200
+; GFX7-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v17, v17, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:68
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:196
+; GFX7-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v16, v16, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:192
+; GFX7-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v15, v15, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:60
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:188
+; GFX7-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v14, v14, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:184
+; GFX7-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v13, v13, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:52
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:180
+; GFX7-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v12, v12, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:176
+; GFX7-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v11, v11, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:44
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:172
+; GFX7-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v10, v10, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:168
+; GFX7-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v9, v9, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:36
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:164
+; GFX7-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v8, v8, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:160
+; GFX7-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v7, v7, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:28
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:156
+; GFX7-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v6, v6, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:152
+; GFX7-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v5, v5, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:20
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:148
+; GFX7-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v4, v4, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:144
+; GFX7-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v3, v3, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:12
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:140
+; GFX7-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v2, v2, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:136
+; GFX7-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v1, v1, v32, v33
+; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:4
+; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:132
+; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX7-NEXT:    s_waitcnt vmcnt(1)
+; GFX7-NEXT:    v_mul_f32_e32 v32, 1.0, v32
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v33, 1.0, v33
+; GFX7-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX7-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX7-NEXT:    v_fma_f32 v0, v0, v32, v33
+; GFX7-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_fma_v32bf16:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32
+; GFX8-NEXT:    v_lshlrev_b32_e32 v31, 16, v15
+; GFX8-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX8-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX8-NEXT:    s_waitcnt vmcnt(1)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v32
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v15, v15, v33, v32
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:60
+; GFX8-NEXT:    v_fma_f32 v31, v31, v35, v34
+; GFX8-NEXT:    v_lshlrev_b32_e32 v32, 16, v30
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v14
+; GFX8-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX8-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v14, v14, v30, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:56
+; GFX8-NEXT:    v_fma_f32 v32, v34, v32, v35
+; GFX8-NEXT:    v_lshlrev_b32_e32 v30, 16, v29
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v13
+; GFX8-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX8-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v13, v13, v29, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:52
+; GFX8-NEXT:    v_fma_f32 v30, v34, v30, v35
+; GFX8-NEXT:    v_lshlrev_b32_e32 v29, 16, v28
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v12
+; GFX8-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX8-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v12, v12, v28, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:48
+; GFX8-NEXT:    v_fma_f32 v29, v34, v29, v35
+; GFX8-NEXT:    v_lshlrev_b32_e32 v28, 16, v27
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v11
+; GFX8-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX8-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v11, v11, v27, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:44
+; GFX8-NEXT:    v_fma_f32 v28, v34, v28, v35
+; GFX8-NEXT:    v_lshlrev_b32_e32 v27, 16, v26
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v10
+; GFX8-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GFX8-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v10, v10, v26, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:40
+; GFX8-NEXT:    v_fma_f32 v27, v34, v27, v35
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v25
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v9
+; GFX8-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX8-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v26, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v9, v9, v25, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:36
+; GFX8-NEXT:    v_fma_f32 v26, v35, v34, v26
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v24
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v8
+; GFX8-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX8-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v25, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v8, v8, v24, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:32
+; GFX8-NEXT:    v_fma_f32 v25, v35, v34, v25
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v23
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v7
+; GFX8-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX8-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v24, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v7, v7, v23, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:28
+; GFX8-NEXT:    v_fma_f32 v24, v35, v34, v24
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v22
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v6
+; GFX8-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX8-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v23, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v6, v6, v22, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:24
+; GFX8-NEXT:    v_fma_f32 v23, v35, v34, v23
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v21
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v5
+; GFX8-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX8-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v22, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v5, v5, v21, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:20
+; GFX8-NEXT:    v_fma_f32 v22, v35, v34, v22
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v20
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v4
+; GFX8-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX8-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v21, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v4, v4, v20, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:16
+; GFX8-NEXT:    v_fma_f32 v21, v35, v34, v21
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v19
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v3
+; GFX8-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX8-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v20, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v3, v3, v19, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:12
+; GFX8-NEXT:    v_fma_f32 v20, v35, v34, v20
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v18
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v2
+; GFX8-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX8-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v19, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v2, v2, v18, v33
+; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:8
+; GFX8-NEXT:    v_fma_f32 v19, v35, v34, v19
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v17
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v1
+; GFX8-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v18, 16, v33
+; GFX8-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX8-NEXT:    v_fma_f32 v1, v1, v17, v33
+; GFX8-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:4
+; GFX8-NEXT:    v_fma_f32 v18, v35, v34, v18
+; GFX8-NEXT:    v_lshlrev_b32_e32 v34, 16, v16
+; GFX8-NEXT:    v_lshlrev_b32_e32 v35, 16, v0
+; GFX8-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX8-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_lshlrev_b32_e32 v33, 16, v17
+; GFX8-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX8-NEXT:    v_fma_f32 v0, v0, v16, v17
+; GFX8-NEXT:    v_bfe_u32 v16, v31, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, v16, v31
+; GFX8-NEXT:    v_add_u32_e32 v16, vcc, s4, v16
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v31, v31
+; GFX8-NEXT:    v_or_b32_e32 v17, 0x400000, v31
+; GFX8-NEXT:    v_cndmask_b32_e32 v16, v16, v17, vcc
+; GFX8-NEXT:    v_bfe_u32 v17, v15, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v17, vcc, v17, v15
+; GFX8-NEXT:    v_add_u32_e32 v17, vcc, s4, v17
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v15, v15
+; GFX8-NEXT:    v_or_b32_e32 v15, 0x400000, v15
+; GFX8-NEXT:    v_cndmask_b32_e32 v15, v17, v15, vcc
+; GFX8-NEXT:    v_bfe_u32 v17, v32, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v17, vcc, v17, v32
+; GFX8-NEXT:    v_add_u32_e32 v17, vcc, s4, v17
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v32, v32
+; GFX8-NEXT:    v_or_b32_e32 v31, 0x400000, v32
+; GFX8-NEXT:    v_cndmask_b32_e32 v17, v17, v31, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v14, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v14
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v14, v14
+; GFX8-NEXT:    v_or_b32_e32 v14, 0x400000, v14
+; GFX8-NEXT:    v_cndmask_b32_e32 v14, v31, v14, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v30, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v30
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v30, v30
+; GFX8-NEXT:    v_or_b32_e32 v30, 0x400000, v30
+; GFX8-NEXT:    v_cndmask_b32_e32 v30, v31, v30, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v13, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v13
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v13, v13
+; GFX8-NEXT:    v_or_b32_e32 v13, 0x400000, v13
+; GFX8-NEXT:    v_cndmask_b32_e32 v13, v31, v13, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v29, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v29
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v29, v29
+; GFX8-NEXT:    v_or_b32_e32 v29, 0x400000, v29
+; GFX8-NEXT:    v_cndmask_b32_e32 v29, v31, v29, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v12, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v12
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v12, v12
+; GFX8-NEXT:    v_or_b32_e32 v12, 0x400000, v12
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, v31, v12, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v28, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v28
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v28, v28
+; GFX8-NEXT:    v_or_b32_e32 v28, 0x400000, v28
+; GFX8-NEXT:    v_cndmask_b32_e32 v28, v31, v28, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v11, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v11
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v11, v11
+; GFX8-NEXT:    v_or_b32_e32 v11, 0x400000, v11
+; GFX8-NEXT:    v_cndmask_b32_e32 v11, v31, v11, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v27, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v27
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v27, v27
+; GFX8-NEXT:    v_or_b32_e32 v27, 0x400000, v27
+; GFX8-NEXT:    v_cndmask_b32_e32 v27, v31, v27, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v10, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v10
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v10, v10
+; GFX8-NEXT:    v_or_b32_e32 v10, 0x400000, v10
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, v31, v10, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v26, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v26
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v26, v26
+; GFX8-NEXT:    v_or_b32_e32 v26, 0x400000, v26
+; GFX8-NEXT:    v_cndmask_b32_e32 v26, v31, v26, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v9, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v9
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v9, v9
+; GFX8-NEXT:    v_or_b32_e32 v9, 0x400000, v9
+; GFX8-NEXT:    v_cndmask_b32_e32 v9, v31, v9, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v25, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v25
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v25, v25
+; GFX8-NEXT:    v_or_b32_e32 v25, 0x400000, v25
+; GFX8-NEXT:    v_cndmask_b32_e32 v25, v31, v25, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v8, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v8
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v8, v8
+; GFX8-NEXT:    v_or_b32_e32 v8, 0x400000, v8
+; GFX8-NEXT:    v_cndmask_b32_e32 v8, v31, v8, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v24, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v24
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v24, v24
+; GFX8-NEXT:    v_or_b32_e32 v24, 0x400000, v24
+; GFX8-NEXT:    v_cndmask_b32_e32 v24, v31, v24, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v7, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v7
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v7, v7
+; GFX8-NEXT:    v_or_b32_e32 v7, 0x400000, v7
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v31, v7, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v23, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v23
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v23, v23
+; GFX8-NEXT:    v_or_b32_e32 v23, 0x400000, v23
+; GFX8-NEXT:    v_cndmask_b32_e32 v23, v31, v23, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v6, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v6
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v6, v6
+; GFX8-NEXT:    v_or_b32_e32 v6, 0x400000, v6
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v31, v6, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v22, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v22
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v22, v22
+; GFX8-NEXT:    v_or_b32_e32 v22, 0x400000, v22
+; GFX8-NEXT:    v_cndmask_b32_e32 v22, v31, v22, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v5, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v5
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v5, v5
+; GFX8-NEXT:    v_or_b32_e32 v5, 0x400000, v5
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v31, v5, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v21, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v21
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v21, v21
+; GFX8-NEXT:    v_or_b32_e32 v21, 0x400000, v21
+; GFX8-NEXT:    v_cndmask_b32_e32 v21, v31, v21, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v4, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v4
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v4, v4
+; GFX8-NEXT:    v_or_b32_e32 v4, 0x400000, v4
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v31, v4, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v20, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v20
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v20, v20
+; GFX8-NEXT:    v_or_b32_e32 v20, 0x400000, v20
+; GFX8-NEXT:    v_cndmask_b32_e32 v20, v31, v20, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v3, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v3
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v3, v3
+; GFX8-NEXT:    v_or_b32_e32 v3, 0x400000, v3
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v31, v3, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v19, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v19
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v19, v19
+; GFX8-NEXT:    v_or_b32_e32 v19, 0x400000, v19
+; GFX8-NEXT:    v_cndmask_b32_e32 v19, v31, v19, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v2, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v2
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v2, v2
+; GFX8-NEXT:    v_or_b32_e32 v2, 0x400000, v2
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v31, v2, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v18, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v18
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v18, v18
+; GFX8-NEXT:    v_or_b32_e32 v18, 0x400000, v18
+; GFX8-NEXT:    v_cndmask_b32_e32 v18, v31, v18, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v1, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_fma_f32 v33, v35, v34, v33
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v1, v1
+; GFX8-NEXT:    v_or_b32_e32 v1, 0x400000, v1
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v31, v1, vcc
+; GFX8-NEXT:    v_bfe_u32 v31, v33, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, v31, v33
+; GFX8-NEXT:    v_add_u32_e32 v31, vcc, s4, v31
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v33, v33
+; GFX8-NEXT:    v_or_b32_e32 v32, 0x400000, v33
+; GFX8-NEXT:    v_cndmask_b32_e32 v31, v31, v32, vcc
+; GFX8-NEXT:    v_bfe_u32 v32, v0, 16, 1
+; GFX8-NEXT:    v_add_u32_e32 v32, vcc, v32, v0
+; GFX8-NEXT:    v_add_u32_e32 v32, vcc, s4, v32
+; GFX8-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX8-NEXT:    v_or_b32_e32 v0, 0x400000, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v32, v0, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GFX8-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX8-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX8-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
+; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
+; GFX8-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
+; GFX8-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
+; GFX8-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
+; GFX8-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
+; GFX8-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
+; GFX8-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
+; GFX8-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
+; GFX8-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
+; GFX8-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
+; GFX8-NEXT:    v_alignbit_b32 v0, v0, v31, 16
+; GFX8-NEXT:    v_alignbit_b32 v1, v1, v18, 16
+; GFX8-NEXT:    v_alignbit_b32 v2, v2, v19, 16
+; GFX8-NEXT:    v_alignbit_b32 v3, v3, v20, 16
+; GFX8-NEXT:    v_alignbit_b32 v4, v4, v21, 16
+; GFX8-NEXT:    v_alignbit_b32 v5, v5, v22, 16
+; GFX8-NEXT:    v_alignbit_b32 v6, v6, v23, 16
+; GFX8-NEXT:    v_alignbit_b32 v7, v7, v24, 16
+; GFX8-NEXT:    v_alignbit_b32 v8, v8, v25, 16
+; GFX8-NEXT:    v_alignbit_b32 v9, v9, v26, 16
+; GFX8-NEXT:    v_alignbit_b32 v10, v10, v27, 16
+; GFX8-NEXT:    v_alignbit_b32 v11, v11, v28, 16
+; GFX8-NEXT:    v_alignbit_b32 v12, v12, v29, 16
+; GFX8-NEXT:    v_alignbit_b32 v13, v13, v30, 16
+; GFX8-NEXT:    v_alignbit_b32 v14, v14, v17, 16
+; GFX8-NEXT:    v_alignbit_b32 v15, v15, v16, 16
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_fma_v32bf16:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32
+; GFX900-NEXT:    v_lshlrev_b32_e32 v31, 16, v15
+; GFX900-NEXT:    v_and_b32_e32 v15, 0xffff0000, v15
+; GFX900-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX900-NEXT:    s_waitcnt vmcnt(1)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v32
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v15, v15, v33, v32
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:60
+; GFX900-NEXT:    v_fma_f32 v31, v31, v35, v34
+; GFX900-NEXT:    v_lshlrev_b32_e32 v32, 16, v30
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v14
+; GFX900-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX900-NEXT:    v_and_b32_e32 v14, 0xffff0000, v14
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v31, v31
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v14, v14, v30, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:56
+; GFX900-NEXT:    v_fma_f32 v32, v34, v32, v35
+; GFX900-NEXT:    v_lshlrev_b32_e32 v30, 16, v29
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v13
+; GFX900-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX900-NEXT:    v_and_b32_e32 v13, 0xffff0000, v13
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v13, v13, v29, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:52
+; GFX900-NEXT:    v_fma_f32 v30, v34, v30, v35
+; GFX900-NEXT:    v_lshlrev_b32_e32 v29, 16, v28
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v12
+; GFX900-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX900-NEXT:    v_and_b32_e32 v12, 0xffff0000, v12
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v12, v12, v28, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:48
+; GFX900-NEXT:    v_fma_f32 v29, v34, v29, v35
+; GFX900-NEXT:    v_lshlrev_b32_e32 v28, 16, v27
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v11
+; GFX900-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX900-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v11, v11, v27, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:44
+; GFX900-NEXT:    v_fma_f32 v28, v34, v28, v35
+; GFX900-NEXT:    v_lshlrev_b32_e32 v27, 16, v26
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v10
+; GFX900-NEXT:    v_and_b32_e32 v26, 0xffff0000, v26
+; GFX900-NEXT:    v_and_b32_e32 v10, 0xffff0000, v10
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v10, v10, v26, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:40
+; GFX900-NEXT:    v_fma_f32 v27, v34, v27, v35
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v25
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v9
+; GFX900-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX900-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v26, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v9, v9, v25, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:36
+; GFX900-NEXT:    v_fma_f32 v26, v35, v34, v26
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v24
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v8
+; GFX900-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX900-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v25, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v8, v8, v24, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:32
+; GFX900-NEXT:    v_fma_f32 v25, v35, v34, v25
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v23
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v7
+; GFX900-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX900-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v24, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v7, v7, v23, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:28
+; GFX900-NEXT:    v_fma_f32 v24, v35, v34, v24
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v22
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v6
+; GFX900-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX900-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v23, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v6, v6, v22, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:24
+; GFX900-NEXT:    v_fma_f32 v23, v35, v34, v23
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v21
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v5
+; GFX900-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX900-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v22, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v5, v5, v21, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:20
+; GFX900-NEXT:    v_fma_f32 v22, v35, v34, v22
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v20
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v4
+; GFX900-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX900-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v21, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v4, v4, v20, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:16
+; GFX900-NEXT:    v_fma_f32 v21, v35, v34, v21
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v19
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v3
+; GFX900-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX900-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v20, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v3, v3, v19, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:12
+; GFX900-NEXT:    v_fma_f32 v20, v35, v34, v20
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v18
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v2
+; GFX900-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX900-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v19, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v2, v2, v18, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:8
+; GFX900-NEXT:    v_fma_f32 v19, v35, v34, v19
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v17
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v1
+; GFX900-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX900-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v18, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v1, v1, v17, v33
+; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:4
+; GFX900-NEXT:    v_fma_f32 v18, v35, v34, v18
+; GFX900-NEXT:    v_lshlrev_b32_e32 v34, 16, v16
+; GFX900-NEXT:    v_lshlrev_b32_e32 v35, 16, v0
+; GFX900-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX900-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_lshlrev_b32_e32 v17, 16, v33
+; GFX900-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX900-NEXT:    v_fma_f32 v0, v0, v16, v33
+; GFX900-NEXT:    v_bfe_u32 v16, v31, 16, 1
+; GFX900-NEXT:    v_add3_u32 v16, v16, v31, s4
+; GFX900-NEXT:    v_or_b32_e32 v31, 0x400000, v31
+; GFX900-NEXT:    v_cndmask_b32_e32 v16, v16, v31, vcc
+; GFX900-NEXT:    v_bfe_u32 v31, v15, 16, 1
+; GFX900-NEXT:    v_add3_u32 v31, v31, v15, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v15, v15
+; GFX900-NEXT:    v_or_b32_e32 v15, 0x400000, v15
+; GFX900-NEXT:    v_cndmask_b32_e32 v15, v31, v15, vcc
+; GFX900-NEXT:    v_bfe_u32 v31, v32, 16, 1
+; GFX900-NEXT:    v_add3_u32 v31, v31, v32, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v32, v32
+; GFX900-NEXT:    v_or_b32_e32 v32, 0x400000, v32
+; GFX900-NEXT:    v_cndmask_b32_e32 v31, v31, v32, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v14, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v14, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v14, v14
+; GFX900-NEXT:    v_or_b32_e32 v14, 0x400000, v14
+; GFX900-NEXT:    v_cndmask_b32_e32 v14, v32, v14, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v30, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v30, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v30, v30
+; GFX900-NEXT:    v_or_b32_e32 v30, 0x400000, v30
+; GFX900-NEXT:    v_cndmask_b32_e32 v30, v32, v30, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v13, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v13, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v13, v13
+; GFX900-NEXT:    v_or_b32_e32 v13, 0x400000, v13
+; GFX900-NEXT:    v_cndmask_b32_e32 v13, v32, v13, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v29, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v29, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v29, v29
+; GFX900-NEXT:    v_or_b32_e32 v29, 0x400000, v29
+; GFX900-NEXT:    v_cndmask_b32_e32 v29, v32, v29, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v12, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v12, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v12, v12
+; GFX900-NEXT:    v_or_b32_e32 v12, 0x400000, v12
+; GFX900-NEXT:    v_cndmask_b32_e32 v12, v32, v12, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v28, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v28, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v28, v28
+; GFX900-NEXT:    v_or_b32_e32 v28, 0x400000, v28
+; GFX900-NEXT:    v_cndmask_b32_e32 v28, v32, v28, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v11, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v11, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v11, v11
+; GFX900-NEXT:    v_or_b32_e32 v11, 0x400000, v11
+; GFX900-NEXT:    v_cndmask_b32_e32 v11, v32, v11, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v27, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v27, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v27, v27
+; GFX900-NEXT:    v_or_b32_e32 v27, 0x400000, v27
+; GFX900-NEXT:    v_cndmask_b32_e32 v27, v32, v27, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v10, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v10, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v10, v10
+; GFX900-NEXT:    v_or_b32_e32 v10, 0x400000, v10
+; GFX900-NEXT:    v_cndmask_b32_e32 v10, v32, v10, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v26, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v26, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v26, v26
+; GFX900-NEXT:    v_or_b32_e32 v26, 0x400000, v26
+; GFX900-NEXT:    v_cndmask_b32_e32 v26, v32, v26, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v9, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v9, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v9, v9
+; GFX900-NEXT:    v_or_b32_e32 v9, 0x400000, v9
+; GFX900-NEXT:    v_cndmask_b32_e32 v9, v32, v9, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v25, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v25, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v25, v25
+; GFX900-NEXT:    v_or_b32_e32 v25, 0x400000, v25
+; GFX900-NEXT:    v_cndmask_b32_e32 v25, v32, v25, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v8, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v8, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v8, v8
+; GFX900-NEXT:    v_or_b32_e32 v8, 0x400000, v8
+; GFX900-NEXT:    v_cndmask_b32_e32 v8, v32, v8, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v24, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v24, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v24, v24
+; GFX900-NEXT:    v_or_b32_e32 v24, 0x400000, v24
+; GFX900-NEXT:    v_cndmask_b32_e32 v24, v32, v24, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v7, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v7, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v7, v7
+; GFX900-NEXT:    v_or_b32_e32 v7, 0x400000, v7
+; GFX900-NEXT:    v_cndmask_b32_e32 v7, v32, v7, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v23, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v23, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v23, v23
+; GFX900-NEXT:    v_or_b32_e32 v23, 0x400000, v23
+; GFX900-NEXT:    v_cndmask_b32_e32 v23, v32, v23, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v6, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v6, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v6, v6
+; GFX900-NEXT:    v_or_b32_e32 v6, 0x400000, v6
+; GFX900-NEXT:    v_cndmask_b32_e32 v6, v32, v6, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v22, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v22, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v22, v22
+; GFX900-NEXT:    v_or_b32_e32 v22, 0x400000, v22
+; GFX900-NEXT:    v_cndmask_b32_e32 v22, v32, v22, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v5, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v5, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v5, v5
+; GFX900-NEXT:    v_or_b32_e32 v5, 0x400000, v5
+; GFX900-NEXT:    v_cndmask_b32_e32 v5, v32, v5, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v21, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v21, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v21, v21
+; GFX900-NEXT:    v_or_b32_e32 v21, 0x400000, v21
+; GFX900-NEXT:    v_cndmask_b32_e32 v21, v32, v21, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v4, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v4, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v4, v4
+; GFX900-NEXT:    v_or_b32_e32 v4, 0x400000, v4
+; GFX900-NEXT:    v_cndmask_b32_e32 v4, v32, v4, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v20, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v20, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v20, v20
+; GFX900-NEXT:    v_or_b32_e32 v20, 0x400000, v20
+; GFX900-NEXT:    v_cndmask_b32_e32 v20, v32, v20, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v3, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v3, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v3, v3
+; GFX900-NEXT:    v_or_b32_e32 v3, 0x400000, v3
+; GFX900-NEXT:    v_cndmask_b32_e32 v3, v32, v3, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v19, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v19, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v19, v19
+; GFX900-NEXT:    v_or_b32_e32 v19, 0x400000, v19
+; GFX900-NEXT:    v_cndmask_b32_e32 v19, v32, v19, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v2, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v2, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v2, v2
+; GFX900-NEXT:    v_or_b32_e32 v2, 0x400000, v2
+; GFX900-NEXT:    v_cndmask_b32_e32 v2, v32, v2, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v18, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v18, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v18, v18
+; GFX900-NEXT:    v_or_b32_e32 v18, 0x400000, v18
+; GFX900-NEXT:    v_cndmask_b32_e32 v18, v32, v18, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v1, 16, 1
+; GFX900-NEXT:    v_fma_f32 v17, v35, v34, v17
+; GFX900-NEXT:    v_add3_u32 v32, v32, v1, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v1, v1
+; GFX900-NEXT:    v_or_b32_e32 v1, 0x400000, v1
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v17, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v17, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v17, v17
+; GFX900-NEXT:    v_or_b32_e32 v17, 0x400000, v17
+; GFX900-NEXT:    v_cndmask_b32_e32 v17, v32, v17, vcc
+; GFX900-NEXT:    v_bfe_u32 v32, v0, 16, 1
+; GFX900-NEXT:    v_add3_u32 v32, v32, v0, s4
+; GFX900-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX900-NEXT:    v_or_b32_e32 v0, 0x400000, v0
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, v32, v0, vcc
+; GFX900-NEXT:    s_mov_b32 s4, 0x7060302
+; GFX900-NEXT:    v_perm_b32 v0, v0, v17, s4
+; GFX900-NEXT:    v_perm_b32 v1, v1, v18, s4
+; GFX900-NEXT:    v_perm_b32 v2, v2, v19, s4
+; GFX900-NEXT:    v_perm_b32 v3, v3, v20, s4
+; GFX900-NEXT:    v_perm_b32 v4, v4, v21, s4
+; GFX900-NEXT:    v_perm_b32 v5, v5, v22, s4
+; GFX900-NEXT:    v_perm_b32 v6, v6, v23, s4
+; GFX900-NEXT:    v_perm_b32 v7, v7, v24, s4
+; GFX900-NEXT:    v_perm_b32 v8, v8, v25, s4
+; GFX900-NEXT:    v_perm_b32 v9, v9, v26, s4
+; GFX900-NEXT:    v_perm_b32 v10, v10, v27, s4
+; GFX900-NEXT:    v_perm_b32 v11, v11, v28, s4
+; GFX900-NEXT:    v_perm_b32 v12, v12, v29, s4
+; GFX900-NEXT:    v_perm_b32 v13, v13, v30, s4
+; GFX900-NEXT:    v_perm_b32 v14, v14, v31, s4
+; GFX900-NEXT:    v_perm_b32 v15, v15, v16, s4
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX950-LABEL: v_fma_v32bf16:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:64
+; GFX950-NEXT:    scratch_load_dword v36, off, s32
+; GFX950-NEXT:    scratch_load_dword v38, off, s32 offset:60
+; GFX950-NEXT:    scratch_load_dword v39, off, s32 offset:56
+; GFX950-NEXT:    scratch_load_dword v48, off, s32 offset:52
+; GFX950-NEXT:    scratch_load_dword v49, off, s32 offset:48
+; GFX950-NEXT:    scratch_load_dword v50, off, s32 offset:44
+; GFX950-NEXT:    scratch_load_dword v51, off, s32 offset:40
+; GFX950-NEXT:    scratch_load_dword v52, off, s32 offset:36
+; GFX950-NEXT:    scratch_load_dword v53, off, s32 offset:32
+; GFX950-NEXT:    scratch_load_dword v54, off, s32 offset:28
+; GFX950-NEXT:    scratch_load_dword v31, off, s32 offset:4
+; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:8
+; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:12
+; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:16
+; GFX950-NEXT:    scratch_load_dword v37, off, s32 offset:20
+; GFX950-NEXT:    scratch_load_dword v55, off, s32 offset:24
+; GFX950-NEXT:    v_accvgpr_write_b32 a3, v43 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a5, v45 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a6, v46 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a8, v56 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a11, v59 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a13, v61 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a14, v62 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a15, v63 ; Reload Reuse
+; GFX950-NEXT:    v_and_b32_e32 v43, 0xffff0000, v14
+; GFX950-NEXT:    v_lshlrev_b32_e32 v45, 16, v14
+; GFX950-NEXT:    v_and_b32_e32 v46, 0xffff0000, v29
+; GFX950-NEXT:    v_lshlrev_b32_e32 v56, 16, v29
+; GFX950-NEXT:    v_and_b32_e32 v59, 0xffff0000, v12
+; GFX950-NEXT:    v_lshlrev_b32_e32 v61, 16, v12
+; GFX950-NEXT:    v_and_b32_e32 v62, 0xffff0000, v27
+; GFX950-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
+; GFX950-NEXT:    v_accvgpr_write_b32 a2, v42 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a4, v44 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a7, v47 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a9, v57 ; Reload Reuse
+; GFX950-NEXT:    v_and_b32_e32 v42, 0xffff0000, v30
+; GFX950-NEXT:    v_lshlrev_b32_e32 v44, 16, v30
+; GFX950-NEXT:    v_and_b32_e32 v47, 0xffff0000, v13
+; GFX950-NEXT:    v_lshlrev_b32_e32 v57, 16, v13
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v40 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v41 ; Reload Reuse
+; GFX950-NEXT:    v_and_b32_e32 v40, 0xffff0000, v15
+; GFX950-NEXT:    v_lshlrev_b32_e32 v41, 16, v15
+; GFX950-NEXT:    v_accvgpr_write_b32 a10, v58 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_write_b32 a12, v60 ; Reload Reuse
+; GFX950-NEXT:    v_and_b32_e32 v58, 0xffff0000, v28
+; GFX950-NEXT:    v_lshlrev_b32_e32 v60, 16, v28
+; GFX950-NEXT:    s_waitcnt vmcnt(16)
+; GFX950-NEXT:    v_and_b32_e32 v15, 0xffff0000, v35
+; GFX950-NEXT:    s_waitcnt vmcnt(15)
+; GFX950-NEXT:    v_and_b32_e32 v12, 0xffff0000, v36
+; GFX950-NEXT:    v_lshlrev_b32_e32 v63, 16, v36
+; GFX950-NEXT:    s_waitcnt vmcnt(14)
+; GFX950-NEXT:    v_and_b32_e32 v14, 0xffff0000, v38
+; GFX950-NEXT:    v_lshlrev_b32_e32 v29, 16, v38
+; GFX950-NEXT:    s_waitcnt vmcnt(11)
+; GFX950-NEXT:    v_and_b32_e32 v36, 0xffff0000, v49
+; GFX950-NEXT:    v_and_b32_e32 v38, 0xffff0000, v11
+; GFX950-NEXT:    v_fmac_f32_e32 v36, v38, v62
+; GFX950-NEXT:    v_lshlrev_b32_e32 v38, 16, v49
+; GFX950-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; GFX950-NEXT:    v_and_b32_e32 v13, 0xffff0000, v39
+; GFX950-NEXT:    v_lshlrev_b32_e32 v30, 16, v39
+; GFX950-NEXT:    v_fmac_f32_e32 v38, v11, v27
+; GFX950-NEXT:    s_waitcnt vmcnt(10)
+; GFX950-NEXT:    v_and_b32_e32 v11, 0xffff0000, v50
+; GFX950-NEXT:    v_and_b32_e32 v27, 0xffff0000, v26
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v10
+; GFX950-NEXT:    v_fmac_f32_e32 v11, v39, v27
+; GFX950-NEXT:    v_lshlrev_b32_e32 v27, 16, v50
+; GFX950-NEXT:    v_lshlrev_b32_e32 v26, 16, v26
+; GFX950-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
+; GFX950-NEXT:    v_fmac_f32_e32 v27, v10, v26
+; GFX950-NEXT:    s_waitcnt vmcnt(9)
+; GFX950-NEXT:    v_and_b32_e32 v10, 0xffff0000, v51
+; GFX950-NEXT:    v_and_b32_e32 v26, 0xffff0000, v25
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v9
+; GFX950-NEXT:    v_fmac_f32_e32 v10, v39, v26
+; GFX950-NEXT:    v_lshlrev_b32_e32 v26, 16, v51
+; GFX950-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
+; GFX950-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
+; GFX950-NEXT:    v_fmac_f32_e32 v26, v9, v25
+; GFX950-NEXT:    s_waitcnt vmcnt(8)
+; GFX950-NEXT:    v_and_b32_e32 v9, 0xffff0000, v52
+; GFX950-NEXT:    v_and_b32_e32 v25, 0xffff0000, v24
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v8
+; GFX950-NEXT:    v_fmac_f32_e32 v9, v39, v25
+; GFX950-NEXT:    v_lshlrev_b32_e32 v25, 16, v52
+; GFX950-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; GFX950-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
+; GFX950-NEXT:    v_fmac_f32_e32 v25, v8, v24
+; GFX950-NEXT:    s_waitcnt vmcnt(7)
+; GFX950-NEXT:    v_and_b32_e32 v8, 0xffff0000, v53
+; GFX950-NEXT:    v_and_b32_e32 v24, 0xffff0000, v23
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v7
+; GFX950-NEXT:    v_fmac_f32_e32 v8, v39, v24
+; GFX950-NEXT:    v_lshlrev_b32_e32 v24, 16, v53
+; GFX950-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX950-NEXT:    v_fmac_f32_e32 v24, v7, v23
+; GFX950-NEXT:    s_waitcnt vmcnt(6)
+; GFX950-NEXT:    v_and_b32_e32 v7, 0xffff0000, v54
+; GFX950-NEXT:    v_and_b32_e32 v23, 0xffff0000, v22
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v6
+; GFX950-NEXT:    v_fmac_f32_e32 v7, v39, v23
+; GFX950-NEXT:    v_lshlrev_b32_e32 v23, 16, v54
+; GFX950-NEXT:    v_lshlrev_b32_e32 v22, 16, v22
+; GFX950-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX950-NEXT:    v_fmac_f32_e32 v23, v6, v22
+; GFX950-NEXT:    s_waitcnt vmcnt(0)
+; GFX950-NEXT:    v_and_b32_e32 v6, 0xffff0000, v55
+; GFX950-NEXT:    v_and_b32_e32 v22, 0xffff0000, v21
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v5
+; GFX950-NEXT:    v_fmac_f32_e32 v6, v39, v22
+; GFX950-NEXT:    v_lshlrev_b32_e32 v22, 16, v55
+; GFX950-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
+; GFX950-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX950-NEXT:    v_fmac_f32_e32 v22, v5, v21
+; GFX950-NEXT:    v_and_b32_e32 v5, 0xffff0000, v37
+; GFX950-NEXT:    v_and_b32_e32 v21, 0xffff0000, v20
+; GFX950-NEXT:    v_and_b32_e32 v39, 0xffff0000, v4
+; GFX950-NEXT:    v_fmac_f32_e32 v5, v39, v21
+; GFX950-NEXT:    v_lshlrev_b32_e32 v21, 16, v37
+; GFX950-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
+; GFX950-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX950-NEXT:    v_fmac_f32_e32 v21, v4, v20
+; GFX950-NEXT:    v_and_b32_e32 v4, 0xffff0000, v34
+; GFX950-NEXT:    v_and_b32_e32 v20, 0xffff0000, v19
+; GFX950-NEXT:    v_and_b32_e32 v37, 0xffff0000, v3
+; GFX950-NEXT:    v_fmac_f32_e32 v4, v37, v20
+; GFX950-NEXT:    v_lshlrev_b32_e32 v20, 16, v34
+; GFX950-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
+; GFX950-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX950-NEXT:    v_fmac_f32_e32 v20, v3, v19
+; GFX950-NEXT:    v_and_b32_e32 v3, 0xffff0000, v33
+; GFX950-NEXT:    v_and_b32_e32 v19, 0xffff0000, v18
+; GFX950-NEXT:    v_and_b32_e32 v34, 0xffff0000, v2
+; GFX950-NEXT:    v_fmac_f32_e32 v3, v34, v19
+; GFX950-NEXT:    v_lshlrev_b32_e32 v19, 16, v33
+; GFX950-NEXT:    v_lshlrev_b32_e32 v18, 16, v18
+; GFX950-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX950-NEXT:    v_fmac_f32_e32 v19, v2, v18
+; GFX950-NEXT:    v_and_b32_e32 v2, 0xffff0000, v32
+; GFX950-NEXT:    v_and_b32_e32 v18, 0xffff0000, v17
+; GFX950-NEXT:    v_and_b32_e32 v33, 0xffff0000, v1
+; GFX950-NEXT:    v_fmac_f32_e32 v2, v33, v18
+; GFX950-NEXT:    v_lshlrev_b32_e32 v18, 16, v32
+; GFX950-NEXT:    v_lshlrev_b32_e32 v17, 16, v17
+; GFX950-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX950-NEXT:    v_fmac_f32_e32 v18, v1, v17
+; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff0000, v31
+; GFX950-NEXT:    v_and_b32_e32 v17, 0xffff0000, v16
+; GFX950-NEXT:    v_and_b32_e32 v32, 0xffff0000, v0
+; GFX950-NEXT:    v_lshlrev_b32_e32 v28, 16, v35
+; GFX950-NEXT:    v_fmac_f32_e32 v15, v40, v12
+; GFX950-NEXT:    v_and_b32_e32 v12, 0xffff0000, v48
+; GFX950-NEXT:    v_lshlrev_b32_e32 v35, 16, v48
+; GFX950-NEXT:    v_fmac_f32_e32 v1, v32, v17
+; GFX950-NEXT:    v_lshlrev_b32_e32 v17, 16, v31
+; GFX950-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
+; GFX950-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX950-NEXT:    v_fmac_f32_e32 v28, v41, v63
+; GFX950-NEXT:    v_fmac_f32_e32 v14, v43, v42
+; GFX950-NEXT:    v_fmac_f32_e32 v29, v45, v44
+; GFX950-NEXT:    v_fmac_f32_e32 v13, v47, v46
+; GFX950-NEXT:    v_fmac_f32_e32 v30, v57, v56
+; GFX950-NEXT:    v_fmac_f32_e32 v12, v59, v58
+; GFX950-NEXT:    v_fmac_f32_e32 v35, v61, v60
+; GFX950-NEXT:    v_fmac_f32_e32 v17, v0, v16
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v0, v17, v1
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v1, v18, v2
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v2, v19, v3
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v3, v20, v4
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v4, v21, v5
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v5, v22, v6
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v6, v23, v7
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v7, v24, v8
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v8, v25, v9
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v9, v26, v10
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v10, v27, v11
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v11, v38, v36
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v12, v35, v12
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v13, v30, v13
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v14, v29, v14
+; GFX950-NEXT:    v_cvt_pk_bf16_f32 v15, v28, v15
+; GFX950-NEXT:    v_accvgpr_read_b32 v63, a15 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v60, a12 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v59, a11 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v58, a10 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v57, a9 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v56, a8 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v47, a7 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v46, a6 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v45, a5 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v44, a4 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v43, a3 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
+; GFX950-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX10-LABEL: v_fma_v32bf16:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    s_clause 0x8
+; GFX10-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
+; GFX10-NEXT:    buffer_load_dword v33, off, s[0:3], s32
+; GFX10-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:60
+; GFX10-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:56
+; GFX10-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:52
+; GFX10-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:48
+; GFX10-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:44
+; GFX10-NEXT:    buffer_load_dword v39, off, s[0:3], s32 offset:40
+; GFX10-NEXT:    buffer_load_dword v48, off, s[0:3], s32 offset:36
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v15
+; GFX10-NEXT:    v_and_b32_e32 v51, 0xffff0000, v15
+; GFX10-NEXT:    v_and_b32_e32 v52, 0xffff0000, v10
+; GFX10-NEXT:    s_waitcnt vmcnt(8)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v31, 16, v32
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v50, 16, v33
+; GFX10-NEXT:    v_and_b32_e32 v15, 0xffff0000, v32
+; GFX10-NEXT:    v_and_b32_e32 v32, 0xffff0000, v33
+; GFX10-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:32
+; GFX10-NEXT:    v_fmac_f32_e32 v31, v49, v50
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v30
+; GFX10-NEXT:    v_lshlrev_b32_e32 v50, 16, v14
+; GFX10-NEXT:    v_fmac_f32_e32 v15, v51, v32
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v32, 16, v34
+; GFX10-NEXT:    v_and_b32_e32 v30, 0xffff0000, v30
+; GFX10-NEXT:    v_and_b32_e32 v51, 0xffff0000, v14
+; GFX10-NEXT:    v_and_b32_e32 v14, 0xffff0000, v34
+; GFX10-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:28
+; GFX10-NEXT:    v_fmac_f32_e32 v32, v50, v49
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v29
+; GFX10-NEXT:    v_lshlrev_b32_e32 v50, 16, v13
+; GFX10-NEXT:    v_fmac_f32_e32 v14, v51, v30
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v30, 16, v35
+; GFX10-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX10-NEXT:    v_and_b32_e32 v51, 0xffff0000, v13
+; GFX10-NEXT:    v_and_b32_e32 v13, 0xffff0000, v35
+; GFX10-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:24
+; GFX10-NEXT:    v_fmac_f32_e32 v30, v50, v49
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v28
+; GFX10-NEXT:    v_lshlrev_b32_e32 v50, 16, v12
+; GFX10-NEXT:    v_fmac_f32_e32 v13, v51, v29
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v29, 16, v36
+; GFX10-NEXT:    v_and_b32_e32 v28, 0xffff0000, v28
+; GFX10-NEXT:    v_and_b32_e32 v51, 0xffff0000, v12
+; GFX10-NEXT:    v_and_b32_e32 v12, 0xffff0000, v36
+; GFX10-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:20
+; GFX10-NEXT:    v_fmac_f32_e32 v29, v50, v49
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v27
+; GFX10-NEXT:    v_lshlrev_b32_e32 v50, 16, v11
+; GFX10-NEXT:    v_fmac_f32_e32 v12, v51, v28
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v28, 16, v37
+; GFX10-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX10-NEXT:    v_and_b32_e32 v51, 0xffff0000, v11
+; GFX10-NEXT:    v_and_b32_e32 v11, 0xffff0000, v37
+; GFX10-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:16
+; GFX10-NEXT:    v_fmac_f32_e32 v28, v50, v49
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v26
+; GFX10-NEXT:    v_lshlrev_b32_e32 v50, 16, v10
+; GFX10-NEXT:    v_fmac_f32_e32 v11, v51, v27
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v27, 16, v38
+; GFX10-NEXT:    v_and_b32_e32 v51, 0xffff0000, v26
+; GFX10-NEXT:    v_and_b32_e32 v10, 0xffff0000, v38
+; GFX10-NEXT:    v_lshlrev_b32_e32 v38, 16, v25
+; GFX10-NEXT:    s_waitcnt vmcnt(6)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v26, 16, v39
+; GFX10-NEXT:    v_fmac_f32_e32 v27, v50, v49
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v9
+; GFX10-NEXT:    v_fmac_f32_e32 v10, v52, v51
+; GFX10-NEXT:    s_clause 0x1
+; GFX10-NEXT:    buffer_load_dword v50, off, s[0:3], s32 offset:12
+; GFX10-NEXT:    buffer_load_dword v51, off, s[0:3], s32 offset:8
+; GFX10-NEXT:    v_and_b32_e32 v25, 0xffff0000, v25
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v31
+; GFX10-NEXT:    v_fmac_f32_e32 v26, v49, v38
+; GFX10-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:4
+; GFX10-NEXT:    v_and_b32_e32 v49, 0xffff0000, v9
+; GFX10-NEXT:    v_and_b32_e32 v9, 0xffff0000, v39
+; GFX10-NEXT:    v_lshlrev_b32_e32 v39, 16, v24
+; GFX10-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v31, v31
+; GFX10-NEXT:    v_fmac_f32_e32 v9, v49, v25
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v8
+; GFX10-NEXT:    s_waitcnt vmcnt(8)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v25, 16, v48
+; GFX10-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX10-NEXT:    v_and_b32_e32 v48, 0xffff0000, v48
+; GFX10-NEXT:    v_fmac_f32_e32 v25, v49, v39
+; GFX10-NEXT:    v_lshlrev_b32_e32 v39, 16, v23
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v7
+; GFX10-NEXT:    v_fmac_f32_e32 v48, v8, v24
+; GFX10-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX10-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX10-NEXT:    v_lshlrev_b32_e32 v24, 16, v22
+; GFX10-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v48, v48
+; GFX10-NEXT:    s_waitcnt vmcnt(7)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v8, 16, v33
+; GFX10-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX10-NEXT:    v_fmac_f32_e32 v8, v49, v39
+; GFX10-NEXT:    v_lshlrev_b32_e32 v39, 16, v6
+; GFX10-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX10-NEXT:    v_fmac_f32_e32 v33, v7, v23
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v21
+; GFX10-NEXT:    s_waitcnt vmcnt(6)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v7, 16, v34
+; GFX10-NEXT:    v_and_b32_e32 v34, 0xffff0000, v34
+; GFX10-NEXT:    v_lshlrev_b32_e32 v23, 16, v5
+; GFX10-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX10-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX10-NEXT:    v_fmac_f32_e32 v7, v39, v24
+; GFX10-NEXT:    v_fmac_f32_e32 v34, v6, v22
+; GFX10-NEXT:    v_lshlrev_b32_e32 v24, 16, v20
+; GFX10-NEXT:    v_lshlrev_b32_e32 v39, 16, v4
+; GFX10-NEXT:    s_waitcnt vmcnt(5)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v6, 16, v35
+; GFX10-NEXT:    v_and_b32_e32 v35, 0xffff0000, v35
+; GFX10-NEXT:    v_lshlrev_b32_e32 v22, 16, v19
+; GFX10-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX10-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX10-NEXT:    v_fmac_f32_e32 v6, v23, v49
+; GFX10-NEXT:    v_fmac_f32_e32 v35, v5, v21
+; GFX10-NEXT:    v_lshlrev_b32_e32 v23, 16, v3
+; GFX10-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX10-NEXT:    s_waitcnt vmcnt(4)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v5, 16, v36
+; GFX10-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX10-NEXT:    v_and_b32_e32 v36, 0xffff0000, v36
+; GFX10-NEXT:    v_lshlrev_b32_e32 v49, 16, v18
+; GFX10-NEXT:    v_lshlrev_b32_e32 v21, 16, v2
+; GFX10-NEXT:    v_fmac_f32_e32 v5, v39, v24
+; GFX10-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX10-NEXT:    v_fmac_f32_e32 v36, v4, v20
+; GFX10-NEXT:    v_lshlrev_b32_e32 v20, 16, v16
+; GFX10-NEXT:    s_waitcnt vmcnt(3)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v39, 16, v37
+; GFX10-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX10-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX10-NEXT:    v_lshlrev_b32_e32 v24, 16, v17
+; GFX10-NEXT:    v_lshlrev_b32_e32 v4, 16, v1
+; GFX10-NEXT:    v_fmac_f32_e32 v39, v23, v22
+; GFX10-NEXT:    v_and_b32_e32 v23, 0xffff0000, v37
+; GFX10-NEXT:    v_lshlrev_b32_e32 v22, 16, v0
+; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX10-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX10-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX10-NEXT:    v_fmac_f32_e32 v23, v3, v19
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v37, 16, v50
+; GFX10-NEXT:    s_waitcnt vmcnt(1)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v3, 16, v51
+; GFX10-NEXT:    v_and_b32_e32 v19, 0xffff0000, v51
+; GFX10-NEXT:    v_and_b32_e32 v50, 0xffff0000, v50
+; GFX10-NEXT:    v_cmp_u_f32_e64 s5, v33, v33
+; GFX10-NEXT:    s_waitcnt vmcnt(0)
+; GFX10-NEXT:    v_lshlrev_b32_e32 v51, 16, v38
+; GFX10-NEXT:    v_and_b32_e32 v38, 0xffff0000, v38
+; GFX10-NEXT:    v_fmac_f32_e32 v37, v21, v49
+; GFX10-NEXT:    v_fmac_f32_e32 v50, v2, v18
+; GFX10-NEXT:    v_fmac_f32_e32 v19, v1, v17
+; GFX10-NEXT:    v_or_b32_e32 v1, 0x400000, v48
+; GFX10-NEXT:    v_fmac_f32_e32 v38, v0, v16
+; GFX10-NEXT:    v_bfe_u32 v0, v48, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v16, v33, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v2, v8, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v17, 0x400000, v33
+; GFX10-NEXT:    v_bfe_u32 v18, v7, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v21, v34, 16, 1
+; GFX10-NEXT:    v_add3_u32 v0, v0, v48, 0x7fff
+; GFX10-NEXT:    v_bfe_u32 v48, v35, 16, 1
+; GFX10-NEXT:    v_add3_u32 v16, v16, v33, 0x7fff
+; GFX10-NEXT:    v_bfe_u32 v33, v5, 16, 1
+; GFX10-NEXT:    v_fmac_f32_e32 v3, v4, v24
+; GFX10-NEXT:    v_fmac_f32_e32 v51, v22, v20
+; GFX10-NEXT:    v_or_b32_e32 v4, 0x400000, v8
+; GFX10-NEXT:    v_or_b32_e32 v20, 0x400000, v7
+; GFX10-NEXT:    v_or_b32_e32 v22, 0x400000, v34
+; GFX10-NEXT:    v_bfe_u32 v24, v6, 16, 1
+; GFX10-NEXT:    v_add3_u32 v2, v2, v8, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s4, v8, v8
+; GFX10-NEXT:    v_or_b32_e32 v8, 0x400000, v35
+; GFX10-NEXT:    v_add3_u32 v18, v18, v7, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s6, v7, v7
+; GFX10-NEXT:    v_or_b32_e32 v7, 0x400000, v5
+; GFX10-NEXT:    v_add3_u32 v21, v21, v34, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s7, v34, v34
+; GFX10-NEXT:    v_bfe_u32 v34, v39, 16, 1
+; GFX10-NEXT:    v_add3_u32 v48, v48, v35, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s9, v35, v35
+; GFX10-NEXT:    v_bfe_u32 v35, v23, 16, 1
+; GFX10-NEXT:    v_add3_u32 v33, v33, v5, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s10, v5, v5
+; GFX10-NEXT:    v_bfe_u32 v5, v37, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v49, 0x400000, v6
+; GFX10-NEXT:    v_add3_u32 v24, v24, v6, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s8, v6, v6
+; GFX10-NEXT:    v_or_b32_e32 v6, 0x400000, v39
+; GFX10-NEXT:    v_add3_u32 v34, v34, v39, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s11, v39, v39
+; GFX10-NEXT:    v_or_b32_e32 v39, 0x400000, v23
+; GFX10-NEXT:    v_add3_u32 v35, v35, v23, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s12, v23, v23
+; GFX10-NEXT:    v_or_b32_e32 v23, 0x400000, v37
+; GFX10-NEXT:    v_add3_u32 v5, v5, v37, 0x7fff
+; GFX10-NEXT:    v_cmp_u_f32_e64 s13, v37, v37
+; GFX10-NEXT:    v_bfe_u32 v37, v31, 16, 1
+; GFX10-NEXT:    v_cndmask_b32_e64 v53, v2, v4, s4
+; GFX10-NEXT:    v_bfe_u32 v4, v3, 16, 1
+; GFX10-NEXT:    v_cndmask_b32_e64 v16, v16, v17, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, v18, v20, s6
+; GFX10-NEXT:    v_add3_u32 v37, v37, v31, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v18, v21, v22, s7
+; GFX10-NEXT:    v_or_b32_e32 v20, 0x400000, v3
+; GFX10-NEXT:    v_bfe_u32 v22, v19, 16, 1
+; GFX10-NEXT:    v_add3_u32 v4, v4, v3, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v31, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v15, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v15
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v15, v15
+; GFX10-NEXT:    v_cndmask_b32_e64 v21, v24, v49, s8
+; GFX10-NEXT:    v_or_b32_e32 v24, 0x400000, v19
+; GFX10-NEXT:    v_add3_u32 v37, v37, v15, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, v33, v7, s10
+; GFX10-NEXT:    v_bfe_u32 v33, v51, 16, 1
+; GFX10-NEXT:    v_add3_u32 v22, v22, v19, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v34, v6, s11
+; GFX10-NEXT:    v_cndmask_b32_e64 v15, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v32, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v32
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v32, v32
+; GFX10-NEXT:    v_or_b32_e32 v34, 0x400000, v51
+; GFX10-NEXT:    v_cndmask_b32_e64 v35, v35, v39, s12
+; GFX10-NEXT:    v_add3_u32 v37, v37, v32, 0x7fff
+; GFX10-NEXT:    v_bfe_u32 v39, v38, 16, 1
+; GFX10-NEXT:    v_add3_u32 v33, v33, v51, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, v23, s13
+; GFX10-NEXT:    v_or_b32_e32 v23, 0x400000, v38
+; GFX10-NEXT:    v_cndmask_b32_e64 v32, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v14, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v14
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v14, v14
+; GFX10-NEXT:    v_add3_u32 v39, v39, v38, 0x7fff
+; GFX10-NEXT:    v_or_b32_e32 v2, 0x400000, v50
+; GFX10-NEXT:    v_add3_u32 v37, v37, v14, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, v48, v8, s9
+; GFX10-NEXT:    v_perm_b32 v15, v15, v31, 0x7060302
+; GFX10-NEXT:    v_cndmask_b32_e64 v14, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v30, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v30
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v30, v30
+; GFX10-NEXT:    v_perm_b32 v14, v14, v32, 0x7060302
+; GFX10-NEXT:    v_add3_u32 v37, v37, v30, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v30, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v13, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v13
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v13, v13
+; GFX10-NEXT:    v_add3_u32 v37, v37, v13, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v29, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v29
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v29, v29
+; GFX10-NEXT:    v_perm_b32 v13, v13, v30, 0x7060302
+; GFX10-NEXT:    v_add3_u32 v37, v37, v29, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v29, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v12, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v12
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v12, v12
+; GFX10-NEXT:    v_add3_u32 v37, v37, v12, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v28, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v28
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v28, v28
+; GFX10-NEXT:    v_perm_b32 v12, v12, v29, 0x7060302
+; GFX10-NEXT:    v_add3_u32 v37, v37, v28, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v28, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v11, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v11
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v11, v11
+; GFX10-NEXT:    v_add3_u32 v37, v37, v11, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v27, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v27
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v27, v27
+; GFX10-NEXT:    v_perm_b32 v11, v11, v28, 0x7060302
+; GFX10-NEXT:    v_add3_u32 v37, v37, v27, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v27, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v10, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v10
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v10, v10
+; GFX10-NEXT:    v_add3_u32 v37, v37, v10, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v26, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v26
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v26, v26
+; GFX10-NEXT:    v_perm_b32 v10, v10, v27, 0x7060302
+; GFX10-NEXT:    v_add3_u32 v37, v37, v26, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v26, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v9, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v9
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v9, v9
+; GFX10-NEXT:    v_add3_u32 v37, v37, v9, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, v37, v52, s14
+; GFX10-NEXT:    v_bfe_u32 v37, v25, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v52, 0x400000, v25
+; GFX10-NEXT:    v_cmp_u_f32_e64 s14, v25, v25
+; GFX10-NEXT:    v_perm_b32 v9, v9, v26, 0x7060302
+; GFX10-NEXT:    v_add3_u32 v37, v37, v25, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e64 v25, v37, v52, s14
+; GFX10-NEXT:    v_cndmask_b32_e32 v52, v0, v1, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v3, v3
+; GFX10-NEXT:    v_bfe_u32 v1, v50, 16, 1
+; GFX10-NEXT:    v_bfe_u32 v37, v36, 16, 1
+; GFX10-NEXT:    v_or_b32_e32 v0, 0x400000, v36
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, v4, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v19, v19
+; GFX10-NEXT:    v_add3_u32 v1, v1, v50, 0x7fff
+; GFX10-NEXT:    v_add3_u32 v37, v37, v36, 0x7fff
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, v22, v24, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v51, v51
+; GFX10-NEXT:    v_cndmask_b32_e32 v19, v33, v34, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v38, v38
+; GFX10-NEXT:    v_cndmask_b32_e32 v20, v39, v23, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v50, v50
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc_lo
+; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v36, v36
+; GFX10-NEXT:    v_perm_b32 v1, v4, v3, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v3, v35, v6, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v6, v18, v17, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v2, v2, v5, 0x7060302
+; GFX10-NEXT:    v_cndmask_b32_e32 v22, v37, v0, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v0, v20, v19, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v5, v8, v21, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v8, v52, v25, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v4, v22, v7, 0x7060302
+; GFX10-NEXT:    v_perm_b32 v7, v16, v53, 0x7060302
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11TRUE16-LABEL: v_fma_v32bf16:
+; GFX11TRUE16:       ; %bb.0:
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11TRUE16-NEXT:    s_clause 0x10
+; GFX11TRUE16-NEXT:    scratch_load_b32 v31, off, s32 offset:64
+; GFX11TRUE16-NEXT:    scratch_load_b32 v32, off, s32
+; GFX11TRUE16-NEXT:    scratch_load_b32 v33, off, s32 offset:60
+; GFX11TRUE16-NEXT:    scratch_load_b32 v34, off, s32 offset:56
+; GFX11TRUE16-NEXT:    scratch_load_b32 v35, off, s32 offset:52
+; GFX11TRUE16-NEXT:    scratch_load_b32 v36, off, s32 offset:48
+; GFX11TRUE16-NEXT:    scratch_load_b32 v37, off, s32 offset:44
+; GFX11TRUE16-NEXT:    scratch_load_b32 v38, off, s32 offset:40
+; GFX11TRUE16-NEXT:    scratch_load_b32 v39, off, s32 offset:36
+; GFX11TRUE16-NEXT:    scratch_load_b32 v48, off, s32 offset:32
+; GFX11TRUE16-NEXT:    scratch_load_b32 v49, off, s32 offset:28
+; GFX11TRUE16-NEXT:    scratch_load_b32 v50, off, s32 offset:24
+; GFX11TRUE16-NEXT:    scratch_load_b32 v51, off, s32 offset:20
+; GFX11TRUE16-NEXT:    scratch_load_b32 v52, off, s32 offset:16
+; GFX11TRUE16-NEXT:    scratch_load_b32 v53, off, s32 offset:12
+; GFX11TRUE16-NEXT:    scratch_load_b32 v54, off, s32 offset:8
+; GFX11TRUE16-NEXT:    scratch_load_b32 v55, off, s32 offset:4
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v99, 0xffff0000, v21
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v100, 0xffff0000, v5
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v101, 0xffff0000, v20
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v102, 0xffff0000, v4
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v115, 0xffff0000, v17
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v116, 0xffff0000, v1
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v97, 0xffff0000, v22
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v22, 16, v22
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v117, 0xffff0000, v16
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v118, 0xffff0000, v0
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v103, 0xffff0000, v19
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v112, 0xffff0000, v3
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v85, 0xffff0000, v24
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v113, 0xffff0000, v18
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v114, 0xffff0000, v2
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(16)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v119, 0xffff0000, v31
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(15)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v128, 0xffff0000, v32
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(14)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v129, 0xffff0000, v33
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v33, 16, v33
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v68, 0xffff0000, v13
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(12)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v131, 0xffff0000, v35
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(10)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v133, 0xffff0000, v37
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(9)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v134, 0xffff0000, v38
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v37, 16, v37
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(7)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v144, 0xffff0000, v48
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v48, 16, v48
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(5)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v146, 0xffff0000, v50
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v145, 0xffff0000, v49
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v49, 16, v49
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(4)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v147, 0xffff0000, v51
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v51, 16, v51
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v96, 0xffff0000, v7
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v148, 0xffff0000, v55
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v87, 0xffff0000, v23
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v83, 0xffff0000, v25
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v146, v100, v99 :: v_dual_lshlrev_b32 v25, 16, v25
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v55, 16, v55
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v98, 0xffff0000, v6
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v84, 0xffff0000, v9
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v48, v7, v23
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v135, 0xffff0000, v39
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v39, 16, v39
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v49, v6, v22
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v134, v84, v83 :: v_dual_lshlrev_b32 v13, 16, v13
+; GFX11TRUE16-NEXT:    v_bfe_u32 v83, v146, 16, 1
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v51, v4, v20 :: v_dual_fmac_f32 v148, v118, v117
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v144, v96, v87 :: v_dual_and_b32 v81, 0xffff0000, v26
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v55, v0, v16 :: v_dual_lshlrev_b32 v26, 16, v26
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v145, v98, v97
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v84, 0x400000, v146
+; GFX11TRUE16-NEXT:    v_add3_u32 v83, v83, v146, 0x7fff
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v18, 16, v18
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v86, 0xffff0000, v8
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v82, 0xffff0000, v10
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v147, v102, v101 :: v_dual_lshlrev_b32 v10, 16, v10
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v38, 16, v38
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v69, 0xffff0000, v28
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v37, v10, v26 :: v_dual_lshlrev_b32 v28, 16, v28
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v39, v8, v24
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v133, v82, v81 :: v_dual_and_b32 v70, 0xffff0000, v12
+; GFX11TRUE16-NEXT:    v_bfe_u32 v97, v51, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v23, v37, 16, 1
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v135, v86, v85 :: v_dual_lshlrev_b32 v12, 16, v12
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v35, 16, v35
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v80, 0xffff0000, v11
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v132, 0xffff0000, v36
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v36, 16, v36
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v50, 16, v50
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v22, 0x400000, v133
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v24, 0x400000, v37
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v98, 0x400000, v51
+; GFX11TRUE16-NEXT:    v_add3_u32 v23, v23, v37, 0x7fff
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v71, 0xffff0000, v27
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
+; GFX11TRUE16-NEXT:    v_add3_u32 v97, v97, v51, 0x7fff
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v17, 16, v17
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v32, 16, v32
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v64, 0xffff0000, v15
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v130, 0xffff0000, v34
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v35, v12, v28 :: v_dual_lshlrev_b32 v34, 16, v34
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v36, v11, v27
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v50, v5, v21
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v132, v80, v71 :: v_dual_and_b32 v67, 0xffff0000, v29
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v15, 16, v15
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v130, v68, v67 :: v_dual_and_b32 v65, 0xffff0000, v30
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v20, 0x400000, v36
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v34, v13, v29 :: v_dual_fmac_f32 v31, v15, v32
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v119, v64, v128 :: v_dual_and_b32 v66, 0xffff0000, v14
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v64, 0xffff0000, v52
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v128, 0xffff0000, v53
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v53, 16, v53
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v129, v66, v65 :: v_dual_lshlrev_b32 v30, 16, v30
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v52, 16, v52
+; GFX11TRUE16-NEXT:    v_and_b32_e32 v32, 0xffff0000, v54
+; GFX11TRUE16-NEXT:    v_lshlrev_b32_e32 v54, 16, v54
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v64, v112, v103
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v38, v9, v25
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v131, v70, v69 :: v_dual_lshlrev_b32 v14, 16, v14
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v53, v2, v18
+; GFX11TRUE16-NEXT:    v_bfe_u32 v0, v119, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v2, v31, 16, 1
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_dual_fmac_f32 v33, v14, v30 :: v_dual_fmac_f32 v52, v3, v19
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v54, v1, v17
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v1, 0x400000, v119
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v3, 0x400000, v31
+; GFX11TRUE16-NEXT:    v_bfe_u32 v4, v129, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v0, v0, v119, 0x7fff
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v119, v119
+; GFX11TRUE16-NEXT:    v_add3_u32 v2, v2, v31, 0x7fff
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e64 s0, v31, v31
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v5, 0x400000, v129
+; GFX11TRUE16-NEXT:    v_bfe_u32 v6, v33, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v14, v132, 16, 1
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v15, v0, v1, vcc_lo
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e64 v149, v2, v3, s0
+; GFX11TRUE16-NEXT:    v_add3_u32 v2, v4, v129, 0x7fff
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v129, v129
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v7, 0x400000, v33
+; GFX11TRUE16-NEXT:    v_bfe_u32 v8, v130, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v3, v6, v33, 0x7fff
+; GFX11TRUE16-NEXT:    v_add3_u32 v150, v14, v132, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v14, v2, v5, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v33, v33
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v9, 0x400000, v130
+; GFX11TRUE16-NEXT:    v_bfe_u32 v10, v34, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v13, v35, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v4, v8, v130, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v33, v3, v7, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v130, v130
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v11, 0x400000, v34
+; GFX11TRUE16-NEXT:    v_bfe_u32 v12, v131, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v6, v10, v34, 0x7fff
+; GFX11TRUE16-NEXT:    v_add3_u32 v10, v13, v35, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v13, v4, v9, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v34, v34
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v16, 0x400000, v131
+; GFX11TRUE16-NEXT:    v_add3_u32 v8, v12, v131, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v17, 0x400000, v35
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v18, 0x400000, v132
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v34, v6, v11, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v131, v131
+; GFX11TRUE16-NEXT:    v_bfe_u32 v19, v36, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v21, v133, 16, 1
+; GFX11TRUE16-NEXT:    v_bfe_u32 v25, v134, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v26, 0x400000, v134
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v12, v8, v16, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v35, v35
+; GFX11TRUE16-NEXT:    v_add3_u32 v19, v19, v36, 0x7fff
+; GFX11TRUE16-NEXT:    v_add3_u32 v21, v21, v133, 0x7fff
+; GFX11TRUE16-NEXT:    v_bfe_u32 v27, v38, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v25, v25, v134, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v16, v10, v17, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v132, v132
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v28, 0x400000, v38
+; GFX11TRUE16-NEXT:    v_bfe_u32 v29, v135, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v27, v27, v38, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v30, 0x400000, v135
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v11, v150, v18, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v36, v36
+; GFX11TRUE16-NEXT:    v_bfe_u32 v65, v39, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v29, v29, v135, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v66, 0x400000, v39
+; GFX11TRUE16-NEXT:    v_bfe_u32 v67, v144, 16, 1
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v17, v19, v20, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v133, v133
+; GFX11TRUE16-NEXT:    v_add3_u32 v65, v65, v39, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v68, 0x400000, v144
+; GFX11TRUE16-NEXT:    v_bfe_u32 v69, v48, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v67, v67, v144, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v10, v21, v22, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v37, v37
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v70, 0x400000, v48
+; GFX11TRUE16-NEXT:    v_bfe_u32 v71, v145, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v69, v69, v48, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v80, 0x400000, v145
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v18, v23, v24, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v134, v134
+; GFX11TRUE16-NEXT:    v_bfe_u32 v81, v49, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v71, v71, v145, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v82, 0x400000, v49
+; GFX11TRUE16-NEXT:    v_bfe_u32 v85, v50, 16, 1
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v9, v25, v26, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v38, v38
+; GFX11TRUE16-NEXT:    v_add3_u32 v81, v81, v49, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v86, 0x400000, v50
+; GFX11TRUE16-NEXT:    v_bfe_u32 v87, v147, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v85, v85, v50, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v19, v27, v28, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v135, v135
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v96, 0x400000, v147
+; GFX11TRUE16-NEXT:    v_add3_u32 v87, v87, v147, 0x7fff
+; GFX11TRUE16-NEXT:    v_bfe_u32 v99, v64, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v100, 0x400000, v64
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v8, v29, v30, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v39, v39
+; GFX11TRUE16-NEXT:    v_bfe_u32 v101, v52, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v99, v99, v64, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v102, 0x400000, v52
+; GFX11TRUE16-NEXT:    v_bfe_u32 v117, v54, 16, 1
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v20, v65, v66, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v144, v144
+; GFX11TRUE16-NEXT:    v_add3_u32 v101, v101, v52, 0x7fff
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v118, 0x400000, v54
+; GFX11TRUE16-NEXT:    v_bfe_u32 v0, v55, 16, 1
+; GFX11TRUE16-NEXT:    v_add3_u32 v117, v117, v54, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v7, v67, v68, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v48, v48
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v1, 0x400000, v55
+; GFX11TRUE16-NEXT:    v_add3_u32 v0, v0, v55, 0x7fff
+; GFX11TRUE16-NEXT:    v_bfe_u32 v119, v148, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v31, 0x400000, v148
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v21, v69, v70, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v145, v145
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v8.l, v20.h
+; GFX11TRUE16-NEXT:    v_add3_u32 v119, v119, v148, 0x7fff
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v9.l, v19.h
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v7.l, v21.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v6, v71, v80, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v49, v49
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v10.l, v18.h
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v11.l, v17.h
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v12.l, v16.h
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v13.l, v34.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v22, v81, v82, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v146, v146
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v14.l, v33.h
+; GFX11TRUE16-NEXT:    v_mov_b16_e64 v15.l, v149.h
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v6.l, v22.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v5, v83, v84, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v50, v50
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v23, v85, v86, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v147, v147
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v5.l, v23.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v4, v87, v96, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v51, v51
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v128, v114, v113
+; GFX11TRUE16-NEXT:    v_bfe_u32 v113, v53, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v114, 0x400000, v53
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v24, v97, v98, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v64, v64
+; GFX11TRUE16-NEXT:    v_bfe_u32 v103, v128, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v112, 0x400000, v128
+; GFX11TRUE16-NEXT:    v_add3_u32 v113, v113, v53, 0x7fff
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v4.l, v24.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v3, v99, v100, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v52, v52
+; GFX11TRUE16-NEXT:    v_add3_u32 v103, v103, v128, 0x7fff
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v25, v101, v102, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v128, v128
+; GFX11TRUE16-NEXT:    v_fmac_f32_e32 v32, v116, v115
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_4)
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v3.l, v25.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v2, v103, v112, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v53, v53
+; GFX11TRUE16-NEXT:    v_bfe_u32 v115, v32, 16, 1
+; GFX11TRUE16-NEXT:    v_or_b32_e32 v116, 0x400000, v32
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v26, v113, v114, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v54, v54
+; GFX11TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11TRUE16-NEXT:    v_add3_u32 v115, v115, v32, 0x7fff
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v2.l, v26.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v27, v117, v118, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v55, v55
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v28, v0, v1, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v32, v32
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v1, v115, v116, vcc_lo
+; GFX11TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v148, v148
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v1.l, v27.h
+; GFX11TRUE16-NEXT:    v_cndmask_b32_e32 v0, v119, v31, vcc_lo
+; GFX11TRUE16-NEXT:    v_mov_b16_e32 v0.l, v28.h
+; GFX11TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11FAKE16-LABEL: v_fma_v32bf16:
+; GFX11FAKE16:       ; %bb.0:
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11FAKE16-NEXT:    s_clause 0x10
+; GFX11FAKE16-NEXT:    scratch_load_b32 v31, off, s32 offset:64
+; GFX11FAKE16-NEXT:    scratch_load_b32 v32, off, s32
+; GFX11FAKE16-NEXT:    scratch_load_b32 v33, off, s32 offset:60
+; GFX11FAKE16-NEXT:    scratch_load_b32 v34, off, s32 offset:56
+; GFX11FAKE16-NEXT:    scratch_load_b32 v35, off, s32 offset:52
+; GFX11FAKE16-NEXT:    scratch_load_b32 v36, off, s32 offset:48
+; GFX11FAKE16-NEXT:    scratch_load_b32 v37, off, s32 offset:44
+; GFX11FAKE16-NEXT:    scratch_load_b32 v38, off, s32 offset:40
+; GFX11FAKE16-NEXT:    scratch_load_b32 v39, off, s32 offset:36
+; GFX11FAKE16-NEXT:    scratch_load_b32 v48, off, s32 offset:32
+; GFX11FAKE16-NEXT:    scratch_load_b32 v49, off, s32 offset:28
+; GFX11FAKE16-NEXT:    scratch_load_b32 v50, off, s32 offset:24
+; GFX11FAKE16-NEXT:    scratch_load_b32 v51, off, s32 offset:20
+; GFX11FAKE16-NEXT:    scratch_load_b32 v52, off, s32 offset:16
+; GFX11FAKE16-NEXT:    scratch_load_b32 v53, off, s32 offset:12
+; GFX11FAKE16-NEXT:    scratch_load_b32 v54, off, s32 offset:8
+; GFX11FAKE16-NEXT:    scratch_load_b32 v55, off, s32 offset:4
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v99, 16, v21
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v100, 16, v5
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v97, 16, v22
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v22, 0xffff0000, v22
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v101, 16, v20
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v102, 16, v4
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v20, 0xffff0000, v20
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff0000, v4
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v117, 16, v16
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v118, 16, v0
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v87, 16, v23
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v23, 0xffff0000, v23
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v16, 0xffff0000, v16
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v98, 16, v6
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff0000, v6
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v103, 16, v19
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v112, 16, v3
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff0000, v19
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff0000, v3
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v85, 16, v24
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v113, 16, v18
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v114, 16, v2
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff0000, v2
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v115, 16, v17
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v116, 16, v1
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v24, 0xffff0000, v24
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff0000, v17
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(15)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v128, 16, v32
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(14)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v129, 16, v33
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v33, 0xffff0000, v33
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v68, 16, v13
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(12)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v131, 16, v35
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(10)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v133, 16, v37
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(9)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v134, 16, v38
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v37, 0xffff0000, v37
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(7)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v144, 16, v48
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v48, 0xffff0000, v48
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(5)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v146, 16, v50
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v145, 16, v49
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v49, 0xffff0000, v49
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v84, 16, v9
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(4)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v147, 16, v51
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v51, 0xffff0000, v51
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v96, 16, v7
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v7, 0xffff0000, v7
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v83, 16, v25
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v146, v100, v99 :: v_dual_and_b32 v25, 0xffff0000, v25
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v135, 16, v39
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v39, 0xffff0000, v39
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v48, v7, v23 :: v_dual_fmac_f32 v49, v6, v22
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v134, v84, v83 :: v_dual_and_b32 v13, 0xffff0000, v13
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v51, v4, v20
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v144, v96, v87 :: v_dual_lshlrev_b32 v81, 16, v26
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v145, v98, v97 :: v_dual_and_b32 v26, 0xffff0000, v26
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v84, 0x400000, v146
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v18, 0xffff0000, v18
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v86, 16, v8
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v8, 0xffff0000, v8
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v82, 16, v10
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v147, v102, v101 :: v_dual_and_b32 v10, 0xffff0000, v10
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v9, 0xffff0000, v9
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v38, 0xffff0000, v38
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v69, 16, v28
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v37, v10, v26 :: v_dual_and_b32 v28, 0xffff0000, v28
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v39, v8, v24
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v133, v82, v81 :: v_dual_lshlrev_b32 v70, 16, v12
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v135, v86, v85 :: v_dual_and_b32 v12, 0xffff0000, v12
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v35, 0xffff0000, v35
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v80, 16, v11
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v11, 0xffff0000, v11
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v132, 16, v36
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v36, 0xffff0000, v36
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v50, 0xffff0000, v50
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v22, 0x400000, v133
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v21, 0xffff0000, v21
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v24, 0x400000, v37
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff0000, v5
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v71, 16, v27
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v27, 0xffff0000, v27
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v32, 0xffff0000, v32
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v130, 16, v34
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v35, v12, v28 :: v_dual_and_b32 v34, 0xffff0000, v34
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v36, v11, v27
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v50, v5, v21
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v132, v80, v71 :: v_dual_lshlrev_b32 v67, 16, v29
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v29, 0xffff0000, v29
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v98, 0x400000, v51
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v119, 16, v31
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v31, 0xffff0000, v31
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v64, 16, v15
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v34, v13, v29 :: v_dual_and_b32 v15, 0xffff0000, v15
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v130, v68, v67 :: v_dual_lshlrev_b32 v65, 16, v30
+; GFX11FAKE16-NEXT:    v_bfe_u32 v23, v37, 16, 1
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v31, v15, v32 :: v_dual_lshlrev_b32 v66, 16, v14
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v119, v64, v128
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(3)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v64, 16, v52
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(2)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v128, 16, v53
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v53, 0xffff0000, v53
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v15, 16, v54
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v32, 0xffff0000, v54
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11FAKE16-NEXT:    v_lshlrev_b32_e32 v54, 16, v55
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v55, 0xffff0000, v55
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v129, v66, v65 :: v_dual_and_b32 v30, 0xffff0000, v30
+; GFX11FAKE16-NEXT:    v_and_b32_e32 v52, 0xffff0000, v52
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v64, v112, v103
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v38, v9, v25
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v131, v70, v69 :: v_dual_and_b32 v14, 0xffff0000, v14
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v53, v2, v18
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v55, v0, v16
+; GFX11FAKE16-NEXT:    v_bfe_u32 v0, v119, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v2, v31, 16, 1
+; GFX11FAKE16-NEXT:    v_dual_fmac_f32 v33, v14, v30 :: v_dual_fmac_f32 v52, v3, v19
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v32, v1, v17
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v1, 0x400000, v119
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v3, 0x400000, v31
+; GFX11FAKE16-NEXT:    v_bfe_u32 v4, v129, 16, 1
+; GFX11FAKE16-NEXT:    v_add3_u32 v0, v0, v119, 0x7fff
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v119, v119
+; GFX11FAKE16-NEXT:    v_add3_u32 v2, v2, v31, 0x7fff
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e64 s0, v31, v31
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v128, v114, v113
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v54, v118, v117
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v5, 0x400000, v129
+; GFX11FAKE16-NEXT:    v_bfe_u32 v6, v33, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v10, v34, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v14, v35, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v19, v36, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v27, v38, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v65, v39, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v69, v48, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v81, v49, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v85, v50, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v97, v51, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v101, v52, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v113, v53, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v117, v32, 16, 1
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v148, v0, v1, vcc_lo
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e64 v149, v2, v3, s0
+; GFX11FAKE16-NEXT:    v_add3_u32 v2, v4, v129, 0x7fff
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v129, v129
+; GFX11FAKE16-NEXT:    v_fmac_f32_e32 v15, v116, v115
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v7, 0x400000, v33
+; GFX11FAKE16-NEXT:    v_bfe_u32 v8, v130, 16, 1
+; GFX11FAKE16-NEXT:    v_add3_u32 v3, v6, v33, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v6, v10, v34, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v10, v14, v35, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v14, v19, v36, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v19, v23, v37, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v23, v27, v38, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v27, v65, v39, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v65, v69, v48, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v69, v81, v49, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v81, v85, v50, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v85, v97, v51, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v97, v101, v52, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v101, v113, v53, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v113, v117, v32, 0x7fff
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v117, v2, v5, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v33, v33
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v9, 0x400000, v130
+; GFX11FAKE16-NEXT:    v_bfe_u32 v12, v131, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v17, v132, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v21, v133, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v25, v134, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v29, v135, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v67, v144, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v71, v145, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v83, v146, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v87, v147, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v99, v64, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v103, v128, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v115, v15, 16, 1
+; GFX11FAKE16-NEXT:    v_bfe_u32 v119, v54, 16, 1
+; GFX11FAKE16-NEXT:    v_add3_u32 v4, v8, v130, 0x7fff
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v33, v3, v7, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v130, v130
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v11, 0x400000, v34
+; GFX11FAKE16-NEXT:    v_add3_u32 v8, v12, v131, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v12, v17, v132, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v17, v21, v133, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v21, v25, v134, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v25, v29, v135, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v29, v67, v144, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v67, v71, v145, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v71, v83, v146, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v83, v87, v147, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v87, v99, v64, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v99, v103, v128, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v103, v115, v15, 0x7fff
+; GFX11FAKE16-NEXT:    v_add3_u32 v115, v119, v54, 0x7fff
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v119, v4, v9, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v34, v34
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v13, 0x400000, v131
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v16, 0x400000, v35
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v18, 0x400000, v132
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v20, 0x400000, v36
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v34, v6, v11, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v131, v131
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v26, 0x400000, v134
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v28, 0x400000, v38
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v30, 0x400000, v135
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v66, 0x400000, v39
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v13, v8, v13, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v35, v35
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v68, 0x400000, v144
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v70, 0x400000, v48
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v80, 0x400000, v145
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v82, 0x400000, v49
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v16, v10, v16, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v132, v132
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v86, 0x400000, v50
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v96, 0x400000, v147
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v100, 0x400000, v64
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v102, 0x400000, v52
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v11, v12, v18, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v36, v36
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v112, 0x400000, v128
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v116, 0x400000, v15
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v118, 0x400000, v32
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v31, 0x400000, v54
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v12, v14, v20, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v133, v133
+; GFX11FAKE16-NEXT:    v_bfe_u32 v0, v55, 16, 1
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v1, 0x400000, v55
+; GFX11FAKE16-NEXT:    v_or_b32_e32 v114, 0x400000, v53
+; GFX11FAKE16-NEXT:    v_perm_b32 v11, v12, v11, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v10, v17, v22, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v37, v37
+; GFX11FAKE16-NEXT:    v_add3_u32 v0, v0, v55, 0x7fff
+; GFX11FAKE16-NEXT:    v_perm_b32 v12, v16, v13, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v13, v34, v119, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v14, v19, v24, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v134, v134
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v10, v14, v10, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v9, v21, v26, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v38, v38
+; GFX11FAKE16-NEXT:    v_perm_b32 v14, v33, v117, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v17, v23, v28, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v135, v135
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v9, v17, v9, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v8, v25, v30, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v39, v39
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v18, v27, v66, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v144, v144
+; GFX11FAKE16-NEXT:    v_perm_b32 v8, v18, v8, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v7, v29, v68, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v48, v48
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v19, v65, v70, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v145, v145
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v7, v19, v7, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v6, v67, v80, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v49, v49
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v20, v69, v82, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v146, v146
+; GFX11FAKE16-NEXT:    v_perm_b32 v6, v20, v6, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v5, v71, v84, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v50, v50
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v21, v81, v86, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v147, v147
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v5, v21, v5, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v4, v83, v96, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v64, v64
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v3, v87, v100, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v52, v52
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v22, v97, v102, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v128, v128
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v3, v22, v3, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v2, v99, v112, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v15, v15
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v15, v103, v116, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v32, v32
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v23, v113, v118, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v54, v54
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v24, v115, v31, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v55, v55
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v53, v53
+; GFX11FAKE16-NEXT:    v_perm_b32 v1, v23, v15, 0x7060302
+; GFX11FAKE16-NEXT:    v_perm_b32 v15, v149, v148, 0x7060302
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX11FAKE16-NEXT:    v_perm_b32 v0, v0, v24, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v25, v101, v114, vcc_lo
+; GFX11FAKE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v51, v51
+; GFX11FAKE16-NEXT:    v_perm_b32 v2, v25, v2, 0x7060302
+; GFX11FAKE16-NEXT:    v_cndmask_b32_e32 v26, v85, v98, vcc_lo
+; GFX11FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11FAKE16-NEXT:    v_perm_b32 v4, v26, v4, 0x7060302
+; GFX11FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GFX1250-LABEL: v_fma_v32bf16:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:     s_wait_loadcnt_dscnt 0x0
-; GFX1250-NEXT:     s_wait_kmcnt 0x0
-; GFX1250-NEXT:     s_clause 0x10
-; GFX1250-NEXT:     scratch_load_b32 v31, off, s32 offset:64
-; GFX1250-NEXT:     scratch_load_b32 v32, off, s32 offset:4
-; GFX1250-NEXT:     scratch_load_b32 v33, off, s32 offset:8
-; GFX1250-NEXT:     scratch_load_b32 v34, off, s32 offset:12
-; GFX1250-NEXT:     scratch_load_b32 v35, off, s32 offset:16
-; GFX1250-NEXT:     scratch_load_b32 v36, off, s32 offset:20
-; GFX1250-NEXT:     scratch_load_b32 v37, off, s32 offset:24
-; GFX1250-NEXT:     scratch_load_b32 v38, off, s32 offset:28
-; GFX1250-NEXT:     scratch_load_b32 v39, off, s32 offset:32
-; GFX1250-NEXT:     scratch_load_b32 v48, off, s32 offset:36
-; GFX1250-NEXT:     scratch_load_b32 v49, off, s32 offset:40
-; GFX1250-NEXT:     scratch_load_b32 v50, off, s32 offset:44
-; GFX1250-NEXT:     scratch_load_b32 v51, off, s32 offset:48
-; GFX1250-NEXT:     scratch_load_b32 v52, off, s32 offset:52
-; GFX1250-NEXT:     scratch_load_b32 v53, off, s32 offset:56
-; GFX1250-NEXT:     scratch_load_b32 v54, off, s32 offset:60
-; GFX1250-NEXT:     scratch_load_b32 v55, off, s32
-; GFX1250-NEXT:     s_wait_loadcnt 0xf
-; GFX1250-NEXT:     v_pk_fma_bf16 v0, v0, v16, v32
-; GFX1250-NEXT:     s_wait_loadcnt 0xe
-; GFX1250-NEXT:     v_pk_fma_bf16 v1, v1, v17, v33
-; GFX1250-NEXT:     s_wait_loadcnt 0xd
-; GFX1250-NEXT:     v_pk_fma_bf16 v2, v2, v18, v34
-; GFX1250-NEXT:     s_wait_loadcnt 0xc
-; GFX1250-NEXT:     v_pk_fma_bf16 v3, v3, v19, v35
-; GFX1250-NEXT:     s_wait_loadcnt 0xb
-; GFX1250-NEXT:     v_pk_fma_bf16 v4, v4, v20, v36
-; GFX1250-NEXT:     s_wait_loadcnt 0xa
-; GFX1250-NEXT:     v_pk_fma_bf16 v5, v5, v21, v37
-; GFX1250-NEXT:     s_wait_loadcnt 0x9
-; GFX1250-NEXT:     v_pk_fma_bf16 v6, v6, v22, v38
-; GFX1250-NEXT:     s_wait_loadcnt 0x8
-; GFX1250-NEXT:     v_pk_fma_bf16 v7, v7, v23, v39
-; GFX1250-NEXT:     s_wait_loadcnt 0x7
-; GFX1250-NEXT:     v_pk_fma_bf16 v8, v8, v24, v48
-; GFX1250-NEXT:     s_wait_loadcnt 0x6
-; GFX1250-NEXT:     v_pk_fma_bf16 v9, v9, v25, v49
-; GFX1250-NEXT:     s_wait_loadcnt 0x5
-; GFX1250-NEXT:     v_pk_fma_bf16 v10, v10, v26, v50
-; GFX1250-NEXT:     s_wait_loadcnt 0x4
-; GFX1250-NEXT:     v_pk_fma_bf16 v11, v11, v27, v51
-; GFX1250-NEXT:     s_wait_loadcnt 0x3
-; GFX1250-NEXT:     v_pk_fma_bf16 v12, v12, v28, v52
-; GFX1250-NEXT:     s_wait_loadcnt 0x2
-; GFX1250-NEXT:     v_pk_fma_bf16 v13, v13, v29, v53
-; GFX1250-NEXT:     s_wait_loadcnt 0x1
-; GFX1250-NEXT:     v_pk_fma_bf16 v14, v14, v30, v54
-; GFX1250-NEXT:     s_wait_loadcnt 0x0
-; GFX1250-NEXT:     v_pk_fma_bf16 v15, v15, v55, v31
-; GFX1250-NEXT:     s_set_pc_i64 s[30:31]
-define <32 x bfloat> @v_fma_v32bf16(<32 x bfloat> %a, <32 x bfloat> %b, <32 x bfloat> %c) {
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    s_clause 0x10
+; GFX1250-NEXT:    scratch_load_b32 v31, off, s32 offset:64
+; GFX1250-NEXT:    scratch_load_b32 v32, off, s32 offset:4
+; GFX1250-NEXT:    scratch_load_b32 v33, off, s32 offset:8
+; GFX1250-NEXT:    scratch_load_b32 v34, off, s32 offset:12
+; GFX1250-NEXT:    scratch_load_b32 v35, off, s32 offset:16
+; GFX1250-NEXT:    scratch_load_b32 v36, off, s32 offset:20
+; GFX1250-NEXT:    scratch_load_b32 v37, off, s32 offset:24
+; GFX1250-NEXT:    scratch_load_b32 v38, off, s32 offset:28
+; GFX1250-NEXT:    scratch_load_b32 v39, off, s32 offset:32
+; GFX1250-NEXT:    scratch_load_b32 v48, off, s32 offset:36
+; GFX1250-NEXT:    scratch_load_b32 v49, off, s32 offset:40
+; GFX1250-NEXT:    scratch_load_b32 v50, off, s32 offset:44
+; GFX1250-NEXT:    scratch_load_b32 v51, off, s32 offset:48
+; GFX1250-NEXT:    scratch_load_b32 v52, off, s32 offset:52
+; GFX1250-NEXT:    scratch_load_b32 v53, off, s32 offset:56
+; GFX1250-NEXT:    scratch_load_b32 v54, off, s32 offset:60
+; GFX1250-NEXT:    scratch_load_b32 v55, off, s32
+; GFX1250-NEXT:    s_wait_loadcnt 0xf
+; GFX1250-NEXT:    v_pk_fma_bf16 v0, v0, v16, v32
+; GFX1250-NEXT:    s_wait_loadcnt 0xe
+; GFX1250-NEXT:    v_pk_fma_bf16 v1, v1, v17, v33
+; GFX1250-NEXT:    s_wait_loadcnt 0xd
+; GFX1250-NEXT:    v_pk_fma_bf16 v2, v2, v18, v34
+; GFX1250-NEXT:    s_wait_loadcnt 0xc
+; GFX1250-NEXT:    v_pk_fma_bf16 v3, v3, v19, v35
+; GFX1250-NEXT:    s_wait_loadcnt 0xb
+; GFX1250-NEXT:    v_pk_fma_bf16 v4, v4, v20, v36
+; GFX1250-NEXT:    s_wait_loadcnt 0xa
+; GFX1250-NEXT:    v_pk_fma_bf16 v5, v5, v21, v37
+; GFX1250-NEXT:    s_wait_loadcnt 0x9
+; GFX1250-NEXT:    v_pk_fma_bf16 v6, v6, v22, v38
+; GFX1250-NEXT:    s_wait_loadcnt 0x8
+; GFX1250-NEXT:    v_pk_fma_bf16 v7, v7, v23, v39
+; GFX1250-NEXT:    s_wait_loadcnt 0x7
+; GFX1250-NEXT:    v_pk_fma_bf16 v8, v8, v24, v48
+; GFX1250-NEXT:    s_wait_loadcnt 0x6
+; GFX1250-NEXT:    v_pk_fma_bf16 v9, v9, v25, v49
+; GFX1250-NEXT:    s_wait_loadcnt 0x5
+; GFX1250-NEXT:    v_pk_fma_bf16 v10, v10, v26, v50
+; GFX1250-NEXT:    s_wait_loadcnt 0x4
+; GFX1250-NEXT:    v_pk_fma_bf16 v11, v11, v27, v51
+; GFX1250-NEXT:    s_wait_loadcnt 0x3
+; GFX1250-NEXT:    v_pk_fma_bf16 v12, v12, v28, v52
+; GFX1250-NEXT:    s_wait_loadcnt 0x2
+; GFX1250-NEXT:    v_pk_fma_bf16 v13, v13, v29, v53
+; GFX1250-NEXT:    s_wait_loadcnt 0x1
+; GFX1250-NEXT:    v_pk_fma_bf16 v14, v14, v30, v54
+; GFX1250-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-NEXT:    v_pk_fma_bf16 v15, v15, v55, v31
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %op = call <32 x bfloat> @llvm.fma.v32bf16(<32 x bfloat> %a, <32 x bfloat> %b, <32 x bfloat> %c)
   ret <32 x bfloat> %op
 }


### PR DESCRIPTION
Looks like there were some checks leftover from before the GFX1250TRUE16 run line was disabled. These were causing problems downstream. Not sure why update_llc_test_checks did not clean these up.

I removed all existing checks and re-ran update_llc_test_checks.