### PR TITLE
[CodeGen][test] Fix Buildbot failure due to uninitialized variables

### DIFF
--- a/llvm/unittests/CodeGen/TypeTraitsTest.cpp
+++ b/llvm/unittests/CodeGen/TypeTraitsTest.cpp
@@ -39,7 +39,7 @@ static_assert(std::is_trivially_copyable_v<IdentifyingPassPtr>,
 template <class Fn> constexpr bool CheckStdCmpRequirements() {
   // std::less and std::equal_to are literal, default constructible, and
   // copyable classes.
-  Fn f1;
+  Fn f1{};
   auto f2 = f1;
   auto f3 = std::move(f2);
   f2 = f3;


### PR DESCRIPTION
Under some options used by LLVM Buildbot, an uninitialized variable (recently added to the test suite) caused constant evaluation failure, despite the type of that variable is an empty class.

This PR explicitly initializes the variables with `{}` to fix the error. Follows-up #160804.