### PR TITLE
[clang] treat deduced-as-dependent as undeduced for constant template parameters

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -7102,7 +7102,7 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
 
   // If the parameter type somehow involves auto, deduce the type now.
   DeducedType *DeducedT = ParamType->getContainedDeducedType();
-  bool IsDeduced = DeducedT && !DeducedT->isDeduced();
+  bool IsDeduced = DeducedT && DeducedT->getDeducedType().isNull();
   if (IsDeduced) {
     // When checking a deduced template argument, deduce from its type even if
     // the type is dependent, in order to check the types of non-type template


### PR DESCRIPTION
The AutoType's deduced-as-dependent mechanism is not really used for constant template parameters, but this is currently harmless to ignore because when dealing which such types, they will have been transformed, turning them back to plain undeduced AutoTypes.

This should be NFC for current main users, but https://github.com/llvm/llvm-project/pull/141776 will depend on this.