### PR TITLE
[SPARC] Prevent meta instructions from being inserted into delay slots

### DIFF
--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -206,8 +206,8 @@ Filler::findDelayInstr(MachineBasicBlock &MBB,
     if (!done)
       --I;
 
-    // Skip debug and meta instructions.
-    if (I->isDebugInstr() || I->isMetaInstruction())
+    // Skip meta instructions.
+    if (I->isMetaInstruction())
       continue;
 
     if (I->hasUnmodeledSideEffects() || I->isInlineAsm() || I->isPosition() ||

--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -206,8 +206,8 @@ Filler::findDelayInstr(MachineBasicBlock &MBB,
     if (!done)
       --I;
 
-    // skip debug instruction
-    if (I->isDebugInstr())
+    // Skip debug and generic instructions.
+    if (I->isDebugInstr() || (I->getOpcode() <= TargetOpcode::GENERIC_OP_END))
       continue;
 
     if (I->hasUnmodeledSideEffects() || I->isInlineAsm() || I->isPosition() ||

--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -206,8 +206,8 @@ Filler::findDelayInstr(MachineBasicBlock &MBB,
     if (!done)
       --I;
 
-    // Skip debug and generic instructions.
-    if (I->isDebugInstr() || (I->getOpcode() <= TargetOpcode::GENERIC_OP_END))
+    // Skip debug and meta instructions.
+    if (I->isDebugInstr() || I->isMetaInstruction())
       continue;
 
     if (I->hasUnmodeledSideEffects() || I->isInlineAsm() || I->isPosition() ||

--- a/llvm/test/CodeGen/SPARC/2011-01-19-DelaySlot.ll
+++ b/llvm/test/CodeGen/SPARC/2011-01-19-DelaySlot.ll
@@ -184,29 +184,28 @@ entry:
   ret i32 %2
 }
 
-define i32 @test_generic_inst(i32 %a) #0 {
+define i32 @test_generic_inst(i32 %arg) #0 {
 ;CHECK-LABEL: test_generic_inst:
 ;CHECK: ! fake_use: {{.*}}
 ;CHECK: bne {{.*}}
 ;CHECK-NEXT: nop
-
-%2 = call i32 @bar(i32 %a)
-  %3 = and i32 %2, 1
-  %4 = icmp eq i32 %3, 0
+  %bar1 = call i32 @bar(i32 %arg)
+  %even = and i32 %bar1, 1
+  %cmp = icmp eq i32 %even, 0
   ; This shouldn't get reordered into a delay slot
-  call void (...) @llvm.fake.use(i32 %a)
-  br i1 %4, label %5, label %7
-5:
-  %6 = call i32 @bar(i32 %2)
-  br label %9
+  call void (...) @llvm.fake.use(i32 %arg)
+  br i1 %cmp, label %true, label %false
+true:
+  %bar2 = call i32 @bar(i32 %bar1)
+  br label %cont
 
-7:
-  %8 = add nsw i32 %2, 1
-  br label %9
+false:
+  %inc = add nsw i32 %bar1, 1
+  br label %cont
 
-9:
-  %10 = phi i32 [ %6, %5 ], [ %8, %7 ]
-  ret i32 %10
+cont:
+  %ret = phi i32 [ %bar2, %true ], [ %inc, %false ]
+  ret i32 %ret
 }
 
 declare void @llvm.fake.use(...)


### PR DESCRIPTION
Do not move meta instructions like `FAKE_USE`/`@llvm.fake.use` into delay slots, as they don't correspond to real machine instructions.

This should fix crashes when compiling with, for example, `clang -Og`.