### PR TITLE
[libunwind][test] Add check for objcopy to improve test compatibility

### DIFF
--- a/libunwind/test/configs/cmake-bridge.cfg.in
+++ b/libunwind/test/configs/cmake-bridge.cfg.in
@@ -14,6 +14,7 @@
 import os, site
 site.addsitedir(os.path.join('@LIBUNWIND_LIBCXX_PATH@', 'utils'))
 import libcxx.test.format
+from lit.util import which
 
 # Basic configuration of the test suite
 config.name = os.path.basename('@LIBUNWIND_TEST_CONFIG@')
@@ -33,3 +34,13 @@ config.substitutions.append(('%{install-prefix}', '@LIBUNWIND_TESTING_INSTALL_PR
 config.substitutions.append(('%{include}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@/include'))
 config.substitutions.append(('%{lib}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@/@LIBUNWIND_INSTALL_LIBRARY_DIR@'))
 config.substitutions.append(('%{benchmark_flags}', ''))
+
+# Check for objcopy tools
+objcopy_path = which('objcopy')
+if not objcopy_path:
+    objcopy_path = which('llvm-objcopy')
+if not objcopy_path:
+    objcopy_path = which('llvm-objcopy', '@LLVM_BUILD_BINARY_DIR@/bin')
+if objcopy_path:
+    config.substitutions.append(('%{objcopy}', objcopy_path))
+    config.available_features.add('objcopy-available')

--- a/libunwind/test/configs/cmake-bridge.cfg.in
+++ b/libunwind/test/configs/cmake-bridge.cfg.in
@@ -36,11 +36,11 @@ config.substitutions.append(('%{lib}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@/@LIBU
 config.substitutions.append(('%{benchmark_flags}', ''))
 
 # Check for objcopy tools
-objcopy_path = which('objcopy')
+objcopy_path = which('llvm-objcopy', '@LLVM_BUILD_BINARY_DIR@/bin')
 if not objcopy_path:
     objcopy_path = which('llvm-objcopy')
 if not objcopy_path:
-    objcopy_path = which('llvm-objcopy', '@LLVM_BUILD_BINARY_DIR@/bin')
+    objcopy_path = which('objcopy')
 if objcopy_path:
     config.substitutions.append(('%{objcopy}', objcopy_path))
     config.available_features.add('objcopy-available')

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -13,17 +13,15 @@
 
 // clang-format off
 
-// REQUIRES: target={{x86_64-.+-linux-gnu}}
-// aarch64,arm have a cross toolchain build(llvm-clang-win-x-aarch64, etc)
-// where objdump is not available.
+// REQUIRES: linux, objcopy-available
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 
 // RUN: %{build}
-// RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: %{objcopy} --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 
-// RUN: objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: %{objcopy} --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: %{exec} %t.exe
 
 // clang-format on

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -13,8 +13,8 @@
 
 // clang-format off
 
-// REQUIRES: linux, objcopy-available
-// UNSUPPORTED: target={{.+-gnueabi.*}}
+// REQUIRES: target={{x86_64-.+-linux-gnu}}
+// REQUIRES: objcopy-available
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -14,6 +14,7 @@
 // clang-format off
 
 // REQUIRES: linux, objcopy-available
+// UNSUPPORTED: target={{.+-gnueabihf}}
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -14,7 +14,7 @@
 // clang-format off
 
 // REQUIRES: linux, objcopy-available
-// UNSUPPORTED: target={{.+-gnueabihf}}
+// UNSUPPORTED: target={{.+-gnueabi.*}}
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan


### PR DESCRIPTION
Previously, we only used `objcopy`, which is not available for some build configurations. With this patch, we not only try to use `objcopy`, but also try to use `llvm-objcopy` if available.

This is a follow-up of https://github.com/llvm/llvm-project/pull/156383.