### PR TITLE
[QualGroup][docs] Add new members to LLVM Qualification Working Group

### DIFF
--- a/llvm/docs/QualGroup.rst
+++ b/llvm/docs/QualGroup.rst
@@ -75,6 +75,16 @@ They meet the criteria for inclusion below. Knowing their handles help us keep t
      - capitan-davide
      - capitan_davide
      - capitan-davide
+   * - Jorge Pinto Sousa
+     - Critical Techworks
+     - sousajo-cc
+     - sousajo-cc
+     - sousajo-cc
+   * - José Rui Simões
+     - Critical Software
+     - jr-simoes
+     - jr_simoes
+     - iznogoud-zz
    * - Oscar Slotosch
      - Validas
      - slotosch
@@ -100,6 +110,11 @@ They meet the criteria for inclusion below. Knowing their handles help us keep t
      - YoungJunLee
      - YoungJunLee
      - IamYJLee
+   * - Zaky Hermawan
+     - No Affiliation
+     - ZakyHermawan
+     - quarkz99
+     - zakyHermawan
 
 
 Organizations are limited to three representatives within the group to maintain diversity.


### PR DESCRIPTION
## Summary

This PR adds three new members to the LLVM Qualification Working Group member table in the documentation.

## Changes

- **Jorge Pinto Sousa** (Critical Techworks)
- **José Rui Simões** (Critical Software)
- **Zaky Hermawan** (Individual contributor)

## Background

These new members have been nominated and approved through the working group's established nomination process as outlined in the QualGroup documentation. They meet the membership criteria for individuals with relevant experience in qualification-related efforts.

## Testing

- [x] Documentation builds successfully
- [x] Member table formatting is correct
- [x] All links and handles are properly formatted

## Related Links

- [LLVM Qualification Working Group Documentation](https://llvm.org/docs/QualGroup.html)