### PR TITLE
[mlir][dataflow] Fix LivenessAnalysis/RemoveDeadValues handling of loop induction variables

### DIFF
--- a/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
@@ -247,9 +247,10 @@ void LivenessAnalysis::visitBranchOperand(OpOperand &operand) {
     for (BlockArgument argument : argumentNotOperand) {
       Liveness *argumentLiveness = getLatticeElement(argument);
       LDBG() << "Marking RegionBranchOp's argument live: " << argument;
-      // TODO: this is overly conservative: we should be able to eliminate unused 
-      // values in a RegionBranchOpInterface operation but that may requires removing
-      // operation results which is beyond current capabilities of this pass right now.
+      // TODO: this is overly conservative: we should be able to eliminate
+      // unused values in a RegionBranchOpInterface operation but that may
+      // requires removing operation results which is beyond current
+      // capabilities of this pass right now.
       propagateIfChanged(argumentLiveness, argumentLiveness->markLive());
     }
   }

--- a/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
@@ -247,6 +247,9 @@ void LivenessAnalysis::visitBranchOperand(OpOperand &operand) {
     for (BlockArgument argument : argumentNotOperand) {
       Liveness *argumentLiveness = getLatticeElement(argument);
       LDBG() << "Marking RegionBranchOp's argument live: " << argument;
+      // TODO: this is overly conservative: we should be able to eliminate unused 
+      // values in a RegionBranchOpInterface operation but that may requires removing
+      // operation results which is beyond current capabilities of this pass right now.
       propagateIfChanged(argumentLiveness, argumentLiveness->markLive());
     }
   }

--- a/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
@@ -339,7 +339,6 @@ RunLivenessAnalysis::RunLivenessAnalysis(Operation *op) {
              << " has no liveness info (unreachable), mark dead";
       solver.getOrCreateState<Liveness>(result.value());
     }
-
     for (auto &region : op->getRegions()) {
       for (auto &block : region) {
         for (auto blockArg : llvm::enumerate(block.getArguments())) {

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -652,13 +652,25 @@ func.func @callee(%arg0: index, %arg1: index, %arg2: index) -> index {
 
 // -----
 
-// This test verifies that the induction variables in loops are not deleted.
+// This test verifies that the induction variables in loops are not deleted, the loop has results.
 
 // CHECK-LABEL: func @dead_value_loop_ivs
-func.func @dead_value_loop_ivs(%lb: index, %ub: index, %step: index, %b : i1) -> i1 {
+func.func @dead_value_loop_ivs_has_result(%lb: index, %ub: index, %step: index, %b: i1) -> i1 {
   %loop_ret = scf.for %iv = %lb to %ub step %step iter_args(%iter = %b) -> (i1) {
     cf.assert %b, "loop not dead"
     scf.yield %b : i1
   }
   return %loop_ret : i1
+}
+
+// -----
+
+// This test verifies that the induction variables in loops are not deleted, the loop has no results.
+
+// CHECK-LABEL: func @dead_value_loop_ivs_no_result
+func.func @dead_value_loop_ivs_no_result(%lb: index, %ub: index, %step: index, %input: memref<?xf32>, %value: f32, %pos: index) {
+  scf.for %iv = %lb to %ub step %step {
+    memref.store %value, %input[%pos] : memref<?xf32>
+  }
+  return
 }

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -649,3 +649,16 @@ func.func @callee(%arg0: index, %arg1: index, %arg2: index) -> index {
   %res = call @mutl_parameter(%arg0, %arg1, %arg2) : (index, index, index) -> (index)
   return %res : index
 }
+
+// -----
+
+// This test verifies that the induction variables in loops are not deleted.
+
+// CHECK-LABEL: func @dead_value_loop_ivs
+func.func @dead_value_loop_ivs(%lb: index, %ub: index, %step: index, %b : i1) -> i1 {
+  %loop_ret = scf.for %iv = %lb to %ub step %step iter_args(%iter = %b) -> (i1) {
+    cf.assert %b, "loop not dead"
+    scf.yield %b : i1
+  }
+  return %loop_ret : i1
+}


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/157934. In liveness analysis, variables that are not analyzed are set as dead variables, but some variables are definitely live.