### PR TITLE
[libclc] Propose new libclc maintainer

### DIFF
--- a/libclc/Maintainers.md
+++ b/libclc/Maintainers.md
@@ -10,6 +10,9 @@ The following people are the active maintainers for the project. Please reach
 out to them for code reviews, questions about their area of expertise, or other
 assistance.
 
+Wenju He \
+wenju.he@intel.com (email), [wenju-he](https://github.com/wenju-he) (GitHub)
+
 Tom Stellard \
 tstellar@redhat.com (email), [tstellar](https://github.com/tstellar) (GitHub)
 


### PR DESCRIPTION
Wenju He has been active on the libclc project for a while now and has been contributing to the overall health and steering the future of the project.