### PR TITLE
[clang-tidy][NFC] Clarify some options use regex to matching in doc (1/N)

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
@@ -39,8 +39,8 @@ Options
 
 .. option:: ExcludeClasses
 
-    Semicolon-delimited list of regular expressions matching class names that
-    overwriting the default exclusion list. The default is:
+    Semicolon-separated list of regular expressions matching class names that
+    overwrites the default exclusion list. The default is:
     `::std::map;::std::unordered_map;::std::flat_map`.
     
 .. option:: FixMode

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
@@ -39,8 +39,8 @@ Options
 
 .. option:: ExcludeClasses
 
-    Semicolon-delimited list of class names for overwriting the default
-    exclusion list. The default is:
+    Semicolon-delimited list of regular expressions matching class names that
+    overwriting the default exclusion list. The default is:
     `::std::map;::std::unordered_map;::std::flat_map`.
     
 .. option:: FixMode

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
@@ -62,12 +62,12 @@ Options
 
 .. option:: StrFormatLikeFunctions
 
-   A semicolon-separated list of (fully qualified) function names to
-   replace, with the requirement that the first parameter contains the
-   printf-style format string and the arguments to be formatted follow
-   immediately afterwards. Qualified member function names are supported,
-   but the replacement function name must be unqualified. The default value
-   for this option is `absl::StrFormat`.
+   A semicolon-separated list of regular expressions matching the 
+   (fully qualified) names of functions to replace, with the requirement that
+   the first parameter contains the printf-style format string and the
+   arguments to be formatted follow immediately afterwards. Qualified member
+   function names are supported, but the replacement function name must be
+   unqualified. The default value for this option is `absl::StrFormat`.
 
 .. option:: ReplacementFormatFunction
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
@@ -67,7 +67,7 @@ Options
    the first parameter contains the printf-style format string and the
    arguments to be formatted follow immediately afterwards. Qualified member
    function names are supported, but the replacement function name must be
-   unqualified. The default value for this option is `absl::StrFormat`.
+   unqualified. The default value is `absl::StrFormat`.
 
 .. option:: ReplacementFormatFunction
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -128,7 +128,8 @@ Options
    arguments to be formatted follow immediately afterwards. Qualified member
    function names are supported, but the replacement function name must be
    unqualified. If neither this option nor `FprintfLikeFunctions` are set then
-   the default value is `printf; absl::PrintF`, otherwise it is the empty string.
+   the default value is `printf; absl::PrintF`, otherwise it is the empty
+   string.
 
 
 .. option:: FprintfLikeFunctions

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -128,7 +128,7 @@ Options
    arguments to be formatted follow immediately afterwards. Qualified member
    function names are supported, but the replacement function name must be
    unqualified. If neither this option nor `FprintfLikeFunctions` are set then
-   the default value is `printf; absl::PrintF`, otherwise it is empty string.
+   the default value is `printf; absl::PrintF`, otherwise it is the empty string.
 
 
 .. option:: FprintfLikeFunctions
@@ -140,7 +140,7 @@ Options
    immediately afterwards. Qualified member function names are supported,
    but the replacement function name must be unqualified. If neither this
    option nor `PrintfLikeFunctions` are set then the default value is 
-   `fprintf;absl::FPrintF`, otherwise it is empty string.
+   `fprintf;absl::FPrintF`, otherwise it is the empty string.
 
 
 .. option:: ReplacementPrintFunction

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -122,25 +122,27 @@ Options
 
 .. option:: PrintfLikeFunctions
 
-   A semicolon-separated list of (fully qualified) function names to
-   replace, with the requirement that the first parameter contains the
-   printf-style format string and the arguments to be formatted follow
-   immediately afterwards. Qualified member function names are supported,
-   but the replacement function name must be unqualified. If neither this
-   option nor `FprintfLikeFunctions` are set then the default value for
-   this option is `printf; absl::PrintF`, otherwise it is empty.
+   A semicolon-separated list of regular expressions matching the 
+   (fully qualified) names of functions to replace, with the requirement
+   that the first parameter contains the printf-style format string and the
+   arguments to be formatted follow immediately afterwards. Qualified member
+   function names are supported, but the replacement function name must be
+   unqualified. If neither this option nor `FprintfLikeFunctions` are set then
+   the default value for this option is `printf; absl::PrintF`, otherwise it is
+   empty.
 
 
 .. option:: FprintfLikeFunctions
 
-   A semicolon-separated list of (fully qualified) function names to
-   replace, with the requirement that the first parameter is retained, the
-   second parameter contains the printf-style format string and the
-   arguments to be formatted follow immediately afterwards. Qualified
-   member function names are supported, but the replacement function name
-   must be unqualified. If neither this option nor `PrintfLikeFunctions`
-   are set then the default value for this option is `fprintf;
-   absl::FPrintF`, otherwise it is empty.
+   A semicolon-separated list of regular expressions matching the 
+   (fully qualified) names of functions to replace, with the requirement
+   that the first parameter is retained, the second parameter contains the
+   printf-style format string and the arguments to be formatted follow
+   immediately afterwards. Qualified member function names are supported,
+   but the replacement function name must be unqualified. If neither this
+   option nor `PrintfLikeFunctions` are set then the default value for this
+   option is `fprintf;absl::FPrintF`, otherwise it is empty.
+
 
 .. option:: ReplacementPrintFunction
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -128,8 +128,7 @@ Options
    arguments to be formatted follow immediately afterwards. Qualified member
    function names are supported, but the replacement function name must be
    unqualified. If neither this option nor `FprintfLikeFunctions` are set then
-   the default value for this option is `printf; absl::PrintF`, otherwise it is
-   empty.
+   the default value is `printf; absl::PrintF`, otherwise it is empty string.
 
 
 .. option:: FprintfLikeFunctions
@@ -140,8 +139,8 @@ Options
    printf-style format string and the arguments to be formatted follow
    immediately afterwards. Qualified member function names are supported,
    but the replacement function name must be unqualified. If neither this
-   option nor `PrintfLikeFunctions` are set then the default value for this
-   option is `fprintf;absl::FPrintF`, otherwise it is empty.
+   option nor `PrintfLikeFunctions` are set then the default value is 
+   `fprintf;absl::FPrintF`, otherwise it is empty string.
 
 
 .. option:: ReplacementPrintFunction

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
@@ -30,8 +30,8 @@ Options
 
 .. option:: ExcludedComparisonTypes
 
-    A semicolon-separated list of regular expressions matching class names that
-    the check will ignore comparisons of objects with default-constructed
+    A semicolon-separated list of regular expressions matching class names for
+    which the check will ignore comparisons of objects with default-constructed
     objects of the same type. If a class is listed here, the check will not
     suggest using ``empty()`` instead of such comparisons for objects of that
     class. Default value is: `::std::array`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
@@ -30,8 +30,8 @@ Options
 
 .. option:: ExcludedComparisonTypes
 
-    A semicolon-separated list of class names for which the check will ignore
-    comparisons of objects with default-constructed objects of the same type.
-    If a class is listed here, the check will not suggest using ``empty()``
-    instead of such comparisons for objects of that class.
-    Default value is: `::std::array`.
+    A semicolon-separated list of regular expressions matching class names that
+    the check will ignore comparisons of objects with default-constructed
+    objects of the same type. If a class is listed here, the check will not
+    suggest using ``empty()`` instead of such comparisons for objects of that
+    class. Default value is: `::std::array`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.rst
@@ -11,10 +11,10 @@ Options
 
 .. option:: StringParameterFunctions
 
-   A semicolon-separated list of (fully qualified) function/method/operator
-   names, with the requirement that any parameter currently accepting a
-   ``const char*`` input should also be able to accept ``std::string``
-   inputs, or proper overload candidates that can do so should exist. This
-   can be used to configure functions such as ``fmt::format``,
-   ``spdlog::logger::info``, or wrappers around these and similar
-   functions. The default value is the empty string.
+   A semicolon-separated list of regular expressions matching the
+   (fully qualified) names of function/method/operator, with the requirement
+   that any parameter currently accepting a ``const char*`` input should also
+   be able to accept ``std::string`` inputs, or proper overload candidates that
+   can do so should exist. This can be used to configure functions such as
+   ``fmt::format``, ``spdlog::logger::info``, or wrappers around these and
+   similar functions. The default value is the empty string.


### PR DESCRIPTION
Some checks use regular expressions to match option values in their implementation ​​but this is not documented, it might makes user confused.

See https://github.com/llvm/llvm-project/issues/160991#issuecomment-3341484431