### PR TITLE
[mlir][Transforms] Greedy pattern rewriter: fix infinite folding loop

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -393,7 +393,7 @@ Value mlir::arith::getZeroConstant(OpBuilder &builder, Location loc,
 
 OpFoldResult arith::AddIOp::fold(FoldAdaptor adaptor) {
   // addi(x, 0) -> x
-  if (matchPattern(adaptor.getRhs(), m_Zero()))
+  if (matchPattern(adaptor.getRhs(), m_Zero()) && getLhs() != *this)
     return getLhs();
 
   // addi(subi(a, b), b) -> a

--- a/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -555,7 +555,8 @@ bool GreedyPatternRewriteDriver::processWorklist() {
           replacements.push_back(constOp->getResult(0));
         }
 
-        if (materializationSucceeded) {
+        if (materializationSucceeded &&
+            !llvm::equal(replacements, op->getResults())) {
           rewriter.replaceOp(op, replacements);
           changed = true;
           LLVM_DEBUG(logSuccessfulFolding(dumpRootOp));

--- a/mlir/test/Transforms/canonicalize.mlir
+++ b/mlir/test/Transforms/canonicalize.mlir
@@ -1248,3 +1248,12 @@ func.func @test_materialize_failure() -> i64 {
   %u = index.castu %const : index to i64
   return %u: i64
 }
+
+// -----
+
+// Make sure that the canonicalizer does not fold infinitely.
+
+// CHECK: %[[c0:.*]] = arith.constant 0 : index
+%c0 = arith.constant 0 : index
+// CHECK: %[[add:.*]] = arith.addi %[[c0]], %[[add]] : index
+%0 = arith.addi %c0, %0 : index


### PR DESCRIPTION
Fix an infinite folding loop when the result of a folding is identical to the folded operation. (This can be the case when the folder is faulty or the input IR is invalid.)

Fixes one issue mentioned in https://github.com/llvm/llvm-project/issues/159675#issuecomment-3345355282.
