### PR TITLE
[llvm-c] Add EmulatedTLS and EnableTLSDESC to LLVMTargetMachineOptions

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -170,6 +170,12 @@ Changes to the Python bindings
 Changes to the C API
 --------------------
 
+* `LLVMCreateTargetMachineWithOptions` now checks with target triple if the EmulatedTLS and
+  TLSDESC target options should be enabled by default.
+* The `LLVMTargetMachineOptionsSetEmulatedTLS` and `LLVMTargetMachineOptionsSetEnableTLSDESC`
+  functions have been added to explicitly enable or disable the EmulatedTLS and TLSDESC target
+  options.
+
 Changes to the CodeGen infrastructure
 -------------------------------------
 

--- a/llvm/include/llvm-c/TargetMachine.h
+++ b/llvm/include/llvm-c/TargetMachine.h
@@ -151,6 +151,14 @@ LLVM_C_ABI void
 LLVMTargetMachineOptionsSetCodeModel(LLVMTargetMachineOptionsRef Options,
                                      LLVMCodeModel CodeModel);
 
+LLVM_C_ABI void
+LLVMTargetMachineOptionsSetEmulatedTLS(LLVMTargetMachineOptionsRef Options,
+                                       LLVMBool EmulatedTLS);
+
+LLVM_C_ABI void
+LLVMTargetMachineOptionsSetEnableTLSDESC(LLVMTargetMachineOptionsRef Options,
+                                         LLVMBool EnableTLSDESC);
+
 /**
  * Create a new llvm::TargetMachine.
  *

--- a/llvm/unittests/Target/TargetMachineOptionsTest.cpp
+++ b/llvm/unittests/Target/TargetMachineOptionsTest.cpp
@@ -29,6 +29,8 @@ TEST(TargetMachineCTest, TargetMachineOptions) {
   LLVMTargetMachineOptionsSetCodeGenOptLevel(Options, LLVMCodeGenLevelNone);
   LLVMTargetMachineOptionsSetRelocMode(Options, LLVMRelocStatic);
   LLVMTargetMachineOptionsSetCodeModel(Options, LLVMCodeModelKernel);
+  LLVMTargetMachineOptionsSetEmulatedTLS(Options, true);
+  LLVMTargetMachineOptionsSetEnableTLSDESC(Options, true);
 
   LLVMDisposeTargetMachineOptions(Options);
 }


### PR DESCRIPTION
Adds a couple functions to LLVM-C to expose the Thread Local Storage options that are only available though the C++ API for now:

- `LLVMTargetMachineOptionsSetEmulatedTLS`
- `LLVMTargetMachineOptionsSetEnableTLSDESC`

We plan to use these options in @crystal-lang to reliably compile and cross compile to some targets regardless of downstream patches in OpenBSD or MingGW for example.