### PR TITLE
[TSan][test-only] Make TSan os_unfair_lock.c test check the weak symbol before usage

### DIFF
--- a/compiler-rt/test/tsan/Darwin/os_unfair_lock.c
+++ b/compiler-rt/test/tsan/Darwin/os_unfair_lock.c
@@ -22,8 +22,12 @@ void *ThreadWithFlags(void *a) {
     defined(__VISIONOS_2_0) || defined(__WATCHOS_11_0)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wunguarded-availability-new"
-  os_unfair_lock_lock_with_flags(&lock, OS_UNFAIR_LOCK_FLAG_ADAPTIVE_SPIN);
-  flags_available = 1;
+  if (os_unfair_lock_lock_with_flags) {
+    os_unfair_lock_lock_with_flags(&lock, OS_UNFAIR_LOCK_FLAG_ADAPTIVE_SPIN);
+    flags_available = 1;
+  } else {
+    os_unfair_lock_lock(&lock);
+  }
 #  pragma clang diagnostic pop
 #else
   os_unfair_lock_lock(&lock);


### PR DESCRIPTION
The os_unfair_lock.c test can currently fail with a null dereference if compiled on a platform with `os_unfair_lock_lock_with_flags`, but then executed on a platform without the function.

This patch fixes this by first checking whether the symbol exists, and falls back to `os_unfair_lock_lock` if not.

rdar://160596542