### PR TITLE
[SYCL] Add RT dependency on interface layer for offloading

### DIFF
--- a/.github/workflows/libsycl-build-and-test.yaml
+++ b/.github/workflows/libsycl-build-and-test.yaml
@@ -1,0 +1,38 @@
+# This file defines pre-commit CI for libsycl.
+name: Build libsycl
+on:
+  pull_request:
+    paths:
+      - 'libsycl/**'
+      - '.github/workflows/libsycl-build-and-test.yaml'
+
+permissions:
+  contents: read # Default everything to read-only
+
+concurrency:
+  # Cancel a currently running workflow from the same PR
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build_ubuntu2204:
+    if: github.repository_owner == 'llvm'
+    # github runner
+    runs-on: ubuntu-22.04
+    # reuse libcxx container for now
+    container: ghcr.io/llvm/libcxx-linux-builder:2b57ebb50b6d418e70382e655feaa619b558e254
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile
+        env:
+          CC: 'clang-21'
+          CXX: 'clang++-21'
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/build
+          mkdir -p $GITHUB_WORKSPACE/install
+          cmake -G Ninja -S $GITHUB_WORKSPACE/runtimes -B $GITHUB_WORKSPACE/build \
+            -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install \
+            -DLLVM_ENABLE_RUNTIMES="libsycl" \
+            -DCMAKE_BUILD_TYPE=Release
+          ninja -C $GITHUB_WORKSPACE/build install --verbose

--- a/libsycl/CMakeLists.txt
+++ b/libsycl/CMakeLists.txt
@@ -31,6 +31,12 @@ endif()
 option(LIBSYCL_ENABLE_WERROR "Treat all warnings as errors in the libsycl project" OFF)
 option(LIBSYCL_ENABLE_PEDANTIC "Compile with pedantic enabled." OFF)
 
+# If LIBSYCL_ENABLE_BACKENDS is undefined, we default to enabling OpenCL and Level
+# Zero backends.
+if (NOT DEFINED LIBSYCL_ENABLE_BACKENDS)
+  set(LIBSYCL_ENABLE_BACKENDS "opencl;level_zero" CACHE STRING "Backends enabled for SYCL")
+endif()
+
 #===============================================================================
 # Configure System
 #===============================================================================
@@ -76,6 +82,14 @@ set(LIBSYCL_ABI_NAMESPACE "__V${LIBSYCL_MAJOR_VERSION}" CACHE STRING
 if (NOT LIBSYCL_ABI_NAMESPACE MATCHES "__V.*")
    message(FATAL_ERROR "LIBSYCL_ABI_NAMESPACE must be a reserved identifier, got '${LIBSYCL_ABI_NAMESPACE}'.")
 endif()
+
+#===============================================================================
+# Dependencies
+#===============================================================================
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+# Download & build dependency for kernel offloading
+include(FetchUnifiedRuntime)
 
 #===============================================================================
 # Setup build & install rules

--- a/libsycl/cmake/Modules/FetchUnifiedRuntime.cmake
+++ b/libsycl/cmake/Modules/FetchUnifiedRuntime.cmake
@@ -1,0 +1,122 @@
+#===============================================================================
+# Fetches Unified Runtime used by SYCL language runtime to abstract SYCL open 
+# standard and vendor heterogeneous offload interfaces.
+#
+# This will in time be replaced by the new LLVM Offload interface.
+#
+# Unified Runtime is Apache 2.0 license with LLVM exceptions. 
+#
+#===============================================================================
+
+option(LIBSYCL_UR_BUILD_TESTS "Build tests for UR" OFF)
+
+set(UR_BUILD_TESTS "${LIBSYCL_UR_BUILD_TESTS}" CACHE BOOL "" FORCE)
+# UR tests require the examples to be built
+set(UR_BUILD_EXAMPLES "${LIBSYCL_UR_BUILD_TESTS}" CACHE BOOL "" FORCE)
+
+if("level_zero" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  set(UR_BUILD_ADAPTER_L0 ON)
+endif()
+if("cuda" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  set(UR_BUILD_ADAPTER_CUDA ON)
+endif()
+if("hip" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  set(UR_BUILD_ADAPTER_HIP ON)
+endif()
+if("opencl" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  set(UR_BUILD_ADAPTER_OPENCL ON)
+endif()
+
+# Disable errors from warnings while building the UR.
+# And remember the original flags before doing that.
+set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
+if(WIN32)
+  append("/WX-" CMAKE_CXX_FLAGS)
+  append("/WX-" CMAKE_C_FLAGS)
+  # Unified runtime build fails with /DUNICODE
+  append("/UUNICODE" CMAKE_CXX_FLAGS)
+  append("/UUNICODE" CMAKE_C_FLAGS)
+  append("/EHsc" CMAKE_CXX_FLAGS)
+  append("/EHsc" CMAKE_C_FLAGS)
+else()
+  append("-Wno-error" CMAKE_CXX_FLAGS)
+  append("-Wno-error" CMAKE_C_FLAGS)
+endif()
+
+if(NOT FETCHCONTENT_SOURCE_DIR_UNIFIED-RUNTIME)
+  find_package(unified-runtime)
+  if(unified-runtime_FOUND)
+    message (STATUS "Found system install of unified-runtime")
+    return()
+  endif()
+endif()
+
+include(FetchContent)
+
+set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+set(UNIFIED_RUNTIME_TAG 8ee4da175c197d4dc5c9ec939e7e4d87d4edfa99)
+
+FetchContent_Declare(unified-runtime
+  GIT_REPOSITORY    ${UNIFIED_RUNTIME_REPO}
+  GIT_TAG           ${UNIFIED_RUNTIME_TAG}
+)
+
+FetchContent_GetProperties(unified-runtime)
+if(FETCHCONTENT_SOURCE_DIR_UNIFIED-RUNTIME)
+  message(STATUS "Using specified Unified Runtime repo location at ${FETCHCONTENT_SOURCE_DIR_UNIFIED-RUNTIME}")
+else()
+  message(STATUS "Cloning Unified Runtime from ${UNIFIED_RUNTIME_REPO}")
+endif()
+FetchContent_MakeAvailable(unified-runtime)
+
+set(UNIFIED_RUNTIME_SOURCE_DIR
+  "${unified-runtime_SOURCE_DIR}" CACHE PATH
+  "Path to Unified Runtime Headers" FORCE)
+
+set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "UMF EXAMPLES")
+# Due to the use of dependentloadflag and no installer for UMF and hwloc we need
+# to link statically on windows
+if(WIN32)
+  set(UMF_BUILD_SHARED_LIBRARY OFF CACHE INTERNAL "Build UMF shared library")
+  set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
+endif()
+
+# Restore original flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BAK}")
+
+message(STATUS
+  "Using Unified Runtime source directory: ${UNIFIED_RUNTIME_SOURCE_DIR}")
+
+set(UNIFIED_RUNTIME_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/include")
+set(UNIFIED_RUNTIME_SRC_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/source")
+set(UNIFIED_RUNTIME_COMMON_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/source/common")
+
+add_library(UnifiedRuntimeLoader ALIAS ur_loader)
+add_library(UnifiedRuntime-Headers INTERFACE)
+
+target_include_directories(UnifiedRuntime-Headers
+  INTERFACE
+    "${UNIFIED_RUNTIME_INCLUDE_DIR}"
+)
+
+add_custom_target(UnifiedRuntimeAdapters)
+
+function(add_sycl_ur_adapter NAME)
+  add_dependencies(UnifiedRuntimeAdapters ur_adapter_${NAME})
+endfunction()
+
+if("level_zero" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  add_sycl_ur_adapter(level_zero)
+endif()
+
+if("cuda" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  add_sycl_ur_adapter(cuda)
+endif()
+
+if("hip" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  add_sycl_ur_adapter(hip)
+endif()
+
+if("opencl" IN_LIST LIBSYCL_ENABLE_BACKENDS)
+  add_sycl_ur_adapter(opencl)
+endif()

--- a/libsycl/docs/DesignDocs/UnifiedRuntime.rst
+++ b/libsycl/docs/DesignDocs/UnifiedRuntime.rst
@@ -1,0 +1,23 @@
+=====================
+Unified Runtime
+=====================
+
+.. contents::
+   :local:
+
+.. _unified runtime:
+
+The Unified Runtime (UR) project serves as an interface layer between the SYCL
+runtime and the device-specific runtime layers which control execution on
+devices. SYCL RT utilizes its C API, loader library, and the adapter libraries
+that implement the API for various backends.
+
+The SYCL runtime accesses the UR API via the Adapter object. Each Adapter
+object owns a ``ur_adapter_handle_t``, which represents a UR backend (e.g. OpenCL,
+Level Zero, etc).
+
+For detailed information about the UR project including
+the API specification see the `Unified Runtime Documentation
+<https://oneapi-src.github.io/unified-runtime/core/INTRO.html>`__. You
+can find the Unified Runtime repo `here
+<https://github.com/oneapi-src/unified-runtime>`__.

--- a/libsycl/src/CMakeLists.txt
+++ b/libsycl/src/CMakeLists.txt
@@ -2,10 +2,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../runtimes/cmake/
 include(WarningFlags)
 
 function(add_sycl_rt_library LIB_TARGET_NAME LIB_OBJ_NAME LIB_OUTPUT_NAME)
-  if (NOT LLVM_ENABLE_PIC)
-    message( FATAL_ERROR "Position-Independent Code generation is required for libsycl shared library" )
-  endif()
-
   cmake_parse_arguments(ARG "" "" "COMPILE_OPTIONS;SOURCES" ${ARGN})
 
   add_library(${LIB_OBJ_NAME} OBJECT ${ARG_SOURCES})
@@ -20,6 +16,13 @@ function(add_sycl_rt_library LIB_TARGET_NAME LIB_OBJ_NAME LIB_OUTPUT_NAME)
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
       ${LIBSYCL_BUILD_INCLUDE_DIR}
+  )
+
+  # Object libraries are not linked, so these "libraries" are in fact include
+  # directories
+  target_link_libraries(${LIB_OBJ_NAME}
+    PRIVATE
+      UnifiedRuntime-Headers
   )
 
   add_library(${LIB_TARGET_NAME} SHARED
@@ -49,7 +52,7 @@ function(add_sycl_rt_library LIB_TARGET_NAME LIB_OBJ_NAME LIB_OUTPUT_NAME)
     target_compile_options(${LIB_OBJ_NAME} PUBLIC /EHsc)
   else()
     target_compile_options(${LIB_OBJ_NAME} PUBLIC
-                           -fvisibility=hidden -fvisibility-inlines-hidden)
+                           -fvisibility=hidden -fvisibility-inlines-hidden -fPIC)
 
     if (UNIX AND NOT APPLE)
       set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
@@ -65,6 +68,7 @@ function(add_sycl_rt_library LIB_TARGET_NAME LIB_OBJ_NAME LIB_OUTPUT_NAME)
     PRIVATE
       ${CMAKE_DL_LIBS}
       ${CMAKE_THREAD_LIBS_INIT}
+      UnifiedRuntimeLoader
   )
 
   set_target_properties(${LIB_TARGET_NAME} PROPERTIES


### PR DESCRIPTION
This is part of the SYCL support upstreaming effort. The relevant RFCs can
be found here:

https://discourse.llvm.org/t/rfc-add-full-support-for-the-sycl-programming-model/74080
https://discourse.llvm.org/t/rfc-sycl-runtime-upstreaming/74479

The SYCL runtime is device-agnostic and uses Unified Runtime (GitHub -
oneapi-src/unified-runtime) as an external dependency. This Unified Runtime
serves as an interface layer between the SYCL runtime and device-specific
backends. Unified Runtime has several adapters that bind to various backends.

NOTE: UR is considered as temporal solution until llvm-project/offload is
fully functional and is able to replace UR.

This commit adds:

fetching UR, UR build as dependency, document with a short overview of UR
with links to repos and documentation.