### PR TITLE
[Headers][X86] Allow AVX1 fixed extraction intrinsics to be used in constexpr

### DIFF
--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2311,7 +2311,7 @@ _mm256_cvttps_epi32(__m256 __a)
 /// \param __a
 ///    A 256-bit vector of [4 x double].
 /// \returns A 64 bit double containing the first element of the input vector.
-static __inline double __DEFAULT_FN_ATTRS
+static __inline double __DEFAULT_FN_ATTRS_CONSTEXPR
 _mm256_cvtsd_f64(__m256d __a)
 {
  return __a[0];
@@ -2327,7 +2327,7 @@ _mm256_cvtsd_f64(__m256d __a)
 /// \param __a
 ///    A 256-bit vector of [8 x i32].
 /// \returns A 32 bit integer containing the first element of the input vector.
-static __inline int __DEFAULT_FN_ATTRS
+static __inline int __DEFAULT_FN_ATTRS_CONSTEXPR
 _mm256_cvtsi256_si32(__m256i __a)
 {
  __v8si __b = (__v8si)__a;
@@ -2344,7 +2344,7 @@ _mm256_cvtsi256_si32(__m256i __a)
 /// \param __a
 ///    A 256-bit vector of [8 x float].
 /// \returns A 32 bit float containing the first element of the input vector.
-static __inline float __DEFAULT_FN_ATTRS
+static __inline float __DEFAULT_FN_ATTRS_CONSTEXPR
 _mm256_cvtss_f32(__m256 __a)
 {
  return __a[0];

--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2313,7 +2313,7 @@ _mm256_cvttps_epi32(__m256 __a)
 /// \returns A 64 bit double containing the first element of the input vector.
 static __inline double __DEFAULT_FN_ATTRS_CONSTEXPR
 _mm256_cvtsd_f64(__m256d __a) {
- return __a[0];
+  return __a[0];
 }
 
 /// Returns the first element of the input vector of [8 x i32].
@@ -2328,8 +2328,8 @@ _mm256_cvtsd_f64(__m256d __a) {
 /// \returns A 32 bit integer containing the first element of the input vector.
 static __inline int __DEFAULT_FN_ATTRS_CONSTEXPR
 _mm256_cvtsi256_si32(__m256i __a) {
- __v8si __b = (__v8si)__a;
- return __b[0];
+  __v8si __b = (__v8si)__a;
+  return __b[0];
 }
 
 /// Returns the first element of the input vector of [8 x float].
@@ -2344,7 +2344,7 @@ _mm256_cvtsi256_si32(__m256i __a) {
 /// \returns A 32 bit float containing the first element of the input vector.
 static __inline float __DEFAULT_FN_ATTRS_CONSTEXPR
 _mm256_cvtss_f32(__m256 __a) {
- return __a[0];
+  return __a[0];
 }
 
 /* Vector replicate */

--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2312,8 +2312,7 @@ _mm256_cvttps_epi32(__m256 __a)
 ///    A 256-bit vector of [4 x double].
 /// \returns A 64 bit double containing the first element of the input vector.
 static __inline double __DEFAULT_FN_ATTRS_CONSTEXPR
-_mm256_cvtsd_f64(__m256d __a)
-{
+_mm256_cvtsd_f64(__m256d __a) {
  return __a[0];
 }
 
@@ -2328,8 +2327,7 @@ _mm256_cvtsd_f64(__m256d __a)
 ///    A 256-bit vector of [8 x i32].
 /// \returns A 32 bit integer containing the first element of the input vector.
 static __inline int __DEFAULT_FN_ATTRS_CONSTEXPR
-_mm256_cvtsi256_si32(__m256i __a)
-{
+_mm256_cvtsi256_si32(__m256i __a) {
  __v8si __b = (__v8si)__a;
  return __b[0];
 }
@@ -2345,8 +2343,7 @@ _mm256_cvtsi256_si32(__m256i __a)
 ///    A 256-bit vector of [8 x float].
 /// \returns A 32 bit float containing the first element of the input vector.
 static __inline float __DEFAULT_FN_ATTRS_CONSTEXPR
-_mm256_cvtss_f32(__m256 __a)
-{
+_mm256_cvtss_f32(__m256 __a) {
  return __a[0];
 }
 

--- a/clang/test/CodeGen/X86/avx-builtins.c
+++ b/clang/test/CodeGen/X86/avx-builtins.c
@@ -985,18 +985,21 @@ double test_mm256_cvtsd_f64(__m256d __a) {
   // CHECK: extractelement <4 x double> %{{.*}}, i32 0
   return _mm256_cvtsd_f64(__a);
 }
+TEST_CONSTEXPR(_mm256_cvtsd_f64((__m256d){8.0, 7.0, 6.0, 5.0}) == 8.0);
 
 int test_mm256_cvtsi256_si32(__m256i __a) {
   // CHECK-LABEL: test_mm256_cvtsi256_si32
   // CHECK: extractelement <8 x i32> %{{.*}}, i32 0
   return _mm256_cvtsi256_si32(__a);
 }
+TEST_CONSTEXPR(_mm256_cvtsi256_si32((__m256i)(__v8si){8, 7, 6, 5, 4, 3, 2, 1}) == 8);
 
 float test_mm256_cvtss_f32(__m256 __a) {
   // CHECK-LABEL: test_mm256_cvtss_f32
   // CHECK: extractelement <8 x float> %{{.*}}, i32 0
   return _mm256_cvtss_f32(__a);
 }
+TEST_CONSTEXPR(_mm256_cvtss_f32((__m256){8.0f, 7.0f, 6.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f}) == 8.0f);
 
 __m128i test_mm256_cvttpd_epi32(__m256d A) {
   // CHECK-LABEL: test_mm256_cvttpd_epi32


### PR DESCRIPTION
Fixes #161204.