### PR TITLE
[compiler-rt] Fix declarations of builtins in test files

### DIFF
--- a/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
@@ -6,19 +6,22 @@
 
 #if _ARCH_PPC || __aarch64__ || __arm64ec__
 
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
 #include "int_lib.h"
 
 // Returns: convert a to a unsigned long long, rounding toward zero.
 //          Negative values all become zero.
 
-// Assumption: long double is a 128 bit floating point type
+// Assumption: fp_t is a 128 bit floating point type
 //             du_int is a 64 bit integral type
-//             value in long double is representable in du_int or is negative 
+//             value in fp_t is representable in du_int or is negative 
 //                 (no range checking performed)
 
-COMPILER_RT_ABI du_int __fixunstfdi(long double a);
+COMPILER_RT_ABI du_int __fixunstfdi(fp_t a);
 
-int test__fixunstfdi(long double a, du_int expected)
+int test__fixunstfdi(fp_t a, du_int expected)
 {
     du_int x = __fixunstfdi(a);
     if (x != expected)
@@ -29,7 +32,7 @@ int test__fixunstfdi(long double a, du_int expected)
 
 char assumption_1[sizeof(du_int) == 2*sizeof(su_int)] = {0};
 char assumption_2[sizeof(du_int)*CHAR_BIT == 64] = {0};
-char assumption_3[sizeof(long double)*CHAR_BIT == 128] = {0};
+char assumption_3[sizeof(fp_t)*CHAR_BIT == 128] = {0};
 
 #endif
 

--- a/compiler-rt/test/builtins/Unit/multc3_test.c
+++ b/compiler-rt/test/builtins/Unit/multc3_test.c
@@ -6,19 +6,22 @@
 
 #if _ARCH_PPC || __aarch64__ || __arm64ec__
 
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
 #include "int_lib.h"
 #include <math.h>
 #include <complex.h>
 
 // Returns: the product of a + ib and c + id
 
-COMPILER_RT_ABI long double _Complex
-__multc3(long double __a, long double __b, long double __c, long double __d);
+COMPILER_RT_ABI Qcomplex
+__multc3(fp_t __a, fp_t __b, fp_t __c, fp_t __d);
 
 enum {zero, non_zero, inf, NaN, non_zero_nan};
 
 int
-classify(long double _Complex x)
+classify(Qcomplex x)
 {
     if (x == 0)
         return zero;
@@ -41,13 +44,13 @@ classify(long double _Complex x)
     return non_zero;
 }
 
-int test__multc3(long double a, long double b, long double c, long double d)
+int test__multc3(fp_t a, fp_t b, fp_t c, fp_t d)
 {
-    long double _Complex r = __multc3(a, b, c, d);
+    Qcomplex r = __multc3(a, b, c, d);
 //     printf("test__multc3(%Lf, %Lf, %Lf, %Lf) = %Lf + I%Lf\n",
 //             a, b, c, d, creall(r), cimagl(r));
-	long double _Complex dividend;
-	long double _Complex divisor;
+	Qcomplex dividend;
+	Qcomplex divisor;
 	
 	__real__ dividend = a;
 	__imag__ dividend = b;
@@ -188,7 +191,7 @@ int test__multc3(long double a, long double b, long double c, long double d)
     return 0;
 }
 
-long double x[][2] =
+fp_t x[][2] =
 {
     { 1.e-6,  1.e-6},
     {-1.e-6,  1.e-6},


### PR DESCRIPTION
Replace `long double` and `long double _Complex` with `fp_t` and `Qcomplex` in the test files.

This prepares for reapplying 656707086e5f6fccd2eb57f5aaf987c328c0f4f1 and running tests on targets where `fp_t` is not `long double`.