### PR TITLE
[CodingStandard] Require Unix line endings for all files

### DIFF
--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -1790,13 +1790,12 @@ would help to avoid running into a "dangling else" situation.
       markAsIgnored(D);
   }
 
-Use Unix style line endings for source files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Use Unix line endings for source files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use Unix style line endings for C/C++ source files (``.c``, ``.cpp`` and header
-files). This is required to avoid various build issue for downstream clients of
-LLVM. Test files like C/C++/HLSL test inputs can continue to use any line ending
-style.
+Use Unix line endings for all source files. CRLF line endings are allowed as an
+exception for test files that intend to test CRLF handling or when the file
+format requires it (like ``.bat`` or ``.rc`` files).
 
 See Also
 ========

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -1790,6 +1790,13 @@ would help to avoid running into a "dangling else" situation.
       markAsIgnored(D);
   }
 
+Use Unix style line endings for source files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use Unix style line endings for C/C++ source files (``.c``, ``.cpp`` and header
+files). This is required to avoid various build issue for downstream clients of
+LLVM. Test files like C/C++/HLSL test inputs can continue to use any line ending
+style.
 
 See Also
 ========

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -1790,10 +1790,10 @@ would help to avoid running into a "dangling else" situation.
       markAsIgnored(D);
   }
 
-Use Unix line endings for source files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Use Unix line endings for files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use Unix line endings for all source files. CRLF line endings are allowed as an
+Use Unix line endings for all files. CRLF line endings are allowed as an
 exception for test files that intend to test CRLF handling or when the file
 format requires it (like ``.bat`` or ``.rc`` files).
 


### PR DESCRIPTION
Require all files to use Unix line endings, formalizing an already followed convention.