### PR TITLE
[mlir][doc] Fix typo in Ch6 tutorial: 'toy.cpp' → 'toyc.cpp' (NFC)

### DIFF
--- a/mlir/docs/Tutorials/Toy/Ch-6.md
+++ b/mlir/docs/Tutorials/Toy/Ch-6.md
@@ -245,7 +245,7 @@ define void @main()
 ```
 
 The full code listing for dumping LLVM IR can be found in
-`examples/toy/Ch6/toy.cpp` in the `dumpLLVMIR()` function:
+`examples/toy/Ch6/toyc.cpp` in the `dumpLLVMIR()` function:
 
 ```c++
 


### PR DESCRIPTION
This patch fixes a documentation typo in the MLIR Toy tutorial (Ch6).
The tutorial currently refers to `examples/toy/Ch6/toy.cpp`, but the correct
file name is `examples/toy/Ch6/toyc.cpp`.
