### PR TITLE
[LLVM] Fix a bug in `Intrinsic::getFnAttributes`

### DIFF
--- a/llvm/unittests/IR/IntrinsicsTest.cpp
+++ b/llvm/unittests/IR/IntrinsicsTest.cpp
@@ -189,4 +189,12 @@ TEST_F(IntrinsicsTest, InstrProfInheritance) {
   }
 }
 
+// Check that getFnAttributes for intrinsics that do not have any function
+// attributes correcty returns an empty set.
+TEST(IntrinsicAttributes, TestGetFnAttributesBug) {
+  using namespace Intrinsic;
+  LLVMContext Context;
+  AttributeSet AS = getFnAttributes(Context, experimental_guard);
+  EXPECT_FALSE(AS.hasAttributes());
+}
 } // end namespace

--- a/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
@@ -794,12 +794,15 @@ AttributeSet Intrinsic::getFnAttributes(LLVMContext &C, ID id) {{
   if (id == 0)
     return AttributeSet();
   auto [FnAttrID, _] = unpackID(IntrinsicsToAttributesMap[id - 1]);
+  if (FnAttrID == {})
+    return AttributeSet();
   return getIntrinsicFnAttributeSet(C, FnAttrID);
 }
 #endif // GET_INTRINSIC_ATTRIBUTES
 
 )",
-                UniqAttributesBitSize, MaxNumAttrs, NoFunctionAttrsID);
+                UniqAttributesBitSize, MaxNumAttrs, NoFunctionAttrsID,
+                NoFunctionAttrsID);
 }
 
 void IntrinsicEmitter::EmitIntrinsicToBuiltinMap(


### PR DESCRIPTION
When an intrinsic has no function attributes, the current code will hit an assert in `getIntrinsicFnAttributeSet`. Fix this by checking for the sentinel `NoFunctionAttrsID` value and returning an empty attribute set.