### PR TITLE
[sanitizer-common] sanitizer_common unit tests should pass -std=c++17

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_common/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SANITIZER_TEST_CFLAGS_COMMON
   -O2
   -Werror=sign-compare
   -Wno-gnu-zero-variadic-macro-arguments
+  -std=c++17
   )
 
 set(SANITIZER_TEST_LINK_FLAGS_COMMON


### PR DESCRIPTION
Currently, sanitizer_array_ref_test requires -std=c++17 or newer, due to is_trivially_copyable_v. This adds -std=c++17 to the list of CFLAGS used for compiling sanitizer_common tests.