### PR TITLE
[CIR] Add missing case for OMPFuseDirectiveClass in emitStmt switch

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -280,6 +280,7 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::OMPReverseDirectiveClass:
   case Stmt::OMPInterchangeDirectiveClass:
   case Stmt::OMPAssumeDirectiveClass:
+  case Stmt::OMPFuseDirectiveClass:
   case Stmt::OMPMaskedDirectiveClass:
   case Stmt::OMPStripeDirectiveClass:
   case Stmt::ObjCAtCatchStmtClass:


### PR DESCRIPTION
Handle OMPFuseDirectiveClass introduced in cd4c5280c73d to fix `-Wswitch` warning in CIRGenStmt.cpp.