### PR TITLE
[compiler-rt] Disable tests for unavailable builtins

### DIFF
--- a/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 
-#if _ARCH_PPC || __aarch64__ || __arm64ec__
+#if defined(CRT_HAS_TF_MODE)
 
 #define QUAD_PRECISION
 #include "fp_lib.h"
@@ -38,7 +38,7 @@ char assumption_3[sizeof(fp_t)*CHAR_BIT == 128] = {0};
 
 int main()
 {
-#if _ARCH_PPC || __aarch64__ || __arm64ec__
+#if defined(CRT_HAS_TF_MODE)
     if (test__fixunstfdi(0.0, 0))
         return 1;
 

--- a/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
@@ -1,15 +1,13 @@
-// XFAIL: target=aarch64-{{.*}}-windows-{{.*}}
 // RUN: %clang_builtins %s %librt -o %t && %run %t
 // REQUIRES: librt_has_fixunstfdi
 
 #include <stdio.h>
+#include "int_lib.h"
 
 #if defined(CRT_HAS_TF_MODE)
 
 #define QUAD_PRECISION
 #include "fp_lib.h"
-
-#include "int_lib.h"
 
 // Returns: convert a to a unsigned long long, rounding toward zero.
 //          Negative values all become zero.

--- a/compiler-rt/test/builtins/Unit/multc3_test.c
+++ b/compiler-rt/test/builtins/Unit/multc3_test.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 
-#if _ARCH_PPC || __aarch64__ || __arm64ec__
+#if defined(CRT_HAS_128BIT) && defined(CRT_HAS_F128)
 
 #define QUAD_PRECISION
 #include "fp_lib.h"
@@ -351,7 +351,7 @@ fp_t x[][2] =
 
 int main()
 {
-#if _ARCH_PPC || __aarch64__ || __arm64ec__
+#if defined(CRT_HAS_128BIT) && defined(CRT_HAS_F128)
     const unsigned N = sizeof(x) / sizeof(x[0]);
     unsigned i, j;
     for (i = 0; i < N; ++i)

--- a/compiler-rt/test/builtins/Unit/multc3_test.c
+++ b/compiler-rt/test/builtins/Unit/multc3_test.c
@@ -1,15 +1,14 @@
-// XFAIL: target=aarch64-{{.*}}-windows-{{.*}}
 // RUN: %clang_builtins %s %librt -o %t && %run %t
 // REQUIRES: librt_has_multc3
 
 #include <stdio.h>
+#include "int_lib.h"
 
 #if defined(CRT_HAS_128BIT) && defined(CRT_HAS_F128)
 
 #define QUAD_PRECISION
 #include "fp_lib.h"
 
-#include "int_lib.h"
 #include <math.h>
 #include <complex.h>
 


### PR DESCRIPTION
The builtins `__fixunstfdi` and `__multc3` may be removed by the
preprocessor depending on configuration flags. When this happens, the
corresponding tests fail at link time due to missing definitions.

Disable these tests when the builtins are not available.

Also remove the XFAILs for aarch64 windows. As this test now became a
no-op on platforms that lack CRT_HAS_128BIT or CRT_HAS_F128 (aarch64
windows lacks the latter), it no longer fails.

This reapplies e9e166e54354330c474457711a8e7a7ca2efd731 and 656707086e5f6fccd2eb57f5aaf987c328c0f4f1 after fixing declarations of
the builtins in the tests in b54250940c2cd70f911386b02239b50c165e5354.

rdar://159705803
rdar://159705705

Co-authored-by: Martin Storsjö <martin@martin.st>