### PR TITLE
[Clang][Sema] Fix crash in CheckUsingDeclQualifier due to diagnostic missing an argument

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -13643,7 +13643,7 @@ bool Sema::CheckUsingDeclQualifier(SourceLocation UsingLoc, bool HasTypename,
 
     if (Cxx20Enumerator) {
       Diag(NameLoc, diag::warn_cxx17_compat_using_decl_non_member_enumerator)
-          << SS.getRange();
+          << SS.getScopeRep() << SS.getRange();
       return false;
     }
 

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -434,3 +434,15 @@ void ctad_test() {
   CTAD t = s; // expected-warning {{class template argument deduction is incompatible with C++ standards before C++17}}
 }
 #endif
+
+namespace GH161702 {
+struct S {
+  enum E { A };
+  using E::A; // expected-warning {{enumeration type in nested name specifier is incompatible with C++98}}
+#ifndef CXX20COMPAT 
+	      // expected-error@-2 {{using declaration refers to its own class}}
+#else
+              // expected-warning@-4 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
+#endif
+};
+}

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -std=c++11 -Wc++98-compat -verify=expected,not-cpp20 %s
 // RUN: %clang_cc1 -fsyntax-only -std=c++14 -Wc++98-compat -verify=expected,not-cpp20 %s -DCXX14COMPAT
 // RUN: %clang_cc1 -fsyntax-only -std=c++17 -Wc++98-compat -verify=expected,not-cpp20 %s -DCXX14COMPAT -DCXX17COMPAT
-// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wc++98-compat -verify=expected,cpp20 %s -DCXX14COMPAT -DCXX17COMPAT -DCXX20COMPAT
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wc++98-compat -verify=expected,cpp20 %s -DCXX14COMPAT -DCXX17COMPAT
 
 namespace std {
   struct type_info;
@@ -437,7 +437,7 @@ namespace GH161702 {
 struct S {
   enum E { A };
   using E::A; // expected-warning {{enumeration type in nested name specifier is incompatible with C++98}}
-	      // not-cpp20-error@-1 {{using declaration refers to its own class}}
-              // cpp20-warning@-2 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
+              // not-cpp20-error@-1 {{using declaration refers to its own class}}
+             // cpp20-warning@-2 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
 };
 }

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -std=c++11 -Wc++98-compat -verify %s
 // RUN: %clang_cc1 -fsyntax-only -std=c++14 -Wc++98-compat -verify %s -DCXX14COMPAT
 // RUN: %clang_cc1 -fsyntax-only -std=c++17 -Wc++98-compat -verify %s -DCXX14COMPAT -DCXX17COMPAT
-// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wc++98-compat -verify %s -DCXX14COMPAT -DCXX17COMPAT -DCXX20COMPAT
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wc++98-compat -verify=expected,cpp20 %s -DCXX14COMPAT -DCXX17COMPAT -DCXX20COMPAT
 
 namespace std {
   struct type_info;
@@ -226,7 +226,7 @@ void TrivialButNonPODThroughEllipsis() {
   Ellipsis(1, TrivialButNonPOD()); // expected-warning {{passing object of trivial but non-POD type 'TrivialButNonPOD' through variadic function is incompatible with C++98}}
 }
 
-// FIXME I think we generate this diagnostic in C++20
+// FIXME I think we should generate this diagnostic in C++20
 #ifndef CXX20COMPAT
 struct HasExplicitConversion {
   explicit operator bool(); // expected-warning {{explicit conversion functions are incompatible with C++98}}
@@ -441,8 +441,7 @@ struct S {
   using E::A; // expected-warning {{enumeration type in nested name specifier is incompatible with C++98}}
 #ifndef CXX20COMPAT 
 	      // expected-error@-2 {{using declaration refers to its own class}}
-#else
-              // expected-warning@-4 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
 #endif
+              // cpp20-warning@-4 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
 };
 }

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsyntax-only -std=c++11 -Wc++98-compat -verify %s
-// RUN: %clang_cc1 -fsyntax-only -std=c++14 -Wc++98-compat -verify %s -DCXX14COMPAT
-// RUN: %clang_cc1 -fsyntax-only -std=c++17 -Wc++98-compat -verify %s -DCXX14COMPAT -DCXX17COMPAT
+// RUN: %clang_cc1 -fsyntax-only -std=c++11 -Wc++98-compat -verify=expected,not-cpp20 %s
+// RUN: %clang_cc1 -fsyntax-only -std=c++14 -Wc++98-compat -verify=expected,not-cpp20 %s -DCXX14COMPAT
+// RUN: %clang_cc1 -fsyntax-only -std=c++17 -Wc++98-compat -verify=expected,not-cpp20 %s -DCXX14COMPAT -DCXX17COMPAT
 // RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wc++98-compat -verify=expected,cpp20 %s -DCXX14COMPAT -DCXX17COMPAT -DCXX20COMPAT
 
 namespace std {
@@ -226,12 +226,10 @@ void TrivialButNonPODThroughEllipsis() {
   Ellipsis(1, TrivialButNonPOD()); // expected-warning {{passing object of trivial but non-POD type 'TrivialButNonPOD' through variadic function is incompatible with C++98}}
 }
 
-// FIXME I think we should generate this diagnostic in C++20
-#ifndef CXX20COMPAT
 struct HasExplicitConversion {
-  explicit operator bool(); // expected-warning {{explicit conversion functions are incompatible with C++98}}
+  // FIXME I think we should generate this diagnostic in C++20
+  explicit operator bool(); // not-cpp20-warning {{explicit conversion functions are incompatible with C++98}}
 };
-#endif
 
 struct Struct {};
 enum Enum { enum_val = 0 };
@@ -439,9 +437,7 @@ namespace GH161702 {
 struct S {
   enum E { A };
   using E::A; // expected-warning {{enumeration type in nested name specifier is incompatible with C++98}}
-#ifndef CXX20COMPAT 
-	      // expected-error@-2 {{using declaration refers to its own class}}
-#endif
-              // cpp20-warning@-4 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
+	      // not-cpp20-error@-1 {{using declaration refers to its own class}}
+              // cpp20-warning@-2 {{member using declaration naming non-class ''E'' enumerator is incompatible with C++ standards before C++20}}
 };
 }

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -std=c++11 -Wc++98-compat -verify %s
 // RUN: %clang_cc1 -fsyntax-only -std=c++14 -Wc++98-compat -verify %s -DCXX14COMPAT
 // RUN: %clang_cc1 -fsyntax-only -std=c++17 -Wc++98-compat -verify %s -DCXX14COMPAT -DCXX17COMPAT
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wc++98-compat -verify %s -DCXX14COMPAT -DCXX17COMPAT -DCXX20COMPAT
 
 namespace std {
   struct type_info;
@@ -225,9 +226,12 @@ void TrivialButNonPODThroughEllipsis() {
   Ellipsis(1, TrivialButNonPOD()); // expected-warning {{passing object of trivial but non-POD type 'TrivialButNonPOD' through variadic function is incompatible with C++98}}
 }
 
+// FIXME I think we generate this diagnostic in C++20
+#ifndef CXX20COMPAT
 struct HasExplicitConversion {
   explicit operator bool(); // expected-warning {{explicit conversion functions are incompatible with C++98}}
 };
+#endif
 
 struct Struct {};
 enum Enum { enum_val = 0 };


### PR DESCRIPTION
Crash report came in and it was pretty obvious the diagnostic line was just missing an argument. I supplied the argument and added a test.

Fixes: https://github.com/llvm/llvm-project/issues/161072