### PR TITLE
[CAS][CMake] Fix rhel bots missing symbol failure from #114100

### DIFF
--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -12,6 +12,9 @@ add_llvm_component_library(LLVMCAS
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CAS
 
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+
   LINK_COMPONENTS
   Support
 )


### PR DESCRIPTION
Link LLVM_PTHREAD_LIB from LLVMCAS library to fix rhel bots.
