### PR TITLE
[Clang][Headers] Fix tgmath.h incompatibility with Glibc

### DIFF
--- a/clang/lib/Headers/tgmath.h
+++ b/clang/lib/Headers/tgmath.h
@@ -17,7 +17,7 @@
  * platforms. This is done after #include <math.h> to avoid depcycle conflicts
  * between libcxx and darwin in C++ modules builds.
  */
-#if defined(__APPLE__) && __STDC_HOSTED__ && __has_include_next(<tgmath.h>)
+#if (defined(__APPLE__) && __STDC_HOSTED__ && __has_include_next(<tgmath.h>)) || defined(__GLIBC__)
 #  include_next <tgmath.h>
 #else
 


### PR DESCRIPTION
When building Glibc with Clang, several conformance and math tests related to <tgmath.h> fail. This is because Clang's built-in <tgmath.h> is used by default, which is not fully compatible with the expectations of the Glibc test suite.

Glibc provides its own <tgmath.h> which is specifically designed to work with its library implementation, supporting all necessary GNU extensions and features.

This patch modifies Clang's <tgmath.h> to detect when it is being used in a Glibc environment (by checking for the `__GLIBC__` macro). When `__GLIBC__` is defined, Clang's header will use `include_next` to include Glibc's system header, effectively deferring to Glibc's implementation. This is the same mechanism already used for macOS (`__APPLE__`).

This change allows Glibc to be successfully built and tested with Clang, resolving the following test failures:
- conform/ISO11/tgmath.h/conform
- conform/ISO99/tgmath.h/conform
- conform/POSIX2008/tgmath.h/conform
- conform/XOPEN2K/tgmath.h/conform
- conform/XOPEN2K8/tgmath.h/conform
- math/test-tgmath
- math/test-tgmath2

This approach addresses the compatibility issue at its source within Clang, rather than requiring workarounds in Glibc.