### PR TITLE
[Darwin][Driver] Avoid duplicate -lc++ with -fsanitize=fuzzer

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1609,7 +1609,12 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
     if (Sanitize.needsFuzzer() && !Args.hasArg(options::OPT_dynamiclib)) {
       AddLinkSanitizerLibArgs(Args, CmdArgs, "fuzzer", /*shared=*/false);
 
-        // Libfuzzer is written in C++ and requires libcxx.
+      // Libfuzzer is written in C++ and requires libcxx.
+      // Since darwin::Linker::ConstructJob already adds -lc++ for clang++
+      // by default if ShouldLinkCXXStdlib(Args), we only add the option if
+      // !ShouldLinkCXXStdlib(Args). This avoids duplicate library errors
+      // on Darwin.
+      if (!ShouldLinkCXXStdlib(Args))
         AddCXXStdlibLibArgs(Args, CmdArgs);
     }
     if (Sanitize.needsStatsRt()) {


### PR DESCRIPTION
On Darwin, duplicate -l options cause a warning to be printed.

Invoking clang as clang++ and using -fsanitize=fuzzer will cause -lc++ to be passed twice to the linker, causing a warning.

i.e. AddCXXStdlibLibArgs is called twice in this case:

1) https://github.com/llvm/llvm-project/blob/19c4e86f3e8582c3f087a9fec5ac036838e58ec4/clang/lib/Driver/ToolChains/Darwin.cpp#L743 because `ShouldLinkCXXStdlib(Args)` is true.
2) The subject of this PR

We now skip adding the -lc++ argument if `ShouldLinkCXXStdlib(Args)` (since that means the other path already added it).

rdar://136431775