### PR TITLE
[ARM][flang] Generate arm abi related module flag

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -58,6 +58,7 @@
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/ProfileData/InstrProfCorrelator.h"
 #include "llvm/Support/AMDGPUAddrSpace.h"
+#include "llvm/Support/ARMBuildAttributes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
@@ -836,6 +837,15 @@ void CodeGenAction::generateLLVMIR() {
                                 "amdhsa_code_object_version",
                                 opts.CodeObjectVersion);
     }
+  }
+
+  if ((triple.isARM() || triple.isThumb()) && triple.isTargetAEABI() &&
+      triple.isOSBinFormatELF()) {
+    llvmModule->addModuleFlag(llvm::Module::Warning, "arm-eabi-fp-number-model",
+                              mathOpts.getNoHonorInfs() &&
+                                      mathOpts.getNoHonorNaNs()
+                                  ? llvm::ARMBuildAttrs::AllowIEEENormal
+                                  : llvm::ARMBuildAttrs::AllowIEEE754);
   }
 }
 

--- a/flang/test/Lower/Arm/build-attributes.f90
+++ b/flang/test/Lower/Arm/build-attributes.f90
@@ -1,0 +1,9 @@
+! REQUIRES: arm-registered-target
+! RUN: %flang_fc1 -triple arm-none-eabi -emit-llvm -o - %s | FileCheck %s --check-prefix=IEEE
+! RUN: %flang_fc1 -triple arm-none-eabi -menable-no-infs -menable-no-nans -emit-llvm -o - %s | FileCheck %s --check-prefix=NORMAL
+
+subroutine func
+end subroutine func
+
+! IEEE: !{i32 2, !"arm-eabi-fp-number-model", i32 3}
+! NORMAL: !{i32 2, !"arm-eabi-fp-number-model", i32 1}


### PR DESCRIPTION
UnsafeFPMath related options in LLVM CodeGen part will be removed in future, generate related module flags as hints.