### PR TITLE
Update http to https in clang-tidy check creation script.

### DIFF
--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -109,7 +109,7 @@ namespace clang::tidy::%(namespace)s {
 %(description)s
 ///
 /// For the user-facing documentation see:
-/// http://clang.llvm.org/extra/clang-tidy/checks/%(module)s/%(check_name)s.html
+/// https://clang.llvm.org/extra/clang-tidy/checks/%(module)s/%(check_name)s.html
 class %(check_name_camel)s : public ClangTidyCheck {
 public:
   %(check_name_camel)s(StringRef Name, ClangTidyContext *Context)


### PR DESCRIPTION
We should be using https in URLs, so let's update add_new_check.py to reflect that.