### PR TITLE
[NFC][TSan] Tidy up DPrintf warnings in TSan runtime

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_fd.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_fd.cpp
@@ -180,7 +180,7 @@ void FdAcquire(ThreadState *thr, uptr pc, int fd) {
     return;
   FdDesc *d = fddesc(thr, pc, fd);
   FdSync *s = d->sync;
-  DPrintf("#%d: FdAcquire(%d) -> %p\n", thr->tid, fd, s);
+  DPrintf("#%d: FdAcquire(%d) -> %p\n", thr->tid, fd, (void*)s);
   MemoryAccess(thr, pc, (uptr)d, 8, kAccessRead);
   if (s)
     Acquire(thr, pc, (uptr)s);
@@ -191,7 +191,7 @@ void FdRelease(ThreadState *thr, uptr pc, int fd) {
     return;
   FdDesc *d = fddesc(thr, pc, fd);
   FdSync *s = d->sync;
-  DPrintf("#%d: FdRelease(%d) -> %p\n", thr->tid, fd, s);
+  DPrintf("#%d: FdRelease(%d) -> %p\n", thr->tid, fd, (void*)s);
   MemoryAccess(thr, pc, (uptr)d, 8, kAccessRead);
   if (s)
     Release(thr, pc, (uptr)s);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp
@@ -86,7 +86,7 @@ static TracePart* TracePartAlloc(ThreadState* thr) {
     if (trace->parts_allocated == max_parts ||
         ctx->trace_part_finished_excess) {
       part = ctx->trace_part_recycle.PopFront();
-      DPrintf("#%d: TracePartAlloc: part=%p\n", thr->tid, part);
+      DPrintf("#%d: TracePartAlloc: part=%p\n", thr->tid, (void*)part);
       if (part && part->trace) {
         Trace* trace1 = part->trace;
         Lock trace_lock(&trace1->mtx);
@@ -938,7 +938,7 @@ static bool TraceSkipGap(ThreadState* thr) {
   DCHECK_EQ(reinterpret_cast<uptr>(pos + 1) & TracePart::kAlignment, 0);
   auto *part = trace->parts.Back();
   DPrintf("#%d: TraceSwitchPart enter trace=%p parts=%p-%p pos=%p\n", thr->tid,
-          trace, trace->parts.Front(), part, pos);
+          (void*)trace, (void*)trace->parts.Front(), (void*)part, (void*)pos);
   if (!part)
     return false;
   // We can get here when we still have space in the current trace part.
@@ -1052,7 +1052,7 @@ void TraceSwitchPartImpl(ThreadState* thr) {
       ctx->trace_part_recycle.PushBack(recycle);
   }
   DPrintf("#%d: TraceSwitchPart exit parts=%p-%p pos=0x%zx\n", thr->tid,
-          trace->parts.Front(), trace->parts.Back(),
+          (void*)trace->parts.Front(), (void*)trace->parts.Back(),
           atomic_load_relaxed(&thr->trace_pos));
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_report.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_report.cpp
@@ -511,7 +511,8 @@ bool RestoreStack(EventType type, Sid sid, Epoch epoch, uptr addr, uptr size,
     Lock lock(&trace->mtx);
     first_part = trace->parts.Front();
     if (!first_part) {
-      DPrintf2("RestoreStack: tid=%d trace=%p no trace parts\n", tid, trace);
+      DPrintf2("RestoreStack: tid=%d trace=%p no trace parts\n", tid,
+               (void*)trace);
       return false;
     }
     last_part = trace->parts.Back();
@@ -527,7 +528,7 @@ bool RestoreStack(EventType type, Sid sid, Epoch epoch, uptr addr, uptr size,
   bool is_atomic = typ & kAccessAtomic;
   bool is_free = typ & kAccessFree;
   DPrintf2("RestoreStack: tid=%d parts=[%p-%p] last_pos=%p\n", tid,
-           trace->parts.Front(), last_part, last_pos);
+           (void*)trace->parts.Front(), (void*)last_part, (void*)last_pos);
   TraceReplay(
       trace, last_part, last_pos, sid, epoch,
       [&](Sid ev_sid, Epoch ev_epoch, Event *evp) {


### PR DESCRIPTION
Currently there are many `warning: format specifies type 'void *'` warnings when compiling TSan with debug output.

This patch adds the `void *` casts where necessary to eliminate the warnings.