### PR TITLE
[flang] Improve presentation of errors after last source line

### DIFF
--- a/flang/include/flang/Parser/message.h
+++ b/flang/include/flang/Parser/message.h
@@ -65,6 +65,8 @@ public:
     return severity_ == Severity::Error || severity_ == Severity::Todo;
   }
 
+  static const MessageFixedText endOfFileMessage; // "end of file"_err_en_US
+
 private:
   CharBlock text_;
   Severity severity_{Severity::None};

--- a/flang/lib/Parser/basic-parsers.h
+++ b/flang/lib/Parser/basic-parsers.h
@@ -828,7 +828,7 @@ struct NextCh {
     if (std::optional<const char *> result{state.GetNextChar()}) {
       return result;
     }
-    state.Say("end of file"_err_en_US);
+    state.Say(MessageFixedText::endOfFileMessage);
     return std::nullopt;
   }
 };

--- a/flang/test/Parser/recovery08.f90
+++ b/flang/test/Parser/recovery08.f90
@@ -1,0 +1,11 @@
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+! CHECK: error: end of file
+! CHECK: ^
+! CHECK: in the context: END PROGRAM statement
+! CHECK: in the context: main program
+
+  integer :: i
+
+  ! Add empty lines for emphasis
+
+  i = 5


### PR DESCRIPTION
We don't emit source file names or line numbers for error messages at EOF.  Detect these and handle them a little better, pointing at the newline at the end of the last source line instead.