### PR TITLE
Fix `run_clang_repl` output when not present

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -145,7 +145,7 @@ def run_clang_repl(args):
     clang_repl_exe = lit.util.which("clang-repl", config.clang_tools_dir)
 
     if not clang_repl_exe:
-        return False
+        return ""
 
     try:
         clang_repl_cmd = subprocess.Popen(
@@ -153,7 +153,7 @@ def run_clang_repl(args):
         )
     except OSError:
         print("could not exec clang-repl")
-        return False
+        return ""
 
     clang_repl_out = clang_repl_cmd.stdout.read().decode("ascii")
     clang_repl_cmd.wait()


### PR DESCRIPTION
On the happy path, when `clang-repl` is present, we will invoke it in order to determine if the host supports JIT features. That will return a string containing "true". However, in cases where `clang-repl` is not present or we fail to invoke it, we previously returned `False`, which would then trigger a failure with our substring check. This PR updates the function to return `""` instead, so the substring check is still valid.

This is related to https://github.com/llvm/llvm-project/pull/157359, where the original change was introduced.