### PR TITLE
[flang] Add #include to fix MSVC build

### DIFF
--- a/flang/lib/Evaluate/constant.cpp
+++ b/flang/lib/Evaluate/constant.cpp
@@ -10,6 +10,7 @@
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/shape.h"
 #include "flang/Evaluate/type.h"
+#include "flang/Semantics/scope.h"
 #include <string>
 
 namespace Fortran::evaluate {


### PR DESCRIPTION
flang/lib/Evaluate/constant.cpp apparently needs this #include for MSVC builds but somehow not for others.