### PR TITLE
[flang] Attempt to work around MSVC build problem

### DIFF
--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -1521,6 +1521,9 @@ bool IsVarSubexpressionOf(
 // it returns std::nullopt.
 std::optional<Expr<SomeType>> GetConvertInput(const Expr<SomeType> &x);
 
+// How many ancestors does have a derived type have?
+std::optional<int> DerivedTypeDepth(const semantics::Scope &);
+
 } // namespace Fortran::evaluate
 
 namespace Fortran::semantics {

--- a/flang/lib/Evaluate/constant.cpp
+++ b/flang/lib/Evaluate/constant.cpp
@@ -10,7 +10,6 @@
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/shape.h"
 #include "flang/Evaluate/type.h"
-#include "flang/Semantics/scope.h"
 #include <string>
 
 namespace Fortran::evaluate {
@@ -388,33 +387,6 @@ std::size_t Constant<SomeDerived>::CopyFrom(const Constant<SomeDerived> &source,
     std::size_t count, ConstantSubscripts &resultSubscripts,
     const std::vector<int> *dimOrder) {
   return Base::CopyFrom(source, count, resultSubscripts, dimOrder);
-}
-
-static std::optional<int> DerivedTypeDepth(const semantics::Scope &scope) {
-  if (scope.IsDerivedType()) {
-    for (auto iter{scope.cbegin()}; iter != scope.cend(); ++iter) {
-      const Symbol &symbol{*iter->second};
-      if (symbol.test(Symbol::Flag::ParentComp)) {
-        if (const semantics::DeclTypeSpec *type{symbol.GetType()}) {
-          if (const semantics::DerivedTypeSpec *derived{type->AsDerived()}) {
-            const semantics::Scope *parent{derived->scope()};
-            if (!parent) {
-              parent = derived->typeSymbol().scope();
-            }
-            if (parent) {
-              if (auto parentDepth{DerivedTypeDepth(*parent)}) {
-                return 1 + *parentDepth;
-              }
-            }
-          }
-        }
-        return std::nullopt; // error recovery
-      }
-    }
-    return 0;
-  } else {
-    return std::nullopt; // error recovery
-  }
 }
 
 bool ComponentCompare::operator()(SymbolRef x, SymbolRef y) const {

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1950,6 +1950,33 @@ bool IsVarSubexpressionOf(
   return VariableFinder{sub}(super);
 }
 
+std::optional<int> DerivedTypeDepth(const semantics::Scope &scope) {
+  if (scope.IsDerivedType()) {
+    for (auto iter{scope.cbegin()}; iter != scope.cend(); ++iter) {
+      const Symbol &symbol{*iter->second};
+      if (symbol.test(Symbol::Flag::ParentComp)) {
+        if (const semantics::DeclTypeSpec *type{symbol.GetType()}) {
+          if (const semantics::DerivedTypeSpec *derived{type->AsDerived()}) {
+            const semantics::Scope *parent{derived->scope()};
+            if (!parent) {
+              parent = derived->typeSymbol().scope();
+            }
+            if (parent) {
+              if (auto parentDepth{DerivedTypeDepth(*parent)}) {
+                return 1 + *parentDepth;
+              }
+            }
+          }
+        }
+        return std::nullopt; // error recovery
+      }
+    }
+    return 0;
+  } else {
+    return std::nullopt; // error recovery
+  }
+}
+
 } // namespace Fortran::evaluate
 
 namespace Fortran::semantics {


### PR DESCRIPTION
Move a function that seems to be running into an MSVC problem from the source file where I created it to another one (tools.cpp) that is already known to be able to access the semantics::Scope type.