### PR TITLE
[MLIR][Standalone] gate wheel build behind MLIR_ENABLE_BINDINGS_PYTHON=ON

### DIFF
--- a/mlir/test/Examples/standalone/lit.local.cfg
+++ b/mlir/test/Examples/standalone/lit.local.cfg
@@ -17,3 +17,5 @@ config.substitutions.append(("%cmake_build_type", config.cmake_build_type))
 
 if not config.llvm_shared_libs_build:
     config.available_features.add("non-shared-libs-build")
+if config.enable_bindings_python:
+    config.available_features.add("bindings-python")

--- a/mlir/test/Examples/standalone/test.wheel.toy
+++ b/mlir/test/Examples/standalone/test.wheel.toy
@@ -3,6 +3,7 @@
 # C/Users/ContainerAdministrator/AppData/Local/Temp.
 # UNSUPPORTED: target={{.*(windows).*}}
 # REQUIRES: non-shared-libs-build
+# REQUIRES: bindings-python
 
 # RUN: export CMAKE_BUILD_TYPE=%cmake_build_type
 # RUN: export CMAKE_CXX_COMPILER=%host_cxx


### PR DESCRIPTION
If MLIR_ENABLE_BINDINGS_PYTHON=ON then [StandalonePythonModules](https://github.com/llvm/llvm-project/blob/main/mlir/examples/standalone/pyproject.toml#L38) isn't a valid target.