### PR TITLE
[OFFLOAD] Restore interop functionality

### DIFF
--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -361,10 +361,9 @@ EXTERN int ompx_interop_add_completion_callback(omp_interop_val_t *Interop,
 
 // Backwards compatibility wrappers
 void __tgt_interop_init(ident_t *LocRef, int32_t Gtid,
-                        omp_interop_val_t *&InteropPtr,
-                        int32_t InteropType, int32_t DeviceId,
-                        int32_t Ndeps, kmp_depend_info_t *DepList,
-                        int32_t HaveNowait) {
+                        omp_interop_val_t *&InteropPtr, int32_t InteropType,
+                        int32_t DeviceId, int32_t Ndeps,
+                        kmp_depend_info_t *DepList, int32_t HaveNowait) {
   interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};
   dep_pack_t Deps = {Ndeps, 0, DepList, nullptr};
   InteropPtr = __tgt_interop_get(LocRef, InteropType == 2 ? 1 : 0, DeviceId, 0,

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -124,7 +124,7 @@ void *getProperty<void *>(omp_interop_val_t &InteropVal,
   case omp_ipr_device_context:
     return InteropVal.device_info.Context;
   case omp_ipr_targetsync:
-    return InteropVal.async_info->Queue;
+    return InteropVal.async_info ? InteropVal.async_info->Queue : nullptr;
   default:;
   }
   getTypeMismatch(Property, Err);
@@ -167,7 +167,6 @@ bool getPropertyCheck(omp_interop_val_t **InteropPtr,
                                        omp_interop_property_t property_id,     \
                                        int *err) {                             \
     omp_interop_val_t *interop_val = (omp_interop_val_t *)interop;             \
-    assert((interop_val)->interop_type == kmp_interop_type_targetsync);        \
     if (!getPropertyCheck(&interop_val, property_id, err)) {                   \
       return (RETURN_TYPE)(0);                                                 \
     }                                                                          \

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -362,7 +362,7 @@ EXTERN int ompx_interop_add_completion_callback(omp_interop_val_t *Interop,
 // Backwards compatibility wrappers
 void __tgt_interop_init(ident_t *LocRef, int32_t Gtid,
                         omp_interop_val_t *&InteropPtr,
-                        kmp_interop_type_t InteropType, int32_t DeviceId,
+                        int32_t InteropType, int32_t DeviceId,
                         int32_t Ndeps, kmp_depend_info_t *DepList,
                         int32_t HaveNowait) {
   interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -367,8 +367,8 @@ void __tgt_interop_init(ident_t *LocRef, int32_t Gtid,
                         int32_t HaveNowait) {
   interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};
   dep_pack_t Deps = {Ndeps, 0, DepList, nullptr};
-  InteropPtr = __tgt_interop_get(LocRef, InteropType, DeviceId, 0, nullptr,
-                                 &Ctx, Ndeps ? &Deps : nullptr);
+  InteropPtr = __tgt_interop_get(LocRef, InteropType == 2 ? 1 : 0, DeviceId, 0,
+                                 nullptr, &Ctx, Ndeps ? &Deps : nullptr);
 }
 
 void __tgt_interop_use(ident_t *LocRef, int32_t Gtid,

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -364,10 +364,15 @@ void __tgt_interop_init(ident_t *LocRef, int32_t Gtid,
                         omp_interop_val_t *&InteropPtr, int32_t InteropType,
                         int32_t DeviceId, int32_t Ndeps,
                         kmp_depend_info_t *DepList, int32_t HaveNowait) {
+  constexpr int32_t old_kmp_interop_type_targetsync = 2;
   interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};
   dep_pack_t Deps = {Ndeps, 0, DepList, nullptr};
-  InteropPtr = __tgt_interop_get(LocRef, InteropType == 2 ? 1 : 0, DeviceId, 0,
-                                 nullptr, &Ctx, Ndeps ? &Deps : nullptr);
+  InteropPtr =
+      __tgt_interop_get(LocRef,
+                        InteropType == old_kmp_interop_type_targetsync
+                            ? kmp_interop_type_targetsync
+                            : kmp_interop_type_target,
+                        DeviceId, 0, nullptr, &Ctx, Ndeps ? &Deps : nullptr);
 }
 
 void __tgt_interop_use(ident_t *LocRef, int32_t Gtid,

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -275,7 +275,7 @@ omp_interop_val_t *__tgt_interop_get(ident_t *LocRef, int32_t InteropType,
   return Interop;
 }
 
-int __tgt_interop_use(ident_t *LocRef, omp_interop_val_t *Interop,
+int __tgt_interop_use60(ident_t *LocRef, omp_interop_val_t *Interop,
                       interop_ctx_t *Ctx, dep_pack_t *Deps) {
   bool Nowait = Ctx->flags.nowait;
   DP("Call to %s with interop " DPxMOD ", nowait %" PRId32 "\n", __func__,
@@ -357,6 +357,36 @@ EXTERN int ompx_interop_add_completion_callback(omp_interop_val_t *Interop,
   Interop->addCompletionCb(CB, Data);
 
   return omp_irc_success;
+}
+
+// Backwards compatibility wrappers
+void __tgt_interop_init(ident_t *LocRef, int32_t Gtid,
+                        omp_interop_val_t *&InteropPtr,
+                        kmp_interop_type_t InteropType, int32_t DeviceId,
+                        int32_t Ndeps, kmp_depend_info_t *DepList,
+                        int32_t HaveNowait) {
+  interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};
+  dep_pack_t Deps = {Ndeps, 0, DepList, nullptr};
+  InteropPtr = __tgt_interop_get(LocRef, InteropType, DeviceId, 0, nullptr,
+                                 &Ctx, Ndeps ? &Deps : nullptr);
+}
+
+void __tgt_interop_use(ident_t *LocRef, int32_t Gtid,
+                       omp_interop_val_t *&InteropPtr, int32_t DeviceId,
+                       int32_t Ndeps, kmp_depend_info_t *DepList,
+                       int32_t HaveNowait) {
+  interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};
+  dep_pack_t Deps = {Ndeps, 0, DepList, nullptr};
+  __tgt_interop_use60(LocRef, InteropPtr, &Ctx, Ndeps ? &Deps : nullptr);
+}
+
+void __tgt_interop_destroy(ident_t *LocRef, int32_t Gtid,
+                           omp_interop_val_t *&InteropPtr, int32_t DeviceId,
+                           int32_t Ndeps, kmp_depend_info_t *DepList,
+                           int32_t HaveNowait) {
+  interop_ctx_t Ctx = {0, {false, (bool)HaveNowait, 0}, Gtid};
+  dep_pack_t Deps = {Ndeps, 0, DepList, nullptr};
+  __tgt_interop_release(LocRef, InteropPtr, &Ctx, Ndeps ? &Deps : nullptr);
 }
 
 } // extern "C"

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -276,7 +276,7 @@ omp_interop_val_t *__tgt_interop_get(ident_t *LocRef, int32_t InteropType,
 }
 
 int __tgt_interop_use60(ident_t *LocRef, omp_interop_val_t *Interop,
-                      interop_ctx_t *Ctx, dep_pack_t *Deps) {
+                        interop_ctx_t *Ctx, dep_pack_t *Deps) {
   bool Nowait = Ctx->flags.nowait;
   DP("Call to %s with interop " DPxMOD ", nowait %" PRId32 "\n", __func__,
      DPxPTR(Interop), Nowait);

--- a/offload/libomptarget/exports
+++ b/offload/libomptarget/exports
@@ -68,8 +68,11 @@ VERS1.0 {
     omp_get_interop_int;
     omp_get_interop_name;
     omp_get_interop_type_desc;
-    __tgt_interop_get;
+    __tgt_interop_init;
     __tgt_interop_use;
+    __tgt_interop_destroy;
+    __tgt_interop_get;
+    __tgt_interop_use60;
     __tgt_interop_release;
     __tgt_target_sync;
     __llvmPushCallConfiguration;

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2712,6 +2712,38 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     return Plugin::success();
   }
 
+  interop_spec_t selectInteropPreference(int32_t InteropType,
+                                         int32_t NumPrefers,
+                                         interop_spec_t *Prefers) override {
+    // TODO: update once targetsync is supported
+    if (InteropType != kmp_interop_type_target)
+      return interop_spec_t{tgt_fr_hip, {false, 0}, 0};
+    return interop_spec_t{tgt_fr_none, {false, 0}, 0};
+  }
+
+  Expected<omp_interop_val_t *>
+  createInterop(int32_t InteropType, interop_spec_t &InteropSpec) override {
+    auto *Ret = new omp_interop_val_t(
+        DeviceId, static_cast<kmp_interop_type_t>(InteropType));
+    Ret->fr_id = tgt_fr_hip;
+    Ret->vendor_id = omp_vendor_amd;
+
+    // TODO: implement targetsync support
+
+    Ret->device_info.Platform = nullptr;
+    Ret->device_info.Device = reinterpret_cast<void *>(Agent.handle);
+    Ret->device_info.Context = nullptr;
+
+    return Ret;
+  }
+
+  Error releaseInterop(omp_interop_val_t *Interop) override {
+    if (!Interop)
+      return Plugin::success();
+    delete Interop;
+    return Plugin::success();
+  }
+
   Error enqueueHostCallImpl(void (*Callback)(void *), void *UserData,
                             AsyncInfoWrapperTy &AsyncInfo) override {
     AMDGPUStreamTy *Stream = nullptr;

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2717,7 +2717,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
                                          interop_spec_t *Prefers) override {
     // TODO: update once targetsync is supported
     if (InteropType != kmp_interop_type_target)
-      return interop_spec_t{tgt_fr_hip, {false, 0}, 0};
+      return interop_spec_t{tgt_fr_hsa, {false, 0}, 0};
     return interop_spec_t{tgt_fr_none, {false, 0}, 0};
   }
 
@@ -2725,7 +2725,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   createInterop(int32_t InteropType, interop_spec_t &InteropSpec) override {
     auto *Ret = new omp_interop_val_t(
         DeviceId, static_cast<kmp_interop_type_t>(InteropType));
-    Ret->fr_id = tgt_fr_hip;
+    Ret->fr_id = tgt_fr_hsa;
     Ret->vendor_id = omp_vendor_amd;
 
     // TODO: implement targetsync support

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2716,7 +2716,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
                                          int32_t NumPrefers,
                                          interop_spec_t *Prefers) override {
     // TODO: update once targetsync is supported
-    if (InteropType != kmp_interop_type_target)
+    if (InteropType == kmp_interop_type_target)
       return interop_spec_t{tgt_fr_hsa, {false, 0}, 0};
     return interop_spec_t{tgt_fr_none, {false, 0}, 0};
   }

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2738,9 +2738,8 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   }
 
   Error releaseInterop(omp_interop_val_t *Interop) override {
-    if (!Interop)
-      return Plugin::success();
-    delete Interop;
+    if (Interop)
+      delete Interop;
     return Plugin::success();
   }
 

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -955,7 +955,9 @@ struct CUDADeviceTy : public GenericDeviceTy {
       return Plugin::success();
 
     if (Interop->async_info) {
-      // TODO: release the stream back to the pool?
+      if (auto Err = CUDAStreamManager.returnResource(
+              *static_cast<CUstream *>(Interop->async_info->Queue)))
+        return Err;
       delete Interop->async_info;
     }
     delete Interop;

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -917,6 +917,53 @@ struct CUDADeviceTy : public GenericDeviceTy {
     return Plugin::success();
   }
 
+  interop_spec_t selectInteropPreference(int32_t InteropType,
+                                         int32_t NumPrefers,
+                                         interop_spec_t *Prefers) override {
+    return interop_spec_t{tgt_fr_cuda, {true, 0}, 0};
+  }
+
+  Expected<omp_interop_val_t *>
+  createInterop(int32_t InteropType, interop_spec_t &InteropSpec) override {
+    auto *Ret = new omp_interop_val_t(
+        DeviceId, static_cast<kmp_interop_type_t>(InteropType));
+    Ret->fr_id = tgt_fr_cuda;
+    Ret->vendor_id = omp_vendor_nvidia;
+
+    if (InteropType == kmp_interop_type_target ||
+        InteropType == kmp_interop_type_targetsync) {
+      Ret->device_info.Platform = nullptr;
+      Ret->device_info.Device = reinterpret_cast<void *>(Device);
+      Ret->device_info.Context = Context;
+    }
+
+    if (InteropType == kmp_interop_type_targetsync) {
+      Ret->async_info = new __tgt_async_info();
+      if (auto Err = setContext())
+        return Err;
+      CUstream Stream;
+      if (auto Err = CUDAStreamManager.getResource(
+              *reinterpret_cast<CUstream *>(&Stream)))
+        return Err;
+
+      Ret->async_info->Queue = Stream;
+    }
+    return Ret;
+  }
+
+  Error releaseInterop(omp_interop_val_t *Interop) override {
+    if (!Interop)
+      return Plugin::success();
+
+    if (Interop->async_info) {
+      // TODO: release the stream back to the pool?
+      delete Interop->async_info;
+    }
+    delete Interop;
+
+    return Plugin::success();
+  }
+
   Error enqueueHostCallImpl(void (*Callback)(void *), void *UserData,
                             AsyncInfoWrapperTy &AsyncInfo) override {
     if (auto Err = setContext())

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -942,8 +942,7 @@ struct CUDADeviceTy : public GenericDeviceTy {
       if (auto Err = setContext())
         return Err;
       CUstream Stream;
-      if (auto Err = CUDAStreamManager.getResource(
-              *reinterpret_cast<CUstream *>(&Stream)))
+      if (auto Err = CUDAStreamManager.getResource(Stream))
         return Err;
 
       Ret->async_info->Queue = Stream;

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -954,14 +954,10 @@ struct CUDADeviceTy : public GenericDeviceTy {
     if (!Interop)
       return Plugin::success();
 
-    if (Interop->async_info) {
-      if (auto Err = CUDAStreamManager.returnResource(
-              *static_cast<CUstream *>(Interop->async_info->Queue)))
-        return Err;
+    if (Interop->async_info)
       delete Interop->async_info;
-    }
-    delete Interop;
 
+    delete Interop;
     return Plugin::success();
   }
 


### PR DESCRIPTION
This implements two pieces to restore the interop functionality (that I broke) when the 6.0 interfaces were added:

* A set of wrappers that support the old interfaces on top of the new ones
* The same level of interop support for the CUDA amd AMD plugins