### PR TITLE
[OpenMP] Add test to print interop identifiers

### DIFF
--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -40,8 +40,7 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  // FIXME: This should be hsa instead of hip
-  // AMDCHECK: {{.*}} hip
+  // AMDCHECK: {{.*}} hsa
   printf("omp_get_interop_int returned %s\n",
          interop_int_to_string(interop_int));
 
@@ -62,8 +61,7 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  // FIXME: This should be hsa instead of hip
-  // AMDCHECK: {{.*}} hip
+  // AMDCHECK: {{.*}} hsa
   printf("omp_get_interop_str returned %s\n", interop_fr_name);
 
 #pragma omp interop destroy(iobj)

--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -1,10 +1,10 @@
 // RUN: %libomptarget-compile-amdgcn-amd-amdhsa
 // RUN:   %libomptarget-run-generic 2>&1 | \
-// RUN:   %fcheck-generic -check-prefix=AMDCHECK
+// RUN:   %fcheck-amdgcn-amd-amdhsa -check-prefixes=AMD
 
 // RUN: %libomptarget-compile-nvptx64-nvidia-cuda
 // RUN:   %libomptarget-run-generic 2>&1 | \
-// RUN:   %fcheck-generic -check-prefix=NVIDIACHECK
+// RUN:   %fcheck-nvptx64-nvidia-cuda -check-prefixes=NVIDIA
 
 // REQUIRES: gpu
 
@@ -35,10 +35,9 @@ const char *interop_int_to_string(const int interop_int) {
 int main(int argc, char **argv) {
 
   // Loop over all available devices
-  // XXX What happens in machines w/ GPUs from different vendors?
   for (int id = 0; id < omp_get_num_devices(); ++id) {
     omp_interop_t iobj = omp_interop_none;
-#pragma omp interop init(target : iobj) device(id)
+#pragma omp interop init(targetsync : iobj) device(id)
 
     int err;
     int interop_int = omp_get_interop_int(iobj, omp_ipr_fr_id, &err);
@@ -48,8 +47,8 @@ int main(int argc, char **argv) {
       return -1;
     }
 
-    // AMDCHECK: {{.*}} hsa
-    // NVIDIACHECK: {{.*}} cuda
+    // AMD: {{.*}} hsa
+    // NVIDIA: {{.*}} cuda
     printf("omp_get_interop_int returned %s\n",
            interop_int_to_string(interop_int));
 
@@ -60,8 +59,8 @@ int main(int argc, char **argv) {
       return -1;
     }
 
-    // AMDCHECK: {{.*}} amd
-    // NVIDIACHECK: {{.*}} nvidia
+    // AMD: {{.*}} amd
+    // NVIDIA: {{.*}} nvidia
     printf("omp_get_interop_str returned %s\n", interop_vendor);
 
     const char *interop_fr_name =
@@ -71,8 +70,8 @@ int main(int argc, char **argv) {
       return -1;
     }
 
-    // AMDCHECK: {{.*}} hsa
-    // NVIDIACHECK: {{.*}} cuda
+    // AMD: {{.*}} hsa
+    // NVIDIA: {{.*}} cuda
     printf("omp_get_interop_str returned %s\n", interop_fr_name);
 
 #pragma omp interop destroy(iobj)

--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     omp_interop_t iobj = omp_interop_none;
 
     // TODO: Change targetsync to target when AMD toolchain supports it.
-#pragma omp interop init(targetsync : iobj) device(id)
+#pragma omp interop init(target : iobj) device(id)
 
     int err;
     int interop_int = omp_get_interop_int(iobj, omp_ipr_fr_id, &err);

--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -1,0 +1,71 @@
+// RUN: %libomptarget-compile-amdgcn-amd-amdhsa
+// RUN:   %libomptarget-run-generic 2>&1 | \
+// RUN:   %fcheck-generic -check-prefix=AMDCHECK
+
+// REQUIRES: amdgpu
+
+#include <omp.h>
+#include <stdio.h>
+
+const char *interop_int_to_string(const int interop_int) {
+  switch (interop_int) {
+  case 1:
+    return "cuda";
+  case 2:
+    return "cuda_driver";
+  case 3:
+    return "opencl";
+  case 4:
+    return "sycl";
+  case 5:
+    return "hip";
+  case 6:
+    return "level_zero";
+  case 7:
+    return "hsa";
+  default:
+    return "unknown";
+  }
+}
+
+int main(int argc, char **argv) {
+  omp_interop_t iobj = omp_interop_none;
+#pragma omp interop init(targetsync : iobj)
+
+  int err;
+  int interop_int = omp_get_interop_int(iobj, omp_ipr_fr_id, &err);
+
+  if (err) {
+    fprintf(stderr, "omp_get_interop_int failed: %d\n", err);
+    return -1;
+  }
+
+  // FIXME: This should be hsa instead of hip
+  // AMDCHECK: {{.*}} hip
+  printf("omp_get_interop_int returned %s\n",
+         interop_int_to_string(interop_int));
+
+  const char *interop_vendor =
+      omp_get_interop_str(iobj, omp_ipr_vendor_name, &err);
+  if (err) {
+    fprintf(stderr, "omp_get_interop_str failed: %d\n", err);
+    return -1;
+  }
+
+  // AMDCHECK: {{.*}} amd
+  printf("omp_get_interop_str returned %s\n", interop_vendor);
+
+  const char *interop_fr_name =
+      omp_get_interop_str(iobj, omp_ipr_fr_name, &err);
+  if (err) {
+    fprintf(stderr, "omp_get_interop_str failed: %d\n", err);
+    return -1;
+  }
+
+  // FIXME: This should be hsa instead of hip
+  // AMDCHECK: {{.*}} hip
+  printf("omp_get_interop_str returned %s\n", interop_fr_name);
+
+#pragma omp interop destroy(iobj)
+  return 0;
+}

--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -7,6 +7,7 @@
 // RUN:   %fcheck-nvptx64-nvidia-cuda -check-prefixes=NVIDIA
 
 // REQUIRES: gpu
+// XFAIL: nvptx64-nvidia-cuda
 
 #include <omp.h>
 #include <stdio.h>
@@ -37,6 +38,8 @@ int main(int argc, char **argv) {
   // Loop over all available devices
   for (int id = 0; id < omp_get_num_devices(); ++id) {
     omp_interop_t iobj = omp_interop_none;
+
+    // TODO: Change targetsync to target when AMD toolchain supports it.
 #pragma omp interop init(targetsync : iobj) device(id)
 
     int err;


### PR DESCRIPTION
The test covers some of the identifier symbols in the interop runtime.

This test, for now, is to guard against complete breakage, which was the result of the other `interop.c` test not being enabled on AMD and thus, not caught by our buildbots.
It can certainly be improved. :)

Depends on https://github.com/llvm/llvm-project/pull/161429 to restore functionality.