### PR TITLE
[flang] Add missing #include for MSVC

### DIFF
--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -1522,7 +1522,7 @@ bool IsVarSubexpressionOf(
 std::optional<Expr<SomeType>> GetConvertInput(const Expr<SomeType> &x);
 
 // How many ancestors does have a derived type have?
-std::optional<int> DerivedTypeDepth(const semantics::Scope &);
+std::optional<int> CountDerivedTypeAncestors(const semantics::Scope &);
 
 } // namespace Fortran::evaluate
 

--- a/flang/lib/Evaluate/constant.cpp
+++ b/flang/lib/Evaluate/constant.cpp
@@ -9,6 +9,7 @@
 #include "flang/Evaluate/constant.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/shape.h"
+#include "flang/Evaluate/tools.h"
 #include "flang/Evaluate/type.h"
 #include <string>
 
@@ -392,8 +393,8 @@ std::size_t Constant<SomeDerived>::CopyFrom(const Constant<SomeDerived> &source,
 bool ComponentCompare::operator()(SymbolRef x, SymbolRef y) const {
   if (&x->owner() != &y->owner()) {
     // Not components of the same derived type; put ancestors' components first.
-    if (auto xDepth{DerivedTypeDepth(x->owner())}) {
-      if (auto yDepth{DerivedTypeDepth(y->owner())}) {
+    if (auto xDepth{CountDerivedTypeAncestors(x->owner())}) {
+      if (auto yDepth{CountDerivedTypeAncestors(y->owner())}) {
         if (*xDepth != *yDepth) {
           return *xDepth < *yDepth;
         }

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1950,7 +1950,7 @@ bool IsVarSubexpressionOf(
   return VariableFinder{sub}(super);
 }
 
-std::optional<int> DerivedTypeDepth(const semantics::Scope &scope) {
+std::optional<int> CountDerivedTypeAncestors(const semantics::Scope &scope) {
   if (scope.IsDerivedType()) {
     for (auto iter{scope.cbegin()}; iter != scope.cend(); ++iter) {
       const Symbol &symbol{*iter->second};
@@ -1962,7 +1962,7 @@ std::optional<int> DerivedTypeDepth(const semantics::Scope &scope) {
               parent = derived->typeSymbol().scope();
             }
             if (parent) {
-              if (auto parentDepth{DerivedTypeDepth(*parent)}) {
+              if (auto parentDepth{CountDerivedTypeAncestors(*parent)}) {
                 return 1 + *parentDepth;
               }
             }


### PR DESCRIPTION
I moved a function to Evaluate/tools.cpp in an attempt to dodge some MSVC compiler issue but didn't add an include directive for Evaluate/tools.h to Evaluate/constant.cpp.