### PR TITLE
Enforce Unix line endings for Clang/LLVM/MLIR projects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+LineEnding: LF

--- a/clang/.clang-format
+++ b/clang/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+LineEnding: LF

--- a/llvm/.clang-format
+++ b/llvm/.clang-format
@@ -1,2 +1,2 @@
 BasedOnStyle: LLVM
-
+LineEnding: LF

--- a/mlir/.clang-format
+++ b/mlir/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 AlwaysBreakTemplateDeclarations: Yes
+LineEnding: LF


### PR DESCRIPTION
Change top-level and LLVM/MLIR/Clang `.clang-format` files to enforce Unix line ending.