### PR TITLE
[HLSL][NFC] Add missing includes for standalone header compilation

### DIFF
--- a/clang/include/clang/AST/HLSLResource.h
+++ b/clang/include/clang/AST/HLSLResource.h
@@ -15,9 +15,12 @@
 #define LLVM_CLANG_AST_HLSLRESOURCE_H
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/DeclBase.h"
 #include "clang/Basic/TargetInfo.h"
+#include "clang/Support/Compiler.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace clang {
 


### PR DESCRIPTION
HLSLResource.h added by #161254 builds in the context of a .cpp file (e.g. CGHLSLRuntime.cpp) but not when doing a header compilation, e.g.:

```
clang/include/clang/AST/Attrs.inc:12:45: error: unknown type name 'raw_ostream'; did you mean 'clang::raw_ostream'?
   12 | static inline void DelimitAttributeArgument(raw_ostream& OS, bool& IsFirst) {
```