### PR TITLE
[ADT, Support] Drop extraneous std::bool_constant (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/IntervalTree.h
+++ b/llvm/include/llvm/ADT/IntervalTree.h
@@ -236,8 +236,7 @@ public:
 //===----------------------------------------------------------------------===//
 // Helper class template that is used by the IntervalTree to ensure that one
 // does instantiate using only fundamental and/or pointer types.
-template <typename T>
-using PointTypeIsValid = std::bool_constant<std::is_fundamental<T>::value>;
+template <typename T> using PointTypeIsValid = std::is_fundamental<T>;
 
 template <typename T>
 using ValueTypeIsValid = std::bool_constant<std::is_fundamental<T>::value ||

--- a/llvm/include/llvm/Support/FormatProviders.h
+++ b/llvm/include/llvm/Support/FormatProviders.h
@@ -29,22 +29,18 @@ namespace support {
 namespace detail {
 template <typename T>
 struct use_integral_formatter
-    : public std::bool_constant<
-          is_one_of<T, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                    uint64_t, int, unsigned, long, unsigned long, long long,
-                    unsigned long long>::value> {};
+    : public is_one_of<T, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+                       int64_t, uint64_t, int, unsigned, long, unsigned long,
+                       long long, unsigned long long> {};
 
 template <typename T>
-struct use_char_formatter : public std::bool_constant<std::is_same_v<T, char>> {
-};
+struct use_char_formatter : public std::is_same<T, char> {};
 
 template <typename T>
-struct is_cstring
-    : public std::bool_constant<is_one_of<T, char *, const char *>::value> {};
+struct is_cstring : public is_one_of<T, char *, const char *> {};
 
 template <typename T>
-struct use_string_formatter
-    : public std::bool_constant<std::is_convertible_v<T, llvm::StringRef>> {};
+struct use_string_formatter : public std::is_convertible<T, llvm::StringRef> {};
 
 template <typename T>
 struct use_pointer_formatter
@@ -52,8 +48,7 @@ struct use_pointer_formatter
 };
 
 template <typename T>
-struct use_double_formatter
-    : public std::bool_constant<std::is_floating_point_v<T>> {};
+struct use_double_formatter : public std::is_floating_point<T> {};
 
 class HelperFunctions {
 protected:

--- a/llvm/include/llvm/Support/FormatVariadicDetails.h
+++ b/llvm/include/llvm/Support/FormatVariadicDetails.h
@@ -92,8 +92,7 @@ public:
 // based format() invocation.
 template <typename T>
 struct uses_format_member
-    : public std::bool_constant<
-          std::is_base_of_v<format_adapter, std::remove_reference_t<T>>> {};
+    : public std::is_base_of<format_adapter, std::remove_reference_t<T>> {};
 
 // Simple template that decides whether a type T should use the format_provider
 // based format() invocation.  The member function takes priority, so this test

--- a/llvm/include/llvm/Support/HashBuilder.h
+++ b/llvm/include/llvm/Support/HashBuilder.h
@@ -31,8 +31,7 @@ namespace llvm {
 namespace hashbuilder_detail {
 /// Trait to indicate whether a type's bits can be hashed directly (after
 /// endianness correction).
-template <typename U>
-struct IsHashableData : std::bool_constant<is_integral_or_enum<U>::value> {};
+template <typename U> struct IsHashableData : is_integral_or_enum<U> {};
 
 } // namespace hashbuilder_detail
 


### PR DESCRIPTION
This patch drops extraneous std::bool_constant, replacing:

  std::bool_constant<std::is_foo_v<...>>

with:

  std::is_foo<...>
