### PR TITLE
[Support] Make getMaxValue and getMinValue constexpr variables (NFC)

### DIFF
--- a/llvm/include/llvm/Support/InstructionCost.h
+++ b/llvm/include/llvm/Support/InstructionCost.h
@@ -59,10 +59,8 @@ private:
       State = Invalid;
   }
 
-  static inline constexpr CostType MaxValue =
-      std::numeric_limits<CostType>::max();
-  static inline constexpr CostType MinValue =
-      std::numeric_limits<CostType>::min();
+  static constexpr CostType MaxValue = std::numeric_limits<CostType>::max();
+  static constexpr CostType MinValue = std::numeric_limits<CostType>::min();
 
 public:
   // A default constructed InstructionCost is a valid zero cost

--- a/llvm/include/llvm/Support/InstructionCost.h
+++ b/llvm/include/llvm/Support/InstructionCost.h
@@ -59,8 +59,10 @@ private:
       State = Invalid;
   }
 
-  static CostType getMaxValue() { return std::numeric_limits<CostType>::max(); }
-  static CostType getMinValue() { return std::numeric_limits<CostType>::min(); }
+  static inline constexpr CostType MaxValue =
+      std::numeric_limits<CostType>::max();
+  static inline constexpr CostType MinValue =
+      std::numeric_limits<CostType>::min();
 
 public:
   // A default constructed InstructionCost is a valid zero cost
@@ -69,8 +71,8 @@ public:
   InstructionCost(CostState) = delete;
   InstructionCost(CostType Val) : Value(Val), State(Valid) {}
 
-  static InstructionCost getMax() { return getMaxValue(); }
-  static InstructionCost getMin() { return getMinValue(); }
+  static InstructionCost getMax() { return MaxValue; }
+  static InstructionCost getMin() { return MinValue; }
   static InstructionCost getInvalid(CostType Val = 0) {
     InstructionCost Tmp(Val);
     Tmp.setInvalid();
@@ -102,7 +104,7 @@ public:
     // Saturating addition.
     InstructionCost::CostType Result;
     if (AddOverflow(Value, RHS.Value, Result))
-      Result = RHS.Value > 0 ? getMaxValue() : getMinValue();
+      Result = RHS.Value > 0 ? MaxValue : MinValue;
 
     Value = Result;
     return *this;
@@ -120,7 +122,7 @@ public:
     // Saturating subtract.
     InstructionCost::CostType Result;
     if (SubOverflow(Value, RHS.Value, Result))
-      Result = RHS.Value > 0 ? getMinValue() : getMaxValue();
+      Result = RHS.Value > 0 ? MinValue : MaxValue;
     Value = Result;
     return *this;
   }
@@ -138,9 +140,9 @@ public:
     InstructionCost::CostType Result;
     if (MulOverflow(Value, RHS.Value, Result)) {
       if ((Value > 0 && RHS.Value > 0) || (Value < 0 && RHS.Value < 0))
-        Result = getMaxValue();
+        Result = MaxValue;
       else
-        Result = getMinValue();
+        Result = MinValue;
     }
 
     Value = Result;


### PR DESCRIPTION
This patch makes getMaxValue and getMinValue constexpr variables and
"inlines" the calls to getMaxValue and getMinValue.

We could probably make InstructionCost constexpr also, but that's left
for another day.
