### PR TITLE
[LLVM] Volunteer myself and Usman Nadeem as DFAJumpThreading maintainers

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -123,6 +123,13 @@ a.bataev@outlook.com (email), [alexey-bataev](https://github.com/alexey-bataev) 
 Chandler Carruth \
 chandlerc@gmail.com, chandlerc@google.com (email), [chandlerc](https://github.com/chandlerc) (GitHub)
 
+#### DFAJumpThreading
+
+Hongyu Chen \
+xxs\_chy@outlook.com (email), [XChy](https://github.com/XChy) (Github) \
+Usman Nadeem \
+mnadeem@quicinc.com (email), [UsmanNadeem](https://github.com/UsmanNadeem) (Github)
+
 ### Instrumentation and sanitizers
 
 #### Sanitizers not covered by someone else


### PR DESCRIPTION
Both Usman Nadeem and I have constantly contributed to the DFAJumpThreading pass so far. To push DFAJumpThreading forwards and make it enabled by default, I volunteer myself and Usman Nadeem as DFAJumpThreading maintainers.
See also the discussion in https://github.com/llvm/llvm-project/pull/157646.