### PR TITLE
[lldb][NFCI] Remove the non-const reference Mangled::GetMangledName accessor

### DIFF
--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -148,7 +148,7 @@ public:
   /// Mangled name get accessor.
   ///
   /// \return
-  ///     A the mangled name string object.
+  ///     The mangled name string object.
   ConstString GetMangledName() const { return m_mangled; }
 
   /// Best name get accessor.

--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -148,13 +148,7 @@ public:
   /// Mangled name get accessor.
   ///
   /// \return
-  ///     A reference to the mangled name string object.
-  ConstString &GetMangledName() { return m_mangled; }
-
-  /// Mangled name get accessor.
-  ///
-  /// \return
-  ///     A const reference to the mangled name string object.
+  ///     A the mangled name string object.
   ConstString GetMangledName() const { return m_mangled; }
 
   /// Best name get accessor.


### PR DESCRIPTION
We've been seen (very sporadic) lifetime issues around this area. We noticed that `GetMangledName` has two accessors, one of which returns a non-const reference. I audited all the callsites and no users of this overload actually mutate the `ConstString` itself (which is a suspicious thing to do anyway since it's just a wrapper around a `const char*`).

This patch removes the redundant overload.

rdar://161128180