### PR TITLE
[lldb][RISCV] Fixed TestSymbolFileJSON for RISC-V

### DIFF
--- a/lldb/test/API/functionalities/json/symbol-file/Makefile
+++ b/lldb/test/API/functionalities/json/symbol-file/Makefile
@@ -1,4 +1,5 @@
 C_SOURCES := main.c
+CFLAGS_EXTRAS := -no-pie
 
 all: stripped.out
 


### PR DESCRIPTION
This test failed during testing on the RISC-V target because we couldn't strip the main label from the binary. main is dynamically linked when the -fPIC flag is enabled. The RISC-V ABI requires that executables support loading at arbitrary addresses to enable shared libraries and secure loading (ASLR). In PIC mode, function addresses cannot be hardcoded in the code. Instead, code is generated to load addresses from the GOT/PLT tables, which are initialized by the dynamic loader. The reference to main thus ends up in .dynsym and is dynamically bound. We cannot strip main or any other dynamically linked functions because these functions are referenced indirectly via dynamic linking tables (.plt and .got). Removing these symbols would break the dynamic linking mechanism needed to resolve function addresses at runtime, causing the executable to fail to correctly call them.