### PR TITLE
[InstCombine] Avoid self-replacing in `getUndefReplacement`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5212,7 +5212,7 @@ Instruction *InstCombinerImpl::visitFreeze(FreezeInst &I) {
       else if (match(U, m_Select(m_Specific(&I), m_Constant(), m_Value())))
         V = ConstantInt::getTrue(Ty);
       else if (match(U, m_c_Select(m_Specific(&I), m_Value(V)))) {
-        if (!isGuaranteedNotToBeUndefOrPoison(V, &AC, &I, &DT))
+        if (V == &I || !isGuaranteedNotToBeUndefOrPoison(V, &AC, &I, &DT))
           V = NullValue;
       } else if (auto *PHI = dyn_cast<PHINode>(U)) {
         if (Value *MaybeV = pickCommonConstantFromPHI(*PHI))
@@ -5225,6 +5225,7 @@ Instruction *InstCombinerImpl::visitFreeze(FreezeInst &I) {
         BestValue = NullValue;
     }
     assert(BestValue && "Must have at least one use");
+    assert(BestValue != &I && "Cannot replace with itself");
     return BestValue;
   };
 

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -1467,7 +1467,7 @@ define ptr @freeze_ptrmask_nonnull(ptr %p, i64 noundef %m) {
 define i64 @pr161492_1(i1 %cond) {
 ; CHECK-LABEL: define i64 @pr161492_1(
 ; CHECK-SAME: i1 [[COND:%.*]]) {
-; CHECK-NEXT:    ret i64 poison
+; CHECK-NEXT:    ret i64 0
 ;
   %fr1 = freeze i64 poison
   %fr2 = freeze i64 poison
@@ -1478,7 +1478,7 @@ define i64 @pr161492_1(i1 %cond) {
 define i64 @pr161492_2(i1 %cond) {
 ; CHECK-LABEL: define i64 @pr161492_2(
 ; CHECK-SAME: i1 [[COND:%.*]]) {
-; CHECK-NEXT:    ret i64 poison
+; CHECK-NEXT:    ret i64 0
 ;
   %fr = freeze i64 poison
   %ret = select i1 %cond, i64 %fr, i64 %fr

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -1464,6 +1464,27 @@ define ptr @freeze_ptrmask_nonnull(ptr %p, i64 noundef %m) {
   ret ptr %fr
 }
 
+define i64 @pr161492_1(i1 %cond) {
+; CHECK-LABEL: define i64 @pr161492_1(
+; CHECK-SAME: i1 [[COND:%.*]]) {
+; CHECK-NEXT:    ret i64 poison
+;
+  %fr1 = freeze i64 poison
+  %fr2 = freeze i64 poison
+  %ret = select i1 %cond, i64 %fr1, i64 %fr2
+  ret i64 %ret
+}
+
+define i64 @pr161492_2(i1 %cond) {
+; CHECK-LABEL: define i64 @pr161492_2(
+; CHECK-SAME: i1 [[COND:%.*]]) {
+; CHECK-NEXT:    ret i64 poison
+;
+  %fr = freeze i64 poison
+  %ret = select i1 %cond, i64 %fr, i64 %fr
+  ret i64 %ret
+}
+
 !0 = !{}
 !1 = !{i64 4}
 !2 = !{i32 0, i32 100}


### PR DESCRIPTION
Self-replacing has a different meaning in InstCombine. It will replace all uses with poison.
Closes https://github.com/llvm/llvm-project/issues/161492.
