### PR TITLE
[flang] handle scalars in getDescriptorWithNewBaseAddress

### DIFF
--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -1943,7 +1943,7 @@ void fir::factory::genDimInfoFromBox(
     return;
 
   unsigned rank = fir::getBoxRank(boxType);
-  assert(rank != 0 && "must be an array of known rank");
+  assert(!boxType.isAssumedRank() && "must be an array of known rank");
   mlir::Type idxTy = builder.getIndexType();
   for (unsigned i = 0; i < rank; ++i) {
     mlir::Value dim = builder.createIntegerConstant(loc, idxTy, i);


### PR DESCRIPTION
Follow up on #161347 to allow scalar fir.box/class reconstruction (at least required for polymorphic types).
The assert in genDimInfoFromBox was rejecting scalars while there is no functional reason for that (only assumed-rank are an issue there).