### PR TITLE
[lldb][test] Fix bf16 test cases on Arm 32-bit

### DIFF
--- a/lldb/test/API/lang/cpp/floating-types-specialization/TestCppFloatingTypesSpecialization.py
+++ b/lldb/test/API/lang/cpp/floating-types-specialization/TestCppFloatingTypesSpecialization.py
@@ -1,4 +1,5 @@
 import lldb
+import lldbsuite.test.lldbplatformutil as lldbplatformutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -11,12 +12,25 @@ class TestCase(TestBase):
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
 
-        self.expect_expr("f0", result_type="Foo<__bf16>")
-        self.expect_expr("f1", result_type="Foo<__fp16>")
+        # On 32-bit Arm, you have to have the bfloat16 extension, or an FPU while
+        # not using the soft float mode. The target we assume has none of that
+        # so instead of __bf16 we get __fp16.
+        is_arm_32_bit = lldbplatformutil.getArchitecture() == "arm"
+
+        self.expect_expr(
+            "f0", result_type=("Foo<__fp16>" if is_arm_32_bit else "Foo<__bf16>")
+        )
+
+        # When __bf16 is actually __fp16, f1 looks like it inherits from itself.
+        # Which clang allows but LLDB fails to evaluate.
+        if not is_arm_32_bit:
+            self.expect_expr("f1", result_type="Foo<__fp16>")
 
         # Test sizeof to ensure while computing layout we don't do
         # infinite recursion.
         v = self.frame().EvaluateExpression("sizeof(f0)")
         self.assertEqual(v.GetValueAsUnsigned() > 0, True)
-        v = self.frame().EvaluateExpression("sizeof(f1)")
-        self.assertEqual(v.GetValueAsUnsigned() > 0, True)
+
+        if not is_arm_32_bit:
+            v = self.frame().EvaluateExpression("sizeof(f1)")
+            self.assertEqual(v.GetValueAsUnsigned() > 0, True)

--- a/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
+++ b/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
@@ -1,4 +1,5 @@
 import lldb
+import lldbsuite.test.lldbplatformutil as lldbplatformutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -82,8 +83,12 @@ class TestCase(TestBase):
         value = self.expect_expr("temp7", result_type="Foo<__fp16, __fp16>")
         self.assertFalse(value.GetType().GetTemplateArgumentValue(target, 1))
 
-        value = self.expect_expr("temp8", result_type="Foo<__bf16, __bf16>")
-        self.assertFalse(value.GetType().GetTemplateArgumentValue(target, 1))
+        # The target we use when evaluating these expressions for Arm leads to there
+        # not being a __bf16 type in the AST so we fall back to __fp16 and evaluating
+        # this fails.
+        if lldbplatformutil.getArchitecture() != "arm":
+            value = self.expect_expr("temp8", result_type="Foo<__bf16, __bf16>")
+            self.assertFalse(value.GetType().GetTemplateArgumentValue(target, 1))
 
         value = self.expect_expr("temp9", result_type="Bar<double, 1.200000e+00>")
         template_param_value = value.GetType().GetTemplateArgumentValue(target, 1)


### PR DESCRIPTION
Fixes #157674

On ARM, the presence of a specific bf16 type in the AST is gated by: 
```
bool ARMTargetInfo::hasBFloat16Type() const {
  // The __bf16 type is generally available so long as we have any fp registers.
  return HasBFloat16 || (FPU && !SoftFloat);
}
```

And the target we use when evaluating symbols (derived from the program file, I think, haven't found it yet) does not enable any of this.

This means that we fall back to __fp16.

So for parts of the testing we just need to expect __fp16 instead, and others we need to skip because now a class looks like it inherits from itself.

There's a proper fix here somewhere but I don't know what it is yet.