### PR TITLE
[flang][debug] Avoid redundant module info.

### DIFF
--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -286,10 +286,11 @@ mlir::LLVM::DIModuleAttr AddDebugInfoPass::getOrCreateModuleAttr(
     modAttr = iter->getValue();
   } else {
     modAttr = mlir::LLVM::DIModuleAttr::get(
-        context, fileAttr, scope, mlir::StringAttr::get(context, name),
+        context, decl ? nullptr : fileAttr, decl ? nullptr : scope,
+        mlir::StringAttr::get(context, name),
         /* configMacros */ mlir::StringAttr(),
         /* includePath */ mlir::StringAttr(),
-        /* apinotes */ mlir::StringAttr(), line, decl);
+        /* apinotes */ mlir::StringAttr(), decl ? 0 : line, decl);
     moduleMap[name] = modAttr;
   }
   return modAttr;

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -285,6 +285,10 @@ mlir::LLVM::DIModuleAttr AddDebugInfoPass::getOrCreateModuleAttr(
   if (auto iter{moduleMap.find(name)}; iter != moduleMap.end()) {
     modAttr = iter->getValue();
   } else {
+    // When decl is true, it means that module is only being used in this
+    // compilation unit and it is defined elsewhere. But if the file/line/scope
+    // fields are valid, the module is not merged with its definition and is
+    // considered different. So we only set those fields when decl is false.
     modAttr = mlir::LLVM::DIModuleAttr::get(
         context, decl ? nullptr : fileAttr, decl ? nullptr : scope,
         mlir::StringAttr::get(context, name),

--- a/flang/test/Transforms/debug-module-3.fir
+++ b/flang/test/Transforms/debug-module-3.fir
@@ -1,0 +1,13 @@
+// RUN: fir-opt --add-debug-info --mlir-print-debuginfo %s | FileCheck %s
+
+module {
+  func.func @_QQmain() {
+    %2 = fir.address_of(@_QMmodEvar1) : !fir.ref<i32> loc(#loc1)
+    %3 = fircg.ext_declare %2 {uniq_name = "_QMmodEvar1"} : (!fir.ref<i32>) -> !fir.ref<i32> loc(#loc1)
+    return
+  } loc(#loc1)
+  fir.global @_QMmodEvar1 : i32 loc(#loc1)
+}
+#loc1 = loc("test1.f90":1:0)
+
+// CHECK: #llvm.di_module<name = "mod", isDecl = true>


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/160907.

When a module is just being used and not defined, we generate it with decl=true. But if the file/line fields are valid, the module is not merged with the original and is considered different. This patch avoids setting file/line/scope in such cases.