### PR TITLE
[Flang] Fix perfect loop nest detection

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2308,7 +2308,7 @@ void OmpAttributeVisitor::CheckPerfectNestAndRectangularLoop(
       auto last = block.end();
       --last;
 
-      // A trailing CONTINUE or CYCLE does not belong to the loop body
+      // A trailing CONTINUE is not considered part of the loop body
       if (parser::Unwrap<parser::ContinueStmt>(*last))
         --last;
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2303,14 +2303,17 @@ void OmpAttributeVisitor::CheckPerfectNestAndRectangularLoop(
     }
 
     auto checkPerfectNest = [&, this]() {
-      auto blockSize = block.size();
-      if (blockSize <= 1)
+      if (block.empty())
         return;
+      auto last = block.end();
+      --last;
 
-      if (parser::Unwrap<parser::ContinueStmt>(x))
-        blockSize -= 1;
+      // A trailing CONTINUE or CYCLE does not belong to the loop body
+      if (parser::Unwrap<parser::ContinueStmt>(*last))
+        --last;
 
-      if (blockSize <= 1)
+      // In a perfectly nested loop, the nested loop must be the only statement
+      if (last == block.begin())
         return;
 
       // Non-perfectly nested loop

--- a/flang/test/Lower/OpenMP/wsloop-collapse-continue.f90
+++ b/flang/test/Lower/OpenMP/wsloop-collapse-continue.f90
@@ -1,0 +1,19 @@
+! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
+
+program wsloop_collapse_continue
+  integer i, j
+
+! CHECK: omp.wsloop {{.*}} {
+! CHECK: omp.loop_nest ({{.*}}) : i32 = ({{.*}}) to ({{.*}}) inclusive step ({{.*}}) collapse(2) {
+  !$omp do collapse(2)
+  do 50 i = 1, 42
+     do 51 j = 1, 84
+! CHECK: fir.call @_FortranAioOutputInteger32(
+        print *, i
+! CHECK: fir.call @_FortranAioOutputInteger32(
+        print *, j
+     51 continue
+  50 continue
+  !$omp end do
+
+end program wsloop_collapse_continue

--- a/flang/test/Semantics/OpenMP/do08.f90
+++ b/flang/test/Semantics/OpenMP/do08.f90
@@ -61,7 +61,6 @@ program omp
   !$omp end do
 
 
-  !ERROR: Canonical loop nest must be perfectly nested.
   !ERROR: The value of the parameter in the COLLAPSE or ORDERED clause must not be larger than the number of nested loops following the construct.
   !$omp do collapse(3)
   do 60 i=2,200,2

--- a/flang/test/Semantics/OpenMP/do13.f90
+++ b/flang/test/Semantics/OpenMP/do13.f90
@@ -59,7 +59,6 @@ program omp
   !$omp end do
 
 
-  !ERROR: Canonical loop nest must be perfectly nested.
   !ERROR: The value of the parameter in the COLLAPSE or ORDERED clause must not be larger than the number of nested loops following the construct.
   !$omp do collapse(3)
   do 60 i=1,10


### PR DESCRIPTION
PR #160283 uses `Unwrap` to detect a `continue` statement, but it applied it on the loop body itelf which sometimes finds a trailing continue statement, but not always. Apply  `Unwrap` on the last body statement instead, where the `continue` is expected.

Fixes #161529