### PR TITLE
[HLSL][TEST] Fix root signature driver test on WSL

### DIFF
--- a/clang/test/Driver/dxc_frs.hlsl
+++ b/clang/test/Driver/dxc_frs.hlsl
@@ -3,7 +3,7 @@
 // Test to demonstrate extracting the root signature to the specified
 // output file with /Frs.
 
-// CHECK: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.obj" "{{.*}}.dxo" "--extract-section=RTS0={{.*}}.rs.dxo"
+// CHECK: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.obj" "{{.*}}.{{(dxo|obj)}}" "--extract-section=RTS0={{.*}}.rs.dxo"
 
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]

--- a/clang/test/Driver/dxc_frs.hlsl
+++ b/clang/test/Driver/dxc_frs.hlsl
@@ -1,10 +1,9 @@
-// RUN: %clang_dxc -T cs_6_0 /Fo %t.dxo /Frs %t.rs.dxo -### %s 2>&1 | FileCheck %s
+// RUN: %clang_dxc -Vd -T cs_6_0 /Fo %t.dxo /Frs %t.rs.dxo -### %s 2>&1 | FileCheck %s
 
 // Test to demonstrate extracting the root signature to the specified
 // output file with /Frs.
 
-// CHECK: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.obj" "{{.*}}.{{(dxo|obj)}}" "--extract-section=RTS0={{.*}}.rs.dxo"
-
+// CHECK: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.obj" "{{.*}}.dxo" "--extract-section=RTS0={{.*}}.rs.dxo"
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]
 void EmptyEntry() {}

--- a/clang/test/Driver/dxc_rootsignature_target.hlsl
+++ b/clang/test/Driver/dxc_rootsignature_target.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_dxc -E EntryRS -Vd -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
+// RUN: %clang_dxc -Vd -E EntryRS -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
 
 // CMDS: "{{.*}}clang{{.*}}" "-cc1"
 // CMDS-SAME: "-triple" "dxilv1.1-unknown-shadermodel1.1-rootsignature"

--- a/clang/test/Driver/dxc_rootsignature_target.hlsl
+++ b/clang/test/Driver/dxc_rootsignature_target.hlsl
@@ -3,6 +3,6 @@
 // CMDS: "{{.*}}clang{{.*}}" "-cc1"
 // CMDS-SAME: "-triple" "dxilv1.1-unknown-shadermodel1.1-rootsignature"
 // CMDS-SAME: "-hlsl-entry" "EntryRS"
-// CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.dxo" "--only-section=RTS0"
+// CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.{{(dxo|obj)}}" "--only-section=RTS0"
 
 #define EntryRS "UAV(u0)"

--- a/clang/test/Driver/dxc_rootsignature_target.hlsl
+++ b/clang/test/Driver/dxc_rootsignature_target.hlsl
@@ -1,8 +1,8 @@
-// RUN: %clang_dxc -E EntryRS -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
+// RUN: %clang_dxc -E EntryRS -Vd -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
 
 // CMDS: "{{.*}}clang{{.*}}" "-cc1"
 // CMDS-SAME: "-triple" "dxilv1.1-unknown-shadermodel1.1-rootsignature"
 // CMDS-SAME: "-hlsl-entry" "EntryRS"
-// CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.{{(dxo|obj)}}" "--only-section=RTS0"
+// CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.dxo" "--only-section=RTS0"
 
 #define EntryRS "UAV(u0)"


### PR DESCRIPTION
Running those test with validation enabled, causes emitting an additional intermediary object, which causes the checks to fail, since it will emit 2 `obj`, instead of one `obj` and one `dxo`. This patch changes the test to make sure validation is disabled, making the test consistent across environments.