### PR TITLE
[FMV][AArch64] Remove last of MRS bits and rename file

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -69,15 +69,15 @@ struct {
 #if defined(__APPLE__)
 #include "aarch64/fmv/apple.inc"
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
-#include "aarch64/fmv/mrs.inc"
+#include "aarch64/fmv/hwcap.inc"
 #include "aarch64/fmv/elf_aux_info.inc"
 #elif defined(__Fuchsia__)
 #include "aarch64/fmv/fuchsia.inc"
 #elif defined(__ANDROID__)
-#include "aarch64/fmv/mrs.inc"
+#include "aarch64/fmv/hwcap.inc"
 #include "aarch64/fmv/android.inc"
 #elif defined(__linux__) && __has_include(<sys/auxv.h>)
-#include "aarch64/fmv/mrs.inc"
+#include "aarch64/fmv/hwcap.inc"
 #include "aarch64/fmv/getauxval.inc"
 #elif defined(_WIN32)
 #include "aarch64/fmv/windows.inc"

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/hwcap.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/hwcap.inc
@@ -7,9 +7,6 @@ static void __init_cpu_features_constructor(unsigned long hwcap,
                                             const __ifunc_arg_t *arg) {
   unsigned long long feat = 0;
 #define setCPUFeature(F) feat |= 1ULL << F
-#define getCPUFeature(id, ftr) __asm__("mrs %0, " #id : "=r"(ftr))
-#define extractBits(val, start, number)                                        \
-  (val & ((1ULL << number) - 1ULL) << start) >> start
   unsigned long hwcap2 = 0;
   if (hwcap & _IFUNC_ARG_HWCAP)
     hwcap2 = arg->_hwcap2;


### PR DESCRIPTION
474f5d2aefb44430b89ed72774a3c1d26a0adfb1 removed the last
bits reading from system registers so remove the last bits
utilizing MRS and rename the file to hwcap as the
code is now only decoding the hwcap flags.