### PR TITLE
[FMV][AArch64] Add initial AT_HWCAP3 / AT_HWCAP4 support

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -19,15 +19,13 @@
 #error This file is intended only for aarch64-based targets
 #endif
 
-#if __has_include(<sys/ifunc.h>)
-#include <sys/ifunc.h>
-#else
 typedef struct __ifunc_arg_t {
   unsigned long _size;
   unsigned long _hwcap;
   unsigned long _hwcap2;
+  unsigned long _hwcap3;
+  unsigned long _hwcap4;
 } __ifunc_arg_t;
-#endif // __has_include(<sys/ifunc.h>)
 
 // LSE support detection for out-of-line atomics
 // using HWCAP and Auxiliary vector

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/android.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/android.inc
@@ -25,12 +25,11 @@ void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
   if (__isExynos9810())
     return;
 
-  unsigned long hwcap = getauxval(AT_HWCAP);
-  unsigned long hwcap2 = getauxval(AT_HWCAP2);
-
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);
-  arg._hwcap = hwcap;
-  arg._hwcap2 = hwcap2;
+  arg._hwcap = getauxval(AT_HWCAP);
+  arg._hwcap2 = getauxval(AT_HWCAP2);
+  arg._hwcap3 = getauxval(AT_HWCAP3);
+  arg._hwcap4 = getauxval(AT_HWCAP4);
   __init_cpu_features_constructor(hwcap | _IFUNC_ARG_HWCAP, &arg);
 }

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/elf_aux_info.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/elf_aux_info.inc
@@ -7,21 +7,21 @@ void __init_cpu_features_resolver(unsigned long hwcap,
 }
 
 void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
-  unsigned long hwcap = 0;
-  unsigned long hwcap2 = 0;
+  unsigned long hwcap, hwcap2, hwcap3, hwcap4 = 0;
   // CPU features already initialized.
   if (__atomic_load_n(&__aarch64_cpu_features.features, __ATOMIC_RELAXED))
     return;
 
-  int res = 0;
-  res = elf_aux_info(AT_HWCAP, &hwcap, sizeof hwcap);
-  res |= elf_aux_info(AT_HWCAP2, &hwcap2, sizeof hwcap2);
-  if (res)
-    return;
+  elf_aux_info(AT_HWCAP, &hwcap, sizeof hwcap);
+  elf_aux_info(AT_HWCAP2, &hwcap2, sizeof hwcap2);
+  elf_aux_info(AT_HWCAP3, &hwcap3, sizeof hwcap3);
+  elf_aux_info(AT_HWCAP4, &hwcap4, sizeof hwcap4);
 
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);
   arg._hwcap = hwcap;
   arg._hwcap2 = hwcap2;
+  arg._hwcap3 = hwcap3;
+  arg._hwcap4 = hwcap4;
   __init_cpu_features_constructor(hwcap | _IFUNC_ARG_HWCAP, &arg);
 }

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/getauxval.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/getauxval.inc
@@ -10,12 +10,11 @@ void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
   if (__atomic_load_n(&__aarch64_cpu_features.features, __ATOMIC_RELAXED))
     return;
 
-  unsigned long hwcap = getauxval(AT_HWCAP);
-  unsigned long hwcap2 = getauxval(AT_HWCAP2);
-
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);
-  arg._hwcap = hwcap;
-  arg._hwcap2 = hwcap2;
+  arg._hwcap = getauxval(AT_HWCAP);
+  arg._hwcap2 = getauxval(AT_HWCAP2);
+  arg._hwcap3 = getauxval(AT_HWCAP3);
+  arg._hwcap4 = getauxval(AT_HWCAP4);
   __init_cpu_features_constructor(hwcap | _IFUNC_ARG_HWCAP, &arg);
 }

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/hwcap.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/hwcap.inc
@@ -7,7 +7,7 @@
 #define _IFUNC_ARG_HWCAP (1ULL << 62)
 #endif
 #ifndef AT_HWCAP
-#define AT_HWCAP 16
+#define AT_HWCAP 16 // Linux value
 #endif
 #ifndef HWCAP_CPUID
 #define HWCAP_CPUID (1 << 11)
@@ -95,7 +95,7 @@
 #endif
 
 #ifndef AT_HWCAP2
-#define AT_HWCAP2 26
+#define AT_HWCAP2 26 // Linux value
 #endif
 #ifndef HWCAP2_DCPODP
 #define HWCAP2_DCPODP (1 << 0)
@@ -189,4 +189,20 @@
 #endif
 #ifndef HWCAP2_CSSC
 #define HWCAP2_CSSC (1UL << 34)
+#endif
+
+#ifndef AT_HWCAP3
+#ifdef __linux__
+#define AT_HWCAP3 29 // Linux value
+#else
+#define AT_HWCAP3 38 // BSD value
+#endif
+#endif
+
+#ifndef AT_HWCAP4
+#ifdef __linux__
+#define AT_HWCAP4 30 // Linux value
+#else
+#define AT_HWCAP4 39 // BSD value
+#endif
 #endif


### PR DESCRIPTION
Add support for AT_HWCAP3 / AT_HWCAP4 which is supported by glibc, musl,
Android and FreeBSD 15/-current.

Stop using sys/ifunc.h as libgcc has done. This is more portable as
older glibc will not have the hwcap3/4 fields.