### PR TITLE
[lldb] Add deleted line in NextRangeBreakpointExplainsStop

### DIFF
--- a/lldb/source/Target/ThreadPlanStepRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepRange.cpp
@@ -487,6 +487,7 @@ bool ThreadPlanStepRange::NextRangeBreakpointExplainsStop(
             "next range breakpoint which has %" PRIu64
             " constituents - explains stop: %u.",
             (uint64_t)num_constituents, explains_stop);
+  ClearNextBranchBreakpoint();
   return explains_stop;
 }
 


### PR DESCRIPTION
Commit f838fa820f9271008617c345c477122d9e29a05c refactored large pointers of the thread plan code. In that refactor, the call to ClearNextBranchBreakpoint in
ThreadPlanStepRange::NextRangeBreakpointExplainsStop was deleted, I believe by mistake.

This patch simply re-adds that call.

rdar://159675204