### PR TITLE
[CIR][NFC] Cleanup MissingFeature asserts in RecordLayoutBuilder

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -133,7 +133,6 @@ struct MissingFeatures {
   // RecordType
   static bool skippedLayout() { return false; }
   static bool astRecordDeclAttr() { return false; }
-  static bool recordZeroInit() { return false; }
   static bool recordZeroInitPadding() { return false; }
   static bool zeroSizeRecordMembers() { return false; }
 
@@ -192,6 +191,7 @@ struct MissingFeatures {
   static bool builtinCheckKind() { return false; }
   static bool cgCapturedStmtInfo() { return false; }
   static bool cgFPOptionsRAII() { return false; }
+  static bool checkBitfieldClipping() { return false; }
   static bool cirgenABIInfo() { return false; }
   static bool cleanupAfterErrorDiags() { return false; }
   static bool cleanupsToDeactivate() { return false; }


### PR DESCRIPTION
This change cleans up some cir::MissingFeature asserts in CIRGenRecordLayoutBuilder.cpp. In a couple of cases the asserts were stale markers that we failed to remove when the correspond support was implemented.

In one case, a cir::MissingFeature::bitfields() assert was ambiguous in meaning and has been replaced by a comment and something more specific. The missing feature in this case is just a bit of debug code to verify certain bitfield-related conditions. This check should be added, but it is not functionally required.