### PR TITLE
[BOLT][AArch64] Skip R_AARCH64_TLSDESC_CALL relocation

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -81,7 +81,6 @@ static bool isSupportedAArch64(uint32_t Type) {
   case ELF::R_AARCH64_LD64_GOT_LO12_NC:
   case ELF::R_AARCH64_TLSDESC_LD64_LO12:
   case ELF::R_AARCH64_TLSDESC_ADD_LO12:
-  case ELF::R_AARCH64_TLSDESC_CALL:
   case ELF::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21:
   case ELF::R_AARCH64_PREL16:
   case ELF::R_AARCH64_PREL32:
@@ -193,7 +192,6 @@ static size_t getSizeForTypeAArch64(uint32_t Type) {
   case ELF::R_AARCH64_LD64_GOT_LO12_NC:
   case ELF::R_AARCH64_TLSDESC_LD64_LO12:
   case ELF::R_AARCH64_TLSDESC_ADD_LO12:
-  case ELF::R_AARCH64_TLSDESC_CALL:
   case ELF::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21:
   case ELF::R_AARCH64_PREL32:
   case ELF::R_AARCH64_MOVW_UABS_G0:
@@ -248,7 +246,14 @@ static bool skipRelocationTypeX86(uint32_t Type) {
 }
 
 static bool skipRelocationTypeAArch64(uint32_t Type) {
-  return Type == ELF::R_AARCH64_NONE || Type == ELF::R_AARCH64_LD_PREL_LO19;
+  switch (Type) {
+  default:
+    return false;
+  case ELF::R_AARCH64_NONE:
+  case ELF::R_AARCH64_LD_PREL_LO19:
+  case ELF::R_AARCH64_TLSDESC_CALL:
+    return true;
+  }
 }
 
 static bool skipRelocationTypeRISCV(uint32_t Type) {
@@ -362,7 +367,6 @@ static uint64_t extractValueAArch64(uint32_t Type, uint64_t Contents,
     return static_cast<int64_t>(PC) + SignExtend64<32>(Contents & 0xffffffff);
   case ELF::R_AARCH64_PREL64:
     return static_cast<int64_t>(PC) + Contents;
-  case ELF::R_AARCH64_TLSDESC_CALL:
   case ELF::R_AARCH64_JUMP26:
   case ELF::R_AARCH64_CALL26:
     // Immediate goes in bits 25:0 of B and BL.
@@ -552,7 +556,6 @@ static bool isGOTAArch64(uint32_t Type) {
   case ELF::R_AARCH64_TLSDESC_ADR_PAGE21:
   case ELF::R_AARCH64_TLSDESC_LD64_LO12:
   case ELF::R_AARCH64_TLSDESC_ADD_LO12:
-  case ELF::R_AARCH64_TLSDESC_CALL:
     return true;
   }
 }
@@ -591,7 +594,6 @@ static bool isTLSAArch64(uint32_t Type) {
   case ELF::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC:
   case ELF::R_AARCH64_TLSDESC_LD64_LO12:
   case ELF::R_AARCH64_TLSDESC_ADD_LO12:
-  case ELF::R_AARCH64_TLSDESC_CALL:
   case ELF::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21:
     return true;
   }
@@ -667,7 +669,6 @@ static bool isPCRelativeAArch64(uint32_t Type) {
   case ELF::R_AARCH64_MOVW_UABS_G2_NC:
   case ELF::R_AARCH64_MOVW_UABS_G3:
     return false;
-  case ELF::R_AARCH64_TLSDESC_CALL:
   case ELF::R_AARCH64_CALL26:
   case ELF::R_AARCH64_JUMP26:
   case ELF::R_AARCH64_TSTBR14:

--- a/bolt/test/AArch64/tls-desc-call.s
+++ b/bolt/test/AArch64/tls-desc-call.s
@@ -1,0 +1,35 @@
+# RUN: %clang %cflags %s -o %t.so -fPIC -shared -Wl,-q
+# RUN: llvm-bolt %t.so -o %t.bolt --debug-only=bolt 2>&1 | FileCheck %s
+
+# REQUIRES: asserts
+
+## Verify that R_AARCH64_TLSDESC_CALL relocations are ignored
+
+# CHECK-NOT: Relocation {{.*}} R_AARCH64_TLSDESC_CALL
+
+  .text
+  .globl  get_tls_var
+  .p2align  2
+  .type get_tls_var,@function
+get_tls_var:
+  .cfi_startproc
+  str     x30, [sp, #-16]!
+  adrp  x0, :tlsdesc:tls_var
+  ldr x1, [x0, :tlsdesc_lo12:tls_var]
+  add x0, x0, :tlsdesc_lo12:tls_var
+  .tlsdesccall tls_var
+  blr x1
+  mrs x8, TPIDR_EL0
+  ldr w0, [x8, x0]
+  ldr x30, [sp], #16
+  ret
+  .size get_tls_var, .-get_tls_var
+  .cfi_endproc
+
+  .type tls_var,@object
+  .section  .tdata,"awT",@progbits
+  .globl  tls_var
+  .p2align  2, 0x0
+tls_var:
+  .word 42
+  .size tls_var, 4


### PR DESCRIPTION
R_AARCH64_TLSDESC_CALL is a relocation emitted as a hint for a linker to replace `blr r` instruction with nop. BOLT does not currently require any special handling for it.

Note that previously existing extraction of the relocated value was incorrect.