### PR TITLE
[mlir][Vector] Fold vector.step compared to constant

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2999,6 +2999,7 @@ def Vector_StepOp : Vector_Op<"step", [
   }];
   let results = (outs VectorOfRankAndType<[1], [Index]>:$result);
   let assemblyFormat = "attr-dict `:` type($result)";
+  let hasCanonicalizer = 1;
 }
 
 def Vector_YieldOp : Vector_Op<"yield", [

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -7608,20 +7608,24 @@ namespace {
 ///
 /// For example, rewrite the 'greater than' comparison below,
 ///
+/// ```mlir
 /// %cst = arith.constant dense<7> : vector<3xindex>
 /// %stp = vector.step : vector<3xindex>
 /// %out = arith.cmpi ugt, %stp, %cst : vector<3xindex>
+/// ```
 ///
 /// as,
 ///
+/// ```mlir
 /// %out = arith.constant dense<false> : vector<3xi1>.
+/// ```
 ///
 /// Above [0, 1, 2] > [7, 7, 7] => [false, false, false]. Because the result is
 /// false at ALL indices we fold. If the constant was 1, then
 /// [0, 1, 2] > [1, 1, 1] => [false, false, true] and we do fold, conservatively
 /// preferring the 'compact' vector.step representation.
 struct StepCompareFolder : public OpRewritePattern<StepOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(StepOp stepOp,
                                 PatternRewriter &rewriter) const override {
@@ -7679,8 +7683,7 @@ struct StepCompareFolder : public OpRewritePattern<StepOp> {
       if (!type)
         continue;
 
-      DenseElementsAttr boolAttr =
-          DenseElementsAttr::get(type, maybeSplat.value());
+      auto boolAttr = DenseElementsAttr::get(type, maybeSplat.value());
       Value splat = mlir::arith::ConstantOp::create(rewriter, cmpiOp.getLoc(),
                                                     type, boolAttr);
 

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -7601,6 +7601,120 @@ void StepOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
   setResultRanges(getResult(), result);
 }
 
+namespace {
+
+/// Constant fold vector.step when it is compared to constant with arith.cmpi
+/// and the result is the same at all indices. For example, rewrite:
+///
+/// %cst = arith.constant dense<7> : vector<3xindex>
+/// %0 = vector.step : vector<3xindex>
+/// %1 = arith.cmpi ugt, %0, %cst : vector<3xindex>
+///
+/// as
+///
+/// %out = arith.constant dense<false> : vector<3xi1>
+///
+/// Above [0, 1, 2] > [7, 7, 7] => [false, false, false]. Because the result is
+/// false at ALL indices we fold to the constant. false. If the constant was 1,
+/// then [0, 1, 2] > [1, 1, 1] => [false, false, true] and we do not constant
+/// fold, preferring the more 'compact' vector.step representation.
+struct StepCompareFolder : public OpRewritePattern<StepOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(StepOp stepOp,
+                                PatternRewriter &rewriter) const override {
+
+    int64_t stepSize = stepOp.getResult().getType().getNumElements();
+
+    for (auto &use : stepOp.getResult().getUses()) {
+      if (auto cmpiOp = dyn_cast<arith::CmpIOp>(use.getOwner())) {
+        unsigned stepOperandNumber = use.getOperandNumber();
+
+        // arith.cmpi has a canonicalizer to put constants on operand 1. Let it
+        // run first.
+        if (stepOperandNumber != 0) {
+          continue;
+        }
+
+        // Check that operand 1 is a constant.
+        unsigned otherOperandNumber = 1;
+        Value otherOperand = cmpiOp.getOperand(otherOperandNumber);
+        auto maybeConstValue = getConstantIntValue(otherOperand);
+        if (!maybeConstValue.has_value())
+          continue;
+        int64_t constValue = maybeConstValue.value();
+
+        arith::CmpIPredicate pred = cmpiOp.getPredicate();
+
+        auto maybeSplat = [&]() -> std::optional<bool> {
+          // Handle ult (unsigned less than) and uge (unsigned greater equal).
+          // Examples where stepSize = constValue = 3, for the 4
+          // cases of [ult, uge] x [stepOperandNumber = 0, 1]:
+          //
+          // pred stepOperandNumber
+          // ==== =================
+          // ult  0                 [0, 1, 2] < 3  ==> true.
+          // ult  1                 3 < [0, 1, 2]  ==> false.
+          // uge  0                 [0, 1, 2] >= 3 ==> true.
+          // uge  1                 3 >= [0, 1, 2] ==> false.
+          //
+          // If constValue is any smaller, the comparison is not constant.
+          if (pred == arith::CmpIPredicate::ult ||
+              pred == arith::CmpIPredicate::uge) {
+            if (stepSize <= constValue) {
+              return pred == arith::CmpIPredicate::ult;
+            }
+          }
+
+          // Handle ule and ugt.
+          //
+          // pred stepOperandNumber
+          // ==== =================
+          // ule  0                 [0, 1, 2] <= 2  ==> true
+          // (stepSize = 3, constValue = 2).
+          if (pred == arith::CmpIPredicate::ule ||
+              pred == arith::CmpIPredicate::ugt) {
+            if (stepSize <= constValue + 1) {
+              return pred == arith::CmpIPredicate::ule;
+            }
+          }
+
+          // Handle eq and ne
+          if (pred == arith::CmpIPredicate::eq ||
+              pred == arith::CmpIPredicate::ne) {
+            if (stepSize <= constValue) {
+              return pred == arith::CmpIPredicate::ne;
+            }
+          }
+
+          return std::optional<bool>();
+        }();
+
+        if (!maybeSplat.has_value())
+          continue;
+
+        rewriter.setInsertionPointAfter(cmpiOp);
+        auto boolConst = mlir::arith::ConstantOp::create(
+            rewriter, cmpiOp.getLoc(),
+            rewriter.getBoolAttr(maybeSplat.value()));
+        auto splat = vector::BroadcastOp::create(
+            rewriter, cmpiOp.getLoc(), cmpiOp.getResult().getType(), boolConst);
+
+        rewriter.replaceOp(cmpiOp, splat.getResult());
+        return success();
+      }
+    }
+
+    return failure();
+  }
+};
+} // namespace
+
+void StepOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
+  results.add<StepCompareFolder>(context);
+}
+
 //===----------------------------------------------------------------------===//
 // Vector Masking Utilities
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
@@ -1,0 +1,379 @@
+// RUN: mlir-opt %s -canonicalize="test-convergence" -split-input-file -allow-unregistered-dialect | FileCheck %s
+
+///===----------------------------------------------===//
+///  Tests of `StepCompareFolder`
+///===----------------------------------------------===//
+
+
+///===--------------===//
+///  Tests of `ugt` (unsigned greater than)
+///===--------------===//
+
+// CHECK-LABEL: @check_ugt_constant_3_lhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ugt_constant_3_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // 3 > [0, 1, 2] => true
+  %1 = arith.cmpi ugt, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ugt_constant_2_lhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ugt_constant_2_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // 2 > [0, 1, 2] => not constant
+  %1 = arith.cmpi ugt, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ugt_constant_1_lhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ugt_constant_1_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // 1 > [0, 1, 2] => not constant
+  %1 = arith.cmpi ugt, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ugt_constant_3_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ugt_constant_3_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] > 3 => false
+  %1 = arith.cmpi ugt, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ugt_constant_2_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ugt_constant_2_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] > 2 => false
+  %1 = arith.cmpi ugt, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ugt_constant_1_rhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ugt_constant_1_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] > 1 => not constant
+  %1 = arith.cmpi ugt, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+///===--------------===//
+///  Tests of `uge` (unsigned greater than or equal)
+///===--------------===//
+
+// CHECK-LABEL: @check_uge_constant_3_lhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_uge_constant_3_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // 3 >= [0, 1, 2] => true
+  %1 = arith.cmpi uge, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_uge_constant_2_lhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_uge_constant_2_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // 2 >= [0, 1, 2] => true
+  %1 = arith.cmpi uge, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_uge_constant_1_lhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_uge_constant_1_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // 1 >= [0, 1, 2] => not constant
+  %1 = arith.cmpi uge, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_uge_constant_3_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_uge_constant_3_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] >= 3 => false
+  %1 = arith.cmpi uge, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_uge_constant_2_rhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_uge_constant_2_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] >= 2 => not constant
+  %1 = arith.cmpi uge, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_uge_constant_1_rhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_uge_constant_1_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] >= 1 => not constant
+  %1 = arith.cmpi uge, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+
+
+///===--------------===//
+///  Tests of `ult` (unsigned less than)
+///===--------------===//
+
+// CHECK-LABEL: @check_ult_constant_3_lhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ult_constant_3_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ult_constant_2_lhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ult_constant_2_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ult_constant_1_lhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ult_constant_1_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ult_constant_3_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ult_constant_3_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ult, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ult_constant_2_rhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ult_constant_2_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ult, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ult_constant_1_rhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ult_constant_1_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ult, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+///===--------------===//
+///  Tests of `ule` (unsigned less than or equal)
+///===--------------===//
+
+// CHECK-LABEL: @check_ule_constant_3_lhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ule_constant_3_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ule_constant_2_lhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ule_constant_2_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ule_constant_1_lhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ule_constant_1_lhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ule_constant_3_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ule_constant_3_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ule, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ule_constant_2_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ule_constant_2_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ule, %0, %cst : vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ule_constant_1_rhs
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ule_constant_1_rhs() -> vector<3xi1> {
+  %cst = arith.constant dense<1> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ule, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+///===--------------===//
+///  Tests of `eq` (equal)
+///===--------------===//
+
+// CHECK-LABEL: @check_eq_constant_3
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_eq_constant_3() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi eq, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_eq_constant_2
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_eq_constant_2() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi eq, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+///===--------------===//
+///  Tests of `ne` (not equal)
+///===--------------===//
+
+// CHECK-LABEL: @check_ne_constant_3
+//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ne_constant_3() -> vector<3xi1> {
+  %cst = arith.constant dense<3> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ne, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @check_ne_constant_2
+//       CHECK: %[[CMP:.*]] = arith.cmpi
+//       CHECK: return %[[CMP]]
+func.func @check_ne_constant_2() -> vector<3xi1> {
+  %cst = arith.constant dense<2> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ne, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+

--- a/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
@@ -15,7 +15,7 @@
 func.func @ugt_constant_3_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // 3 > [0, 1, 2] => true
+  // 3 > [0, 1, 2] => [true, true, true] => true for all indices => fold
   %1 = arith.cmpi ugt, %cst, %0 : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -28,20 +28,7 @@ func.func @ugt_constant_3_lhs() -> vector<3xi1> {
 func.func @negative_ugt_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // 2 > [0, 1, 2] => not constant
-  %1 = arith.cmpi ugt, %cst, %0 : vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
-
-// CHECK-LABEL: @negative_ugt_constant_1_lhs
-//       CHECK: %[[CMP:.*]] = arith.cmpi
-//       CHECK: return %[[CMP]]
-func.func @negative_ugt_constant_1_lhs() -> vector<3xi1> {
-  %cst = arith.constant dense<1> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  // 1 > [0, 1, 2] => not constant
+  // 2 > [0, 1, 2] => [true, true, false] => not same for all indices => don't fold
   %1 = arith.cmpi ugt, %cst, %0 : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -54,7 +41,7 @@ func.func @negative_ugt_constant_1_lhs() -> vector<3xi1> {
 func.func @ugt_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // [0, 1, 2] > 3 => false
+  // [0, 1, 2] > 3 => [false, false, false] => false for all indices => fold
   %1 = arith.cmpi ugt, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -81,7 +68,7 @@ func.func @ugt_constant_max_rhs() -> vector<3xi1> {
 func.func @ugt_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // [0, 1, 2] > 2 => false
+  // [0, 1, 2] > 2 => [false, false, false] => false for all indices => fold
   %1 = arith.cmpi ugt, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -94,7 +81,7 @@ func.func @ugt_constant_2_rhs() -> vector<3xi1> {
 func.func @negative_ugt_constant_1_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // [0, 1, 2] > 1 => not constant
+  // [0, 1, 2] > 1 => [false, false, true] => not same for all indices => don't fold
   %1 = arith.cmpi ugt, %0, %cst: vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -105,18 +92,6 @@ func.func @negative_ugt_constant_1_rhs() -> vector<3xi1> {
 ///  Tests of `uge` (unsigned greater than or equal)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @uge_constant_3_lhs
-//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
-//       CHECK: return %[[CST]] : vector<3xi1>
-func.func @uge_constant_3_lhs() -> vector<3xi1> {
-  %cst = arith.constant dense<3> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  // 3 >= [0, 1, 2] => true
-  %1 = arith.cmpi uge, %cst, %0 : vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
 
 // CHECK-LABEL: @uge_constant_2_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
@@ -124,7 +99,7 @@ func.func @uge_constant_3_lhs() -> vector<3xi1> {
 func.func @uge_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // 2 >= [0, 1, 2] => true
+  // 2 >= [0, 1, 2] => [true, true, true] => true for all indices => fold
   %1 = arith.cmpi uge, %cst, %0 : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -137,7 +112,7 @@ func.func @uge_constant_2_lhs() -> vector<3xi1> {
 func.func @negative_uge_constant_1_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // 1 >= [0, 1, 2] => not constant
+  // 1 >= [0, 1, 2] => [true, false, false] => not same for all indices => don't fold
   %1 = arith.cmpi uge, %cst, %0 : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -150,7 +125,7 @@ func.func @negative_uge_constant_1_lhs() -> vector<3xi1> {
 func.func @uge_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // [0, 1, 2] >= 3 => false
+  // [0, 1, 2] >= 3 => [false, false, false] => false for all indices => fold
   %1 = arith.cmpi uge, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -163,43 +138,18 @@ func.func @uge_constant_3_rhs() -> vector<3xi1> {
 func.func @negative_uge_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
-  // [0, 1, 2] >= 2 => not constant
+  // [0, 1, 2] >= 2 => [false, false, true] => not same for all indices => don't fold
   %1 = arith.cmpi uge, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
 
 // -----
 
-// CHECK-LABEL: @negative_uge_constant_1_rhs
-//       CHECK: %[[CMP:.*]] = arith.cmpi
-//       CHECK: return %[[CMP]]
-func.func @negative_uge_constant_1_rhs() -> vector<3xi1> {
-  %cst = arith.constant dense<1> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  // [0, 1, 2] >= 1 => not constant
-  %1 = arith.cmpi uge, %0, %cst: vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
-
-
 
 ///===------------------------------------===//
 ///  Tests of `ult` (unsigned less than)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @ult_constant_3_lhs
-//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
-//       CHECK: return %[[CST]] : vector<3xi1>
-func.func @ult_constant_3_lhs() -> vector<3xi1> {
-  %cst = arith.constant dense<3> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
 
 // CHECK-LABEL: @ult_constant_2_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
@@ -207,6 +157,7 @@ func.func @ult_constant_3_lhs() -> vector<3xi1> {
 func.func @ult_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
+  // 2 < [0, 1, 2] => [false, false, false] => false for all indices => fold
   %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -219,6 +170,7 @@ func.func @ult_constant_2_lhs() -> vector<3xi1> {
 func.func @negative_ult_constant_1_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
+  // 1 < [0, 1, 2] => [false, false, true] => not same for all indices => don't fold
   %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -231,6 +183,7 @@ func.func @negative_ult_constant_1_lhs() -> vector<3xi1> {
 func.func @ult_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] < 3 => [true, true, true] => true for all indices => fold
   %1 = arith.cmpi ult, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
@@ -243,19 +196,8 @@ func.func @ult_constant_3_rhs() -> vector<3xi1> {
 func.func @negative_ult_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
+  // [0, 1, 2] < 2 => [true, true, false] => not same for all indices => don't fold
   %1 = arith.cmpi ult, %0, %cst : vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
-
-// CHECK-LABEL: @negative_ult_constant_1_rhs
-//       CHECK: %[[CMP:.*]] = arith.cmpi
-//       CHECK: return %[[CMP]]
-func.func @negative_ult_constant_1_rhs() -> vector<3xi1> {
-  %cst = arith.constant dense<1> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  %1 = arith.cmpi ult, %0, %cst: vector<3xindex>
   return %1 : vector<3xi1>
 }
 
@@ -284,30 +226,6 @@ func.func @negative_ule_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
-
-// CHECK-LABEL: @negative_ule_constant_1_lhs
-//       CHECK: %[[CMP:.*]] = arith.cmpi
-//       CHECK: return %[[CMP]]
-func.func @negative_ule_constant_1_lhs() -> vector<3xi1> {
-  %cst = arith.constant dense<1> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
-  return %1 : vector<3xi1>
-}
-
-// -----
-
-// CHECK-LABEL: @ule_constant_3_rhs
-//       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
-//       CHECK: return %[[CST]] : vector<3xi1>
-func.func @ule_constant_3_rhs() -> vector<3xi1> {
-  %cst = arith.constant dense<3> : vector<3xindex>
-  %0 = vector.step : vector<3xindex>
-  %1 = arith.cmpi ule, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
 

--- a/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
@@ -5,9 +5,9 @@
 ///===----------------------------------------------===//
 
 
-///===--------------===//
+///===------------------------------------===//
 ///  Tests of `ugt` (unsigned greater than)
-///===--------------===//
+///===------------------------------------===//
 
 // CHECK-LABEL: @check_ugt_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
@@ -87,9 +87,9 @@ func.func @check_ugt_constant_1_rhs() -> vector<3xi1> {
 
 // -----
 
-///===--------------===//
+///===------------------------------------===//
 ///  Tests of `uge` (unsigned greater than or equal)
-///===--------------===//
+///===------------------------------------===//
 
 // CHECK-LABEL: @check_uge_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
@@ -171,9 +171,9 @@ func.func @check_uge_constant_1_rhs() -> vector<3xi1> {
 
 
 
-///===--------------===//
+///===------------------------------------===//
 ///  Tests of `ult` (unsigned less than)
-///===--------------===//
+///===------------------------------------===//
 
 // CHECK-LABEL: @check_ult_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
@@ -247,9 +247,9 @@ func.func @check_ult_constant_1_rhs() -> vector<3xi1> {
 
 // -----
 
-///===--------------===//
+///===------------------------------------===//
 ///  Tests of `ule` (unsigned less than or equal)
-///===--------------===//
+///===------------------------------------===//
 
 // CHECK-LABEL: @check_ule_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
@@ -323,9 +323,9 @@ func.func @check_ule_constant_1_rhs() -> vector<3xi1> {
 
 // -----
 
-///===--------------===//
+///===------------------------------------===//
 ///  Tests of `eq` (equal)
-///===--------------===//
+///===------------------------------------===//
 
 // CHECK-LABEL: @check_eq_constant_3
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
@@ -351,9 +351,9 @@ func.func @check_eq_constant_2() -> vector<3xi1> {
 
 // -----
 
-///===--------------===//
+///===------------------------------------===//
 ///  Tests of `ne` (not equal)
-///===--------------===//
+///===------------------------------------===//
 
 // CHECK-LABEL: @check_ne_constant_3
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>

--- a/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -canonicalize="test-convergence" -split-input-file -allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s -canonicalize="test-convergence" -split-input-file | FileCheck %s
 
 ///===----------------------------------------------===//
 ///  Tests of `StepCompareFolder`
@@ -58,6 +58,20 @@ func.func @check_ugt_constant_3_rhs() -> vector<3xi1> {
   %1 = arith.cmpi ugt, %0, %cst : vector<3xindex>
   return %1 : vector<3xi1>
 }
+
+// -----
+
+// CHECK-LABEL: @check_ugt_constant_max_rhs
+//       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
+//       CHECK: return %[[CST]] : vector<3xi1>
+func.func @check_ugt_constant_max_rhs() -> vector<3xi1> {
+  // The largest i64 possible:
+  %cst = arith.constant dense<0x7fffffffffffffff> : vector<3xindex>
+  %0 = vector.step : vector<3xindex>
+  %1 = arith.cmpi ugt, %0, %cst: vector<3xindex>
+  return %1 : vector<3xi1>
+}
+
 
 // -----
 

--- a/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-step.mlir
@@ -9,10 +9,10 @@
 ///  Tests of `ugt` (unsigned greater than)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @check_ugt_constant_3_lhs
+// CHECK-LABEL: @ugt_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ugt_constant_3_lhs() -> vector<3xi1> {
+func.func @ugt_constant_3_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // 3 > [0, 1, 2] => true
@@ -22,10 +22,10 @@ func.func @check_ugt_constant_3_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ugt_constant_2_lhs
+// CHECK-LABEL: @negative_ugt_constant_2_lhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ugt_constant_2_lhs() -> vector<3xi1> {
+func.func @negative_ugt_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // 2 > [0, 1, 2] => not constant
@@ -35,10 +35,10 @@ func.func @check_ugt_constant_2_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ugt_constant_1_lhs
+// CHECK-LABEL: @negative_ugt_constant_1_lhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ugt_constant_1_lhs() -> vector<3xi1> {
+func.func @negative_ugt_constant_1_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // 1 > [0, 1, 2] => not constant
@@ -48,10 +48,10 @@ func.func @check_ugt_constant_1_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ugt_constant_3_rhs
+// CHECK-LABEL: @ugt_constant_3_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ugt_constant_3_rhs() -> vector<3xi1> {
+func.func @ugt_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // [0, 1, 2] > 3 => false
@@ -61,10 +61,10 @@ func.func @check_ugt_constant_3_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ugt_constant_max_rhs
+// CHECK-LABEL: @ugt_constant_max_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ugt_constant_max_rhs() -> vector<3xi1> {
+func.func @ugt_constant_max_rhs() -> vector<3xi1> {
   // The largest i64 possible:
   %cst = arith.constant dense<0x7fffffffffffffff> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
@@ -75,10 +75,10 @@ func.func @check_ugt_constant_max_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ugt_constant_2_rhs
+// CHECK-LABEL: @ugt_constant_2_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ugt_constant_2_rhs() -> vector<3xi1> {
+func.func @ugt_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // [0, 1, 2] > 2 => false
@@ -88,10 +88,10 @@ func.func @check_ugt_constant_2_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ugt_constant_1_rhs
+// CHECK-LABEL: @negative_ugt_constant_1_rhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ugt_constant_1_rhs() -> vector<3xi1> {
+func.func @negative_ugt_constant_1_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // [0, 1, 2] > 1 => not constant
@@ -105,10 +105,10 @@ func.func @check_ugt_constant_1_rhs() -> vector<3xi1> {
 ///  Tests of `uge` (unsigned greater than or equal)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @check_uge_constant_3_lhs
+// CHECK-LABEL: @uge_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_uge_constant_3_lhs() -> vector<3xi1> {
+func.func @uge_constant_3_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // 3 >= [0, 1, 2] => true
@@ -118,10 +118,10 @@ func.func @check_uge_constant_3_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_uge_constant_2_lhs
+// CHECK-LABEL: @uge_constant_2_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_uge_constant_2_lhs() -> vector<3xi1> {
+func.func @uge_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // 2 >= [0, 1, 2] => true
@@ -131,10 +131,10 @@ func.func @check_uge_constant_2_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_uge_constant_1_lhs
+// CHECK-LABEL: @negative_uge_constant_1_lhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_uge_constant_1_lhs() -> vector<3xi1> {
+func.func @negative_uge_constant_1_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // 1 >= [0, 1, 2] => not constant
@@ -144,10 +144,10 @@ func.func @check_uge_constant_1_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_uge_constant_3_rhs
+// CHECK-LABEL: @uge_constant_3_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_uge_constant_3_rhs() -> vector<3xi1> {
+func.func @uge_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // [0, 1, 2] >= 3 => false
@@ -157,10 +157,10 @@ func.func @check_uge_constant_3_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_uge_constant_2_rhs
+// CHECK-LABEL: @negative_uge_constant_2_rhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_uge_constant_2_rhs() -> vector<3xi1> {
+func.func @negative_uge_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // [0, 1, 2] >= 2 => not constant
@@ -170,10 +170,10 @@ func.func @check_uge_constant_2_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_uge_constant_1_rhs
+// CHECK-LABEL: @negative_uge_constant_1_rhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_uge_constant_1_rhs() -> vector<3xi1> {
+func.func @negative_uge_constant_1_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   // [0, 1, 2] >= 1 => not constant
@@ -189,10 +189,10 @@ func.func @check_uge_constant_1_rhs() -> vector<3xi1> {
 ///  Tests of `ult` (unsigned less than)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @check_ult_constant_3_lhs
+// CHECK-LABEL: @ult_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ult_constant_3_lhs() -> vector<3xi1> {
+func.func @ult_constant_3_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
@@ -201,10 +201,10 @@ func.func @check_ult_constant_3_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ult_constant_2_lhs
+// CHECK-LABEL: @ult_constant_2_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ult_constant_2_lhs() -> vector<3xi1> {
+func.func @ult_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
@@ -213,10 +213,10 @@ func.func @check_ult_constant_2_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ult_constant_1_lhs
+// CHECK-LABEL: @negative_ult_constant_1_lhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ult_constant_1_lhs() -> vector<3xi1> {
+func.func @negative_ult_constant_1_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ult, %cst, %0 : vector<3xindex>
@@ -225,10 +225,10 @@ func.func @check_ult_constant_1_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ult_constant_3_rhs
+// CHECK-LABEL: @ult_constant_3_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ult_constant_3_rhs() -> vector<3xi1> {
+func.func @ult_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ult, %0, %cst : vector<3xindex>
@@ -237,10 +237,10 @@ func.func @check_ult_constant_3_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ult_constant_2_rhs
+// CHECK-LABEL: @negative_ult_constant_2_rhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ult_constant_2_rhs() -> vector<3xi1> {
+func.func @negative_ult_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ult, %0, %cst : vector<3xindex>
@@ -249,10 +249,10 @@ func.func @check_ult_constant_2_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ult_constant_1_rhs
+// CHECK-LABEL: @negative_ult_constant_1_rhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ult_constant_1_rhs() -> vector<3xi1> {
+func.func @negative_ult_constant_1_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ult, %0, %cst: vector<3xindex>
@@ -265,10 +265,10 @@ func.func @check_ult_constant_1_rhs() -> vector<3xi1> {
 ///  Tests of `ule` (unsigned less than or equal)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @check_ule_constant_3_lhs
+// CHECK-LABEL: @ule_constant_3_lhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ule_constant_3_lhs() -> vector<3xi1> {
+func.func @ule_constant_3_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
@@ -277,10 +277,10 @@ func.func @check_ule_constant_3_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ule_constant_2_lhs
+// CHECK-LABEL: @negative_ule_constant_2_lhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ule_constant_2_lhs() -> vector<3xi1> {
+func.func @negative_ule_constant_2_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
@@ -289,10 +289,10 @@ func.func @check_ule_constant_2_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ule_constant_1_lhs
+// CHECK-LABEL: @negative_ule_constant_1_lhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ule_constant_1_lhs() -> vector<3xi1> {
+func.func @negative_ule_constant_1_lhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %cst, %0 : vector<3xindex>
@@ -301,10 +301,10 @@ func.func @check_ule_constant_1_lhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ule_constant_3_rhs
+// CHECK-LABEL: @ule_constant_3_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ule_constant_3_rhs() -> vector<3xi1> {
+func.func @ule_constant_3_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %0, %cst : vector<3xindex>
@@ -313,10 +313,10 @@ func.func @check_ule_constant_3_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ule_constant_2_rhs
+// CHECK-LABEL: @ule_constant_2_rhs
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ule_constant_2_rhs() -> vector<3xi1> {
+func.func @ule_constant_2_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %0, %cst : vector<3xindex>
@@ -325,10 +325,10 @@ func.func @check_ule_constant_2_rhs() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ule_constant_1_rhs
+// CHECK-LABEL: @negative_ule_constant_1_rhs
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ule_constant_1_rhs() -> vector<3xi1> {
+func.func @negative_ule_constant_1_rhs() -> vector<3xi1> {
   %cst = arith.constant dense<1> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ule, %0, %cst: vector<3xindex>
@@ -341,10 +341,10 @@ func.func @check_ule_constant_1_rhs() -> vector<3xi1> {
 ///  Tests of `eq` (equal)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @check_eq_constant_3
+// CHECK-LABEL: @eq_constant_3
 //       CHECK: %[[CST:.*]] = arith.constant dense<false> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_eq_constant_3() -> vector<3xi1> {
+func.func @eq_constant_3() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi eq, %0, %cst: vector<3xindex>
@@ -353,10 +353,10 @@ func.func @check_eq_constant_3() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_eq_constant_2
+// CHECK-LABEL: @negative_eq_constant_2
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_eq_constant_2() -> vector<3xi1> {
+func.func @negative_eq_constant_2() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi eq, %0, %cst: vector<3xindex>
@@ -369,10 +369,10 @@ func.func @check_eq_constant_2() -> vector<3xi1> {
 ///  Tests of `ne` (not equal)
 ///===------------------------------------===//
 
-// CHECK-LABEL: @check_ne_constant_3
+// CHECK-LABEL: @ne_constant_3
 //       CHECK: %[[CST:.*]] = arith.constant dense<true> : vector<3xi1>
 //       CHECK: return %[[CST]] : vector<3xi1>
-func.func @check_ne_constant_3() -> vector<3xi1> {
+func.func @ne_constant_3() -> vector<3xi1> {
   %cst = arith.constant dense<3> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ne, %0, %cst: vector<3xindex>
@@ -381,10 +381,10 @@ func.func @check_ne_constant_3() -> vector<3xi1> {
 
 // -----
 
-// CHECK-LABEL: @check_ne_constant_2
+// CHECK-LABEL: @negative_ne_constant_2
 //       CHECK: %[[CMP:.*]] = arith.cmpi
 //       CHECK: return %[[CMP]]
-func.func @check_ne_constant_2() -> vector<3xi1> {
+func.func @negative_ne_constant_2() -> vector<3xi1> {
   %cst = arith.constant dense<2> : vector<3xindex>
   %0 = vector.step : vector<3xindex>
   %1 = arith.cmpi ne, %0, %cst: vector<3xindex>


### PR DESCRIPTION
This PR adds a canonicalizer to vector.step that folds vector.step iff the result of the fold is a splat value. An alternative would be to always constant fold it, but that might result in some very large/cumbersome constants. 

I do wonder if vector.step might be better represented as some sort of attribute in the arith dialect, like %step = arith.constant iota<32> : vector<32xindex>. 