### PR TITLE
[Hexagon] Add opcode V6_vS32Ub_npred_ai for offset validity check

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -2804,6 +2804,7 @@ bool HexagonInstrInfo::isValidOffset(unsigned Opcode, int Offset,
   case Hexagon::V6_vL32b_nt_cur_npred_ai:
   case Hexagon::V6_vL32b_nt_tmp_pred_ai:
   case Hexagon::V6_vL32b_nt_tmp_npred_ai:
+  case Hexagon::V6_vS32Ub_npred_ai:
   case Hexagon::V6_vgathermh_pseudo:
   case Hexagon::V6_vgathermw_pseudo:
   case Hexagon::V6_vgathermhw_pseudo:

--- a/llvm/test/CodeGen/Hexagon/unaligned-vec-store.ll
+++ b/llvm/test/CodeGen/Hexagon/unaligned-vec-store.ll
@@ -1,0 +1,23 @@
+; RUN: llc -march=hexagon -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128B < %s | FileCheck %s
+; REQUIRES: asserts
+
+; Check that the test does not assert when unaligned vector store V6_vS32Ub_npred_ai is generated.
+; CHECK: if (!p{{[0-3]}}) vmemu
+
+target triple = "hexagon-unknown-unknown-elf"
+
+define fastcc void @test(i1 %cmp.i.i) {
+entry:
+  %call.i.i.i172 = load ptr, ptr null, align 4
+  %add.ptr = getelementptr i8, ptr %call.i.i.i172, i32 1
+  store <32 x i32> zeroinitializer, ptr %add.ptr, align 128
+  %add.ptr4.i4 = getelementptr i8, ptr %call.i.i.i172, i32 129
+  br i1 %cmp.i.i, label %common.ret, label %if.end.i.i
+
+common.ret:                                       ; preds = %if.end.i.i, %entry
+  ret void
+
+if.end.i.i:                                       ; preds = %entry
+  store <32 x i32> zeroinitializer, ptr %add.ptr4.i4, align 1
+  br label %common.ret
+}


### PR DESCRIPTION
Check for a valid offset for unaligned vector store V6_vS32Ub_npred_ai. isValidOffset() is updated to evaluate offset of this instruction. 
Fixes #160647