### PR TITLE
[LLVM-Test] Fix a regression in test dependencies introduced by 0e14973

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -247,7 +247,7 @@ if (LLVM_INCLUDE_SPIRV_TOOLS_TESTS)
   list(APPEND LLVM_TEST_DEPENDS spirv-link)
 endif()
 
-add_custom_target(llvm-test-depends DEPENDS ${LLVM_TEST_DEPENDS})
+add_custom_target(llvm-test-depends DEPENDS ${LLVM_TEST_DEPENDS} UnitTests)
 set_target_properties(llvm-test-depends PROPERTIES FOLDER "LLVM/Tests")
 
 if(LLVM_BUILD_TOOLS)
@@ -259,7 +259,7 @@ endif()
 add_lit_testsuite(check-llvm "Running the LLVM regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   ${exclude_from_check_all}
-  DEPENDS ${LLVM_TEST_DEPENDS}
+  DEPENDS ${LLVM_TEST_DEPENDS} UnitTests
   )
 set_target_properties(check-llvm PROPERTIES FOLDER "LLVM/Tests")
 


### PR DESCRIPTION
Add `UnitTests` as an explicit dependency for `check-llvm` and `llvm-test-depends`. In  https://github.com/llvm/llvm-project/pull/161442, the intent was to remove `UnitTests` as a dependency for the individual per-directory `check-llvm-*` test suites created but not to drop it from `check-llvm`   or `llvm-test-depends`. This missing dependency will cause LLVM unit tests to be not rebuilt and resulting in either `warning: test suite 'LLVM-Unit' contained no tests` or running stale running versions of the unit tests when running `check-llvm`.