### PR TITLE
[compiler-rt][asan][tests] Stabilize wchar tests on Darwin/Android

### DIFF
--- a/compiler-rt/test/asan/TestCases/wcscat.cpp
+++ b/compiler-rt/test/asan/TestCases/wcscat.cpp
@@ -1,26 +1,26 @@
-// RUN: %clangxx_asan -O0 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O1 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O0 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O1 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O2 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O3 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
 
 #include <stdio.h>
 #include <wchar.h>
 
 int main() {
-  wchar_t *start = L"X means ";
-  wchar_t *append = L"dog";
+  const wchar_t *start = L"X means ";
+  const wchar_t *append = L"dog";
   wchar_t goodDst[12];
   wcscpy(goodDst, start);
   wcscat(goodDst, append);
 
   wchar_t badDst[9];
   wcscpy(badDst, start);
-  printf("Good so far.\n");
+  fprintf(stderr, "Good so far.\n");
   // CHECK: Good so far.
-  fflush(stdout);
+  fflush(stderr);
   wcscat(badDst, append); // Boom!
   // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
-  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR:0x[0-9a-f]+]] thread T0
-  // CHECK: #0 [[ADDR:0x[0-9a-f]+]] in wcscat{{.*}}sanitizer_common_interceptors.inc:{{[0-9]+}}
+  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
+  // CHECK: #0 {{0x[0-9a-f]+}} in wcscat
   printf("Should have failed with ASAN error.\n");
 }

--- a/compiler-rt/test/asan/TestCases/wcscpy.cpp
+++ b/compiler-rt/test/asan/TestCases/wcscpy.cpp
@@ -1,23 +1,23 @@
-// RUN: %clangxx_asan -O0 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O1 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O0 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O1 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O2 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O3 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
 
 #include <stdio.h>
 #include <wchar.h>
 
 int main() {
-  wchar_t *src = L"X means dog";
+  const wchar_t *src = L"X means dog";
   wchar_t goodDst[12];
   wcscpy(goodDst, src);
 
   wchar_t badDst[7];
-  printf("Good so far.\n");
+  fprintf(stderr, "Good so far.\n");
   // CHECK: Good so far.
-  fflush(stdout);
+  fflush(stderr);
   wcscpy(badDst, src); // Boom!
-  // CHECK:ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
-  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR:0x[0-9a-f]+]] thread T0
-  // CHECK: #0 [[ADDR:0x[0-9a-f]+]] in wcscpy{{.*}}asan_interceptors.cpp:{{[0-9]+}}
+  // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
+  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
+  // CHECK: #0 {{0x[0-9a-f]+}} in wcscpy
   printf("Should have failed with ASAN error.\n");
 }

--- a/compiler-rt/test/asan/TestCases/wcsncat.cpp
+++ b/compiler-rt/test/asan/TestCases/wcsncat.cpp
@@ -1,14 +1,14 @@
-// RUN: %clangxx_asan -O0 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O1 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O0 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O1 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O2 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O3 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
 
 #include <stdio.h>
 #include <wchar.h>
 
 int main() {
-  wchar_t *start = L"X means ";
-  wchar_t *append = L"dog";
+  const wchar_t *start = L"X means ";
+  const wchar_t *append = L"dog";
   wchar_t goodDst[15];
   wcscpy(goodDst, start);
   wcsncat(goodDst, append, 5);
@@ -16,12 +16,12 @@ int main() {
   wchar_t badDst[11];
   wcscpy(badDst, start);
   wcsncat(badDst, append, 1);
-  printf("Good so far.\n");
+  fprintf(stderr, "Good so far.\n");
   // CHECK: Good so far.
-  fflush(stdout);
+  fflush(stderr);
   wcsncat(badDst, append, 3); // Boom!
   // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
-  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR:0x[0-9a-f]+]] thread T0
-  // CHECK: #0 [[ADDR:0x[0-9a-f]+]] in wcsncat{{.*}}sanitizer_common_interceptors.inc:{{[0-9]+}}
+  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
+  // CHECK: #0 {{0x[0-9a-f]+}} in wcsncat
   printf("Should have failed with ASAN error.\n");
 }

--- a/compiler-rt/test/asan/TestCases/wcsncpy.cpp
+++ b/compiler-rt/test/asan/TestCases/wcsncpy.cpp
@@ -1,25 +1,25 @@
-// RUN: %clangxx_asan -O0 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O1 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
-// RUN: %clangxx_asan -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O0 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O1 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O2 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx_asan -O3 %s -o %t && not %env_asan_opts=log_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
 
 #include <stdio.h>
 #include <wchar.h>
 
 int main() {
-  wchar_t *src = L"X means dog";
+  const wchar_t *src = L"X means dog";
   wchar_t goodDst[12];
   wcsncpy(goodDst, src, 12);
 
   wchar_t badDst[7];
   wcsncpy(badDst, src, 7); // This should still work.
-  printf("Good so far.\n");
+  fprintf(stderr, "Good so far.\n");
   // CHECK: Good so far.
-  fflush(stdout);
+  fflush(stderr);
 
   wcsncpy(badDst, src, 15); // Boom!
-  // CHECK:ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
-  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR:0x[0-9a-f]+]] thread T0
-  // CHECK: #0 [[ADDR:0x[0-9a-f]+]] in wcsncpy{{.*}}asan_interceptors.cpp:{{[0-9]+}}
+  // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
+  // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
+  // CHECK: #0 {{0x[0-9a-f]+}} in wcsncpy
   printf("Should have failed with ASAN error.\n");
 }


### PR DESCRIPTION
### Summary
Stabilize ASan wchar tests across Darwin and Android. NFC: test-only. Follow-up to PR #160493 (adds wchar interceptors/tests).

### Motivation
- Darwin: The top frame often resolves to `libclang_rt.asan_*` rather than a source file, so strict checks that include file/line can fail. See Chromium issue [448631142](https://g-issues.chromium.org/issues/448631142).
- Android: The “ERROR:” header can go to logcat instead of stderr, so FileCheck may not see it; stdout/stderr reordering also makes pre-crash markers racy. See Android Buildbot [186/12821](https://lab.llvm.org/buildbot/#/builders/186/builds/12821).

### Changes
- Android:
  - Force reports to stderr via `%env_asan_opts=log_to_stderr=1`, avoiding the “ERROR:” header going to logcat.
  - Print the pre-crash “Good so far.” to stderr and `fflush(stderr)` to avoid stdout/stderr reordering.
- Darwin:
  - Relax the stack-frame check to only require the function name (`wcscpy/wcsncpy/wcscat/wcsncat`) to tolerate `libclang_rt.asan_*` frames.
- Common:
  - Reuse FileCheck var `[[ADDR]]` instead of redefining.
  - Make wide string literals `const wchar_t*` to silence `-Wwritable-strings`.

### Risk
- NFC: test-only; no change to runtime behavior.

### References
- Follow-up to PR #160493.
- Chromium: [448631142](https://g-issues.chromium.org/issues/448631142) (Darwin failures).
- Android Buildbot: [186/12821](https://lab.llvm.org/buildbot/#/builders/186/builds/12821).