### PR TITLE
[ADT] Fix a bug in DoubleAPFloat::frexp

### DIFF
--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -5857,7 +5857,7 @@ DoubleAPFloat frexp(const DoubleAPFloat &Arg, int &Exp,
   // practice.
   if (Exp == APFloat::IEK_NaN) {
     DoubleAPFloat Quiet{Arg};
-    Quiet.getFirst().makeQuiet();
+    Quiet.getFirst() = Quiet.getFirst().makeQuiet();
     return Quiet;
   }
 

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -10176,4 +10176,11 @@ TEST(APFloatTest, hasSignBitInMSB) {
   EXPECT_FALSE(APFloat::hasSignBitInMSB(APFloat::Float8E8M0FNU()));
 }
 
+TEST(APFloatTest, FrexpQuietSNaN) {
+  APFloat SNaN = APFloat::getSNaN(APFloat::PPCDoubleDouble());
+  int Exp;
+  APFloat Result = frexp(SNaN, Exp, APFloat::rmNearestTiesToEven);
+  EXPECT_FALSE(Result.isSignaling());
+}
+
 } // namespace


### PR DESCRIPTION
Without this patch, we call APFloat::makeQuiet() in frexp like so:

  Quiet.getFirst().makeQuiet();

The problem is that makeQuiet returns a new value instead of modifying
"*this" in place, so we end up discarding the newly returned value.

This patch fixes the problem by assigning the result back to
Quiet.getFirst().

We should put [[nodiscard]] on APFloat::makeQuiet, but I'll do that in
another patch.
