### PR TITLE
[ADT] Use "= default" in DirectedGraph.h

### DIFF
--- a/llvm/include/llvm/ADT/DirectedGraph.h
+++ b/llvm/include/llvm/ADT/DirectedGraph.h
@@ -181,10 +181,6 @@ public:
 
   DirectedGraph() = default;
   explicit DirectedGraph(NodeType &N) : Nodes() { addNode(N); }
-  DirectedGraph(const DGraphType &G) = default;
-  DirectedGraph(DGraphType &&RHS) = default;
-  DGraphType &operator=(const DGraphType &G) = default;
-  DGraphType &operator=(DGraphType &&G) = default;
 
   const_iterator begin() const { return Nodes.begin(); }
   const_iterator end() const { return Nodes.end(); }

--- a/llvm/include/llvm/ADT/DirectedGraph.h
+++ b/llvm/include/llvm/ADT/DirectedGraph.h
@@ -181,16 +181,10 @@ public:
 
   DirectedGraph() = default;
   explicit DirectedGraph(NodeType &N) : Nodes() { addNode(N); }
-  DirectedGraph(const DGraphType &G) : Nodes(G.Nodes) {}
-  DirectedGraph(DGraphType &&RHS) : Nodes(std::move(RHS.Nodes)) {}
-  DGraphType &operator=(const DGraphType &G) {
-    Nodes = G.Nodes;
-    return *this;
-  }
-  DGraphType &operator=(const DGraphType &&G) {
-    Nodes = std::move(G.Nodes);
-    return *this;
-  }
+  DirectedGraph(const DGraphType &G) = default;
+  DirectedGraph(DGraphType &&RHS) = default;
+  DGraphType &operator=(const DGraphType &G) = default;
+  DGraphType &operator=(DGraphType &&G) = default;
 
   const_iterator begin() const { return Nodes.begin(); }
   const_iterator end() const { return Nodes.end(); }


### PR DESCRIPTION
This patch drops user copy/move constructors and assignment operators
of DirectedGraph to adhere to the Rule of Zero.

Now, the original code:

  DGraphType &operator=(const DGraphType &&G)

is most likely unintended -- a move assignment operator with const
r-value reference.  This patch fixes that.
