### PR TITLE
[OpenMP][omptest] Enable missing callback

### DIFF
--- a/openmp/tools/omptest/src/OmptTester.cpp
+++ b/openmp/tools/omptest/src/OmptTester.cpp
@@ -390,7 +390,7 @@ int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
   register_ompt_callback(ompt_callback_parallel_begin);
   register_ompt_callback(ompt_callback_parallel_end);
   register_ompt_callback(ompt_callback_work);
-  // register_ompt_callback(ompt_callback_dispatch);
+  register_ompt_callback(ompt_callback_dispatch);
   register_ompt_callback(ompt_callback_task_create);
   // register_ompt_callback(ompt_callback_dependences);
   // register_ompt_callback(ompt_callback_task_dependence);


### PR DESCRIPTION
The registration of this callback handler was disabled for some reason. Local testing did not bring up any issues when I enabled it.

Side effect is: Silences current warning about unused function.