### PR TITLE
[CIR] Upstream handling of integral-to-pointer casts

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -14,11 +14,7 @@
 
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
-#include "llvm/IR/DataLayout.h"
-#include "llvm/Support/Alignment.h"
-#include "llvm/Support/TypeSize.h"
 
 namespace cir {
 
@@ -88,13 +84,13 @@ public:
   llvm::TypeSize getTypeSizeInBits(mlir::Type ty) const;
 
   llvm::TypeSize getPointerTypeSizeInBits(mlir::Type ty) const {
-    assert(mlir::isa<cir::PointerType>(Ty) &&
+    assert(mlir::isa<cir::PointerType>(ty) &&
            "This should only be called with a pointer type");
-    return layout.getTypeSizeInBits(Ty);
+    return layout.getTypeSizeInBits(ty);
   }
 
-  mlir::Type getIntPtrType(mlir::Type Ty) const {
-    assert(mlir::isa<cir::PointerType>(Ty) && "Expected pointer type");
+  mlir::Type getIntPtrType(mlir::Type ty) const {
+    assert(mlir::isa<cir::PointerType>(ty) && "Expected pointer type");
     return cir::IntType::get(ty.getContext(), getPointerTypeSizeInBits(ty), false);
   }
 };

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -91,7 +91,8 @@ public:
 
   mlir::Type getIntPtrType(mlir::Type ty) const {
     assert(mlir::isa<cir::PointerType>(ty) && "Expected pointer type");
-    return cir::IntType::get(ty.getContext(), getPointerTypeSizeInBits(ty), false);
+    return cir::IntType::get(ty.getContext(), getPointerTypeSizeInBits(ty),
+                             false);
   }
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -14,6 +14,11 @@
 
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/TypeSize.h"
 
 namespace cir {
 
@@ -81,6 +86,19 @@ public:
   }
 
   llvm::TypeSize getTypeSizeInBits(mlir::Type ty) const;
+
+    llvm::TypeSize getPointerTypeSizeInBits(mlir::Type Ty) const {
+    assert(mlir::isa<cir::PointerType>(Ty) &&
+           "This should only be called with a pointer type");
+    return layout.getTypeSizeInBits(Ty);
+  }
+
+  mlir::Type getIntPtrType(mlir::Type Ty) const {
+    assert(mlir::isa<cir::PointerType>(Ty) && "Expected pointer type");
+    auto IntTy =
+        cir::IntType::get(Ty.getContext(), getPointerTypeSizeInBits(Ty), false);
+    return IntTy;
+  }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -95,9 +95,7 @@ public:
 
   mlir::Type getIntPtrType(mlir::Type Ty) const {
     assert(mlir::isa<cir::PointerType>(Ty) && "Expected pointer type");
-    auto IntTy =
-        cir::IntType::get(Ty.getContext(), getPointerTypeSizeInBits(Ty), false);
-    return IntTy;
+    return cir::IntType::get(ty.getContext(), getPointerTypeSizeInBits(ty), false);
   }
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -87,7 +87,7 @@ public:
 
   llvm::TypeSize getTypeSizeInBits(mlir::Type ty) const;
 
-    llvm::TypeSize getPointerTypeSizeInBits(mlir::Type Ty) const {
+  llvm::TypeSize getPointerTypeSizeInBits(mlir::Type Ty) const {
     assert(mlir::isa<cir::PointerType>(Ty) &&
            "This should only be called with a pointer type");
     return layout.getTypeSizeInBits(Ty);

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -87,7 +87,7 @@ public:
 
   llvm::TypeSize getTypeSizeInBits(mlir::Type ty) const;
 
-  llvm::TypeSize getPointerTypeSizeInBits(mlir::Type Ty) const {
+  llvm::TypeSize getPointerTypeSizeInBits(mlir::Type ty) const {
     assert(mlir::isa<cir::PointerType>(Ty) &&
            "This should only be called with a pointer type");
     return layout.getTypeSizeInBits(Ty);

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1890,18 +1890,18 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     return v;
   }
   case CK_IntegralToPointer: {
-    mlir:Type destCIRTy = cgf.convertType(destTy);
+    mlir::Type destCIRTy = cgf.convertType(destTy);
     mlir::Value src = Visit(const_cast<Expr *>(subExpr));
 
     // Properly resize by casting to an int of the same size as the pointer.
     // Clang's IntegralToPointer includes 'bool' as the source, but in CIR
     // 'bool' is not an integral type.  So check the source type to get the
     // correct CIR conversion.
-    mlirType middleTy = cgf.cgm.getDataLayout().getIntPtrType(destCIRTy);
-    cir::CastOp middleVal = builder.createCast(subExpr->getType()->isBooleanType()
-                                            ? cir::CastKind::bool_to_int
+    mlir::Type middleTy = cgf.cgm.getDataLayout().getIntPtrType(destCIRTy);
+    mlir::Value middleVal = builder.createCast(
+        subExpr->getType()->isBooleanType() ? cir::CastKind::bool_to_int
                                             : cir::CastKind::integral,
-                                        src, middleTy);
+        src, middleTy);
 
     if (cgf.cgm.getCodeGenOpts().StrictVTablePointers) {
       cgf.cgm.errorNYI(subExpr->getSourceRange(), "IntegralToPointer: strict vtable pointers");

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1904,7 +1904,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
         src, middleTy);
 
     if (cgf.cgm.getCodeGenOpts().StrictVTablePointers) {
-      cgf.cgm.errorNYI(subExpr->getSourceRange(), "IntegralToPointer: strict vtable pointers");
+      cgf.cgm.errorNYI(subExpr->getSourceRange(),
+                       "IntegralToPointer: strict vtable pointers");
       return {};
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1908,7 +1908,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
       return {};
     }
 
-    return builder.createIntToPtr(MiddleVal, DestCIRTy);
+    return builder.createIntToPtr(middleVal, destCIRTy);
   }
 
   case CK_ArrayToPointerDecay:

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1901,7 +1901,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     cir::CastOp middleVal = builder.createCast(subExpr->getType()->isBooleanType()
                                             ? cir::CastKind::bool_to_int
                                             : cir::CastKind::integral,
-                                        Src, MiddleTy);
+                                        src, middleTy);
 
     if (cgf.cgm.getCodeGenOpts().StrictVTablePointers)
       cgf.cgm.errorNYI(subExpr->getSourceRange(), "IntegralToPointer: strict vtable pointers");

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1903,8 +1903,10 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
                                             : cir::CastKind::integral,
                                         src, middleTy);
 
-    if (cgf.cgm.getCodeGenOpts().StrictVTablePointers)
+    if (cgf.cgm.getCodeGenOpts().StrictVTablePointers) {
       cgf.cgm.errorNYI(subExpr->getSourceRange(), "IntegralToPointer: strict vtable pointers");
+      return {};
+    }
 
     return builder.createIntToPtr(MiddleVal, DestCIRTy);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1904,7 +1904,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
                                         Src, MiddleTy);
 
     if (cgf.cgm.getCodeGenOpts().StrictVTablePointers)
-      llvm_unreachable("NYI");
+      cgf.cgm.errorNYI(subExpr->getSourceRange(), "IntegralToPointer: strict vtable pointers");
 
     return builder.createIntToPtr(MiddleVal, DestCIRTy);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1891,7 +1891,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
   }
   case CK_IntegralToPointer: {
     mlir:Type destCIRTy = cgf.convertType(destTy);
-    mlir::Value Src = Visit(const_cast<Expr *>(subExpr));
+    mlir::Value src = Visit(const_cast<Expr *>(subExpr));
 
     // Properly resize by casting to an int of the same size as the pointer.
     // Clang's IntegralToPointer includes 'bool' as the source, but in CIR

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1890,7 +1890,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     return v;
   }
   case CK_IntegralToPointer: {
-    auto DestCIRTy = cgf.convertType(destTy);
+    mlir:Type destCIRTy = cgf.convertType(destTy);
     mlir::Value Src = Visit(const_cast<Expr *>(subExpr));
 
     // Properly resize by casting to an int of the same size as the pointer.

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1897,7 +1897,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     // Clang's IntegralToPointer includes 'bool' as the source, but in CIR
     // 'bool' is not an integral type.  So check the source type to get the
     // correct CIR conversion.
-    auto MiddleTy = cgf.cgm.getDataLayout().getIntPtrType(DestCIRTy);
+    mlirType middleTy = cgf.cgm.getDataLayout().getIntPtrType(destCIRTy);
     cir::CastOp middleVal = builder.createCast(subExpr->getType()->isBooleanType()
                                             ? cir::CastKind::bool_to_int
                                             : cir::CastKind::integral,

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1907,7 +1907,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
       llvm_unreachable("NYI");
 
     return builder.createIntToPtr(MiddleVal, DestCIRTy);
-  }  
+  }
 
   case CK_ArrayToPointerDecay:
     return cgf.emitArrayToPointerDecay(subExpr).getPointer();

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1898,7 +1898,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     // 'bool' is not an integral type.  So check the source type to get the
     // correct CIR conversion.
     auto MiddleTy = cgf.cgm.getDataLayout().getIntPtrType(DestCIRTy);
-    auto MiddleVal = builder.createCast(subExpr->getType()->isBooleanType()
+    cir::CastOp middleVal = builder.createCast(subExpr->getType()->isBooleanType()
                                             ? cir::CastKind::bool_to_int
                                             : cir::CastKind::integral,
                                         Src, MiddleTy);

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -139,6 +139,15 @@ void f(long int start) {
 // CIR: %[[MID:.*]] = cir.cast integral %[[L]] : !s64i -> !u64i
 // CIR:          cir.cast int_to_ptr %[[MID]] : !u64i -> !cir.ptr<!void>
 
+// LLVM-LABEL: define{{.*}} void @_Z1fl(i64 %0)
+// LLVM: %[[ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[PADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: store i64 %0, ptr %[[ADDR]], align 8
+// LLVM: %[[L:.*]] = load i64, ptr %[[ADDR]], align 8
+// LLVM: %[[PTR:.*]] = inttoptr i64 %[[L]] to ptr
+// LLVM: store ptr %[[PTR]], ptr %[[PADDR]], align 8
+// LLVM: ret void
+
 struct A { int x; };
 
 void int_cast(long ptr) {
@@ -151,5 +160,7 @@ void null_cast(long) {
   *(int *)0 = 0;
   ((A *)0)->x = 0;
 }
-// CIR: #cir.ptr<null> : !cir.ptr<!s32i>
-// CIR: #cir.ptr<null> : !cir.ptr<!rec_A>
+// CIR:    %[[NULLPTR:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
+// CIR:    cir.store{{.*}} %{{.*}}, %[[NULLPTR]] : !s32i, !cir.ptr<!s32i>
+// CIR:    %[[NULLPTR_A:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!rec_A>
+// CIR:    %[[A_X:.*]] = cir.get_member %[[NULLPTR_A]][0] {name = "x"} : !cir.ptr<!rec_A> -> !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -131,3 +131,25 @@ void bitcast() {
 
 // LLVM: %[[D_VEC:.*]] = load <2 x double>, ptr {{.*}}, align 16
 // LLVM: %[[I_VEC:.*]] = bitcast <2 x double> %[[D_VEC]] to <4 x i32>
+
+void f(long int start) {
+  void *p = (void*)start;
+}
+// CIR: %[[L:.*]] = cir.load {{.*}} : !cir.ptr<!s64i>, !s64i
+// CIR: %[[MID:.*]] = cir.cast integral %[[L]] : !s64i -> !u64i
+// CIR:          cir.cast int_to_ptr %[[MID]] : !u64i -> !cir.ptr<!void>
+
+struct A { int x; };
+
+void int_cast(long ptr) {
+  ((A *)ptr)->x = 0;
+}
+// CIR: cir.cast int_to_ptr {{.*}} : !u64i -> !cir.ptr<!rec_A>
+// LLVM: inttoptr {{.*}} to ptr
+
+void null_cast(long) {
+  *(int *)0 = 0;
+  ((A *)0)->x = 0;
+}
+// CIR: #cir.ptr<null> : !cir.ptr<!s32i>
+// CIR: #cir.ptr<null> : !cir.ptr<!rec_A>


### PR DESCRIPTION
Fix #153658

Handle integral to pointer casts and port the relevant `cast.cpp` test cases from incubator.