### PR TITLE
[orc-rt] Add support for constructing Expected<Error> values.

### DIFF
--- a/orc-rt/unittests/ErrorTest.cpp
+++ b/orc-rt/unittests/ErrorTest.cpp
@@ -386,6 +386,29 @@ TEST(ErrorTest, ExpectedCovariance) {
   (void)!!A2;
 }
 
+// Test that Expected<Error> works as expected with .
+TEST(ErrorTest, ExpectedError) {
+  {
+    // Test success-success case.
+    Expected<Error> E(Error::success(), ForceExpectedSuccessValue());
+    EXPECT_TRUE(!!E);
+    cantFail(E.takeError());
+    auto Err = std::move(*E);
+    EXPECT_FALSE(!!Err);
+  }
+
+  {
+    // Test "failure" success case.
+    Expected<Error> E(make_error<StringError>("foo"),
+                      ForceExpectedSuccessValue());
+    EXPECT_TRUE(!!E);
+    cantFail(E.takeError());
+    auto Err = std::move(*E);
+    EXPECT_TRUE(!!Err);
+    EXPECT_EQ(toString(std::move(Err)), "foo");
+  }
+}
+
 // Test that the ExitOnError utility works as expected.
 TEST(ErrorTest, CantFailSuccess) {
   cantFail(Error::success());


### PR DESCRIPTION
These will be used in upcoming RPC support patches where the outer Expected value captures any RPC-infrastructure errors, and the inner Error is returned from the romet call (i.e. the remote handler's return type is Error).