### PR TITLE
[libc++] Make the naming of the iterator_traits aliases consistent

### DIFF
--- a/libcxx/include/__algorithm/copy.h
+++ b/libcxx/include/__algorithm/copy.h
@@ -197,7 +197,8 @@ struct __copy_impl {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
-    using _DiffT  = typename common_type<__iter_diff_t<_InIter>, __iter_diff_t<_OutIter> >::type;
+    using _DiffT =
+        typename common_type<__iterator_difference_type<_InIter>, __iterator_difference_type<_OutIter> >::type;
 
     if (__first == __last)
       return std::make_pair(std::move(__first), std::move(__result));

--- a/libcxx/include/__algorithm/copy_backward.h
+++ b/libcxx/include/__algorithm/copy_backward.h
@@ -214,7 +214,8 @@ struct __copy_backward_impl {
 
     auto __local_last = _Traits::__local(__result);
     while (true) {
-      using _DiffT = typename common_type<__iter_diff_t<_InIter>, __iter_diff_t<_OutIter> >::type;
+      using _DiffT =
+          typename common_type<__iterator_difference_type<_InIter>, __iterator_difference_type<_OutIter> >::type;
 
       auto __local_first = _Traits::__begin(__segment_iterator);
       auto __size        = std::min<_DiffT>(__local_last - __local_first, __last - __first);

--- a/libcxx/include/__algorithm/count.h
+++ b/libcxx/include/__algorithm/count.h
@@ -72,7 +72,7 @@ __count_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_t
 }
 
 template <class, class _Cp, bool _IsConst, class _Tp, class _Proj, __enable_if_t<__is_identity<_Proj>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __iter_diff_t<__bit_iterator<_Cp, _IsConst> >
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __iterator_difference_type<__bit_iterator<_Cp, _IsConst> >
 __count(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, const _Tp& __value, _Proj&) {
   if (__value)
     return std::__count_bool<true>(
@@ -82,7 +82,7 @@ __count(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __l
 }
 
 template <class _InputIterator, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __iter_diff_t<_InputIterator>
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __iterator_difference_type<_InputIterator>
 count(_InputIterator __first, _InputIterator __last, const _Tp& __value) {
   __identity __proj;
   return std::__count<_ClassicAlgPolicy>(__first, __last, __value, __proj);

--- a/libcxx/include/__algorithm/is_permutation.h
+++ b/libcxx/include/__algorithm/is_permutation.h
@@ -78,7 +78,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation_impl(
     _Pred&& __pred,
     _Proj1&& __proj1,
     _Proj2&& __proj2) {
-  using _D1 = __iter_diff_t<_Iter1>;
+  using _D1 = __iterator_difference_type<_Iter1>;
 
   for (auto __i = __first1; __i != __last1; ++__i) {
     //  Have we already counted the number of *__i in [f1, l1)?
@@ -126,7 +126,7 @@ template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _Fo
     return true;
 
   //  __first1 != __last1 && *__first1 != *__first2
-  using _D1 = __iter_diff_t<_ForwardIterator1>;
+  using _D1 = __iterator_difference_type<_ForwardIterator1>;
   _D1 __l1  = _IterOps<_AlgPolicy>::distance(__first1, __last1);
   if (__l1 == _D1(1))
     return false;
@@ -173,10 +173,10 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
   if (__first2 == __last2) // Second range is shorter
     return false;
 
-  using _D1 = __iter_diff_t<_Iter1>;
+  using _D1 = __iterator_difference_type<_Iter1>;
   _D1 __l1  = _IterOps<_AlgPolicy>::distance(__first1, __last1);
 
-  using _D2 = __iter_diff_t<_Iter2>;
+  using _D2 = __iterator_difference_type<_Iter2>;
   _D2 __l2  = _IterOps<_AlgPolicy>::distance(__first2, __last2);
   if (__l1 != __l2)
     return false;

--- a/libcxx/include/__algorithm/lexicographical_compare_three_way.h
+++ b/libcxx/include/__algorithm/lexicographical_compare_three_way.h
@@ -37,13 +37,13 @@ template <class _InputIterator1, class _InputIterator2, class _Cmp>
 _LIBCPP_HIDE_FROM_ABI constexpr auto __lexicographical_compare_three_way_fast_path(
     _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Cmp& __comp)
     -> decltype(__comp(*__first1, *__first2)) {
-  static_assert(
-      signed_integral<__iter_diff_t<_InputIterator1>>, "Using a non-integral difference_type is undefined behavior.");
-  static_assert(
-      signed_integral<__iter_diff_t<_InputIterator2>>, "Using a non-integral difference_type is undefined behavior.");
+  static_assert(signed_integral<__iterator_difference_type<_InputIterator1>>,
+                "Using a non-integral difference_type is undefined behavior.");
+  static_assert(signed_integral<__iterator_difference_type<_InputIterator2>>,
+                "Using a non-integral difference_type is undefined behavior.");
 
-  using _Len1   = __iter_diff_t<_InputIterator1>;
-  using _Len2   = __iter_diff_t<_InputIterator2>;
+  using _Len1   = __iterator_difference_type<_InputIterator1>;
+  using _Len2   = __iterator_difference_type<_InputIterator2>;
   using _Common = common_type_t<_Len1, _Len2>;
 
   _Len1 __len1      = __last1 - __first1;

--- a/libcxx/include/__algorithm/make_heap.h
+++ b/libcxx/include/__algorithm/make_heap.h
@@ -33,10 +33,10 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp) {
   __comp_ref_type<_Compare> __comp_ref = __comp;
 
-  using __diff_t     = __iter_diff_t<_RandomAccessIterator>;
+  using __diff_t     = __iterator_difference_type<_RandomAccessIterator>;
   const __diff_t __n = __last - __first;
 
-  const bool __assume_both_children = is_arithmetic<__iter_value_type<_RandomAccessIterator> >::value;
+  const bool __assume_both_children = is_arithmetic<__iterator_value_type<_RandomAccessIterator> >::value;
 
   // While it would be correct to always assume we have both children, in practice we observed this to be a performance
   // improvement only for arithmetic types.

--- a/libcxx/include/__algorithm/mismatch.h
+++ b/libcxx/include/__algorithm/mismatch.h
@@ -60,7 +60,7 @@ __mismatch(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Pred& __pred, _Pro
 template <class _Iter>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter, _Iter>
 __mismatch_vectorized(_Iter __first1, _Iter __last1, _Iter __first2) {
-  using __value_type              = __iter_value_type<_Iter>;
+  using __value_type              = __iterator_value_type<_Iter>;
   constexpr size_t __unroll_count = 4;
   constexpr size_t __vec_size     = __native_vector_size<__value_type>;
   using __vec                     = __simd_vector<__value_type, __vec_size>;

--- a/libcxx/include/__algorithm/move.h
+++ b/libcxx/include/__algorithm/move.h
@@ -80,7 +80,8 @@ struct __move_impl {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
-    using _DiffT  = typename common_type<__iter_diff_t<_InIter>, __iter_diff_t<_OutIter> >::type;
+    using _DiffT =
+        typename common_type<__iterator_difference_type<_InIter>, __iterator_difference_type<_OutIter> >::type;
 
     if (__first == __last)
       return std::make_pair(std::move(__first), std::move(__result));

--- a/libcxx/include/__algorithm/move_backward.h
+++ b/libcxx/include/__algorithm/move_backward.h
@@ -86,7 +86,8 @@ struct __move_backward_impl {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
-    using _DiffT  = typename common_type<__iter_diff_t<_InIter>, __iter_diff_t<_OutIter> >::type;
+    using _DiffT =
+        typename common_type<__iterator_difference_type<_InIter>, __iterator_difference_type<_OutIter> >::type;
 
     // When the range contains no elements, __result might not be a valid iterator
     if (__first == __last)

--- a/libcxx/include/__algorithm/pstl.h
+++ b/libcxx/include/__algorithm/pstl.h
@@ -115,7 +115,7 @@ template <class _ExecutionPolicy,
           class _Predicate,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI __iter_diff_t<_ForwardIterator>
+_LIBCPP_HIDE_FROM_ABI __iterator_difference_type<_ForwardIterator>
 count_if(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(
       _ForwardIterator, "count_if(first, last, pred) requires [first, last) to be ForwardIterators");
@@ -129,7 +129,7 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI __iter_diff_t<_ForwardIterator>
+_LIBCPP_HIDE_FROM_ABI __iterator_difference_type<_ForwardIterator>
 count(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(
       _ForwardIterator, "count(first, last, val) requires [first, last) to be ForwardIterators");

--- a/libcxx/include/__algorithm/radix_sort.h
+++ b/libcxx/include/__algorithm/radix_sort.h
@@ -72,14 +72,14 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 14
 
 template <class _InputIterator, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI constexpr pair<_OutputIterator, __iter_value_type<_InputIterator>>
+_LIBCPP_HIDE_FROM_ABI constexpr pair<_OutputIterator, __iterator_value_type<_InputIterator>>
 __partial_sum_max(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
   if (__first == __last)
     return {__result, 0};
 
-  auto __max                              = *__first;
-  __iter_value_type<_InputIterator> __sum = *__first;
-  *__result                               = __sum;
+  auto __max                                  = *__first;
+  __iterator_value_type<_InputIterator> __sum = *__first;
+  *__result                                   = __sum;
 
   while (++__first != __last) {
     if (__max < *__first) {
@@ -124,7 +124,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __nth_radix(size_t __radix_number, _Radix _
 template <class _ForwardIterator, class _Map, class _RandomAccessIterator>
 _LIBCPP_HIDE_FROM_ABI constexpr void
 __collect(_ForwardIterator __first, _ForwardIterator __last, _Map __map, _RandomAccessIterator __counters) {
-  using __value_type = __iter_value_type<_ForwardIterator>;
+  using __value_type = __iterator_value_type<_ForwardIterator>;
   using __traits     = __counting_sort_traits<__value_type, _Map>;
 
   std::for_each(__first, __last, [&__counters, &__map](const auto& __preimage) { ++__counters[__map(__preimage)]; });
@@ -160,7 +160,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __collect_impl(
     _RandomAccessIterator1 __counters,
     _RandomAccessIterator2 __maximums,
     index_sequence<_Radices...>) {
-  using __value_type                 = __iter_value_type<_ForwardIterator>;
+  using __value_type                 = __iterator_value_type<_ForwardIterator>;
   constexpr auto __radix_value_range = __radix_sort_traits<__value_type, _Map, _Radix>::__radix_value_range;
 
   auto __previous  = numeric_limits<__invoke_result_t<_Map, __value_type>>::min();
@@ -189,7 +189,7 @@ __collect(_ForwardIterator __first,
           _Radix __radix,
           _RandomAccessIterator1 __counters,
           _RandomAccessIterator2 __maximums) {
-  using __value_type           = __iter_value_type<_ForwardIterator>;
+  using __value_type           = __iterator_value_type<_ForwardIterator>;
   constexpr auto __radix_count = __radix_sort_traits<__value_type, _Map, _Radix>::__radix_count;
   return std::__collect_impl(
       __first, __last, __map, __radix, __counters, __maximums, make_index_sequence<__radix_count>());
@@ -213,10 +213,10 @@ _LIBCPP_HIDE_FROM_ABI constexpr void __dispose_backward(
 template <class _ForwardIterator, class _RandomAccessIterator, class _Map>
 _LIBCPP_HIDE_FROM_ABI constexpr _RandomAccessIterator
 __counting_sort_impl(_ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __result, _Map __map) {
-  using __value_type = __iter_value_type<_ForwardIterator>;
+  using __value_type = __iterator_value_type<_ForwardIterator>;
   using __traits     = __counting_sort_traits<__value_type, _Map>;
 
-  __iter_diff_t<_RandomAccessIterator> __counters[__traits::__value_range + 1] = {0};
+  __iterator_difference_type<_RandomAccessIterator> __counters[__traits::__value_range + 1] = {0};
 
   std::__collect(__first, __last, __map, std::next(std::begin(__counters)));
   std::__dispose(__first, __last, __result, __map, std::begin(__counters));
@@ -224,12 +224,13 @@ __counting_sort_impl(_ForwardIterator __first, _ForwardIterator __last, _RandomA
   return __result + __counters[__traits::__value_range];
 }
 
-template <class _RandomAccessIterator1,
-          class _RandomAccessIterator2,
-          class _Map,
-          class _Radix,
-          enable_if_t< __radix_sort_traits<__iter_value_type<_RandomAccessIterator1>, _Map, _Radix>::__radix_count == 1,
-                       int> = 0>
+template <
+    class _RandomAccessIterator1,
+    class _RandomAccessIterator2,
+    class _Map,
+    class _Radix,
+    enable_if_t<__radix_sort_traits<__iterator_value_type<_RandomAccessIterator1>, _Map, _Radix>::__radix_count == 1,
+                int> = 0>
 _LIBCPP_HIDE_FROM_ABI constexpr void __radix_sort_impl(
     _RandomAccessIterator1 __first,
     _RandomAccessIterator1 __last,
@@ -243,24 +244,25 @@ _LIBCPP_HIDE_FROM_ABI constexpr void __radix_sort_impl(
   std::move(__buffer, __buffer_end, __first);
 }
 
-template <
-    class _RandomAccessIterator1,
-    class _RandomAccessIterator2,
-    class _Map,
-    class _Radix,
-    enable_if_t< __radix_sort_traits<__iter_value_type<_RandomAccessIterator1>, _Map, _Radix>::__radix_count % 2 == 0,
-                 int> = 0 >
+template <class _RandomAccessIterator1,
+          class _RandomAccessIterator2,
+          class _Map,
+          class _Radix,
+          enable_if_t<
+              __radix_sort_traits<__iterator_value_type<_RandomAccessIterator1>, _Map, _Radix>::__radix_count % 2 == 0,
+              int> = 0>
 _LIBCPP_HIDE_FROM_ABI constexpr void __radix_sort_impl(
     _RandomAccessIterator1 __first,
     _RandomAccessIterator1 __last,
     _RandomAccessIterator2 __buffer_begin,
     _Map __map,
     _Radix __radix) {
-  using __value_type = __iter_value_type<_RandomAccessIterator1>;
+  using __value_type = __iterator_value_type<_RandomAccessIterator1>;
   using __traits     = __radix_sort_traits<__value_type, _Map, _Radix>;
 
-  __iter_diff_t<_RandomAccessIterator1> __counters[__traits::__radix_count][__traits::__radix_value_range] = {{0}};
-  __iter_diff_t<_RandomAccessIterator1> __maximums[__traits::__radix_count]                                = {0};
+  __iterator_difference_type<_RandomAccessIterator1>
+      __counters[__traits::__radix_count][__traits::__radix_value_range]                 = {{0}};
+  __iterator_difference_type<_RandomAccessIterator1> __maximums[__traits::__radix_count] = {0};
   const auto __is_sorted = std::__collect(__first, __last, __map, __radix, __counters, __maximums);
   if (!__is_sorted) {
     const auto __range_size = std::distance(__first, __last);

--- a/libcxx/include/__algorithm/sift_down.h
+++ b/libcxx/include/__algorithm/sift_down.h
@@ -28,8 +28,8 @@ template <class _AlgPolicy, bool __assume_both_children, class _Compare, class _
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __sift_down(_RandomAccessIterator __first,
             _Compare&& __comp,
-            __iter_diff_t<_RandomAccessIterator> __len,
-            __iter_diff_t<_RandomAccessIterator> __start) {
+            __iterator_difference_type<_RandomAccessIterator> __len,
+            __iterator_difference_type<_RandomAccessIterator> __start) {
   using _Ops = _IterOps<_AlgPolicy>;
 
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;

--- a/libcxx/include/__algorithm/stable_sort.h
+++ b/libcxx/include/__algorithm/stable_sort.h
@@ -247,7 +247,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void __stable_sort(
   constexpr auto __default_comp = __desugars_to_v<__less_tag, _Compare, value_type, value_type >;
   constexpr auto __radix_sortable =
       __is_ordered_integer_representable_v<value_type> &&
-      is_same_v< value_type&, __iter_reference<_RandomAccessIterator>>;
+      is_same_v< value_type&, __iterator_reference<_RandomAccessIterator>>;
   if constexpr (__default_comp && __radix_sortable) {
     if (__len <= __buff_size && __len >= static_cast<difference_type>(std::__radix_sort_min_bound<value_type>()) &&
         __len <= static_cast<difference_type>(std::__radix_sort_max_bound<value_type>())) {

--- a/libcxx/include/__debug_utils/strict_weak_ordering_check.h
+++ b/libcxx/include/__debug_utils/strict_weak_ordering_check.h
@@ -27,7 +27,7 @@ template <class _RandomAccessIterator, class _Comp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __check_strict_weak_ordering_sorted(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp& __comp) {
 #if _LIBCPP_HARDENING_MODE == _LIBCPP_HARDENING_MODE_DEBUG
-  using __diff_t  = __iter_diff_t<_RandomAccessIterator>;
+  using __diff_t  = __iterator_difference_type<_RandomAccessIterator>;
   using _Comp_ref = __comp_ref_type<_Comp>;
   if (!__libcpp_is_constant_evaluated()) {
     // Check if the range is actually sorted.

--- a/libcxx/include/__flat_set/flat_multiset.h
+++ b/libcxx/include/__flat_set/flat_multiset.h
@@ -718,15 +718,15 @@ template <class _KeyContainer, class _Compare, class _Allocator>
 flat_multiset(sorted_equivalent_t, _KeyContainer, _Compare, _Allocator)
     -> flat_multiset<typename _KeyContainer::value_type, _Compare, _KeyContainer>;
 
-template <class _InputIterator, class _Compare = less<__iter_value_type<_InputIterator>>>
+template <class _InputIterator, class _Compare = less<__iterator_value_type<_InputIterator>>>
   requires(__has_input_iterator_category<_InputIterator>::value && !__is_allocator_v<_Compare>)
 flat_multiset(_InputIterator, _InputIterator, _Compare = _Compare())
-    -> flat_multiset<__iter_value_type<_InputIterator>, _Compare>;
+    -> flat_multiset<__iterator_value_type<_InputIterator>, _Compare>;
 
-template <class _InputIterator, class _Compare = less<__iter_value_type<_InputIterator>>>
+template <class _InputIterator, class _Compare = less<__iterator_value_type<_InputIterator>>>
   requires(__has_input_iterator_category<_InputIterator>::value && !__is_allocator_v<_Compare>)
 flat_multiset(sorted_equivalent_t, _InputIterator, _InputIterator, _Compare = _Compare())
-    -> flat_multiset<__iter_value_type<_InputIterator>, _Compare>;
+    -> flat_multiset<__iterator_value_type<_InputIterator>, _Compare>;
 
 template <ranges::input_range _Range,
           class _Compare   = less<ranges::range_value_t<_Range>>,

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -807,15 +807,15 @@ template <class _KeyContainer, class _Compare, class _Allocator>
 flat_set(sorted_unique_t, _KeyContainer, _Compare, _Allocator)
     -> flat_set<typename _KeyContainer::value_type, _Compare, _KeyContainer>;
 
-template <class _InputIterator, class _Compare = less<__iter_value_type<_InputIterator>>>
+template <class _InputIterator, class _Compare = less<__iterator_value_type<_InputIterator>>>
   requires(__has_input_iterator_category<_InputIterator>::value && !__is_allocator_v<_Compare>)
 flat_set(_InputIterator, _InputIterator, _Compare = _Compare())
-    -> flat_set<__iter_value_type<_InputIterator>, _Compare>;
+    -> flat_set<__iterator_value_type<_InputIterator>, _Compare>;
 
-template <class _InputIterator, class _Compare = less<__iter_value_type<_InputIterator>>>
+template <class _InputIterator, class _Compare = less<__iterator_value_type<_InputIterator>>>
   requires(__has_input_iterator_category<_InputIterator>::value && !__is_allocator_v<_Compare>)
 flat_set(sorted_unique_t, _InputIterator, _InputIterator, _Compare = _Compare())
-    -> flat_set<__iter_value_type<_InputIterator>, _Compare>;
+    -> flat_set<__iterator_value_type<_InputIterator>, _Compare>;
 
 template <ranges::input_range _Range,
           class _Compare   = less<ranges::range_value_t<_Range>>,

--- a/libcxx/include/__iterator/bounded_iter.h
+++ b/libcxx/include/__iterator/bounded_iter.h
@@ -74,12 +74,12 @@ struct __bounded_iter {
   _LIBCPP_HIDE_FROM_ABI __bounded_iter(__bounded_iter const&) = default;
   _LIBCPP_HIDE_FROM_ABI __bounded_iter(__bounded_iter&&)      = default;
 
-  template < class _OtherIterator,
-             __enable_if_t<
-                 _And< is_convertible<const _OtherIterator&, _Iterator>,
-                       _Or<is_same<reference, __iter_reference<_OtherIterator> >,
-                           is_same<reference, __make_const_lvalue_ref<__iter_reference<_OtherIterator> > > > >::value,
-                 int> = 0>
+  template <class _OtherIterator,
+            __enable_if_t<
+                _And<is_convertible<const _OtherIterator&, _Iterator>,
+                     _Or<is_same<reference, __iterator_reference<_OtherIterator> >,
+                         is_same<reference, __make_const_lvalue_ref<__iterator_reference<_OtherIterator> > > > >::value,
+                int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __bounded_iter(__bounded_iter<_OtherIterator> const& __other) _NOEXCEPT
       : __current_(__other.__current_),
         __begin_(__other.__begin_),

--- a/libcxx/include/__iterator/cpp17_iterator_concepts.h
+++ b/libcxx/include/__iterator/cpp17_iterator_concepts.h
@@ -68,7 +68,8 @@ concept __cpp17_default_constructible = is_default_constructible_v<_Tp>;
 template <class _Iter>
 concept __cpp17_iterator =
     __cpp17_copy_constructible<_Iter> && __cpp17_copy_assignable<_Iter> && __cpp17_destructible<_Iter> &&
-    (is_signed_v<__iter_diff_t<_Iter>> || is_void_v<__iter_diff_t<_Iter>>) && requires(_Iter __iter) {
+    (is_signed_v<__iterator_difference_type<_Iter>> || is_void_v<__iterator_difference_type<_Iter>>) &&
+    requires(_Iter __iter) {
       { *__iter };
       { ++__iter } -> same_as<_Iter&>;
     };
@@ -81,8 +82,8 @@ concept __cpp17_input_iterator =
       { __lhs != std::as_const(__rhs) } -> __boolean_testable;
       { std::as_const(__lhs) != std::as_const(__rhs) } -> __boolean_testable;
 
-      { *__lhs } -> same_as<__iter_reference<_Iter>>;
-      { *std::as_const(__lhs) } -> same_as<__iter_reference<_Iter>>;
+      { *__lhs } -> same_as<__iterator_reference<_Iter>>;
+      { *std::as_const(__lhs) } -> same_as<__iterator_reference<_Iter>>;
 
       { ++__lhs } -> same_as<_Iter&>;
       { (void)__lhs++ };
@@ -101,19 +102,19 @@ template <class _Iter>
 concept __cpp17_forward_iterator =
     __cpp17_input_iterator<_Iter> && __cpp17_default_constructible<_Iter> && requires(_Iter __iter) {
       { __iter++ } -> convertible_to<const _Iter&>;
-      { *__iter++ } -> same_as<__iter_reference<_Iter>>;
+      { *__iter++ } -> same_as<__iterator_reference<_Iter>>;
     };
 
 template <class _Iter>
 concept __cpp17_bidirectional_iterator = __cpp17_forward_iterator<_Iter> && requires(_Iter __iter) {
   { --__iter } -> same_as<_Iter&>;
   { __iter-- } -> convertible_to<const _Iter&>;
-  { *__iter-- } -> same_as<__iter_reference<_Iter>>;
+  { *__iter-- } -> same_as<__iterator_reference<_Iter>>;
 };
 
 template <class _Iter>
 concept __cpp17_random_access_iterator =
-    __cpp17_bidirectional_iterator<_Iter> && requires(_Iter __iter, __iter_diff_t<_Iter> __n) {
+    __cpp17_bidirectional_iterator<_Iter> && requires(_Iter __iter, __iterator_difference_type<_Iter> __n) {
       { __iter += __n } -> same_as<_Iter&>;
 
       { __iter + __n } -> same_as<_Iter>;
@@ -125,13 +126,13 @@ concept __cpp17_random_access_iterator =
       { __iter - __n } -> same_as<_Iter>;
       { std::as_const(__iter) - __n } -> same_as<_Iter>;
 
-      { __iter - __iter } -> same_as<__iter_diff_t<_Iter>>;
-      { std::as_const(__iter) - __iter } -> same_as<__iter_diff_t<_Iter>>;
-      { __iter - std::as_const(__iter) } -> same_as<__iter_diff_t<_Iter>>;
-      { std::as_const(__iter) - std::as_const(__iter) } -> same_as<__iter_diff_t<_Iter>>;
+      { __iter - __iter } -> same_as<__iterator_difference_type<_Iter>>;
+      { std::as_const(__iter) - __iter } -> same_as<__iterator_difference_type<_Iter>>;
+      { __iter - std::as_const(__iter) } -> same_as<__iterator_difference_type<_Iter>>;
+      { std::as_const(__iter) - std::as_const(__iter) } -> same_as<__iterator_difference_type<_Iter>>;
 
-      { __iter[__n] } -> convertible_to<__iter_reference<_Iter>>;
-      { std::as_const(__iter)[__n] } -> convertible_to<__iter_reference<_Iter>>;
+      { __iter[__n] } -> convertible_to<__iterator_reference<_Iter>>;
+      { std::as_const(__iter)[__n] } -> convertible_to<__iterator_reference<_Iter>>;
 
       { __iter < __iter } -> __boolean_testable;
       { std::as_const(__iter) < __iter } -> __boolean_testable;

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -420,44 +420,43 @@ using __has_exactly_bidirectional_iterator_category _LIBCPP_NODEBUG =
                           !__has_iterator_category_convertible_to<_Tp, random_access_iterator_tag>::value>;
 
 template <class _InputIterator>
-using __iter_value_type _LIBCPP_NODEBUG = typename iterator_traits<_InputIterator>::value_type;
+using __iterator_value_type _LIBCPP_NODEBUG = typename iterator_traits<_InputIterator>::value_type;
 
 #if _LIBCPP_STD_VER >= 23
 template <class _InputIterator>
-using __iter_key_type _LIBCPP_NODEBUG = remove_const_t<tuple_element_t<0, __iter_value_type<_InputIterator>>>;
+using __iter_key_type _LIBCPP_NODEBUG = remove_const_t<tuple_element_t<0, __iterator_value_type<_InputIterator>>>;
 
 template <class _InputIterator>
-using __iter_mapped_type _LIBCPP_NODEBUG = tuple_element_t<1, __iter_value_type<_InputIterator>>;
+using __iter_mapped_type _LIBCPP_NODEBUG = tuple_element_t<1, __iterator_value_type<_InputIterator>>;
 
 template <class _InputIterator>
 using __iter_to_alloc_type _LIBCPP_NODEBUG =
-    pair<const tuple_element_t<0, __iter_value_type<_InputIterator>>,
-         tuple_element_t<1, __iter_value_type<_InputIterator>>>;
+    pair<const tuple_element_t<0, __iterator_value_type<_InputIterator>>,
+         tuple_element_t<1, __iterator_value_type<_InputIterator>>>;
 #else
 template <class _InputIterator>
-using __iter_key_type _LIBCPP_NODEBUG =
-    __remove_const_t<typename iterator_traits<_InputIterator>::value_type::first_type>;
+using __iter_key_type _LIBCPP_NODEBUG = __remove_const_t<typename __iterator_value_type<_InputIterator>::first_type>;
 
 template <class _InputIterator>
-using __iter_mapped_type _LIBCPP_NODEBUG = typename iterator_traits<_InputIterator>::value_type::second_type;
+using __iter_mapped_type _LIBCPP_NODEBUG = typename __iterator_value_type<_InputIterator>::second_type;
 
 template <class _InputIterator>
 using __iter_to_alloc_type _LIBCPP_NODEBUG =
-    pair<const typename iterator_traits<_InputIterator>::value_type::first_type,
-         typename iterator_traits<_InputIterator>::value_type::second_type>;
+    pair<const typename __iterator_value_type<_InputIterator>::first_type,
+         typename __iterator_value_type<_InputIterator>::second_type>;
 #endif // _LIBCPP_STD_VER >= 23
 
 template <class _Iter>
-using __iterator_category_type _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::iterator_category;
+using __iterator_iterator_category _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::iterator_category;
 
 template <class _Iter>
-using __iterator_pointer_type _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::pointer;
+using __iterator_pointer _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::pointer;
 
 template <class _Iter>
-using __iter_diff_t _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::difference_type;
+using __iterator_difference_type _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::difference_type;
 
 template <class _Iter>
-using __iter_reference _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::reference;
+using __iterator_reference _LIBCPP_NODEBUG = typename iterator_traits<_Iter>::reference;
 
 #if _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__iterator/static_bounded_iter.h
+++ b/libcxx/include/__iterator/static_bounded_iter.h
@@ -99,9 +99,9 @@ struct __static_bounded_iter {
 
   template <class _OtherIterator,
             __enable_if_t<
-                _And< is_convertible<const _OtherIterator&, _Iterator>,
-                      _Or<is_same<reference, __iter_reference<_OtherIterator> >,
-                          is_same<reference, __make_const_lvalue_ref<__iter_reference<_OtherIterator> > > > >::value,
+                _And<is_convertible<const _OtherIterator&, _Iterator>,
+                     _Or<is_same<reference, __iterator_reference<_OtherIterator> >,
+                         is_same<reference, __make_const_lvalue_ref<__iterator_reference<_OtherIterator> > > > >::value,
                 int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
   __static_bounded_iter(__static_bounded_iter<_OtherIterator, _Size> const& __other) _NOEXCEPT

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -49,12 +49,12 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter() _NOEXCEPT : __i_() {}
-  template <
-      class _OtherIter,
-      __enable_if_t< _And< is_convertible<const _OtherIter&, _Iter>,
-                           _Or<is_same<reference, __iter_reference<_OtherIter> >,
-                               is_same<reference, __make_const_lvalue_ref<__iter_reference<_OtherIter> > > > >::value,
-                     int> = 0>
+  template <class _OtherIter,
+            __enable_if_t<
+                _And<is_convertible<const _OtherIter&, _Iter>,
+                     _Or<is_same<reference, __iterator_reference<_OtherIter> >,
+                         is_same<reference, __make_const_lvalue_ref<__iterator_reference<_OtherIter> > > > >::value,
+                int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter(const __wrap_iter<_OtherIter>& __u) _NOEXCEPT
       : __i_(__u.__i_) {}
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 reference operator*() const _NOEXCEPT { return *__i_; }

--- a/libcxx/include/__numeric/pstl.h
+++ b/libcxx/include/__numeric/pstl.h
@@ -70,7 +70,7 @@ template <class _ExecutionPolicy,
           class _ForwardIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI __iter_value_type<_ForwardIterator>
+_LIBCPP_HIDE_FROM_ABI __iterator_value_type<_ForwardIterator>
 reduce(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "reduce requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__reduce, __pstl::__current_configuration, _RawPolicy>;
@@ -78,7 +78,7 @@ reduce(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator _
       std::forward<_ExecutionPolicy>(__policy),
       std::move(__first),
       std::move(__last),
-      __iter_value_type<_ForwardIterator>(),
+      __iterator_value_type<_ForwardIterator>(),
       plus{});
 }
 

--- a/libcxx/include/__pstl/backends/default.h
+++ b/libcxx/include/__pstl/backends/default.h
@@ -102,7 +102,7 @@ struct __find<__default_backend_tag, _ExecutionPolicy> {
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) const noexcept {
     using _FindIf = __dispatch<__find_if, __current_configuration, _ExecutionPolicy>;
     return _FindIf()(
-        __policy, std::move(__first), std::move(__last), [&](__iter_reference<_ForwardIterator> __element) {
+        __policy, std::move(__first), std::move(__last), [&](__iterator_reference<_ForwardIterator> __element) {
           return __element == __value;
         });
   }
@@ -137,7 +137,7 @@ struct __all_of<__default_backend_tag, _ExecutionPolicy> {
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<bool>
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Pred&& __pred) const noexcept {
     using _AnyOf = __dispatch<__any_of, __current_configuration, _ExecutionPolicy>;
-    auto __res   = _AnyOf()(__policy, __first, __last, [&](__iter_reference<_ForwardIterator> __value) {
+    auto __res   = _AnyOf()(__policy, __first, __last, [&](__iterator_reference<_ForwardIterator> __value) {
       return !__pred(__value);
     });
     if (!__res)
@@ -204,7 +204,7 @@ struct __fill<__default_backend_tag, _ExecutionPolicy> {
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__empty>
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Tp const& __value) const noexcept {
     using _ForEach = __dispatch<__for_each, __current_configuration, _ExecutionPolicy>;
-    using _Ref     = __iter_reference<_ForwardIterator>;
+    using _Ref     = __iterator_reference<_ForwardIterator>;
     return _ForEach()(__policy, std::move(__first), std::move(__last), [&](_Ref __element) { __element = __value; });
   }
 };
@@ -233,7 +233,7 @@ struct __replace<__default_backend_tag, _ExecutionPolicy> {
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Tp const& __old, _Tp const& __new)
       const noexcept {
     using _ReplaceIf = __dispatch<__replace_if, __current_configuration, _ExecutionPolicy>;
-    using _Ref       = __iter_reference<_ForwardIterator>;
+    using _Ref       = __iterator_reference<_ForwardIterator>;
     return _ReplaceIf()(
         __policy, std::move(__first), std::move(__last), [&](_Ref __element) { return __element == __old; }, __new);
   }
@@ -246,7 +246,7 @@ struct __replace_if<__default_backend_tag, _ExecutionPolicy> {
       _Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Pred&& __pred, _Tp const& __new_value)
       const noexcept {
     using _ForEach = __dispatch<__for_each, __current_configuration, _ExecutionPolicy>;
-    using _Ref     = __iter_reference<_ForwardIterator>;
+    using _Ref     = __iterator_reference<_ForwardIterator>;
     return _ForEach()(__policy, std::move(__first), std::move(__last), [&](_Ref __element) {
       if (__pred(__element))
         __element = __new_value;
@@ -260,7 +260,7 @@ struct __generate<__default_backend_tag, _ExecutionPolicy> {
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__empty>
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Generator&& __gen) const noexcept {
     using _ForEach = __dispatch<__for_each, __current_configuration, _ExecutionPolicy>;
-    using _Ref     = __iter_reference<_ForwardIterator>;
+    using _Ref     = __iterator_reference<_ForwardIterator>;
     return _ForEach()(__policy, std::move(__first), std::move(__last), [&](_Ref __element) { __element = __gen(); });
   }
 };
@@ -271,7 +271,7 @@ struct __generate_n<__default_backend_tag, _ExecutionPolicy> {
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__empty>
   operator()(_Policy&& __policy, _ForwardIterator __first, _Size __n, _Generator&& __gen) const noexcept {
     using _ForEachN = __dispatch<__for_each_n, __current_configuration, _ExecutionPolicy>;
-    using _Ref      = __iter_reference<_ForwardIterator>;
+    using _Ref      = __iterator_reference<_ForwardIterator>;
     return _ForEachN()(__policy, std::move(__first), __n, [&](_Ref __element) { __element = __gen(); });
   }
 };
@@ -295,11 +295,11 @@ struct __sort<__default_backend_tag, _ExecutionPolicy> {
 template <class _ExecutionPolicy>
 struct __count_if<__default_backend_tag, _ExecutionPolicy> {
   template <class _Policy, class _ForwardIterator, class _Predicate>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__iter_diff_t<_ForwardIterator>> operator()(
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__iterator_difference_type<_ForwardIterator>> operator()(
       _Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate&& __pred) const noexcept {
     using _TransformReduce = __dispatch<__transform_reduce, __current_configuration, _ExecutionPolicy>;
-    using _DiffT           = __iter_diff_t<_ForwardIterator>;
-    using _Ref             = __iter_reference<_ForwardIterator>;
+    using _DiffT           = __iterator_difference_type<_ForwardIterator>;
+    using _Ref             = __iterator_reference<_ForwardIterator>;
     return _TransformReduce()(
         __policy, std::move(__first), std::move(__last), _DiffT{}, std::plus{}, [&](_Ref __element) -> _DiffT {
           return __pred(__element) ? _DiffT(1) : _DiffT(0);
@@ -310,10 +310,10 @@ struct __count_if<__default_backend_tag, _ExecutionPolicy> {
 template <class _ExecutionPolicy>
 struct __count<__default_backend_tag, _ExecutionPolicy> {
   template <class _Policy, class _ForwardIterator, class _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__iter_diff_t<_ForwardIterator>>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<__iterator_difference_type<_ForwardIterator>>
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Tp const& __value) const noexcept {
     using _CountIf = __dispatch<__count_if, __current_configuration, _ExecutionPolicy>;
-    using _Ref     = __iter_reference<_ForwardIterator>;
+    using _Ref     = __iterator_reference<_ForwardIterator>;
     return _CountIf()(__policy, std::move(__first), std::move(__last), [&](_Ref __element) -> bool {
       return __element == __value;
     });
@@ -402,7 +402,7 @@ struct __replace_copy_if<__default_backend_tag, _ExecutionPolicy> {
              _Pred&& __pred,
              _Tp const& __new_value) const noexcept {
     using _Transform = __dispatch<__transform, __current_configuration, _ExecutionPolicy>;
-    using _Ref       = __iter_reference<_ForwardIterator>;
+    using _Ref       = __iterator_reference<_ForwardIterator>;
     auto __res =
         _Transform()(__policy, std::move(__first), std::move(__last), std::move(__out_it), [&](_Ref __element) {
           return __pred(__element) ? __new_value : __element;
@@ -424,7 +424,7 @@ struct __replace_copy<__default_backend_tag, _ExecutionPolicy> {
              _Tp const& __old_value,
              _Tp const& __new_value) const noexcept {
     using _ReplaceCopyIf = __dispatch<__replace_copy_if, __current_configuration, _ExecutionPolicy>;
-    using _Ref           = __iter_reference<_ForwardIterator>;
+    using _Ref           = __iterator_reference<_ForwardIterator>;
     return _ReplaceCopyIf()(
         __policy,
         std::move(__first),

--- a/libcxx/include/__pstl/backends/libdispatch.h
+++ b/libcxx/include/__pstl/backends/libdispatch.h
@@ -269,7 +269,7 @@ struct __cpu_traits<__libdispatch_backend_tag> {
       return __empty{};
     }
 
-    using _Value = __iter_value_type<_RandomAccessIterator>;
+    using _Value = __iterator_value_type<_RandomAccessIterator>;
 
     auto __destroy = [__size](_Value* __ptr) {
       std::destroy_n(__ptr, __size);
@@ -282,7 +282,7 @@ struct __cpu_traits<__libdispatch_backend_tag> {
     // Initialize all elements to a moved-from state
     // TODO: Don't do this - this can be done in the first merge - see https://llvm.org/PR63928
     std::__construct_at(__values.get(), std::move(*__first));
-    for (__iter_diff_t<_RandomAccessIterator> __i = 1; __i != __size; ++__i) {
+    for (__iterator_difference_type<_RandomAccessIterator> __i = 1; __i != __size; ++__i) {
       std::__construct_at(__values.get() + __i, std::move(__values.get()[__i - 1]));
     }
     *__first = std::move(__values.get()[__size - 1]);

--- a/libcxx/include/__pstl/cpu_algos/find_if.h
+++ b/libcxx/include/__pstl/cpu_algos/find_if.h
@@ -119,7 +119,7 @@ struct __cpu_parallel_find_if {
           true);
     } else if constexpr (__is_unsequenced_execution_policy_v<_RawExecutionPolicy> &&
                          __has_random_access_iterator_category_or_concept<_ForwardIterator>::value) {
-      using __diff_t = __iter_diff_t<_ForwardIterator>;
+      using __diff_t = __iterator_difference_type<_ForwardIterator>;
       return __pstl::__simd_first<_Backend>(
           __first, __diff_t(0), __last - __first, [&__pred](_ForwardIterator __iter, __diff_t __i) {
             return __pred(__iter[__i]);

--- a/libcxx/include/__pstl/cpu_algos/transform.h
+++ b/libcxx/include/__pstl/cpu_algos/transform.h
@@ -84,9 +84,8 @@ struct __cpu_parallel_transform {
           __first,
           __last - __first,
           __result,
-          [&](__iter_reference<_ForwardIterator> __in_value, __iter_reference<_ForwardOutIterator> __out_value) {
-            __out_value = __op(__in_value);
-          });
+          [&](__iterator_reference<_ForwardIterator> __in_value,
+              __iterator_reference<_ForwardOutIterator> __out_value) { __out_value = __op(__in_value); });
     } else {
       return std::transform(__first, __last, __result, __op);
     }
@@ -138,9 +137,9 @@ struct __cpu_parallel_transform_binary {
           __last1 - __first1,
           __first2,
           __result,
-          [&](__iter_reference<_ForwardIterator1> __in1,
-              __iter_reference<_ForwardIterator2> __in2,
-              __iter_reference<_ForwardOutIterator> __out_value) { __out_value = __op(__in1, __in2); });
+          [&](__iterator_reference<_ForwardIterator1> __in1,
+              __iterator_reference<_ForwardIterator2> __in2,
+              __iterator_reference<_ForwardOutIterator> __out_value) { __out_value = __op(__in1, __in2); });
     } else {
       return std::transform(__first1, __last1, __first2, __result, __op);
     }

--- a/libcxx/include/__pstl/cpu_algos/transform_reduce.h
+++ b/libcxx/include/__pstl/cpu_algos/transform_reduce.h
@@ -148,9 +148,10 @@ struct __cpu_parallel_transform_reduce_binary {
                          __has_random_access_iterator_category_or_concept<_ForwardIterator1>::value &&
                          __has_random_access_iterator_category_or_concept<_ForwardIterator2>::value) {
       return __pstl::__simd_transform_reduce<_Backend>(
-          __last1 - __first1, std::move(__init), std::move(__reduce), [&](__iter_diff_t<_ForwardIterator1> __i) {
-            return __transform(__first1[__i], __first2[__i]);
-          });
+          __last1 - __first1,
+          std::move(__init),
+          std::move(__reduce),
+          [&](__iterator_difference_type<_ForwardIterator1> __i) { return __transform(__first1[__i], __first2[__i]); });
     } else {
       return std::transform_reduce(
           std::move(__first1),
@@ -200,7 +201,7 @@ struct __cpu_parallel_transform_reduce {
           __last - __first,
           std::move(__init),
           std::move(__reduce),
-          [=, &__transform](__iter_diff_t<_ForwardIterator> __i) { return __transform(__first[__i]); });
+          [=, &__transform](__iterator_difference_type<_ForwardIterator> __i) { return __transform(__first[__i]); });
     } else {
       return std::transform_reduce(
           std::move(__first), std::move(__last), std::move(__init), std::move(__reduce), std::move(__transform));

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -844,16 +844,16 @@ private:
 
 #if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
+          class _Alloc = allocator<__iterator_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class        = enable_if_t<__is_allocator_v<_Alloc>>>
-vector(_InputIterator, _InputIterator) -> vector<__iter_value_type<_InputIterator>, _Alloc>;
+vector(_InputIterator, _InputIterator) -> vector<__iterator_value_type<_InputIterator>, _Alloc>;
 
 template <class _InputIterator,
           class _Alloc,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Alloc>>>
-vector(_InputIterator, _InputIterator, _Alloc) -> vector<__iter_value_type<_InputIterator>, _Alloc>;
+vector(_InputIterator, _InputIterator, _Alloc) -> vector<__iterator_value_type<_InputIterator>, _Alloc>;
 #endif
 
 #if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -1258,16 +1258,16 @@ _LIBCPP_CONSTEXPR const typename allocator_traits<_Alloc>::difference_type deque
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
+          class _Alloc = allocator<__iterator_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class        = enable_if_t<__is_allocator_v<_Alloc>>>
-deque(_InputIterator, _InputIterator) -> deque<__iter_value_type<_InputIterator>, _Alloc>;
+deque(_InputIterator, _InputIterator) -> deque<__iterator_value_type<_InputIterator>, _Alloc>;
 
 template <class _InputIterator,
           class _Alloc,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Alloc>>>
-deque(_InputIterator, _InputIterator, _Alloc) -> deque<__iter_value_type<_InputIterator>, _Alloc>;
+deque(_InputIterator, _InputIterator, _Alloc) -> deque<__iterator_value_type<_InputIterator>, _Alloc>;
 #  endif
 
 #  if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -918,16 +918,16 @@ private:
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
+          class _Alloc = allocator<__iterator_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class        = enable_if_t<__is_allocator_v<_Alloc>>>
-forward_list(_InputIterator, _InputIterator) -> forward_list<__iter_value_type<_InputIterator>, _Alloc>;
+forward_list(_InputIterator, _InputIterator) -> forward_list<__iterator_value_type<_InputIterator>, _Alloc>;
 
 template <class _InputIterator,
           class _Alloc,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Alloc>>>
-forward_list(_InputIterator, _InputIterator, _Alloc) -> forward_list<__iter_value_type<_InputIterator>, _Alloc>;
+forward_list(_InputIterator, _InputIterator, _Alloc) -> forward_list<__iterator_value_type<_InputIterator>, _Alloc>;
 #  endif
 
 #  if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -1000,16 +1000,16 @@ private:
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
+          class _Alloc = allocator<__iterator_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class        = enable_if_t<__is_allocator_v<_Alloc>>>
-list(_InputIterator, _InputIterator) -> list<__iter_value_type<_InputIterator>, _Alloc>;
+list(_InputIterator, _InputIterator) -> list<__iterator_value_type<_InputIterator>, _Alloc>;
 
 template <class _InputIterator,
           class _Alloc,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Alloc>>>
-list(_InputIterator, _InputIterator, _Alloc) -> list<__iter_value_type<_InputIterator>, _Alloc>;
+list(_InputIterator, _InputIterator, _Alloc) -> list<__iterator_value_type<_InputIterator>, _Alloc>;
 #  endif
 
 #  if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -449,7 +449,7 @@ queue(_Container, _Alloc) -> queue<typename _Container::value_type, _Container>;
 
 #  if _LIBCPP_STD_VER >= 23
 template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
-queue(_InputIterator, _InputIterator) -> queue<__iter_value_type<_InputIterator>>;
+queue(_InputIterator, _InputIterator) -> queue<__iterator_value_type<_InputIterator>>;
 
 template <ranges::input_range _Range>
 queue(from_range_t, _Range&&) -> queue<ranges::range_value_t<_Range>>;
@@ -459,7 +459,7 @@ template <class _InputIterator,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
           __enable_if_t<__is_allocator_v<_Alloc>, int>                             = 0>
 queue(_InputIterator, _InputIterator, _Alloc)
-    -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+    -> queue<__iterator_value_type<_InputIterator>, deque<__iterator_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator_v<_Alloc>, int> = 0>
 queue(from_range_t, _Range&&, _Alloc)
@@ -705,13 +705,13 @@ template <class _Compare,
 priority_queue(_Compare, _Container) -> priority_queue<typename _Container::value_type, _Container, _Compare>;
 
 template <class _InputIterator,
-          class _Compare   = less<__iter_value_type<_InputIterator>>,
-          class _Container = vector<__iter_value_type<_InputIterator>>,
+          class _Compare   = less<__iterator_value_type<_InputIterator>>,
+          class _Container = vector<__iterator_value_type<_InputIterator>>,
           class            = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class            = enable_if_t<!__is_allocator_v<_Compare>>,
           class            = enable_if_t<!__is_allocator_v<_Container>>>
 priority_queue(_InputIterator, _InputIterator, _Compare = _Compare(), _Container = _Container())
-    -> priority_queue<__iter_value_type<_InputIterator>, _Container, _Compare>;
+    -> priority_queue<__iterator_value_type<_InputIterator>, _Container, _Compare>;
 
 template <class _Compare,
           class _Container,
@@ -726,9 +726,9 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 priority_queue(_InputIterator, _InputIterator, _Allocator)
-    -> priority_queue<__iter_value_type<_InputIterator>,
-                      vector<__iter_value_type<_InputIterator>, _Allocator>,
-                      less<__iter_value_type<_InputIterator>>>;
+    -> priority_queue<__iterator_value_type<_InputIterator>,
+                      vector<__iterator_value_type<_InputIterator>, _Allocator>,
+                      less<__iterator_value_type<_InputIterator>>>;
 
 template <class _InputIterator,
           class _Compare,
@@ -737,8 +737,8 @@ template <class _InputIterator,
           class = enable_if_t<!__is_allocator_v<_Compare>>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 priority_queue(_InputIterator, _InputIterator, _Compare, _Allocator)
-    -> priority_queue<__iter_value_type<_InputIterator>,
-                      vector<__iter_value_type<_InputIterator>, _Allocator>,
+    -> priority_queue<__iterator_value_type<_InputIterator>,
+                      vector<__iterator_value_type<_InputIterator>, _Allocator>,
                       _Compare>;
 
 template <class _InputIterator,

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -896,13 +896,13 @@ public:
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Compare   = less<__iter_value_type<_InputIterator>>,
-          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
+          class _Compare   = less<__iterator_value_type<_InputIterator>>,
+          class _Allocator = allocator<__iterator_value_type<_InputIterator>>,
           class            = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class            = enable_if_t<__is_allocator_v<_Allocator>>,
           class            = enable_if_t<!__is_allocator_v<_Compare>>>
 set(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
-    -> set<__iter_value_type<_InputIterator>, _Compare, _Allocator>;
+    -> set<__iterator_value_type<_InputIterator>, _Compare, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
@@ -926,7 +926,7 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 set(_InputIterator, _InputIterator, _Allocator)
-    -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
+    -> set<__iterator_value_type<_InputIterator>, less<__iterator_value_type<_InputIterator>>, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator_v<_Allocator>>>
@@ -1348,13 +1348,13 @@ public:
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Compare   = less<__iter_value_type<_InputIterator>>,
-          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
+          class _Compare   = less<__iterator_value_type<_InputIterator>>,
+          class _Allocator = allocator<__iterator_value_type<_InputIterator>>,
           class            = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class            = enable_if_t<__is_allocator_v<_Allocator>>,
           class            = enable_if_t<!__is_allocator_v<_Compare>>>
 multiset(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
-    -> multiset<__iter_value_type<_InputIterator>, _Compare, _Allocator>;
+    -> multiset<__iterator_value_type<_InputIterator>, _Compare, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
@@ -1379,7 +1379,7 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 multiset(_InputIterator, _InputIterator, _Allocator)
-    -> multiset<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
+    -> multiset<__iterator_value_type<_InputIterator>, less<__iterator_value_type<_InputIterator>>, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator_v<_Allocator>>>

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -306,7 +306,7 @@ stack(_Container, _Alloc) -> stack<typename _Container::value_type, _Container>;
 
 #  if _LIBCPP_STD_VER >= 23
 template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
-stack(_InputIterator, _InputIterator) -> stack<__iter_value_type<_InputIterator>>;
+stack(_InputIterator, _InputIterator) -> stack<__iterator_value_type<_InputIterator>>;
 
 template <ranges::input_range _Range>
 stack(from_range_t, _Range&&) -> stack<ranges::range_value_t<_Range>>;
@@ -316,7 +316,7 @@ template <class _InputIterator,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
           __enable_if_t<__is_allocator_v<_Alloc>, int>                             = 0>
 stack(_InputIterator, _InputIterator, _Alloc)
-    -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+    -> stack<__iterator_value_type<_InputIterator>, deque<__iterator_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator_v<_Alloc>, int> = 0>
 stack(from_range_t, _Range&&, _Alloc)

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2585,7 +2585,7 @@ inline const bool __is_transparently_comparable_v<_Comparator,
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _CharT     = __iter_value_type<_InputIterator>,
+          class _CharT     = __iterator_value_type<_InputIterator>,
           class _Allocator = allocator<_CharT>,
           class            = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class            = enable_if_t<__is_allocator_v<_Allocator>>>

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -913,9 +913,9 @@ public:
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Hash      = hash<__iter_value_type<_InputIterator>>,
-          class _Pred      = equal_to<__iter_value_type<_InputIterator>>,
-          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
+          class _Hash      = hash<__iterator_value_type<_InputIterator>>,
+          class _Pred      = equal_to<__iterator_value_type<_InputIterator>>,
+          class _Allocator = allocator<__iterator_value_type<_InputIterator>>,
           class            = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class            = enable_if_t<!__is_allocator_v<_Hash>>,
           class            = enable_if_t<!is_integral<_Hash>::value>,
@@ -926,7 +926,8 @@ unordered_set(_InputIterator,
               typename allocator_traits<_Allocator>::size_type = 0,
               _Hash                                            = _Hash(),
               _Pred                                            = _Pred(),
-              _Allocator = _Allocator()) -> unordered_set<__iter_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
+              _Allocator                                       = _Allocator())
+    -> unordered_set<__iterator_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
@@ -965,9 +966,9 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 unordered_set(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Allocator)
-    -> unordered_set<__iter_value_type<_InputIterator>,
-                     hash<__iter_value_type<_InputIterator>>,
-                     equal_to<__iter_value_type<_InputIterator>>,
+    -> unordered_set<__iterator_value_type<_InputIterator>,
+                     hash<__iterator_value_type<_InputIterator>>,
+                     equal_to<__iterator_value_type<_InputIterator>>,
                      _Allocator>;
 
 template <class _InputIterator,
@@ -978,7 +979,10 @@ template <class _InputIterator,
           class = enable_if_t<!is_integral<_Hash>::value>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 unordered_set(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
-    -> unordered_set<__iter_value_type<_InputIterator>, _Hash, equal_to<__iter_value_type<_InputIterator>>, _Allocator>;
+    -> unordered_set<__iterator_value_type<_InputIterator>,
+                     _Hash,
+                     equal_to<__iterator_value_type<_InputIterator>>,
+                     _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 
@@ -1498,9 +1502,9 @@ public:
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
-          class _Hash      = hash<__iter_value_type<_InputIterator>>,
-          class _Pred      = equal_to<__iter_value_type<_InputIterator>>,
-          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
+          class _Hash      = hash<__iterator_value_type<_InputIterator>>,
+          class _Pred      = equal_to<__iterator_value_type<_InputIterator>>,
+          class _Allocator = allocator<__iterator_value_type<_InputIterator>>,
           class            = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class            = enable_if_t<!__is_allocator_v<_Hash>>,
           class            = enable_if_t<!is_integral<_Hash>::value>,
@@ -1512,7 +1516,7 @@ unordered_multiset(
     typename allocator_traits<_Allocator>::size_type = 0,
     _Hash                                            = _Hash(),
     _Pred                                            = _Pred(),
-    _Allocator = _Allocator()) -> unordered_multiset<__iter_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
+    _Allocator = _Allocator()) -> unordered_multiset<__iterator_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
@@ -1551,9 +1555,9 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Allocator)
-    -> unordered_multiset<__iter_value_type<_InputIterator>,
-                          hash<__iter_value_type<_InputIterator>>,
-                          equal_to<__iter_value_type<_InputIterator>>,
+    -> unordered_multiset<__iterator_value_type<_InputIterator>,
+                          hash<__iterator_value_type<_InputIterator>>,
+                          equal_to<__iterator_value_type<_InputIterator>>,
                           _Allocator>;
 
 template <class _InputIterator,
@@ -1564,9 +1568,9 @@ template <class _InputIterator,
           class = enable_if_t<!is_integral<_Hash>::value>,
           class = enable_if_t<__is_allocator_v<_Allocator>>>
 unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
-    -> unordered_multiset<__iter_value_type<_InputIterator>,
+    -> unordered_multiset<__iterator_value_type<_InputIterator>,
                           _Hash,
-                          equal_to<__iter_value_type<_InputIterator>>,
+                          equal_to<__iterator_value_type<_InputIterator>>,
                           _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23

--- a/libcxx/test/libcxx/algorithms/cpp17_iterator_concepts.verify.cpp
+++ b/libcxx/test/libcxx/algorithms/cpp17_iterator_concepts.verify.cpp
@@ -102,7 +102,7 @@ void check_iterator_requirements() {
   // expected-note@*:* {{because 'not_copy_assignable' does not satisfy '__cpp17_copy_assignable'}}
 
   static_assert(std::__cpp17_iterator<diff_t_not_signed>); // expected-error {{static assertion failed}}
-  // expected-note-re@*:* {{because 'is_signed_v<__iter_diff_t<diff_t_not_signed>{{.*}}>' evaluated to false}}
+  // expected-note-re@*:* {{because 'is_signed_v<__iterator_difference_type<diff_t_not_signed>{{.*}}>' evaluated to false}}
 }
 
 struct not_equality_comparable : valid_iterator<not_equality_comparable> {};
@@ -173,7 +173,7 @@ void check_bidirectional_iterator_requirements() {
   _LIBCPP_REQUIRE_CPP17_BIDIRECTIONAL_ITERATOR(missing_postdecrement, ""); // expected-error {{static assertion failed}}
   // expected-note@*:* {{cannot decrement value of type 'missing_postdecrement'}}
   _LIBCPP_REQUIRE_CPP17_BIDIRECTIONAL_ITERATOR(not_returning_iter_reference, ""); // expected-error {{static assertion failed}}
-  // expected-note-re@*:* {{'same_as<int, __iter_reference<not_returning_iter_reference>{{ ?}}>'}}
+  // expected-note-re@*:* {{'same_as<int, __iterator_reference<not_returning_iter_reference>{{ ?}}>'}}
   // clang-format on
 }
 


### PR DESCRIPTION
This renames all the `iterator_traits` alises to be `__iterator_<type-name>`. e.g `iterator_traits<T>::value_type` will be `__iterator_value_type<T>`.
