### PR TITLE
[VPlan] Introduce vputils::getSingleScalarClone

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -537,6 +537,38 @@ vputils::getRecipesForUncountableExit(VPlan &Plan,
   return UncountableCondition;
 }
 
+VPSingleDefRecipe *vputils::getSingleScalarClone(VPSingleDefRecipe *R) {
+  return TypeSwitch<VPSingleDefRecipe *, VPSingleDefRecipe *>(R)
+      .Case<VPInstruction, VPWidenRecipe, VPWidenCallRecipe, VPReplicateRecipe>(
+          [](auto *I) {
+            assert(I->getUnderlyingValue() &&
+                   "Cannot clone recipe without underlying value");
+            return new VPReplicateRecipe(I->getUnderlyingInstr(), I->operands(),
+                                         /*IsSingleScalar*/ true,
+                                         /*Mask*/ nullptr, /*Flags*/ *I,
+                                         /*Metadata*/ *I, I->getDebugLoc());
+          })
+      .Case<VPWidenGEPRecipe>([](auto *I) {
+        assert(I->getUnderlyingValue() &&
+               "Cannot clone recipe without underlying value");
+        // WidenGEP does not have metadata.
+        return new VPReplicateRecipe(I->getUnderlyingInstr(), I->operands(),
+                                     /*IsSingleScalar*/ true, /*Mask*/ nullptr,
+                                     /*Flags*/ *I, /*Metadata*/ {},
+                                     I->getDebugLoc());
+      })
+      .Case<VPWidenCastRecipe>([](auto *I) {
+        return new VPInstructionWithType(
+            I->getOpcode(), I->operands(), I->getResultType(),
+            /*Flags*/ *I, /*Metadata*/ *I, I->getDebugLoc());
+      })
+      .Default([](auto *I) {
+        assert(isa<VPScalarIVStepsRecipe>(I) &&
+               "Don't know how to convert to single-scalar");
+        return I->clone();
+      });
+}
+
 bool VPBlockUtils::isHeader(const VPBlockBase *VPB,
                             const VPDominatorTree &VPDT) {
   auto *VPBB = dyn_cast<VPBasicBlock>(VPB);

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -103,6 +103,10 @@ inline VPIRFlags getFlagsFromIndDesc(const InductionDescriptor &ID) {
          "Expected int induction");
   return VPIRFlags::WrapFlagsTy(false, false);
 }
+
+/// Returns a single-scalar version of \p R, creating a fresh single-scalar
+/// VPReplicateRecipe or just cloning the recipe.
+VPSingleDefRecipe *getSingleScalarClone(VPSingleDefRecipe *R);
 } // namespace vputils
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The idiom of taking a recipe and creating a single-scalar clone (often a replicate), is repeated over and over: introduce a VPUtils helper to factor out the common code.