### PR TITLE
[lldb][Linux] Fix checking of error values when attach fails

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -219,7 +219,8 @@ static llvm::Error AddPtraceScopeNote(llvm::Error original_error) {
   Expected<int> ptrace_scope = GetPtraceScope();
   if (auto E = ptrace_scope.takeError()) {
     Log *log = GetLog(POSIXLog::Process);
-    LLDB_LOG(log, "error reading value of ptrace_scope: {0}", E);
+    LLDB_LOG(log, "error reading value of ptrace_scope: {0}",
+             llvm::toString(std::move(E)));
 
     // The original error is probably more interesting than not being able to
     // read or interpret ptrace_scope.
@@ -230,6 +231,7 @@ static llvm::Error AddPtraceScopeNote(llvm::Error original_error) {
   switch (*ptrace_scope) {
   case 1:
   case 2:
+    llvm::consumeError(std::move(original_error));
     return llvm::createStringError(
         std::error_code(errno, std::generic_category()),
         "The current value of ptrace_scope is %d, which can cause ptrace to "
@@ -239,6 +241,7 @@ static llvm::Error AddPtraceScopeNote(llvm::Error original_error) {
         "https://www.kernel.org/doc/Documentation/security/Yama.txt.",
         *ptrace_scope);
   case 3:
+    llvm::consumeError(std::move(original_error));
     return llvm::createStringError(
         std::error_code(errno, std::generic_category()),
         "The current value of ptrace_scope is 3, which will cause ptrace to "

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -218,9 +218,8 @@ static Status EnsureFDFlags(int fd, int flags) {
 static llvm::Error AddPtraceScopeNote(llvm::Error original_error) {
   Expected<int> ptrace_scope = GetPtraceScope();
   if (auto E = ptrace_scope.takeError()) {
-    Log *log = GetLog(POSIXLog::Process);
-    LLDB_LOG(log, "error reading value of ptrace_scope: {0}",
-             llvm::toString(std::move(E)));
+    LLDB_LOG_ERROR(GetLog(POSIXLog::Process), std::move(E),
+                   "error reading value of ptrace_scope: {0}");
 
     // The original error is probably more interesting than not being able to
     // read or interpret ptrace_scope.


### PR DESCRIPTION
Relates to #161510

Fixes 6db44e52ce474bbeb66042073a6e3c6c586f78a2

(it's not fixing it, it's just making the error not be an unhandled error)

When we fail to attach to a process we see if we can add more information about why it happened:
```
  if (status.GetError() == EPERM) {
    // Depending on the value of ptrace_scope, we can return a different
    // error that suggests how to fix it.
    return AddPtraceScopeNote(status.ToError());
  }
```
ToError creates a new error value and leaves the one in `status` unchecked. `status`'s error is ok because it will be checked by Status' destructor.

The problem happens in `AddPtraceScopeNote`. If we take certain return paths, this new error, or the one we get when trying to find the ptrace scope, may be unchecked on destruction when the function returns.

To fix this, in AddPtraceScopeNote, consume any errors that we are not going to return. Anything returned will be checked by some caller.

Reproducing this failure mode is difficult but it can be faked by calling AddPtraceScopeNote earlier. Which is what I did to prove the concept of the problem.