### PR TITLE
[NFC][clang-sycl-linker] Avoid ambiguous call to CallingConv

### DIFF
--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -463,7 +463,8 @@ static Error runAOTCompile(StringRef InputFile, StringRef OutputFile,
 // TODO: Consider using LLVM-IR metadata to identify globals of interest
 bool isKernel(const Function &F) {
   const llvm::CallingConv::ID CC = F.getCallingConv();
-  return CC == llvm::CallingConv::SPIR_KERNEL || CC == llvm::CallingConv::AMDGPU_KERNEL ||
+  return CC == llvm::CallingConv::SPIR_KERNEL ||
+         CC == llvm::CallingConv::AMDGPU_KERNEL ||
          CC == llvm::CallingConv::PTX_Kernel;
 }
 

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -462,9 +462,9 @@ static Error runAOTCompile(StringRef InputFile, StringRef OutputFile,
 
 // TODO: Consider using LLVM-IR metadata to identify globals of interest
 bool isKernel(const Function &F) {
-  const CallingConv::ID CC = F.getCallingConv();
-  return CC == CallingConv::SPIR_KERNEL || CC == CallingConv::AMDGPU_KERNEL ||
-         CC == CallingConv::PTX_Kernel;
+  const llvm::CallingConv::ID CC = F.getCallingConv();
+  return CC == llvm::CallingConv::SPIR_KERNEL || CC == llvm::CallingConv::AMDGPU_KERNEL ||
+         CC == llvm::CallingConv::PTX_Kernel;
 }
 
 /// Performs the following steps:


### PR DESCRIPTION
both llvm and clang namespace have CallingConv.
Add namespace prefix to avoid ambiguous call .
