### PR TITLE
[clang] Fix device_kernel attribute crash on unsupported targets when not using AMDGPU spelling

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -397,6 +397,8 @@ Bug Fixes to Attribute Support
 - Using ``[[gnu::cleanup(some_func)]]`` where some_func is annotated with
   ``[[gnu::error("some error")]]`` now correctly triggers an error. (#GH146520)
 - Fix a crash when the function name is empty in the `swift_name` attribute. (#GH157075)
+- Fix a crash and missing diagnostic when using some device_kernel attributes in
+  unsupported targets. (#GH161077)
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5204,7 +5204,11 @@ static void handleCallConvAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 static void handleDeviceKernelAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   const auto *FD = dyn_cast_or_null<FunctionDecl>(D);
   bool IsFunctionTemplate = FD && FD->getDescribedFunctionTemplate();
-  if (S.getLangOpts().SYCLIsDevice) {
+  if (!S.getLangOpts().OpenCL && !S.getLangOpts().CUDA && !DeviceKernelAttr::isAMDGPUSpelling(AL)) {
+    // This is already diagnosed for AMDGPU in getCCForDeclaratorChunk
+    S.Diag(AL.getLoc(), diag::warn_cconv_unsupported)
+        << AL << (int)Sema::CallingConventionIgnoredReason::ForThisTarget;
+  } else if (S.getLangOpts().SYCLIsDevice) {
     if (!IsFunctionTemplate) {
       S.Diag(AL.getLoc(), diag::warn_attribute_wrong_decl_type_str)
           << AL << AL.isRegularKeywordAttribute() << "function templates";

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5204,7 +5204,8 @@ static void handleCallConvAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 static void handleDeviceKernelAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   const auto *FD = dyn_cast_or_null<FunctionDecl>(D);
   bool IsFunctionTemplate = FD && FD->getDescribedFunctionTemplate();
-  if (!S.getLangOpts().OpenCL && !S.getLangOpts().CUDA && !DeviceKernelAttr::isAMDGPUSpelling(AL)) {
+  if (!S.getLangOpts().OpenCL && !S.getLangOpts().CUDA &&
+      !DeviceKernelAttr::isAMDGPUSpelling(AL)) {
     // This is already diagnosed for AMDGPU in getCCForDeclaratorChunk
     S.Diag(AL.getLoc(), diag::warn_cconv_unsupported)
         << AL << (int)Sema::CallingConventionIgnoredReason::ForThisTarget;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -3780,7 +3780,7 @@ static CallingConv getCCForDeclaratorChunk(
       }
     }
   }
-  if (!S.getLangOpts().isSYCL()) {
+  if (S.getLangOpts().OpenCL || S.getLangOpts().CUDA) {
     for (const ParsedAttr &AL : D.getDeclSpec().getAttributes()) {
       if (AL.getKind() == ParsedAttr::AT_DeviceKernel) {
         CC = CC_DeviceKernel;

--- a/clang/test/Sema/callingconv.c
+++ b/clang/test/Sema/callingconv.c
@@ -55,6 +55,10 @@ int __attribute__((aarch64_vector_pcs)) aavpcs(void); // expected-warning {{'aar
 int __attribute__((aarch64_sve_pcs)) aasvepcs(void);  // expected-warning {{'aarch64_sve_pcs' calling convention is not supported for this target}}
 
 int __attribute__((amdgpu_kernel)) amdgpu_kernel(void); // expected-warning {{'amdgpu_kernel' calling convention is not supported for this target}}
+int __attribute__((device_kernel)) device_kernel(void) { // expected-warning {{'device_kernel' calling convention is not supported for this target}}
+}
+int __attribute__((sycl_kernel)) sycl_kernel(void) { // expected-warning {{'sycl_kernel' calling convention is not supported for this target}}
+}
 
 // PR6361
 void ctest3();


### PR DESCRIPTION
Resolves #161077

For non-AMDGPU spellings, modify sema attr handling to ignore and diagnose the device_kernel attribute when not on a supported target. For the AMDGPU spelling, this is already performed via getCCForDeclaratorChunk, unfortunately not simple to unify these cases, ([discussion](https://github.com/llvm/llvm-project/pull/161349#discussion_r2391039436)).