### PR TITLE
[libc] Fix issue with fuzz input too short for atoi diff fuzz

### DIFF
--- a/libc/fuzzing/stdlib/strtointeger_differential_fuzz.cpp
+++ b/libc/fuzzing/stdlib/strtointeger_differential_fuzz.cpp
@@ -44,6 +44,10 @@
 // greater than 50% chance for each character to end the string, making the odds
 // of getting long numbers very low.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 2) // Needs at least one byte for the base and one byte for the
+                // string.
+    return 0;
+
   uint8_t *container = new uint8_t[size + 1];
   if (!container)
     __builtin_trap();


### PR DESCRIPTION
The string to integer differential fuzzer assumes at least one byte of
meaningful input, but wasn't explicitly checking that. Now it does.
