### PR TITLE
[AMDGPU] Use correct SlotIndex to calculate live-out register set.

### DIFF
--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -481,13 +481,11 @@ class raw_ostream;
     /// This index corresponds to the dead slot of the last non-debug
     /// instruction and can be used to find live-out ranges of the block. Note
     /// that getMBBEndIdx returns the start index of the next block, which is
-    /// also used as the start index for segments with phi-def values. Returns
-    /// an invalid SlotIndex if the block has no non-debug instructions.
+    /// also used as the start index for segments with phi-def values. If the
+    /// basic block doesn't contain any non-debug instructions, this returns
+    /// the same as getMBBStartIdx.getDeadSlot().
     SlotIndex getMBBLastIdx(const MachineBasicBlock *MBB) const {
-      auto LastInstrI = MBB->getLastNonDebugInstr();
-      return LastInstrI == MBB->end()
-                 ? SlotIndex()
-                 : getInstructionIndex(*LastInstrI).getDeadSlot();
+      return getMBBEndIdx(MBB).getPrevSlot();
     }
 
     /// Iterator over the idx2MBBMap (sorted pairs of slot index of basic block

--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -467,14 +467,27 @@ class raw_ostream;
       return getMBBRange(mbb).first;
     }
 
-    /// Returns the last index in the given basic block number.
+    /// Returns the index past the last valid index in the given basic block.
     SlotIndex getMBBEndIdx(unsigned Num) const {
       return getMBBRange(Num).second;
     }
 
-    /// Returns the last index in the given basic block.
+    /// Returns the index past the last valid index in the given basic block.
     SlotIndex getMBBEndIdx(const MachineBasicBlock *mbb) const {
       return getMBBRange(mbb).second;
+    }
+
+    /// Returns the last valid index in the given basic block.
+    /// This index corresponds to the dead slot of the last non-debug
+    /// instruction and can be used to find live-out ranges of the block. Note
+    /// that getMBBEndIdx returns the start index of the next block, which is
+    /// also used as the start index for segments with phi-def values. Returns
+    /// an invalid SlotIndex if the block has no non-debug instructions.
+    SlotIndex getMBBLastIdx(const MachineBasicBlock *MBB) const {
+      auto LastInstrI = MBB->getLastNonDebugInstr();
+      return LastInstrI == MBB->end()
+                 ? SlotIndex()
+                 : getInstructionIndex(*LastInstrI).getDeadSlot();
     }
 
     /// Iterator over the idx2MBBMap (sorted pairs of slot index of basic block

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -313,8 +313,8 @@ public:
 
   /// reset tracker to the end of the \p MBB.
   void reset(const MachineBasicBlock &MBB) {
-    reset(MBB.getParent()->getRegInfo(),
-          LIS.getSlotIndexes()->getMBBEndIdx(&MBB));
+    SlotIndex MBBLastSlot = LIS.getSlotIndexes()->getMBBLastIdx(&MBB);
+    reset(MBB.getParent()->getRegInfo(), MBBLastSlot);
   }
 
   /// reset tracker to the point just after \p MI (in program order).

--- a/llvm/test/CodeGen/AMDGPU/regpressure_printer.mir
+++ b/llvm/test/CodeGen/AMDGPU/regpressure_printer.mir
@@ -510,14 +510,14 @@ body: |
   ; RPU-NEXT:   0     0      $sgpr0 = S_BUFFER_LOAD_DWORD_IMM $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0
   ; RPU-NEXT:   0     0
   ; RPU-NEXT:   0     1      undef %0.sub5:vreg_512 = V_MOV_B32_e32 5, implicit $exec
-  ; RPU-NEXT:   0     0
-  ; RPU-NEXT:   0     0      S_CMP_GT_U32 $sgpr0, 15, implicit-def $scc
-  ; RPU-NEXT:   0     0
-  ; RPU-NEXT:   0     0      S_CBRANCH_SCC1 %bb.2, implicit $scc
-  ; RPU-NEXT:   0     0
-  ; RPU-NEXT:   0     0      S_BRANCH %bb.1
-  ; RPU-NEXT:   0     0
-  ; RPU-NEXT:   Live-out:
+  ; RPU-NEXT:   0     1
+  ; RPU-NEXT:   0     1      S_CMP_GT_U32 $sgpr0, 15, implicit-def $scc
+  ; RPU-NEXT:   0     1
+  ; RPU-NEXT:   0     1      S_CBRANCH_SCC1 %bb.2, implicit $scc
+  ; RPU-NEXT:   0     1
+  ; RPU-NEXT:   0     1      S_BRANCH %bb.1
+  ; RPU-NEXT:   0     1
+  ; RPU-NEXT:   Live-out: %0:0000000000000C00
   ; RPU-NEXT:   Live-thr:
   ; RPU-NEXT:   0     0
   ; RPU-NEXT: bb.1:
@@ -571,8 +571,6 @@ body: |
   ; RPD-NEXT:   0     1      S_BRANCH %bb.1
   ; RPD-NEXT:   0     1
   ; RPD-NEXT:   Live-out: %0:0000000000000C00
-  ; RPD-NEXT:   mis LIS:
-  ; RPD-NEXT:     %0:L0000000000000C00 isn't found in LIS reported set
   ; RPD-NEXT:   Live-thr:
   ; RPD-NEXT:   0     0
   ; RPD-NEXT: bb.1:


### PR DESCRIPTION
Using SlotIndexes::getMBBEndIdx() isn't the correct choice here because it returns the starting index of the next basic block, causing live-ins of the next block to be calculated instead of the intended live-outs of the current block.

Add SlotIndexes::getMBBLastIdx() method to return the last valid SlotIndex within a basic block, enabling correct live-out calculations.