### PR TITLE
[lldb] Add lld requirement to NativePDB test

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/symtab.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/symtab.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: x86
+// REQUIRES: lld, x86
 
 // Test symtab reading
 // RUN: %build --compiler=clang-cl --arch=64 --nodefaultlib -o %t.exe -- %s


### PR DESCRIPTION
The cpp file fails to build without `lld-link`.