### PR TITLE
[lldb] Prevent early exit for weak symbol found in IRExecutionUnit::FindInSymbols

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -822,7 +822,8 @@ IRExecutionUnit::FindInSymbols(const std::vector<ConstString> &names,
       sc.module_sp->FindSymbolsWithNameAndType(name, lldb::eSymbolTypeAny,
                                                sc_list);
       if (auto load_addr = resolver.Resolve(sc_list))
-        return *load_addr;
+        if (!symbol_was_missing_weak)
+          return *load_addr;
     }
 
     {
@@ -830,7 +831,8 @@ IRExecutionUnit::FindInSymbols(const std::vector<ConstString> &names,
       m_preferred_modules.FindSymbolsWithNameAndType(name, lldb::eSymbolTypeAny,
                                                      sc_list);
       if (auto load_addr = resolver.Resolve(sc_list))
-        return *load_addr;
+        if (!symbol_was_missing_weak)
+          return *load_addr;
     }
 
     {
@@ -838,7 +840,8 @@ IRExecutionUnit::FindInSymbols(const std::vector<ConstString> &names,
       non_local_images.FindSymbolsWithNameAndType(name, lldb::eSymbolTypeAny,
                                                   sc_list);
       if (auto load_addr = resolver.Resolve(sc_list))
-        return *load_addr;
+        if (!symbol_was_missing_weak)
+          return *load_addr;
     }
 
     lldb::addr_t best_internal_load_address =


### PR DESCRIPTION
`LoadAddressResolver::Resolve` returns zero for weak symbols. However `FindInSymbols` does multiple searches (each starting with `FindSymbolsWithNameAndType`), and a resolved address of zero from one step of the search should not conclude the search.

This change continues the searching for a symbol by only performing an early exit when a concrete address is found.

This was identified by an objc class which is available only in newer OSes. Such classes are weak linked. Expressions involving this class were failing, because the search first found the weak linked symbol (which eagerly returned an address of zero).

rdar://161406615
