### PR TITLE
[libcxx] [ci] Make the CI find the right version of Clang-cl

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -281,6 +281,10 @@ jobs:
       - name: Set up the MSVC dev environment
         if: ${{ matrix.mingw != true }}
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - name: Add the installed Clang at the start of the path
+        if: ${{ matrix.mingw != true }}
+        run: |
+          echo "c:\Program Files\LLVM\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build and test
         run: |
           bash libcxx/utils/ci/run-buildbot ${{ matrix.config }}


### PR DESCRIPTION
We install a (or in practice, update a preexisting) copy of Clang, in order to get a specific version that we want. At that point in the procedure, this is the only version of Clang in the PATH.

However, the step of adding the MSVC build tools to the environment also ends up adding another copy of Clang, bundled with MSVC, into the PATH.

Due to this, CMake ends up finding and preferring the older version of Clang bundled with MSVC, rather than the one we intend to be used.

Manually add the directory of the version of Clang we want to use at the head of the search path, after initializing the MSVC build tool environment.

The directory name we add is a hardcoded guess of where it is installed - this is not ideal, but seems like the most straightforward solution for now.