### PR TITLE
[HLSL] Add missing dependency to Frontend unittest

### DIFF
--- a/llvm/unittests/Frontend/CMakeLists.txt
+++ b/llvm/unittests/Frontend/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_LINK_COMPONENTS
   Analysis
+  BinaryFormat
   Core
   FrontendHLSL
   FrontendOffloading


### PR DESCRIPTION
Recently, a bot fails on `DefinedStaticSamplerDump` unittest. After some debugging, we come to the conclusion that the issue might because due to a missing dependency when compiling. This adds that dependency that was idenfied missing 