### PR TITLE
[SelectionDAG] add ISD::BITCAST handling for isGuaranteedNotToBeUndefOrPoison

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5819,8 +5819,9 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
                                               Depth + 1);
     }
 
-    // Case 2: Vector -> Scalar
-    if (SrcVT.isVector() && !TgtVT.isVector())
+    // Case 2: Vector -> Scalar, or Scalable Vector -> Scalable Vector
+    if ((SrcVT.isVector() && !TgtVT.isVector()) ||
+        (SrcVT.isScalableVT() && TgtVT.isScalableVT()))
       return isGuaranteedNotToBeUndefOrPoison(Src, PoisonOnly, Depth + 1);
 
     // Case 3: Vector -> Vector

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5807,6 +5807,30 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
            });
   }
 
+  case ISD::BITCAST: {
+    SDValue Src = Op.getOperand(0);
+    EVT SrcVT = Src.getValueType();
+    EVT TgtVT = Op.getValueType();
+
+    // Case 1: Scalar -> Vector, or Scalar -> Scalar
+    if (!SrcVT.isVector()) {
+      APInt DemandedSrcElts(1, 1);
+      return isGuaranteedNotToBeUndefOrPoison(Src, DemandedSrcElts, PoisonOnly,
+                                              Depth + 1);
+    }
+
+    // Case 2: Vector -> Scalar
+    if (SrcVT.isVector() && !TgtVT.isVector())
+      return isGuaranteedNotToBeUndefOrPoison(Src, PoisonOnly, Depth + 1);
+
+    // Case 3: Vector -> Vector
+    unsigned NumSrcElts = SrcVT.getVectorNumElements();
+    APInt ScaledDemandedElts = APIntOps::ScaleBitMask(DemandedElts, NumSrcElts);
+
+    return isGuaranteedNotToBeUndefOrPoison(Src, ScaledDemandedElts, PoisonOnly,
+                                            Depth + 1);
+  }
+
     // TODO: Search for noundef attributes from library functions.
 
     // TODO: Pointers dereferenced by ISD::LOAD/STORE ops are noundef.


### PR DESCRIPTION
Add `ISD::BITCAST` handling in isGuaranteedNotToBeUndefOrPoison by rescaling the demanded elements mask to match the source type, rather than conservatively testing all elements.


Solves #161512.