### PR TITLE
[libc] Simplify mman tests

### DIFF
--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -99,7 +99,6 @@ add_libc_unittest(
     libc.src.sys.mman.mincore
     libc.src.sys.mman.mlock
     libc.src.sys.mman.munlock
-    libc.src.unistd.sysconf
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
@@ -125,7 +124,6 @@ add_libc_unittest(
     libc.src.sys.mman.munlockall
     libc.src.sys.resource.getrlimit
     libc.src.__support.OSUtil.osutil
-    libc.src.unistd.sysconf
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
@@ -146,7 +144,6 @@ add_libc_unittest(
     libc.src.sys.mman.mincore
     libc.src.sys.mman.mlock
     libc.src.sys.mman.munlock
-    libc.src.unistd.sysconf
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
@@ -160,13 +157,14 @@ add_libc_unittest(
   DEPENDS
     libc.include.sys_mman
     libc.include.sys_stat
-    libc.src.unistd.sysconf
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
     libc.src.sys.mman.remap_file_pages
     libc.src.errno.errno
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
+    libc.src.fcntl.open
+    libc.src.unistd.close
 )
 
 add_libc_unittest(

--- a/libc/test/src/sys/mman/linux/mincore_test.cpp
+++ b/libc/test/src/sys/mman/linux/mincore_test.cpp
@@ -12,7 +12,6 @@
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munlock.h"
 #include "src/sys/mman/munmap.h"
-#include "src/unistd/sysconf.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -21,6 +20,9 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LlvmLibcMincoreTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+//TODO: Replace with sysconf call once the function is properly implemented.
+constexpr size_t PAGE_SIZE = 4096;
+
 TEST_F(LlvmLibcMincoreTest, UnMappedMemory) {
   unsigned char vec;
   int res = LIBC_NAMESPACE::mincore(nullptr, 1, &vec);
@@ -28,7 +30,7 @@ TEST_F(LlvmLibcMincoreTest, UnMappedMemory) {
 }
 
 TEST_F(LlvmLibcMincoreTest, UnalignedAddr) {
-  unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  unsigned long page_size = PAGE_SIZE;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
@@ -39,7 +41,7 @@ TEST_F(LlvmLibcMincoreTest, UnalignedAddr) {
 }
 
 TEST_F(LlvmLibcMincoreTest, InvalidVec) {
-  unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  unsigned long page_size = PAGE_SIZE;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, 4 * page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
@@ -49,7 +51,7 @@ TEST_F(LlvmLibcMincoreTest, InvalidVec) {
 }
 
 TEST_F(LlvmLibcMincoreTest, NoError) {
-  unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  unsigned long page_size = PAGE_SIZE;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
@@ -61,7 +63,7 @@ TEST_F(LlvmLibcMincoreTest, NoError) {
 }
 
 TEST_F(LlvmLibcMincoreTest, NegativeLength) {
-  unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  unsigned long page_size = PAGE_SIZE;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
@@ -73,7 +75,7 @@ TEST_F(LlvmLibcMincoreTest, NegativeLength) {
 }
 
 TEST_F(LlvmLibcMincoreTest, PageOut) {
-  unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  unsigned long page_size = PAGE_SIZE;
   unsigned char vec;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ | PROT_WRITE,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);

--- a/libc/test/src/sys/mman/linux/mincore_test.cpp
+++ b/libc/test/src/sys/mman/linux/mincore_test.cpp
@@ -20,7 +20,7 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LlvmLibcMincoreTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-//TODO: Replace with sysconf call once the function is properly implemented.
+// TODO: Replace with sysconf call once the function is properly implemented.
 constexpr size_t PAGE_SIZE = 4096;
 
 TEST_F(LlvmLibcMincoreTest, UnMappedMemory) {

--- a/libc/test/src/sys/mman/linux/mlock_test.cpp
+++ b/libc/test/src/sys/mman/linux/mlock_test.cpp
@@ -28,7 +28,7 @@
 
 #include <sys/syscall.h>
 
-//TODO: Replace with sysconf call once the function is properly implemented.
+// TODO: Replace with sysconf call once the function is properly implemented.
 constexpr size_t PAGE_SIZE = 4096;
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;

--- a/libc/test/src/sys/mman/linux/mlock_test.cpp
+++ b/libc/test/src/sys/mman/linux/mlock_test.cpp
@@ -22,13 +22,14 @@
 #include "src/sys/mman/munlockall.h"
 #include "src/sys/mman/munmap.h"
 #include "src/sys/resource/getrlimit.h"
-#include "src/unistd/sysconf.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-#include <linux/capability.h>
 #include <sys/syscall.h>
+
+//TODO: Replace with sysconf call once the function is properly implemented.
+constexpr size_t PAGE_SIZE = 4096;
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcMlockTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
@@ -38,7 +39,7 @@ struct PageHolder {
   void *addr;
 
   PageHolder()
-      : size(LIBC_NAMESPACE::sysconf(_SC_PAGESIZE)),
+      : size(PAGE_SIZE),
         addr(LIBC_NAMESPACE::mmap(nullptr, size, PROT_READ | PROT_WRITE,
                                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0)) {}
   ~PageHolder() {
@@ -51,28 +52,10 @@ struct PageHolder {
   bool is_valid() { return addr != MAP_FAILED; }
 };
 
-static bool get_capacity(unsigned int cap) {
-  __user_cap_header_struct header;
-  header.pid = 0;
-  header.version = _LINUX_CAPABILITY_VERSION_3;
-  __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
-  // TODO: use capget wrapper once implemented.
-  // https://github.com/llvm/llvm-project/issues/80037
-  long res = LIBC_NAMESPACE::syscall_impl(
-      SYS_capget, LIBC_NAMESPACE::cpp::bit_cast<long>(&header),
-      LIBC_NAMESPACE::cpp::bit_cast<long>(&data));
-  if (res < 0)
-    return false;
-  unsigned idx = CAP_TO_INDEX(cap);
-  unsigned shift = CAP_TO_MASK(cap);
-  return (data[idx].effective & shift) != 0;
-}
-
 static bool is_permitted_size(size_t size) {
   rlimit rlimits;
   LIBC_NAMESPACE::getrlimit(RLIMIT_MEMLOCK, &rlimits);
-  return size <= static_cast<size_t>(rlimits.rlim_cur) ||
-         get_capacity(CAP_IPC_LOCK);
+  return size <= static_cast<size_t>(rlimits.rlim_cur);
 }
 
 TEST_F(LlvmLibcMlockTest, UnMappedMemory) {

--- a/libc/test/src/sys/mman/linux/msync_test.cpp
+++ b/libc/test/src/sys/mman/linux/msync_test.cpp
@@ -11,10 +11,12 @@
 #include "src/sys/mman/msync.h"
 #include "src/sys/mman/munlock.h"
 #include "src/sys/mman/munmap.h"
-#include "src/unistd/sysconf.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
+
+//TODO: Replace with sysconf call once the function is properly implemented.
+constexpr size_t PAGE_SIZE = 4096;
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcMsyncTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
@@ -24,7 +26,7 @@ struct PageHolder {
   void *addr;
 
   PageHolder()
-      : size(LIBC_NAMESPACE::sysconf(_SC_PAGESIZE)),
+      : size(PAGE_SIZE),
         addr(LIBC_NAMESPACE::mmap(nullptr, size, PROT_READ | PROT_WRITE,
                                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0)) {}
   ~PageHolder() {

--- a/libc/test/src/sys/mman/linux/msync_test.cpp
+++ b/libc/test/src/sys/mman/linux/msync_test.cpp
@@ -15,7 +15,7 @@
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-//TODO: Replace with sysconf call once the function is properly implemented.
+// TODO: Replace with sysconf call once the function is properly implemented.
 constexpr size_t PAGE_SIZE = 4096;
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;

--- a/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
+++ b/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
@@ -18,7 +18,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h> // For S_IRWXU
 
-//TODO: Replace with sysconf call once the function is properly implemented.
+// TODO: Replace with sysconf call once the function is properly implemented.
 constexpr size_t PAGE_SIZE = 4096;
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;

--- a/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
+++ b/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
@@ -11,7 +11,6 @@
 #include "src/sys/mman/munmap.h"
 #include "src/sys/mman/remap_file_pages.h"
 #include "src/unistd/close.h"
-#include "src/unistd/sysconf.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -19,12 +18,15 @@
 #include <sys/mman.h>
 #include <sys/stat.h> // For S_IRWXU
 
+//TODO: Replace with sysconf call once the function is properly implemented.
+constexpr size_t PAGE_SIZE = 4096;
+
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LlvmLibcRemapFilePagesTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcRemapFilePagesTest, NoError) {
-  size_t page_size = LIBC_NAMESPACE::sysconf(_SC_PAGE_SIZE);
+  size_t page_size = PAGE_SIZE;
   ASSERT_GT(page_size, size_t(0));
 
   // Create a file-backed mapping
@@ -50,7 +52,7 @@ TEST_F(LlvmLibcRemapFilePagesTest, NoError) {
 }
 
 TEST_F(LlvmLibcRemapFilePagesTest, ErrorInvalidFlags) {
-  size_t page_size = LIBC_NAMESPACE::sysconf(_SC_PAGE_SIZE);
+  size_t page_size = PAGE_SIZE;
   ASSERT_GT(page_size, size_t(0));
 
   // Create a file-backed mapping
@@ -77,7 +79,7 @@ TEST_F(LlvmLibcRemapFilePagesTest, ErrorInvalidFlags) {
 }
 
 TEST_F(LlvmLibcRemapFilePagesTest, ErrorInvalidAddress) {
-  size_t page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  size_t page_size = PAGE_SIZE;
   ASSERT_GT(page_size, size_t(0));
 
   // Use an address that we haven't mapped


### PR DESCRIPTION
Previously they called sysconf and capget. Those were blocking adding
bazel rules for those tests since sysconf isn't done.
