### PR TITLE
[clang] fix lambda dependency issue with late parse attributes

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1251,6 +1251,10 @@ Sema::CXXThisScopeRAII::CXXThisScopeRAII(Sema &S,
   else
     Record = cast<CXXRecordDecl>(ContextDecl);
 
+  // 'this' never refers to the lambda class itself.
+  if (Record->isLambda())
+    return;
+
   QualType T = S.Context.getCanonicalTagType(Record);
   T = S.getASTContext().getQualifiedType(T, CXXThisTypeQuals);
 

--- a/clang/test/SemaTemplate/GH161657.cpp
+++ b/clang/test/SemaTemplate/GH161657.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -ffp-exception-behavior=strict -verify %s
+// expected-no-diagnostics
+
+template <class T> struct S {
+  template <class U> using type1 = decltype([] { return U{}; });
+};
+
+void foo() {
+  using T1 = S<int>::type1<int>;
+  int x = T1()();
+}


### PR DESCRIPTION
This fixes a regression introduced in #147835

When parsing a lambda where the call operator has a late parsed attribute, we would try to build a 'this' type for the lambda, but in a lambda 'this' never refers to the lambda class itself.

This late parsed attribute can be added implicitly by the -ftrapping-math flag.

This patch patch makes it so CXXThisScopeRAII ignores lambdas.

This became observable in #147835 because that made clang lazily create tag types, and it removed a workaround for a lambda dependency bug where any previously created tag type for the lambda is discarded after its dependency is recalculated.

But the 'this' scope created above would defeat this laziness and create the lambda type too soon, before its dependency was updated.

Since this regression was never released, there are no release notes.

Fixes #161657