### PR TITLE
[clang] fix #161765 test triple dependency

### DIFF
--- a/clang/test/SemaTemplate/GH161657.cpp
+++ b/clang/test/SemaTemplate/GH161657.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -std=c++20 -ffp-exception-behavior=strict -verify %s
+// RUN: %clang_cc1 -triple=x86_64 -fsyntax-only -std=c++20 -ffp-exception-behavior=strict -verify %s
 // expected-no-diagnostics
 
 template <class T> struct S {


### PR DESCRIPTION
Fixes the new test introduced in #161765, so that it always uses a triple which supports floating point exceptions.

Otherwise, some post-commit bots fail.