### PR TITLE
[lldb][test] Fix TestEmptyFuncThreadStepOut.py

### DIFF
--- a/lldb/test/API/functionalities/thread/finish-from-empty-func/TestEmptyFuncThreadStepOut.py
+++ b/lldb/test/API/functionalities/thread/finish-from-empty-func/TestEmptyFuncThreadStepOut.py
@@ -13,12 +13,15 @@ class FinishFromEmptyFunctionTestCase(TestBase):
 
     @skipIf(compiler="clang", compiler_version=['<', '17.0'])
     def test_finish_from_empty_function(self):
-        """Test that when stopped at a breakpoint in an empty function, finish leaves it correctly."""
+        """Test that when stopped at a breakpoint located at the last instruction
+        of a function, finish leaves it correctly."""
         self.build()
         target, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "// Set breakpoint here", lldb.SBFileSpec("main.c")
         )
-        # Find the last instruction address of 'done()' and set a breakpoint there.
+        # Find the address of the last instruction of 'done()' and set a breakpoint there.
+        # Even though 'done()' is empty, it may contain prologue and epilogue code, so
+        # simply setting a breakpoint at the function can place it before 'ret'.
         error = lldb.SBError()
         ret_bp_addr = lldb.SBAddress()
         while True:
@@ -28,9 +31,12 @@ class FinishFromEmptyFunctionTestCase(TestBase):
             if "done" in frame.GetFunctionName():
                 ret_bp_addr = frame.GetPCAddress()
             elif ret_bp_addr.IsValid():
+                # The entire function 'done()' has been stepped through, so 'ret_bp_addr'
+                # now contains the address of its last instruction, i.e. 'ret'.
                 break
         ret_bp = target.BreakpointCreateByAddress(ret_bp_addr.GetLoadAddress(target))
         self.assertTrue(ret_bp.IsValid())
+        # Resume the execution and hit the new breakpoint.
         self.runCmd("cont")
         if self.TraceOn():
             self.runCmd("bt")

--- a/lldb/test/API/functionalities/thread/finish-from-empty-func/main.c
+++ b/lldb/test/API/functionalities/thread/finish-from-empty-func/main.c
@@ -2,6 +2,7 @@
 void done() {}
 int main() {
   puts("in main");
+  done(); // Set breakpoint here
   done();
   puts("leaving main");
   return 0;


### PR DESCRIPTION
The test did not work as intended when the empty function 'done()' contained prologue/epilog code, because a breakpoint was set before the last instruction of the function, which caused the test to pass even with the fix from #126838 having been reverted.

The test was intended to check a case when a breakpoint is set on a return instruction, which is the very last instruction of a function. When stepping out from this breakpoint, there is some interaction between `ThreadPlanStepOut` and `ThreadPlanStepOverBreakpoint` that could lead to missing the stop location in the outer frame; the detailed explanation can be found in #126838.

On `Linux/AArch64`, the source is compiled into:
```
> objdump -d main.o
0000000000000000 <done>:
   0:   d65f03c0        ret
```
So, when the command `bt set -n done` from the original test sets a breakpoint to the first instruction of `done()`, this instruction luckily also happens to be the last one.

On `Linux/x86_64`, it compiles into:
```
> objdump -d main.o
0000000000000000 <done>:
   0:   55                      push   %rbp
   1:   48 89 e5                mov    %rsp,%rbp
   4:   5d                      pop    %rbp
   5:   c3                      ret
```
And in this case, setting a breakpoint by a function name means setting it several instructions before `ret`, which does not provoke the interaction between `ThreadPlanStepOut` and `ThreadPlanStepOverBreakpoint`.