### PR TITLE
[RISCV] fixup_riscv_rvc_imm may be linker relaxable

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -823,6 +823,7 @@ static bool relaxableFixupNeedsRelocation(const MCFixupKind Kind) {
     break;
   case RISCV::fixup_riscv_rvc_jump:
   case RISCV::fixup_riscv_rvc_branch:
+  case RISCV::fixup_riscv_rvc_imm:
   case RISCV::fixup_riscv_jal:
     return false;
   }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -688,6 +688,7 @@ uint64_t RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
       // the `jal` again in the assembler.
     } else if (MIFrm == RISCVII::InstFormatCI) {
       FixupKind = RISCV::fixup_riscv_rvc_imm;
+      AsmRelaxToLinkerRelaxableWithFeature(RISCV::FeatureVendorXqcili);
     } else if (MIFrm == RISCVII::InstFormatI) {
       FixupKind = RISCV::fixup_riscv_12_i;
     } else if (MIFrm == RISCVII::InstFormatQC_EB) {

--- a/llvm/test/MC/RISCV/xqcili-linker-relaxation.s
+++ b/llvm/test/MC/RISCV/xqcili-linker-relaxation.s
@@ -1,4 +1,3 @@
-
 # RUN: llvm-mc --triple=riscv32 -mattr=+relax,+experimental-xqcili \
 # RUN:    %s -filetype=obj -o - -riscv-add-build-attributes \
 # RUN:    | llvm-objdump -dr -M no-aliases - \
@@ -8,11 +7,9 @@
 ## emitting `QC.E.LI` and `QC.LI`.
 
   .section .text.ex1, "ax", @progbits
-  .global ex1
-ex1:
-# CHECK-LABEL: <ex1>:
+# CHECK-LABEL: <.text.ex1>:
   blez    a1, .L1
-# CHECK-NEXT: bge zero, a1, 0x0 <ex1>
+# CHECK-NEXT: bge zero, a1, 0x0 <.text.ex1>
 # CHECK-NEXT: R_RISCV_BRANCH .L1{{$}}
   qc.e.li a0, sym
 # CHECK-NEXT: qc.e.li a0, 0x0
@@ -24,13 +21,10 @@ ex1:
   ret
 # CHECK-NEXT: c.jr ra
 
-
   .section .text.ex2, "ax", @progbits
-  .global ex2
-ex2:
-# CHECK-LABEL: <ex2>:
+# CHECK-LABEL: <.text.ex2>:
   blez    a1, .L2
-# CHECK-NEXT: bge zero, a1, 0x0 <ex2>
+# CHECK-NEXT: bge zero, a1, 0x0 <.text.ex2>
 # CHECK-NEXT: R_RISCV_BRANCH .L2{{$}}
   qc.li a0,  %qc.abs20(sym)
 # CHECK-NEXT: qc.li a0, 0x0

--- a/llvm/test/MC/RISCV/xqcili-linker-relaxation.s
+++ b/llvm/test/MC/RISCV/xqcili-linker-relaxation.s
@@ -1,0 +1,43 @@
+
+# RUN: llvm-mc --triple=riscv32 -mattr=+relax,+experimental-xqcili \
+# RUN:    %s -filetype=obj -o - -riscv-add-build-attributes \
+# RUN:    | llvm-objdump -dr -M no-aliases - \
+# RUN:    | FileCheck %s
+
+## This tests that we correctly emit relocations for linker relaxation when
+## emitting `QC.E.LI` and `QC.LI`.
+
+  .section .text.ex1, "ax", @progbits
+  .global ex1
+ex1:
+# CHECK-LABEL: <ex1>:
+  blez    a1, .L1
+# CHECK-NEXT: bge zero, a1, 0x0 <ex1>
+# CHECK-NEXT: R_RISCV_BRANCH .L1{{$}}
+  qc.e.li a0, sym
+# CHECK-NEXT: qc.e.li a0, 0x0
+# CHECK-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# CHECK-NEXT: R_RISCV_CUSTOM194 sym{{$}}
+# CHECK-NEXT: R_RISCV_RELAX *ABS*{{$}}
+.L1:
+# CHECK: <.L1>:
+  ret
+# CHECK-NEXT: c.jr ra
+
+
+  .section .text.ex2, "ax", @progbits
+  .global ex2
+ex2:
+# CHECK-LABEL: <ex2>:
+  blez    a1, .L2
+# CHECK-NEXT: bge zero, a1, 0x0 <ex2>
+# CHECK-NEXT: R_RISCV_BRANCH .L2{{$}}
+  qc.li a0,  %qc.abs20(sym)
+# CHECK-NEXT: qc.li a0, 0x0
+# CHECK-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# CHECK-NEXT: R_RISCV_CUSTOM192 sym{{$}}
+# CHECK-NEXT: R_RISCV_RELAX *ABS*{{$}}
+.L2:
+# CHECK: <.L2>:
+  ret
+# CHECK-NEXT: c.jr ra


### PR DESCRIPTION
With Xqcili, `c.li` may be relaxed to `qc.e.li` (this is because `qc.e.li` is compressed into `c.li`, which needs to be undone). `qc.e.li` is relaxable, so we need to mark `c.li` as linker relaxable when it is emitted.

This fixup cannot be emitted as a relocation, but we still mark it as requiring no R_RISCV_RELAX in case this changes in the future.