### PR TITLE
[llvm-jitlink] Use MachOObjectFile::getArchTriple for triple identifi…

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/AArch64/Inputs/x-0.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/Inputs/x-0.s
@@ -1,0 +1,7 @@
+	.section	__DATA,__data
+	.globl	x
+	.p2align	2, 0x0
+x:
+	.long	0
+
+.subsections_via_symbols

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/Inputs/x-1.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/Inputs/x-1.s
@@ -1,0 +1,7 @@
+	.section	__DATA,__data
+	.globl	x
+	.p2align	2, 0x0
+x:
+	.long	1
+
+.subsections_via_symbols

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_universal_slice_selection.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_universal_slice_selection.s
@@ -1,0 +1,32 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=arm64e-apple-darwin -filetype=obj -o %t/main.o %s
+# RUN: llvm-mc -triple=arm64-apple-darwin -filetype=obj -o %t/x.arm64.o \
+# RUN:     %S/Inputs/x-1.s
+# RUN: llvm-ar crs %t/libX.arm64.a %t/x.arm64.o
+# RUN: llvm-mc -triple=arm64e-apple-darwin -filetype=obj -o %t/x.arm64e.o \
+# RUN:     %S/Inputs/x-0.s
+# RUN: llvm-ar crs %t/libX.arm64e.a %t/x.arm64e.o
+# RUN: llvm-lipo --create --output %t/libX.a %t/libX.arm64.a %t/libX.arm64e.a
+# RUN: llvm-jitlink -noexec -check=%s %t/main.o -L%t -lX
+#
+# Create a universal archive with two slices (arm64e, arm64) each containing
+# a definition of X: in arm64e X = 0, in arm64 X = 1.
+# Check that if we load an arm64e object file then we link the arm64e slice
+# of the archive by verifying that X = 0.
+#
+
+# jitlink-check: *{4}x = 0
+
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main
+	.p2align	2
+_main:
+	mov     w0, #0
+        ret
+
+	.section	__DATA,__data
+	.globl	p
+p:
+	.quad   x
+
+.subsections_via_symbols

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1636,7 +1636,11 @@ static std::pair<Triple, SubtargetFeatures> getFirstFileTripleAndFeatures() {
       case file_magic::macho_object: {
         auto Obj = ExitOnErr(
             object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef()));
-        Triple TT = Obj->makeTriple();
+        Triple TT;
+        if (auto *MachOObj = dyn_cast<object::MachOObjectFile>(Obj.get()))
+          TT = MachOObj->getArchTriple();
+        else
+          TT = Obj->makeTriple();
         if (Magic == file_magic::coff_object) {
           // TODO: Move this to makeTriple() if possible.
           TT.setObjectFormat(Triple::COFF);


### PR DESCRIPTION
…cation.

Replaces a call to ObjectFile::makeTriple (still used for ELF and COFF) with a call to MachOObjectFile::getArchTriple. The latter knows how to build correct triples for different MachO CPU subtypes, e.g. arm64 vs arm64e, which is important for selecting the right slice from universal archives.