### PR TITLE
[lldb][Language] Simplify SourceLanguage::GetDescription

### DIFF
--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -559,11 +559,8 @@ lldb::LanguageType SourceLanguage::AsLanguageType() const {
 }
 
 llvm::StringRef SourceLanguage::GetDescription() const {
-  LanguageType type = AsLanguageType();
-  if (type)
-    return Language::GetNameForLanguageType(type);
   return llvm::dwarf::LanguageDescription(
-      (llvm::dwarf::SourceLanguageName)name);
+      static_cast<llvm::dwarf::SourceLanguageName>(name));
 }
 bool SourceLanguage::IsC() const { return name == llvm::dwarf::DW_LNAME_C; }
 

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -550,10 +550,9 @@ ToDwarfSourceLanguage(lldb::LanguageType language_type) {
   switch (language_type) {
   case eLanguageTypeMipsAssembler:
     return llvm::dwarf::DW_LANG_Mips_Assembler;
-  default: break;
+  default:
+    llvm_unreachable("Unhandled language type");
   }
-
-  llvm_unreachable("Unhandled language type");
 }
 
 SourceLanguage::SourceLanguage(lldb::LanguageType language_type) {

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -542,7 +542,7 @@ Language::Language() = default;
 // Destructor
 Language::~Language() = default;
 
-static llvm::dwarf::SourceLanguage
+static std::optional<llvm::dwarf::SourceLanguage>
 ToDwarfSourceLanguage(lldb::LanguageType language_type) {
   if (language_type < lldb::eLanguageTypeLastStandardLanguage)
     return static_cast<llvm::dwarf::SourceLanguage>(language_type);
@@ -551,12 +551,17 @@ ToDwarfSourceLanguage(lldb::LanguageType language_type) {
   case eLanguageTypeMipsAssembler:
     return llvm::dwarf::DW_LANG_Mips_Assembler;
   default:
-    llvm_unreachable("Unhandled language type");
+    return std::nullopt;
   }
 }
 
 SourceLanguage::SourceLanguage(lldb::LanguageType language_type) {
-  auto lname = llvm::dwarf::toDW_LNAME(ToDwarfSourceLanguage(language_type));
+  std::optional<llvm::dwarf::SourceLanguage> dwarf_lang =
+      ToDwarfSourceLanguage(language_type);
+  if (!dwarf_lang)
+    return;
+
+  auto lname = llvm::dwarf::toDW_LNAME(*dwarf_lang);
   if (!lname)
     return;
   name = lname->first;

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -550,9 +550,10 @@ ToDwarfSourceLanguage(lldb::LanguageType language_type) {
   switch (language_type) {
   case eLanguageTypeMipsAssembler:
     return llvm::dwarf::DW_LANG_Mips_Assembler;
-  default:
-    return llvm::dwarf::DW_LANG_hi_user;
+  default: break;
   }
+
+  llvm_unreachable("Unhandled language type");
 }
 
 SourceLanguage::SourceLanguage(lldb::LanguageType language_type) {

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -542,9 +542,21 @@ Language::Language() = default;
 // Destructor
 Language::~Language() = default;
 
+static llvm::dwarf::SourceLanguage
+ToDwarfSourceLanguage(lldb::LanguageType language_type) {
+  if (language_type < lldb::eLanguageTypeLastStandardLanguage)
+    return static_cast<llvm::dwarf::SourceLanguage>(language_type);
+
+  switch (language_type) {
+  case eLanguageTypeMipsAssembler:
+    return llvm::dwarf::DW_LANG_Mips_Assembler;
+  default:
+    return llvm::dwarf::DW_LANG_hi_user;
+  }
+}
+
 SourceLanguage::SourceLanguage(lldb::LanguageType language_type) {
-  auto lname =
-      llvm::dwarf::toDW_LNAME((llvm::dwarf::SourceLanguage)language_type);
+  auto lname = llvm::dwarf::toDW_LNAME(ToDwarfSourceLanguage(language_type));
   if (!lname)
     return;
   name = lname->first;

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -2,6 +2,7 @@ add_lldb_unittest(TargetTests
   ABITest.cpp
   DynamicRegisterInfoTest.cpp
   ExecutionContextTest.cpp
+  Language.cpp
   LocateModuleCallbackTest.cpp
   MemoryRegionInfoTest.cpp
   MemoryTest.cpp

--- a/lldb/unittests/Target/Language.cpp
+++ b/lldb/unittests/Target/Language.cpp
@@ -54,3 +54,16 @@ TEST_F(LanguageTest, SourceLanguage_GetDescription) {
 
   EXPECT_EQ(SourceLanguage(eLanguageTypeUnknown).GetDescription(), "Unknown");
 }
+
+TEST_F(LanguageTest, SourceLanguage_AsLanguageType) {
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus).AsLanguageType(),
+            eLanguageTypeC_plus_plus);
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus_03).AsLanguageType(),
+            eLanguageTypeC_plus_plus_03);
+
+  // Vendor-specific language code.
+  EXPECT_EQ(SourceLanguage(eLanguageTypeMipsAssembler).AsLanguageType(),
+            eLanguageTypeAssembly);
+  EXPECT_EQ(SourceLanguage(eLanguageTypeUnknown).AsLanguageType(),
+            eLanguageTypeUnknown);
+}

--- a/lldb/unittests/Target/Language.cpp
+++ b/lldb/unittests/Target/Language.cpp
@@ -1,0 +1,56 @@
+//===-- LanguageTest.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Target/Language.h"
+#include "lldb/lldb-enumerations.h"
+#include "gtest/gtest.h"
+
+using namespace lldb_private;
+using namespace lldb;
+
+namespace {
+class LanguageTest : public ::testing::Test {};
+} // namespace
+
+TEST_F(LanguageTest, SourceLanguage_GetDescription) {
+  for (uint32_t i = 1; i < lldb::eNumLanguageTypes; ++i) {
+    // 0x29 is unassigned
+    if (i == 0x29)
+      continue;
+
+    auto lang_type = static_cast<lldb::LanguageType>(i);
+    if (lang_type == lldb::eLanguageTypeLastStandardLanguage)
+      continue;
+
+    SourceLanguage lang(lang_type);
+
+    // eLanguageTypeHIP is not implemented as a DW_LNAME because of a conflict.
+    if (lang_type == lldb::eLanguageTypeHIP)
+      EXPECT_FALSE(lang);
+    else
+      EXPECT_TRUE(lang);
+  }
+
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus).GetDescription(),
+            "ISO C++");
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus_17).GetDescription(),
+            "ISO C++");
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus_20).GetDescription(),
+            "ISO C++");
+
+  EXPECT_EQ(SourceLanguage(eLanguageTypeObjC).GetDescription(), "Objective C");
+  EXPECT_EQ(SourceLanguage(eLanguageTypeMipsAssembler).GetDescription(),
+            "Assembly");
+
+  auto next_vendor_language =
+      static_cast<lldb::LanguageType>(eLanguageTypeMipsAssembler + 1);
+  if (next_vendor_language < eNumLanguageTypes)
+    EXPECT_NE(SourceLanguage(next_vendor_language).GetDescription(), "Unknown");
+
+  EXPECT_EQ(SourceLanguage(eLanguageTypeUnknown).GetDescription(), "Unknown");
+}


### PR DESCRIPTION
Currently we don't benefit from the user-friendly names that `LanguageDescription` returns because we would always use `Language::GetNameForLanguageType`. I'm not aware of a situation where `GetDescription` should prefer the non-human readable form of the name with. This patch removes the call to `GetNameForLanguageType`.

`LanguageDescription` already handles languages that it doesn't know about. For those it would return `Unknown`. The LLDB language types should all be available via DWARF. If there are languages that don't map cleanly between `lldb::LanguageType` and `DW_LANG`, then we should add explicit support for that in the `SourceLanguage::SourceLanguage` constructor.