### PR TITLE
[lldb][Language] Sync LanguageType enumeration with DWARF codes

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -522,6 +522,16 @@ enum LanguageType {
   eLanguageTypeAssembly = 0x0031,
   eLanguageTypeC_sharp = 0x0032,
   eLanguageTypeMojo = 0x0033,
+  eLanguageTypeGLSL = 0x0034,
+  eLanguageTypeGLSL_ES = 0x0035,
+  eLanguageTypeHLSL = 0x0036,
+  eLanguageTypeOpenCL_CPP = 0x0037,
+  eLanguageTypeCppForOpenCL = 0x0038,
+  eLanguageTypeSycl = 0x0039,
+  eLanguageTypeMetal = 0x003d,
+  eLanguageTypeRuby = 0x0040,
+  eLanguageTypeMove = 0x0041,
+  eLanguageTypeHylo = 0x0042,
   eLanguageTypeLastStandardLanguage = eLanguageTypeMojo,
 
   // Vendor Extensions

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -532,7 +532,7 @@ enum LanguageType {
   eLanguageTypeRuby = 0x0040,
   eLanguageTypeMove = 0x0041,
   eLanguageTypeHylo = 0x0042,
-  eLanguageTypeLastStandardLanguage = eLanguageTypeMojo,
+  eLanguageTypeLastStandardLanguage = eLanguageTypeHylo,
 
   // Vendor Extensions
   // Note: Language::GetNameForLanguageType

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -244,6 +244,16 @@ struct language_name_pair language_names[] = {
     {"assembly", eLanguageTypeAssembly},
     {"c-sharp", eLanguageTypeC_sharp},
     {"mojo", eLanguageTypeMojo},
+    {"GLSL", eLanguageTypeGLSL},
+    {"GLSL_ES", eLanguageTypeGLSL_ES},
+    {"HLSL", eLanguageTypeHLSL},
+    {"OpenCL_CPP", eLanguageTypeOpenCL_CPP},
+    {"CPP_for_OpenCL", eLanguageTypeCppForOpenCL},
+    {"SYCL", eLanguageTypeSycl},
+    {"Metal", eLanguageTypeMetal},
+    {"Ruby", eLanguageTypeRuby},
+    {"Move", eLanguageTypeMove},
+    {"Hylo", eLanguageTypeHylo},
     // Vendor Extensions
     {"assembler", eLanguageTypeMipsAssembler},
     // Now synonyms, in arbitrary order


### PR DESCRIPTION
Synchronized with the values in https://github.com/llvm/llvm-project/blob/c2765b74ed2bb71bebe96c7dd49f69ade714e5a8/llvm/include/llvm/BinaryFormat/Dwarf.def#L1012-L1021

Added somewhere between DWARFv5 and DWARFv6