### PR TITLE
[libcxx] Mark system_reserved_names.gen.py unsupported on clang-20 && msvc

### DIFF
--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -10,6 +10,13 @@
 # alphabetic macros. Also ensure that we don't swallow the definition of user
 # provided macros (in other words, ensure that we push/pop correctly everywhere).
 
+# This test fails with MSVC headers, with Clang 20 (and early 21 versions);
+# the headers end up pulling in Clang intrinsics headers, which in 20.x and
+# early 21.x versions use unreserved identifiers,
+# see https://github.com/llvm/llvm-project/issues/161808.
+#
+# UNSUPPORTED: clang-20 && msvc
+
 # RUN: %{python} %s %{libcxx-dir}/utils
 # END.
 


### PR DESCRIPTION
Clang 20 (and early 21 versions; let's hope it can be fixed before the later versions before such versions become relevant for libcxx CI) have got an issue with its intrinsics headers, where they use unreserved names, that users are allowed to override.

See https://github.com/llvm/llvm-project/issues/161808 for the issue report.

This only crops up in the MSVC build configurations, as recent versions of some MSVC/UCRT headers include `<intrin.h>`, which ends up pulling in most intrinsics headers, exposing this issue in the Clang headers.

This should unblock https://github.com/llvm/llvm-project/pull/161736 from being merged.