### PR TITLE
[llvm][HashRecognize] Fix compiler warning on Arm 32-bit

### DIFF
--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -97,8 +97,7 @@ static bool containsUnreachable(const Loop &L,
       }
     }
   }
-  return static_cast<size_t>(std::distance(Latch->begin(), Latch->end())) !=
-         Visited.size();
+  return Latch->size() != Visited.size();
 }
 
 /// A structure that can hold either a Simple Recurrence or a Conditional

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -97,7 +97,8 @@ static bool containsUnreachable(const Loop &L,
       }
     }
   }
-  return std::distance(Latch->begin(), Latch->end()) != Visited.size();
+  return static_cast<size_t>(std::distance(Latch->begin(), Latch->end())) !=
+         Visited.size();
 }
 
 /// A structure that can hold either a Simple Recurrence or a Conditional


### PR DESCRIPTION
```
/home/david.spickett/llvm-project/llvm/lib/Analysis/HashRecognize.cpp:100:54: warning: comparison of integers of different signs:
'typename iterator_traits<ilist_iterator_w_bits<node_options<Instruction, true, false, void, true, BasicBlock>, false, false>>::difference_type' (aka 'int') and 'size_type' (aka 'unsigned int') [-Wsign-compare]
  100 |   return std::distance(Latch->begin(), Latch->end()) != Visited.size();
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~
```

By using Latch->size() instead.