### PR TITLE
[TableGen] Fix inconsistent indexing of the RegistersByName table.

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -1189,7 +1189,7 @@ CodeGenRegBank::CodeGenRegBank(const RecordKeeper &Records,
     // causes some failures in MIPS - perhaps they have duplicate register name
     // entries? (or maybe there's a reason for it - I don't know much about this
     // code, just drive-by refactoring)
-    RegistersByName.try_emplace(Reg.TheDef->getValueAsString("AsmName"), &Reg);
+    RegistersByName.try_emplace(Reg.getName().lower(), &Reg);
 
   // Precompute all sub-register maps.
   // This will create Composite entries for all inferred sub-register indices.


### PR DESCRIPTION
Previously, the initialization of this table in CodeGenRegBank() indexed the table with the AsmName, while the only user of the table in CompressInstEmitter::validateRegister() indexed it using the name of the tblgen Def. Apparently these were the same essentially all of the time, so the issue never manifested. This patch standardizes on indexing using the tblgen def name, as that is guaranteed to be unique.

This issue impacted the forthcoming implementation of the RISC Y extension (CHERI), in which the capability registers have the same AsmName as the GPRs, causing llvm-tblgen assertion failures.
