### PR TITLE
[mlir][NFC] Remove redundant insertion point changes

### DIFF
--- a/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
@@ -267,7 +267,8 @@ class GPULaunchLowering : public ConvertOpToLLVMPattern<gpu::LaunchFuncOp> {
       copyInfo.push_back(info);
     }
     // Create a call to the kernel and copy the data back.
-    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, kernelFunc, ArrayRef<Value>());
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, kernelFunc,
+                                              ArrayRef<Value>());
     for (CopyInfo info : copyInfo)
       copy(loc, info.src, info.dst, info.size, rewriter);
     return success();

--- a/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
@@ -267,9 +267,7 @@ class GPULaunchLowering : public ConvertOpToLLVMPattern<gpu::LaunchFuncOp> {
       copyInfo.push_back(info);
     }
     // Create a call to the kernel and copy the data back.
-    Operation *callOp = rewriter.replaceOpWithNewOp<LLVM::CallOp>(
-        op, kernelFunc, ArrayRef<Value>());
-    rewriter.setInsertionPointAfter(callOp);
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, kernelFunc, ArrayRef<Value>());
     for (CopyInfo info : copyInfo)
       copy(loc, info.src, info.dst, info.size, rewriter);
     return success();

--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
@@ -802,7 +802,6 @@ public:
         ValueRange{paddedInput, fakeWindowDims}, filledEmptyTensor, strideAttr,
         dilationAttr);
 
-    rewriter.setInsertionPointAfter(op);
     NanPropagationMode nanMode = op.getNanMode();
     rewriter.replaceOp(op, resultOp);
 


### PR DESCRIPTION
These insertion points were added in https://github.com/llvm/llvm-project/pull/146551 and https://github.com/llvm/llvm-project/pull/146908 to support the one-shot dialect conversion driver which performs changes to the IR immediately and would otherwise invalidate previous insertion points.

Since then, the insertion point has been made resilient against op erasure (https://github.com/llvm/llvm-project/pull/146955) making the changes now redundant.