### PR TITLE
Fix error: '__outer_iterator' redeclared with 'public' access

### DIFF
--- a/libcxx/include/__ranges/lazy_split_view.h
+++ b/libcxx/include/__ranges/lazy_split_view.h
@@ -76,6 +76,7 @@ class lazy_split_view : public view_interface<lazy_split_view<_View, _Pattern>> 
       _If<!forward_range<_View>, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _MaybeCurrent __current_ = _MaybeCurrent();
 
+private:
   template <bool>
   struct __outer_iterator;
   template <bool>


### PR DESCRIPTION
Fixes the following compilation error:
```
$(SOURCE_ROOT)/contrib/libs/cxxsupp/libcxx/include/__ranges/lazy_split_view.h:143:10: error: '__outer_iterator' redeclared with 'public' access
  143 |   struct __outer_iterator : __outer_iterator_category<__maybe_const<_Const, _View>> {
      |          ^
$(SOURCE_ROOT)/contrib/libs/cxxsupp/libcxx/include/__ranges/lazy_split_view.h:79:10: note: previously declared 'private' here
   79 |   struct __outer_iterator;
```