### PR TITLE
Disable Driver/env.c on AIX (NFC)

### DIFF
--- a/clang/test/Driver/env.c
+++ b/clang/test/Driver/env.c
@@ -1,6 +1,6 @@
 // Some assertions in this test use Linux style (/) file paths.
+// TODO: Use LIBPATH on AIX
 // UNSUPPORTED: system-windows, system-aix
-// FIXME: Use LIBPATH on AIX
 
 // RUN: bash -c env | grep LD_LIBRARY_PATH | sed -ne 's/^.*=//p' | tr -d '\n' > %t.ld_library_path
 // The PATH variable is heavily used when trying to find a linker.

--- a/clang/test/Driver/env.c
+++ b/clang/test/Driver/env.c
@@ -1,5 +1,7 @@
 // Some assertions in this test use Linux style (/) file paths.
-// UNSUPPORTED: system-windows
+// UNSUPPORTED: system-windows, system-aix
+// FIXME: Use LIBPATH on AIX
+
 // RUN: bash -c env | grep LD_LIBRARY_PATH | sed -ne 's/^.*=//p' | tr -d '\n' > %t.ld_library_path
 // The PATH variable is heavily used when trying to find a linker.
 // RUN: env -i LC_ALL=C LD_LIBRARY_PATH="%{readfile:%t.ld_library_path}" CLANG_NO_DEFAULT_CONFIG=1 \


### PR DESCRIPTION
AIX does not use LD_LIBRARY_PATH.