### PR TITLE
[RISCV] Reverse the operands in ins for Zalasr store instructions. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZalasr.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZalasr.td
@@ -26,7 +26,7 @@ class LAQ_r<bit aq, bit rl, bits<3> funct3, string opcodestr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class SRL_r<bit aq, bit rl, bits<3> funct3, string opcodestr>
     : RVInstRAtomic<0b00111, aq, rl, funct3, OPC_AMO,
-                    (outs ), (ins GPRMemZeroOffset:$rs1, GPR:$rs2),
+                    (outs), (ins GPR:$rs2, GPRMemZeroOffset:$rs1),
                     opcodestr, "$rs2, $rs1"> {
   let rd = 0;
 }
@@ -71,7 +71,7 @@ class PatLAQ<SDPatternOperator OpNode, RVInst Inst, ValueType vt = XLenVT>
 //  while atomic_store has data, addr
 class PatSRL<SDPatternOperator OpNode, RVInst Inst, ValueType vt = XLenVT>
     : Pat<(OpNode (vt GPR:$rs2), (XLenVT GPRMemZeroOffset:$rs1)),
-          (Inst GPRMemZeroOffset:$rs1, GPR:$rs2)>;
+          (Inst GPR:$rs2, GPRMemZeroOffset:$rs1)>;
 
 
 let Predicates = [HasStdExtZalasr] in {


### PR DESCRIPTION
Match the assembly printing order rather than sorting by operand name.

Tnis is consistent with normal store instructions.