### PR TITLE
[TableGen][SchedModel] Introduce a new SchedPredicate that checks against SubtargetFeature

### DIFF
--- a/llvm/include/llvm/Target/TargetSchedule.td
+++ b/llvm/include/llvm/Target/TargetSchedule.td
@@ -377,6 +377,7 @@ class MCSchedPredicate<MCInstPredicate P> : SchedPredicateBase {
   SchedMachineModel SchedModel = ?;
 }
 
+// A scheduling predicate whose logic depends on a SubtargetFeature.
 class FeatureSchedPredicate<SubtargetFeature SF> : SchedPredicateBase {
   SubtargetFeature Feature = SF;
   SchedMachineModel SchedModel = ?;

--- a/llvm/include/llvm/Target/TargetSchedule.td
+++ b/llvm/include/llvm/Target/TargetSchedule.td
@@ -377,6 +377,11 @@ class MCSchedPredicate<MCInstPredicate P> : SchedPredicateBase {
   SchedMachineModel SchedModel = ?;
 }
 
+class FeatureSchedPredicate<SubtargetFeature SF> : SchedPredicateBase {
+  SubtargetFeature Feature = SF;
+  SchedMachineModel SchedModel = ?;
+}
+
 // Define a predicate to determine which SchedVariant applies to a
 // particular MachineInstr. The code snippet is used as an
 // if-statement's expression. Available variables are MI, SchedModel,

--- a/llvm/test/TableGen/ResolveSchedClass.td
+++ b/llvm/test/TableGen/ResolveSchedClass.td
@@ -8,11 +8,57 @@ def TestTarget : Target {
   let InstructionSet = TestTargetInstrInfo;
 }
 
+def FeatureFoo : SubtargetFeature<"foo", "HasFoo", "true", "enable foo">;
+
+def ResX0 : ProcResource<1>;
+
+let OutOperandList = (outs), InOperandList = (ins) in
+def Inst_A : Instruction;
+
+def SchedModel_A: SchedMachineModel {
+  let CompleteModel = false;
+}
+
+let SchedModel = SchedModel_A in {
+def SchedWriteResA : SchedWriteRes<[ResX0]> {
+  let Latency = 2;
+}
+def SchedWriteResB : SchedWriteRes<[ResX0]> {
+  let Latency = 4;
+}
+
+// Check SchedPredicate with subtarget feature.
+def FeatureFooPred : FeatureSchedPredicate<FeatureFoo>;
+
+def Variant : SchedWriteVariant<[
+  SchedVar<FeatureFooPred, [SchedWriteResA]>,
+  SchedVar<NoSchedPred,    [SchedWriteResB]>
+]>;
+
+def : InstRW<[Variant], (instrs Inst_A)>;
+}
+
+def ProcessorA: ProcessorModel<"ProcessorA", SchedModel_A, []>;
+
 // CHECK:  unsigned resolveVariantSchedClassImpl(unsigned SchedClass,
 // CHECK-NEXT:      const MCInst *MI, const MCInstrInfo *MCII, const MCSubtargetInfo &STI, unsigned CPUID)
+// CHECK:  case {{.*}}: // Inst_A
+// CHECK-NEXT:   if (CPUID == {{.*}}) { // SchedModel_A
+// CHECK-NEXT:     if (STI.hasFeature(TestTarget::FeatureFoo))
+// CHECK-NEXT:       return {{.*}}; // SchedWriteResA
+// CHECK-NEXT:     return {{.*}}; // SchedWriteResB
 
 // CHECK: unsigned resolveVariantSchedClass(unsigned SchedClass,
 // CHECK-NEXT:    const MCInst *MI, const MCInstrInfo *MCII,
 // CHECK-NEXT:    unsigned CPUID) const override {
 // CHECK-NEXT:   return TestTarget_MC::resolveVariantSchedClassImpl(SchedClass, MI, MCII, *this, CPUID);
 // CHECK-NEXT: }
+
+// CHECK: unsigned TestTargetGenSubtargetInfo
+// CHECK-NEXT: ::resolveSchedClass(unsigned SchedClass, const MachineInstr *MI, const TargetSchedModel *SchedModel) const {
+// CHECK-NEXT:   switch (SchedClass) {
+// CHECK-NEXT:   case {{.*}}: // Inst_A
+// CHECK-NEXT:     if (SchedModel->getProcessorID() == {{.*}}) { // SchedModel_A
+// CHECK-NEXT:       if (this->hasFeature(TestTarget::FeatureFoo))
+// CHECK-NEXT:         return {{.*}}; // SchedWriteResA
+// CHECK-NEXT:       return {{.*}}; // SchedWriteResB

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1588,16 +1588,17 @@ static void emitPredicates(const CodeGenSchedTransition &T,
 
       if (Rec->isSubClassOf("FeatureSchedPredicate")) {
         const Record *FR = Rec->getValueAsDef("Feature");
-        if (PE.shouldExpandForMC())
+        if (PE.shouldExpandForMC()) {
           // MC version of this predicate will be emitted into
           // resolveVariantSchedClassImpl, which accesses MCSubtargetInfo
           // through argument STI.
           SS << "STI.";
-        else
+        } else {
           // Otherwise, this predicate will be emitted directly into
           // TargetGenSubtargetInfo::resolveSchedClass, which can just access
           // TargetSubtargetInfo / MCSubtargetInfo through `this`.
           SS << "this->";
+        }
         SS << "hasFeature(" << PE.getTargetName() << "::" << FR->getName()
            << ")";
         continue;

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1589,8 +1589,14 @@ static void emitPredicates(const CodeGenSchedTransition &T,
       if (Rec->isSubClassOf("FeatureSchedPredicate")) {
         const Record *FR = Rec->getValueAsDef("Feature");
         if (PE.shouldExpandForMC())
+          // MC version of this predicate will be emitted into
+          // resolveVariantSchedClassImpl, which accesses MCSubtargetInfo
+          // through argument STI.
           SS << "STI.";
         else
+          // Otherwise, this predicate will be emitted directly into
+          // TargetGenSubtargetInfo::resolveSchedClass, which can just access
+          // TargetSubtargetInfo / MCSubtargetInfo through `this`.
           SS << "this->";
         SS << "hasFeature(" << PE.getTargetName() << "::" << FR->getName()
            << ")";

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1586,6 +1586,17 @@ static void emitPredicates(const CodeGenSchedTransition &T,
         continue;
       }
 
+      if (Rec->isSubClassOf("FeatureSchedPredicate")) {
+        const Record *FR = Rec->getValueAsDef("Feature");
+        if (PE.shouldExpandForMC())
+          SS << "STI.";
+        else
+          SS << "this->";
+        SS << "hasFeature(" << PE.getTargetName() << "::" << FR->getName()
+           << ")";
+        continue;
+      }
+
       // Expand this legacy predicate and wrap it around braces if there is more
       // than one predicate to expand.
       SS << ((NumNonTruePreds > 1) ? "(" : "")
@@ -1618,7 +1629,8 @@ static void emitSchedModelHelperEpilogue(raw_ostream &OS,
 
 static bool hasMCSchedPredicates(const CodeGenSchedTransition &T) {
   return all_of(T.PredTerm, [](const Record *Rec) {
-    return Rec->isSubClassOf("MCSchedPredicate");
+    return Rec->isSubClassOf("MCSchedPredicate") ||
+           Rec->isSubClassOf("FeatureSchedPredicate");
   });
 }
 


### PR DESCRIPTION
Introduce a new SchedPredicate, `FeatureSchedPredicate`, that holds true when a certain SubtargetFeature is enabled. This could be useful when we want to configure a scheduling model with subtarget features.

I add this as a separate SchedPredicate rather than piggy-back on the existing `SchedPredicate<[{....}]>` because first and foremost, `SchedPredicate` is expected to only operate on MachineInstr, so it does _not_ appear in `MCGenSubtargetInfo::resolveVariantSchedClass` but only show up in `TargetGenSubtargetInfo::resolveSchedClass`. Yet I think `FeatureSchedPredicate` will be useful for both MCInst and MachineInstr. There is another subtle difference between  `resolveVariantSchedClass` and `resolveSchedClass` regarding how we access the MCSubtargetInfo instance, if we really want to express `FeatureSchedPredicate` using `SchedPredicate<[{.....}]>`. 

So I thought it'll be easier to add another new SchedPredicate for SubtargetFeature.

------

This stacks on top of #161886 