### PR TITLE
[scudo] Only read urandom if getrandom syscall isn't available.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/linux.cpp
@@ -192,6 +192,12 @@ bool getRandom(void *Buffer, uptr Length, UNUSED bool Blocking) {
       syscall(SYS_getrandom, Buffer, Length, Blocking ? 0 : GRND_NONBLOCK);
   if (ReadBytes == static_cast<ssize_t>(Length))
     return true;
+  // If this system call is not implemented in the kernel, then we will try
+  // and use /dev/urandom. Otherwise, if the syscall fails, return false
+  // assuming that trying to read /dev/urandom will cause a delay waiting for
+  // the random data to be usable.
+  if (errno != ENOSYS)
+    return false;
 #endif // defined(SYS_getrandom)
   // Up to 256 bytes, a read off /dev/urandom will not be interrupted.
   // Blocking is moot here, O_NONBLOCK has no effect when opening /dev/urandom.


### PR DESCRIPTION
If the getrandom system call is available, but the call returns an error, it could mean that the system doesn't have enough randomness to respond yet. Trying to read /dev/urandom will likely block and cause initialization to be stalled. Therefore, return false in this case and use the backup random data.