### PR TITLE
[Android] Drop workarounds for older Android API levels pre 23

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8205,7 +8205,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (Triple.isAArch64() &&
       (Args.hasArg(options::OPT_mno_fmv) ||
-       (Triple.isAndroid() && Triple.isAndroidVersionLT(23)) ||
        getToolChain().GetRuntimeLibType(Args) != ToolChain::RLT_CompilerRT)) {
     // Disable Function Multiversioning on AArch64 target.
     CmdArgs.push_back("-target-feature");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8495,7 +8495,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (Triple.isAArch64() &&
       (Args.hasArg(options::OPT_mno_fmv) ||
-       (Triple.isAndroid() && Triple.isAndroidVersionLT(23)) ||
        getToolChain().GetRuntimeLibType(Args) != ToolChain::RLT_CompilerRT)) {
     // Disable Function Multiversioning on AArch64 target.
     CmdArgs.push_back("-target-feature");

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -279,13 +279,12 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
     }
     // SHT_RELR relocations are only supported at API level >= 30.
     // ANDROID_RELR relocations were supported at API level >= 28.
-    // Relocation packer was supported at API level >= 23.
     if (!Triple.isAndroidVersionLT(30)) {
       ExtraOpts.push_back("--pack-dyn-relocs=android+relr");
     } else if (!Triple.isAndroidVersionLT(28)) {
       ExtraOpts.push_back("--pack-dyn-relocs=android+relr");
       ExtraOpts.push_back("--use-android-relr-tags");
-    } else if (!Triple.isAndroidVersionLT(23)) {
+    } else {
       ExtraOpts.push_back("--pack-dyn-relocs=android");
     }
   }
@@ -317,11 +316,10 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
   // and the MIPS ABI require .dynsym to be sorted in different ways.
   // .gnu.hash needs symbols to be grouped by hash code whereas the MIPS
   // ABI requires a mapping between the GOT and the symbol table.
-  // Android loader does not support .gnu.hash until API 23.
   // Hexagon linker/loader does not support .gnu.hash.
   // SUSE SLES 11 will stop being supported Mar 2028.
   if (!IsMips && !IsHexagon) {
-    if (Distro.IsOpenSUSE() || (IsAndroid && Triple.isAndroidVersionLT(23)))
+    if (Distro.IsOpenSUSE())
       ExtraOpts.push_back("--hash-style=both");
     else
       ExtraOpts.push_back("--hash-style=gnu");

--- a/clang/test/Driver/aarch64-features.c
+++ b/clang/test/Driver/aarch64-features.c
@@ -8,13 +8,9 @@
 // CHECK: fno-signed-char
 
 // Check Function Multi Versioning option and rtlib dependency.
-// RUN: %clang --target=aarch64-linux-android23 -rtlib=compiler-rt \
-// RUN: -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-FMV %s
 // RUN: %clang --target=aarch64-linux-android -rtlib=compiler-rt \
-// RUN: -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-FMV-OFF %s
+// RUN: -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-FMV %s
 // RUN: %clang --target=aarch64-linux-android -rtlib=compiler-rt -mno-fmv \
-// RUN: -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-FMV-OFF %s
-// RUN: %clang --target=aarch64-linux-android22 -rtlib=compiler-rt \
 // RUN: -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-FMV-OFF %s
 
 // RUN: %clang --target=aarch64-linux-gnu -rtlib=libgcc \

--- a/clang/test/Driver/aarch64-fmv.c
+++ b/clang/test/Driver/aarch64-fmv.c
@@ -1,23 +1,15 @@
 // Test which driver flags enable/disable Function Multiversioning on aarch64.
 
-// FMV is enabled for non-android aarch64 targets:
+// FMV is enabled with compiler-rt:
 // RUN: %clang --target=aarch64 --rtlib=compiler-rt -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
 // RUN: %clang --target=aarch64-linux-gnu --rtlib=compiler-rt -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
+// RUN: %clang --target=aarch64-linux-android --rtlib=compiler-rt -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
 // RUN: %clang --target=arm64-apple-ios --rtlib=compiler-rt -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
 // RUN: %clang --target=arm64-apple-macosx --rtlib=compiler-rt -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
-
-// android23 defaults to --rtlib=compiler-rt:
-// RUN: %clang --target=aarch64-linux-android23 -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
-// RUN: %clang --target=aarch64-linux-android23 --rtlib=compiler-rt  -### -c %s 2>&1 | FileCheck -check-prefix=FMV-ENABLED %s
 
 // FMV is disabled without compiler-rt:
 // RUN: %clang --rtlib=libgcc --target=aarch64 -### -c %s 2>&1 | FileCheck -check-prefix=FMV-DISABLED %s
 // RUN: %clang --rtlib=libgcc --target=aarch64-linux-gnu -### -c %s 2>&1 | FileCheck -check-prefix=FMV-DISABLED %s
-
-// Disabled for older android versions:
-// RUN: %clang --rtlib=compiler-rt --target=aarch64-linux-android               -### -c %s 2>&1 | FileCheck -check-prefix=FMV-DISABLED %s
-// RUN: %clang --rtlib=compiler-rt --target=aarch64-linux-android22             -### -c %s 2>&1 | FileCheck -check-prefix=FMV-DISABLED %s
-// RUN: %clang --rtlib=compiler-rt --target=aarch64-linux-android22  -mno-fmv   -### -c %s 2>&1 | FileCheck -check-prefix=FMV-DISABLED %s
 
 // Disabled explicitly:
 // RUN: %clang --rtlib=compiler-rt --target=aarch64 -mno-fmv -### -c %s 2>&1 | FileCheck -check-prefix=FMV-DISABLED %s

--- a/clang/test/Driver/linux-ld.c
+++ b/clang/test/Driver/linux-ld.c
@@ -930,16 +930,9 @@
 // CHECK-MIPS64EL-REDHAT-NOT: "-dynamic-linker" "{{.*}}/lib{{(64)?}}/ld-musl-mipsel.so.1"
 // CHECK-MIPS64EL-REDHAT-NOT: "--hash-style={{gnu|both}}"
 
-// Check that we pass --hash-style=both for pre-M Android versions and
-// --hash-style=gnu for newer Android versions.
+// Check that we pass --hash-style=gnu.
 // RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=armv7-linux-android21 \
-// RUN:   | FileCheck --check-prefix=CHECK-ANDROID-HASH-STYLE-L %s
-// CHECK-ANDROID-HASH-STYLE-L: "{{.*}}ld{{(.exe)?}}"
-// CHECK-ANDROID-HASH-STYLE-L: "--hash-style=both"
-//
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=armv7-linux-android23 \
+// RUN:     --target=armv7-linux-android \
 // RUN:   | FileCheck --check-prefix=CHECK-ANDROID-HASH-STYLE-M %s
 // CHECK-ANDROID-HASH-STYLE-M: "{{.*}}ld{{(.exe)?}}"
 // CHECK-ANDROID-HASH-STYLE-M: "--hash-style=gnu"
@@ -958,16 +951,7 @@
 // CHECK-ANDROID-ROSEGMENT-29: "{{.*}}ld{{(.exe)?}}"
 // CHECK-ANDROID-ROSEGMENT-29-NOT: "--no-rosegment"
 
-// Check that we pass --pack-dyn-relocs=android for API 23-27 and not before.
-// RUN: %clang %s -### -o %t.o 2>&1 \
-// RUN:     --target=armv7-linux-android22 \
-// RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-22 %s
-// CHECK-ANDROID-RELR-22: "{{.*}}ld{{(.exe)?}}"
-// CHECK-ANDROID-RELR-22-NOT: "--pack-dyn-relocs=android"
-// CHECK-ANDROID-RELR-22-NOT: "--pack-dyn-relocs=relr"
-// CHECK-ANDROID-RELR-22-NOT: "--pack-dyn-relocs=android+relr"
-// CHECK-ANDROID-RELR-22-NOT: "--use-android-relr-tags"
-//
+// Check that we pass --pack-dyn-relocs=android for API pre 27.
 // RUN: %clang %s -### -o %t.o 2>&1 \
 // RUN:     --target=armv7-linux-android23 \
 // RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-23 %s


### PR DESCRIPTION
Drop workarounds for Android API levels pre 23.

The minimum Android API currently supported by the LTS NDK is 23.