### PR TITLE
[TableGen] Set `G_GLOBAL_VALUE` out operand type to `ptype0`

### DIFF
--- a/llvm/include/llvm/Target/GenericOpcodes.td
+++ b/llvm/include/llvm/Target/GenericOpcodes.td
@@ -126,7 +126,7 @@ def G_FRAME_INDEX : GenericInstruction {
 }
 
 def G_GLOBAL_VALUE : GenericInstruction {
-  let OutOperandList = (outs type0:$dst);
+  let OutOperandList = (outs ptype0:$dst);
   let InOperandList = (ins unknown:$src);
   let hasSideEffects = false;
 }


### PR DESCRIPTION
I'm not familiar with how every target handles this generic opcode but I think it shouldn't break anything and it makes sense to use `ptype0` because `G_GLOBAL_VALUE` returns a pointer.