### PR TITLE
[NFC][DirectX] Moving IsValidXYZ Functions to cpp file

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -201,19 +201,9 @@ enum class RootParameterType : uint32_t {
 
 LLVM_ABI ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
 
-#define ROOT_PARAMETER(Val, Enum)                                              \
-  case Val:                                                                    \
-    return true;
-inline bool isValidParameterType(uint32_t V) {
-  switch (V) {
-#include "DXContainerConstants.def"
-  }
-  return false;
-}
+bool isValidParameterType(uint32_t V);
 
-inline bool isValidRangeType(uint32_t V) {
-  return V <= llvm::to_underlying(dxil::ResourceClass::LastEntry);
-}
+bool isValidRangeType(uint32_t V);
 
 #define SHADER_VISIBILITY(Val, Enum) Enum = Val,
 enum class ShaderVisibility : uint32_t {
@@ -222,30 +212,14 @@ enum class ShaderVisibility : uint32_t {
 
 LLVM_ABI ArrayRef<EnumEntry<ShaderVisibility>> getShaderVisibility();
 
-#define SHADER_VISIBILITY(Val, Enum)                                           \
-  case Val:                                                                    \
-    return true;
-inline bool isValidShaderVisibility(uint32_t V) {
-  switch (V) {
-#include "DXContainerConstants.def"
-  }
-  return false;
-}
+bool isValidShaderVisibility(uint32_t V);
 
 #define FILTER(Val, Enum) Enum = Val,
 enum class SamplerFilter : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-#define FILTER(Val, Enum)                                                      \
-  case Val:                                                                    \
-    return true;
-inline bool isValidSamplerFilter(uint32_t V) {
-  switch (V) {
-#include "DXContainerConstants.def"
-  }
-  return false;
-}
+bool isValidSamplerFilter(uint32_t V);
 
 LLVM_ABI ArrayRef<EnumEntry<SamplerFilter>> getSamplerFilters();
 
@@ -256,15 +230,7 @@ enum class TextureAddressMode : uint32_t {
 
 LLVM_ABI ArrayRef<EnumEntry<TextureAddressMode>> getTextureAddressModes();
 
-#define TEXTURE_ADDRESS_MODE(Val, Enum)                                        \
-  case Val:                                                                    \
-    return true;
-inline bool isValidAddress(uint32_t V) {
-  switch (V) {
-#include "DXContainerConstants.def"
-  }
-  return false;
-}
+bool isValidAddress(uint32_t V);
 
 #define COMPARISON_FUNC(Val, Enum) Enum = Val,
 enum class ComparisonFunc : uint32_t {
@@ -273,30 +239,14 @@ enum class ComparisonFunc : uint32_t {
 
 LLVM_ABI ArrayRef<EnumEntry<ComparisonFunc>> getComparisonFuncs();
 
-#define COMPARISON_FUNC(Val, Enum)                                             \
-  case Val:                                                                    \
-    return true;
-inline bool isValidComparisonFunc(uint32_t V) {
-  switch (V) {
-#include "DXContainerConstants.def"
-  }
-  return false;
-}
+bool isValidComparisonFunc(uint32_t V);
 
 #define STATIC_BORDER_COLOR(Val, Enum) Enum = Val,
 enum class StaticBorderColor : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-#define STATIC_BORDER_COLOR(Val, Enum)                                         \
-  case Val:                                                                    \
-    return true;
-inline bool isValidBorderColor(uint32_t V) {
-  switch (V) {
-#include "DXContainerConstants.def"
-  }
-  return false;
-}
+bool isValidBorderColor(uint32_t V);
 
 LLVM_ABI ArrayRef<EnumEntry<StaticBorderColor>> getStaticBorderColors();
 

--- a/llvm/lib/BinaryFormat/DXContainer.cpp
+++ b/llvm/lib/BinaryFormat/DXContainer.cpp
@@ -18,6 +18,70 @@
 using namespace llvm;
 using namespace llvm::dxbc;
 
+#define ROOT_PARAMETER(Val, Enum)                                              \
+  case Val:                                                                    \
+    return true;
+bool llvm::dxbc::isValidParameterType(uint32_t V) {
+  switch (V) {
+#include "llvm/BinaryFormat/DXContainerConstants.def"
+  }
+  return false;
+}
+
+bool llvm::dxbc::isValidRangeType(uint32_t V) {
+  return V <= llvm::to_underlying(dxil::ResourceClass::LastEntry);
+}
+
+#define SHADER_VISIBILITY(Val, Enum)                                           \
+  case Val:                                                                    \
+    return true;
+bool llvm::dxbc::isValidShaderVisibility(uint32_t V) {
+  switch (V) {
+#include "llvm/BinaryFormat/DXContainerConstants.def"
+  }
+  return false;
+}
+
+#define FILTER(Val, Enum)                                                      \
+  case Val:                                                                    \
+    return true;
+bool llvm::dxbc::isValidSamplerFilter(uint32_t V) {
+  switch (V) {
+#include "llvm/BinaryFormat/DXContainerConstants.def"
+  }
+  return false;
+}
+
+#define TEXTURE_ADDRESS_MODE(Val, Enum)                                        \
+  case Val:                                                                    \
+    return true;
+bool llvm::dxbc::isValidAddress(uint32_t V) {
+  switch (V) {
+#include "llvm/BinaryFormat/DXContainerConstants.def"
+  }
+  return false;
+}
+
+#define COMPARISON_FUNC(Val, Enum)                                             \
+  case Val:                                                                    \
+    return true;
+bool llvm::dxbc::isValidComparisonFunc(uint32_t V) {
+  switch (V) {
+#include "llvm/BinaryFormat/DXContainerConstants.def"
+  }
+  return false;
+}
+
+#define STATIC_BORDER_COLOR(Val, Enum)                                         \
+  case Val:                                                                    \
+    return true;
+bool llvm::dxbc::isValidBorderColor(uint32_t V) {
+  switch (V) {
+#include "llvm/BinaryFormat/DXContainerConstants.def"
+  }
+  return false;
+}
+
 dxbc::PartType dxbc::parsePartType(StringRef S) {
 #define CONTAINER_PART(PartName) .Case(#PartName, PartType::PartName)
   return StringSwitch<dxbc::PartType>(S)


### PR DESCRIPTION
Originally, DXContainer `isValid...` functions were defined din the header. That cause a problem, that made this specific file huge, since every function also includes a `def` file. To fix this problem, this PR moves the function to the cpp equivalent file.

Closes: [158162](https://github.com/llvm/llvm-project/issues/158162)