### PR TITLE
[libcxx] Run tests on Windows/arm64 too

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -236,7 +236,6 @@ jobs:
             **/crash_diagnostics/*
 
   windows:
-    runs-on: windows-2022
     needs: [ stage2 ]
     strategy:
       fail-fast: false
@@ -251,6 +250,8 @@ jobs:
         - { config: mingw-static, mingw: true }
         - { config: mingw-dll-i686, mingw: true }
         - { config: mingw-incomplete-sysroot, mingw: true }
+        - { config: mingw-static-aarch64, mingw: true, runner: windows-11-arm }
+    runs-on: ${{ matrix.runner != '' && matrix.runner || 'windows-latest' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
@@ -264,7 +265,7 @@ jobs:
       - name: Install llvm-mingw
         if: ${{ matrix.mingw == true }}
         run: |
-          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250709/llvm-mingw-20250709-ucrt-x86_64.zip
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250709/llvm-mingw-20250709-ucrt-${{ matrix.runner == 'windows-11-arm' && 'aarch64' || 'x86_64' }}.zip
           powershell Expand-Archive llvm-mingw*.zip -DestinationPath .
           del llvm-mingw*.zip
           mv llvm-mingw* c:\llvm-mingw

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -250,8 +250,8 @@ jobs:
         - { config: mingw-static, mingw: true }
         - { config: mingw-dll-i686, mingw: true }
         - { config: mingw-incomplete-sysroot, mingw: true }
-        - { config: mingw-static-aarch64, mingw: true, runner: windows-11-arm }
-    runs-on: ${{ matrix.runner != '' && matrix.runner || 'windows-latest' }}
+        - { config: mingw-static, mingw: true, runner: windows-11-arm }
+    runs-on: ${{ matrix.runner != '' && matrix.runner || 'windows-2022' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies

--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -147,7 +147,7 @@ macOS 10.13+          i386, x86_64, arm64
 FreeBSD 12+           i386, x86_64, arm
 Linux                 i386, x86_64, arm, arm64  Only glibc-2.24 and later and no other libc is officially supported
 Android 5.0+          i386, x86_64, arm, arm64
-Windows               i386, x86_64              Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
+Windows               i386, x86_64, arm64       Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
 AIX 7.2TL5+           powerpc, powerpc64
 Embedded (picolibc)   arm
 ===================== ========================= ============================

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -706,7 +706,7 @@ mingw-dll)
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake"
     check-runtimes
 ;;
-mingw-static|mingw-static-aarch64)
+mingw-static)
     clean
     generate-cmake \
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake" \

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -706,7 +706,7 @@ mingw-dll)
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake"
     check-runtimes
 ;;
-mingw-static)
+mingw-static|mingw-static-aarch64)
     clean
     generate-cmake \
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake" \


### PR DESCRIPTION
Github Actions has got free runners with Windows on ARM64 these days, which can be used for running CI, just as well as the other existing cases.

This qualifies this configuration as a supported target platform, thus add it to the docs in the listing of supported platforms.