### PR TITLE
[libcxx] [ci] Stop manually installing ninja in the Windows build jobs

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -255,7 +255,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
         run: |
-          choco install -y ninja
           pip install psutil
       - name: Install a current LLVM
         if: ${{ matrix.mingw != true }}


### PR DESCRIPTION
Ninja is officially included among the preinstalled tools on the Windows runners now.

This should reduce the risk for stray failures here; sometimes, attempting to install Ninja through Chocolatey have caused spurious failures.