### PR TITLE
[Android] Drop workarounds for older Android API levels pre 9, 17 and 21

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -225,8 +225,7 @@ private:
 
   /// Return true if the target has sincosf/sincos/sincosl functions
   static bool hasSinCos(const Triple &TT) {
-    return TT.isGNUEnvironment() || TT.isOSFuchsia() ||
-           (TT.isAndroid() && !TT.isAndroidVersionLT(9));
+    return TT.isGNUEnvironment() || TT.isOSFuchsia() || TT.isAndroid();
   }
 
   static bool hasSinCos_f32_f64(const Triple &TT) {

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -740,11 +740,6 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setAvailable(LibFunc_fgets_unlocked);
   }
 
-  if (T.isAndroid() && T.isAndroidVersionLT(21)) {
-    TLI.setUnavailable(LibFunc_stpcpy);
-    TLI.setUnavailable(LibFunc_stpncpy);
-  }
-
   if (T.isPS()) {
     // PS4/PS5 do have memalign.
     TLI.setAvailable(LibFunc_memalign);

--- a/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
+++ b/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
@@ -547,7 +547,7 @@ unsigned X86TargetLowering::getAddressSpace() const {
 
 static bool hasStackGuardSlotTLS(const Triple &TargetTriple) {
   return TargetTriple.isOSGlibc() || TargetTriple.isOSFuchsia() ||
-         (TargetTriple.isAndroid() && !TargetTriple.isAndroidVersionLT(17));
+         TargetTriple.isAndroid();
 }
 
 static Constant* SegmentOffset(IRBuilderBase &IRB,

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -600,9 +600,7 @@ static ShadowMapping getShadowMapping(const Triple &TargetTriple, int LongSize,
                            !IsRISCV64 && !IsLoongArch64 &&
                            !(Mapping.Offset & (Mapping.Offset - 1)) &&
                            Mapping.Offset != kDynamicShadowSentinel;
-  bool IsAndroidWithIfuncSupport =
-      IsAndroid && !TargetTriple.isAndroidVersionLT(21);
-  Mapping.InGlobal = ClWithIfunc && IsAndroidWithIfuncSupport && IsArmOrThumb;
+  Mapping.InGlobal = ClWithIfunc && IsAndroid && IsArmOrThumb;
 
   return Mapping;
 }

--- a/llvm/test/CodeGen/ARM/sincos.ll
+++ b/llvm/test/CodeGen/ARM/sincos.ll
@@ -2,8 +2,7 @@
 ; RUN: llc < %s -mtriple=armv7-apple-ios7 -mcpu=cortex-a8 | FileCheck %s --check-prefix=SINCOS
 ; RUN: llc < %s -mtriple=armv7-linux-gnu -mcpu=cortex-a8 | FileCheck %s --check-prefix=SINCOS-GNU
 ; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a8 | FileCheck %s --check-prefix=SINCOS-GNU
-; RUN: llc < %s -mtriple=armv7-linux-android -mcpu=cortex-a8 | FileCheck %s --check-prefix=NOOPT-ANDROID
-; RUN: llc < %s -mtriple=armv7-linux-android9 -mcpu=cortex-a8 | FileCheck %s --check-prefix=SINCOS-GNU
+; RUN: llc < %s -mtriple=armv7-linux-android -mcpu=cortex-a8 | FileCheck %s --check-prefix=SINCOS-GNU
 
 ; Combine sin / cos into a single call unless they may write errno (as
 ; captured by readnone attrbiute, controlled by clang -fmath-errno
@@ -22,10 +21,6 @@ entry:
 ; NOOPT: bl _sinf
 ; NOOPT: bl _cosf
 
-; NOOPT-ANDROID-LABEL: test1:
-; NOOPT-ANDROID: bl sinf
-; NOOPT-ANDROID: bl cosf
-
   %call = tail call float @sinf(float %x) readnone
   %call1 = tail call float @cosf(float %x) readnone
   %add = fadd float %call, %call1
@@ -43,10 +38,6 @@ entry:
 ; NOOPT-LABEL: test1_fast:
 ; NOOPT: bl _sinf
 ; NOOPT: bl _cosf
-
-; NOOPT-ANDROID-LABEL: test1_fast:
-; NOOPT-ANDROID: bl sinf
-; NOOPT-ANDROID: bl cosf
 
   %call = tail call fast float @sinf(float %x) readnone
   %call1 = tail call fast float @cosf(float %x) readnone
@@ -68,10 +59,6 @@ entry:
 ; NOOPT: bl _sinf
 ; NOOPT: bl _cosf
 
-; NOOPT-ANDROID-LABEL: test1_errno:
-; NOOPT-ANDROID: bl sinf
-; NOOPT-ANDROID: bl cosf
-
   %call = tail call float @sinf(float %x)
   %call1 = tail call float @cosf(float %x)
   %add = fadd float %call, %call1
@@ -90,10 +77,6 @@ entry:
 ; NOOPT: bl _sin
 ; NOOPT: bl _cos
 
-; NOOPT-ANDROID-LABEL: test2:
-; NOOPT-ANDROID: bl sin
-; NOOPT-ANDROID: bl cos
-
   %call = tail call double @sin(double %x) readnone
   %call1 = tail call double @cos(double %x) readnone
   %add = fadd double %call, %call1
@@ -111,10 +94,6 @@ entry:
 ; NOOPT-LABEL: test2_fast:
 ; NOOPT: bl _sin
 ; NOOPT: bl _cos
-
-; NOOPT-ANDROID-LABEL: test2_fast:
-; NOOPT-ANDROID: bl sin
-; NOOPT-ANDROID: bl cos
 
   %call = tail call fast double @sin(double %x) readnone
   %call1 = tail call fast double @cos(double %x) readnone
@@ -135,10 +114,6 @@ entry:
 ; NOOPT-LABEL: test2_errno:
 ; NOOPT: bl _sin
 ; NOOPT: bl _cos
-
-; NOOPT-ANDROID-LABEL: test2_errno:
-; NOOPT-ANDROID: bl sin
-; NOOPT-ANDROID: bl cos
 
   %call = tail call double @sin(double %x)
   %call1 = tail call double @cos(double %x)

--- a/llvm/test/CodeGen/X86/stack-protector-target.ll
+++ b/llvm/test/CodeGen/X86/stack-protector-target.ll
@@ -2,13 +2,8 @@
 ; RUN: llc -mtriple=i386-linux < %s -o - | FileCheck --check-prefix=I386-TLS %s
 ; RUN: llc -mtriple=x86_64-linux < %s -o - | FileCheck --check-prefix=X64-TLS %s
 
-; RUN: llc -mtriple=i386-linux-android < %s -o - | FileCheck --check-prefix=I386 %s
-; RUN: llc -mtriple=i386-linux-android16 < %s -o - | FileCheck --check-prefix=I386 %s
-; RUN: llc -mtriple=i386-linux-android17 < %s -o - | FileCheck --check-prefix=I386-TLS %s
-; RUN: llc -mtriple=i386-linux-android24 < %s -o - | FileCheck --check-prefix=I386-TLS %s
+; RUN: llc -mtriple=i386-linux-android < %s -o - | FileCheck --check-prefix=I386-TLS %s
 ; RUN: llc -mtriple=x86_64-linux-android < %s -o - | FileCheck --check-prefix=X64-TLS %s
-; RUN: llc -mtriple=x86_64-linux-android17 < %s -o - | FileCheck --check-prefix=X64-TLS %s
-; RUN: llc -mtriple=x86_64-linux-android24 < %s -o - | FileCheck --check-prefix=X64-TLS %s
 
 ; RUN: llc -mtriple=i386-kfreebsd < %s -o - | FileCheck --check-prefix=I386-TLS %s
 ; RUN: llc -mtriple=x86_64-kfreebsd < %s -o - | FileCheck --check-prefix=X64-TLS %s
@@ -26,11 +21,6 @@ declare void @_Z7CapturePi(ptr)
 ; X64-TLS: movq %[[B]], 16(%rsp)
 ; X64-TLS: movq %fs:40, %[[C:.*]]
 ; X64-TLS: cmpq 16(%rsp), %[[C]]
-
-; I386: movl __stack_chk_guard, %[[B:.*]]
-; I386: movl %[[B]], 8(%esp)
-; I386: movl __stack_chk_guard, %[[C:.*]]
-; I386: cmpl 8(%esp), %[[C]]
 
 ; I386-TLS: movl %gs:20, %[[B:.*]]
 ; I386-TLS: movl %[[B]], 8(%esp)

--- a/llvm/test/Instrumentation/AddressSanitizer/with-ifunc.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/with-ifunc.ll
@@ -4,13 +4,10 @@
 ; RUN: opt -passes=asan -S -asan-with-ifunc=1 -asan-with-ifunc-suppress-remat=0 < %s | FileCheck %s --check-prefixes=CHECK,CHECK-IFUNC
 ; RUN: opt -passes=asan -S -asan-with-ifunc=1 -asan-with-ifunc-suppress-remat=1 < %s | FileCheck %s --check-prefixes=CHECK,CHECK-IFUNC-NOREMAT
 
-; Pre-Lollipop Android does not support ifunc.
-; RUN: opt -passes=asan -S -asan-with-ifunc=1 -asan-with-ifunc-suppress-remat=0 -mtriple=armv7-linux-android20 < %s | FileCheck %s --check-prefixes=CHECK,CHECK-NOIFUNC
-; RUN: opt -passes=asan -S -asan-with-ifunc=1 -asan-with-ifunc-suppress-remat=0 -mtriple=armv7-linux-android < %s | FileCheck %s --check-prefixes=CHECK,CHECK-NOIFUNC
-; RUN: opt -passes=asan -S -asan-with-ifunc=1 -asan-with-ifunc-suppress-remat=0 -mtriple=armv7-linux-android21 < %s | FileCheck %s --check-prefixes=CHECK,CHECK-IFUNC
+; RUN: opt -passes=asan -S -asan-with-ifunc=1 -asan-with-ifunc-suppress-remat=0 -mtriple=armv7-linux-android < %s | FileCheck %s --check-prefixes=CHECK,CHECK-IFUNC
 
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
-target triple = "armv7--linux-android22"
+target triple = "armv7--linux-android"
 
 ; CHECK-IFUNC: @__asan_shadow = external global [0 x i8]
 ; CHECK-NOIFUNC: @__asan_shadow_memory_dynamic_address = external global i32

--- a/llvm/test/Transforms/InstCombine/sprintf-1.ll
+++ b/llvm/test/Transforms/InstCombine/sprintf-1.ll
@@ -5,8 +5,7 @@
 ; RUN: opt < %s -mtriple xcore-xmos-elf -passes=instcombine -S | FileCheck %s -check-prefixes=CHECK,WITHSTPCPY,CHECK-IPRINTF
 ; RUN: opt < %s -mtriple=i386-pc-windows-msvc -passes=instcombine -S | FileCheck %s --check-prefixes=CHECK,NOSTPCPY
 ; RUN: opt < %s -mtriple=i386-mingw32 -passes=instcombine -S | FileCheck %s --check-prefixes=CHECK,NOSTPCPY
-; RUN: opt < %s -mtriple=armv7-none-linux-android16 -passes=instcombine -S | FileCheck %s --check-prefixes=CHECK,NOSTPCPY
-; RUN: opt < %s -mtriple=armv7-none-linux-android21 -passes=instcombine -S | FileCheck %s --check-prefixes=CHECK,WITHSTPCPY
+; RUN: opt < %s -mtriple=armv7-none-linux-android -passes=instcombine -S | FileCheck %s --check-prefixes=CHECK,WITHSTPCPY
 ; RUN: opt < %s -mtriple=x86_64-scei-ps4 -passes=instcombine -S | FileCheck %s --check-prefixes=CHECK,NOSTPCPY
 
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:128:128"

--- a/llvm/test/Transforms/SafeStack/X86/abi_ssp.ll
+++ b/llvm/test/Transforms/SafeStack/X86/abi_ssp.ll
@@ -1,9 +1,7 @@
 ; RUN: opt -safe-stack -S -mtriple=i686-pc-linux-gnu < %s -o - | FileCheck --check-prefixes=COMMON,TLS32 %s
 ; RUN: opt -safe-stack -S -mtriple=x86_64-pc-linux-gnu < %s -o - | FileCheck --check-prefixes=COMMON,TLS64 %s
 
-; RUN: opt -safe-stack -S -mtriple=i686-linux-android < %s -o - | FileCheck --check-prefixes=COMMON,GLOBAL32 %s
-; RUN: opt -safe-stack -S -mtriple=i686-linux-android24 < %s -o - | FileCheck --check-prefixes=COMMON,TLS32 %s
-
+; RUN: opt -safe-stack -S -mtriple=i686-linux-android < %s -o - | FileCheck --check-prefixes=COMMON,TLS32 %s
 ; RUN: opt -safe-stack -S -mtriple=x86_64-linux-android < %s -o - | FileCheck --check-prefixes=COMMON,TLS64 %s
 
 ; RUN: opt -safe-stack -S -mtriple=x86_64-unknown-fuchsia < %s -o - | FileCheck --check-prefixes=COMMON,FUCHSIA64 %s
@@ -11,9 +9,7 @@
 ; RUN: opt -passes=safe-stack -S -mtriple=i686-pc-linux-gnu < %s -o - | FileCheck --check-prefixes=COMMON,TLS32 %s
 ; RUN: opt -passes=safe-stack -S -mtriple=x86_64-pc-linux-gnu < %s -o - | FileCheck --check-prefixes=COMMON,TLS64 %s
 
-; RUN: opt -passes=safe-stack -S -mtriple=i686-linux-android < %s -o - | FileCheck --check-prefixes=COMMON,GLOBAL32 %s
-; RUN: opt -passes=safe-stack -S -mtriple=i686-linux-android24 < %s -o - | FileCheck --check-prefixes=COMMON,TLS32 %s
-
+; RUN: opt -passes=safe-stack -S -mtriple=i686-linux-android < %s -o - | FileCheck --check-prefixes=COMMON,TLS32 %s
 ; RUN: opt -passes=safe-stack -S -mtriple=x86_64-linux-android < %s -o - | FileCheck --check-prefixes=COMMON,TLS64 %s
 
 ; RUN: opt -passes=safe-stack -S -mtriple=x86_64-unknown-fuchsia < %s -o - | FileCheck --check-prefixes=COMMON,FUCHSIA64 %s


### PR DESCRIPTION
Drop workarounds for Android API levels pre 9, 17, 21.

The minimum Android API currently supported by the LTS NDK is 21.