### PR TITLE
[flang] remove sequences of duplicate messages

### DIFF
--- a/flang/include/flang/Parser/message.h
+++ b/flang/include/flang/Parser/message.h
@@ -307,9 +307,9 @@ public:
   bool Merge(const Message &);
   bool operator==(const Message &that) const;
   bool operator!=(const Message &that) const { return !(*this == that); }
+  bool AtSameLocation(const Message &) const;
 
 private:
-  bool AtSameLocation(const Message &) const;
   std::variant<ProvenanceRange, CharBlock> location_;
   std::variant<MessageFixedText, MessageFormattedText, MessageExpectedText>
       text_;

--- a/flang/lib/Parser/message.cpp
+++ b/flang/lib/Parser/message.cpp
@@ -477,15 +477,31 @@ void Messages::Emit(llvm::raw_ostream &o, const AllCookedSources &allCooked,
   }
   std::stable_sort(sorted.begin(), sorted.end(),
       [](const Message *x, const Message *y) { return x->SortBefore(*y); });
-  const Message *lastMsg{nullptr};
+  std::vector<const Message *> msgsWithLastLocation;
   std::size_t errorsEmitted{0};
   for (const Message *msg : sorted) {
-    if (lastMsg && *msg == *lastMsg) {
-      // Don't emit two identical messages for the same location
+    bool shouldSkipMsg = false;
+    // Don't emit two identical messages for the same location
+    // At the same location messages are sorted by the order they were
+    // added to the list, which is a decent proxy for the causality
+    // of the messages.
+    if (!msgsWithLastLocation.empty()) {
+      if (msgsWithLastLocation[0]->AtSameLocation(*msg)) {
+        for (const Message *msgAtThisLocation : msgsWithLastLocation) {
+          if (*msg == *msgAtThisLocation) {
+            shouldSkipMsg = true; // continue loop over sorted messages
+            break;
+          }
+        }
+      } else {
+        msgsWithLastLocation.clear();
+      }
+    }
+    if (shouldSkipMsg) {
       continue;
     }
+    msgsWithLastLocation.push_back(msg);
     msg->Emit(o, allCooked, echoSourceLines, hintFlagPtr);
-    lastMsg = msg;
     if (warningsAreErrors || msg->IsFatal()) {
       ++errorsEmitted;
     }

--- a/flang/lib/Parser/message.cpp
+++ b/flang/lib/Parser/message.cpp
@@ -480,7 +480,7 @@ void Messages::Emit(llvm::raw_ostream &o, const AllCookedSources &allCooked,
   std::vector<const Message *> msgsWithLastLocation;
   std::size_t errorsEmitted{0};
   for (const Message *msg : sorted) {
-    bool shouldSkipMsg = false;
+    bool shouldSkipMsg{false};
     // Don't emit two identical messages for the same location
     // At the same location messages are sorted by the order they were
     // added to the list, which is a decent proxy for the causality

--- a/flang/lib/Parser/message.cpp
+++ b/flang/lib/Parser/message.cpp
@@ -481,10 +481,10 @@ void Messages::Emit(llvm::raw_ostream &o, const AllCookedSources &allCooked,
   std::size_t errorsEmitted{0};
   for (const Message *msg : sorted) {
     bool shouldSkipMsg{false};
-    // Don't emit two identical messages for the same location
-    // At the same location messages are sorted by the order they were
-    // added to the list, which is a decent proxy for the causality
-    // of the messages.
+    // Don't emit two identical messages for the same location.
+    // At the same location, messages are sorted by the order they were
+    // added to the Messages buffer, which is a decent proxy for the
+    // causality of the messages.
     if (!msgsWithLastLocation.empty()) {
       if (msgsWithLastLocation[0]->AtSameLocation(*msg)) {
         for (const Message *msgAtThisLocation : msgsWithLastLocation) {

--- a/flang/test/Semantics/associated.f90
+++ b/flang/test/Semantics/associated.f90
@@ -253,8 +253,6 @@ subroutine assoc()
     lvar = associated(intPointerVar1, targetIntCoarray[1])
     !ERROR: 'neverdeclared' is not a procedure
     !ERROR: Could not characterize intrinsic function actual argument 'badpointer'
-    !ERROR: 'neverdeclared' is not a procedure
-    !ERROR: Could not characterize intrinsic function actual argument 'badpointer'
     lvar = associated(badPointer)
   end subroutine test
 end subroutine assoc


### PR DESCRIPTION
Fixes bug exposed by https://github.com/llvm/llvm-project/pull/161915 by keeping a cache of messages printed at a given location.