### PR TITLE
[clang][x86][bytecode] Replace interp__builtin_rotate with static bool interp__builtin_elementwise_int_binop callback #160289

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -3144,8 +3144,8 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_lrotl:
   case Builtin::BI_rotl64:
     return interp__builtin_elementwise_int_binop(
-        S, OpPC, Call, [](const APSInt &A, const APSInt &B) -> APInt {
-          return A.rotl(B.urem(A.getBitWidth()));
+        S, OpPC, Call, [](const APSInt &Value, const APSInt &Amount) -> APInt {
+          return Value.rotl(Amount);
         });
 
   case Builtin::BI__builtin_rotateright8:
@@ -3158,8 +3158,8 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_lrotr:
   case Builtin::BI_rotr64:
     return interp__builtin_elementwise_int_binop(
-        S, OpPC, Call, [](const APSInt &A, const APSInt &B) -> APInt {
-          return A.rotr(B.urem(A.getBitWidth()));
+        S, OpPC, Call, [](const APSInt &Value, const APSInt &Amount) -> APInt {
+          return Value.rotr(Amount);
         });
 
   case Builtin::BI__builtin_ffs:

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -736,25 +736,6 @@ static bool interp__builtin_expect(InterpState &S, CodePtr OpPC,
   return true;
 }
 
-/// rotateleft(value, amount)
-static bool interp__builtin_rotate(InterpState &S, CodePtr OpPC,
-                                   const InterpFrame *Frame,
-                                   const CallExpr *Call, bool Right) {
-  APSInt Amount = popToAPSInt(S, Call->getArg(1));
-  APSInt Value = popToAPSInt(S, Call->getArg(0));
-
-  APSInt Result;
-  if (Right)
-    Result = APSInt(Value.rotr(Amount.urem(Value.getBitWidth())),
-                    /*IsUnsigned=*/true);
-  else // Left.
-    Result = APSInt(Value.rotl(Amount.urem(Value.getBitWidth())),
-                    /*IsUnsigned=*/true);
-
-  pushInteger(S, Result, Call->getType());
-  return true;
-}
-
 static bool interp__builtin_ffs(InterpState &S, CodePtr OpPC,
                                 const InterpFrame *Frame,
                                 const CallExpr *Call) {
@@ -3164,7 +3145,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_rotl64:
     return interp__builtin_elementwise_int_binop(
         S, OpPC, Call, [](const APSInt &A, const APSInt &B) -> APInt {
-          return A.rotl((unsigned)B.getLimitedValue());
+          return A.rotl(B.urem(A.getBitWidth()));
         });
 
   case Builtin::BI__builtin_rotateright8:
@@ -3178,7 +3159,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_rotr64:
     return interp__builtin_elementwise_int_binop(
         S, OpPC, Call, [](const APSInt &A, const APSInt &B) -> APInt {
-          return A.rotr((unsigned)B.getLimitedValue());
+          return A.rotr(B.urem(A.getBitWidth()));
         });
 
   case Builtin::BI__builtin_ffs:

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -56,20 +56,6 @@ static APSInt popToAPSInt(InterpState &S, QualType T) {
   return popToAPSInt(S.Stk, *S.getContext().classify(T));
 }
 
-static APInt ROTL_fn(const APSInt &A, const APSInt &B) {
-  const APInt &X = static_cast<const APInt &>(A);
-  const unsigned BW = X.getBitWidth();
-  const uint64_t Amt = B.getZExtValue();
-  return X.rotl(static_cast<unsigned>(Amt % BW));
-}
-
-static APInt ROTR_fn(const APSInt &A, const APSInt &B) {
-  const APInt &X = static_cast<const APInt &>(A);
-  const unsigned BW = X.getBitWidth();
-  const uint64_t Amt = B.getZExtValue();
-  return X.rotr(static_cast<unsigned>(Amt % BW));
-}
-
 /// Pushes \p Val on the stack as the type given by \p QT.
 static void pushInteger(InterpState &S, const APSInt &Val, QualType QT) {
   assert(QT->isSignedIntegerOrEnumerationType() ||
@@ -3176,7 +3162,10 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_rotl:
   case Builtin::BI_lrotl:
   case Builtin::BI_rotl64:
-    return interp__builtin_elementwise_int_binop(S, OpPC, Call, ROTL_fn);
+    return interp__builtin_elementwise_int_binop(
+        S, OpPC, Call, [](const APSInt &A, const APSInt &B) -> APInt {
+          return A.rotl((unsigned)B.getLimitedValue());
+        });
 
   case Builtin::BI__builtin_rotateright8:
   case Builtin::BI__builtin_rotateright16:
@@ -3187,7 +3176,10 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_rotr:
   case Builtin::BI_lrotr:
   case Builtin::BI_rotr64:
-    return interp__builtin_elementwise_int_binop(S, OpPC, Call, ROTR_fn);
+    return interp__builtin_elementwise_int_binop(
+        S, OpPC, Call, [](const APSInt &A, const APSInt &B) -> APInt {
+          return A.rotr((unsigned)B.getLimitedValue());
+        });
 
   case Builtin::BI__builtin_ffs:
   case Builtin::BI__builtin_ffsl:

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -56,6 +56,20 @@ static APSInt popToAPSInt(InterpState &S, QualType T) {
   return popToAPSInt(S.Stk, *S.getContext().classify(T));
 }
 
+static APInt ROTL_fn(const APSInt &A, const APSInt &B) {
+  const APInt &X = static_cast<const APInt &>(A);
+  const unsigned BW = X.getBitWidth();
+  const uint64_t Amt = B.getZExtValue();
+  return X.rotl(static_cast<unsigned>(Amt % BW));
+}
+
+static APInt ROTR_fn(const APSInt &A, const APSInt &B) {
+  const APInt &X = static_cast<const APInt &>(A);
+  const unsigned BW = X.getBitWidth();
+  const uint64_t Amt = B.getZExtValue();
+  return X.rotr(static_cast<unsigned>(Amt % BW));
+}
+
 /// Pushes \p Val on the stack as the type given by \p QT.
 static void pushInteger(InterpState &S, const APSInt &Val, QualType QT) {
   assert(QT->isSignedIntegerOrEnumerationType() ||
@@ -3162,7 +3176,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_rotl:
   case Builtin::BI_lrotl:
   case Builtin::BI_rotl64:
-    return interp__builtin_rotate(S, OpPC, Frame, Call, /*Right=*/false);
+    return interp__builtin_elementwise_int_binop(S, OpPC, Call, ROTL_fn);
 
   case Builtin::BI__builtin_rotateright8:
   case Builtin::BI__builtin_rotateright16:
@@ -3173,7 +3187,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI_rotr:
   case Builtin::BI_lrotr:
   case Builtin::BI_rotr64:
-    return interp__builtin_rotate(S, OpPC, Frame, Call, /*Right=*/true);
+    return interp__builtin_elementwise_int_binop(S, OpPC, Call, ROTR_fn);
 
   case Builtin::BI__builtin_ffs:
   case Builtin::BI__builtin_ffsl:


### PR DESCRIPTION
Fixes #160289