### PR TITLE
Fix typos: 'auxilliary' to 'auxiliary' and multiple other typos

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -174,9 +174,9 @@ public:
   /// object files.
   ///
   /// \param comp_unit
-  ///     When this SymbolFile consists of multiple auxilliary
+  ///     When this SymbolFile consists of multiple auxiliary
   ///     SymbolFiles, for example, a Darwin debug map that references
-  ///     multiple .o files, comp_unit helps choose the auxilliary
+  ///     multiple .o files, comp_unit helps choose the auxiliary
   ///     file. In most other cases comp_unit's symbol file is
   ///     identical with *this.
   ///

--- a/llvm/include/llvm/BinaryFormat/XCOFF.h
+++ b/llvm/include/llvm/BinaryFormat/XCOFF.h
@@ -412,7 +412,7 @@ struct TracebackTable {
   static constexpr uint8_t LanguageIdShift = 16;
 
   // Byte 3
-  static constexpr uint32_t IsGlobaLinkageMask = 0x0000'8000;
+  static constexpr uint32_t IsGlobalLinkageMask = 0x0000'8000;
   static constexpr uint32_t IsOutOfLineEpilogOrPrologueMask = 0x0000'4000;
   static constexpr uint32_t HasTraceBackTableOffsetMask = 0x0000'2000;
   static constexpr uint32_t IsInternalProcedureMask = 0x0000'1000;

--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -143,7 +143,7 @@ public:
   // PC sections metadata.
   //===------------------------------------------------------------------===//
 
-  /// A pair of PC section name with auxilliary constant data.
+  /// A pair of PC section name with auxiliary constant data.
   using PCSection = std::pair<StringRef, SmallVector<Constant *>>;
 
   /// Return metadata for PC sections.

--- a/llvm/lib/MC/XCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/XCOFFObjectWriter.cpp
@@ -946,15 +946,15 @@ void XCOFFWriter::writeSymbolEntryForCsectMemberLabel(
                      (is64Bit() && ExceptionSection.isDebugEnabled) ? 3 : 2);
     if (is64Bit() && ExceptionSection.isDebugEnabled) {
       // On 64 bit with debugging enabled, we have a csect, exception, and
-      // function auxilliary entries, so we must increment symbol index by 4.
+      // function auxiliary entries, so we must increment symbol index by 4.
       writeSymbolAuxExceptionEntry(
           ExceptionSection.FileOffsetToData +
               getExceptionOffset(Entry->second.FunctionSymbol),
           Entry->second.FunctionSize,
           SymbolIndexMap[Entry->second.FunctionSymbol] + 4);
     }
-    // For exception section entries, csect and function auxilliary entries
-    // must exist. On 64-bit there is also an exception auxilliary entry.
+    // For exception section entries, csect and function auxiliary entries
+    // must exist. On 64-bit there is also an exception auxiliary entry.
     writeSymbolAuxFunctionEntry(
         ExceptionSection.FileOffsetToData +
             getExceptionOffset(Entry->second.FunctionSymbol),
@@ -1015,7 +1015,7 @@ void XCOFFWriter::writeSymbolAuxFunctionEntry(uint32_t EntryOffset,
 void XCOFFWriter::writeSymbolAuxExceptionEntry(uint64_t EntryOffset,
                                                uint32_t FunctionSize,
                                                uint32_t EndIndex) {
-  assert(is64Bit() && "Exception auxilliary entries are 64-bit only.");
+  assert(is64Bit() && "Exception auxiliary entries are 64-bit only.");
   W.write<uint64_t>(EntryOffset);
   W.write<uint32_t>(FunctionSize);
   W.write<uint32_t>(EndIndex);
@@ -1348,7 +1348,7 @@ void XCOFFWriter::addExceptionEntry(const MCSymbol *Symbol,
                                     unsigned ReasonCode, unsigned FunctionSize,
                                     bool hasDebug) {
   // If a module had debug info, debugging is enabled and XCOFF emits the
-  // exception auxilliary entry.
+  // exception auxiliary entry.
   if (hasDebug)
     ExceptionSection.isDebugEnabled = true;
   auto Entry = ExceptionSection.ExceptionTable.find(Symbol->getName());
@@ -1474,8 +1474,8 @@ void XCOFFWriter::assignAddressesAndIndices(MCAssembler &Asm) {
           SymbolIndexMap[Sym.MCSym] = Sym.SymbolTableIndex;
           // 1 main and 1 auxiliary symbol table entry for each contained
           // symbol. For symbols with exception section entries, a function
-          // auxilliary entry is needed, and on 64-bit XCOFF with debugging
-          // enabled, an additional exception auxilliary entry is needed.
+          // auxiliary entry is needed, and on 64-bit XCOFF with debugging
+          // enabled, an additional exception auxiliary entry is needed.
           SymbolTableIndex += 2;
           if (hasExceptionSection() && hasExceptEntry) {
             if (is64Bit() && ExceptionSection.isDebugEnabled)

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -379,7 +379,7 @@ Expected<StringRef> XCOFFObjectFile::getSectionName(DataRefImpl Sec) const {
 }
 
 uint64_t XCOFFObjectFile::getSectionAddress(DataRefImpl Sec) const {
-  // Avoid ternary due to failure to convert the ubig32_t value to a unit64_t
+  // Avoid ternary due to failure to convert the ubig32_t value to a uint64_t
   // with MSVC.
   if (is64Bit())
     return toSection64(Sec)->VirtualAddress;
@@ -397,7 +397,7 @@ uint64_t XCOFFObjectFile::getSectionIndex(DataRefImpl Sec) const {
 }
 
 uint64_t XCOFFObjectFile::getSectionSize(DataRefImpl Sec) const {
-  // Avoid ternary due to failure to convert the ubig32_t value to a unit64_t
+  // Avoid ternary due to failure to convert the ubig32_t value to a uint64_t
   // with MSVC.
   if (is64Bit())
     return toSection64(Sec)->SectionSize;
@@ -473,7 +473,7 @@ Expected<uintptr_t> XCOFFObjectFile::getSectionFileOffsetToRawData(
       ECASE(STYP_TEXT, "text");
       ECASE(STYP_DATA, "data");
       ECASE(STYP_BSS, "bss");
-      ECASE(STYP_EXCEPT, "expect");
+      ECASE(STYP_EXCEPT, "except");
       ECASE(STYP_INFO, "info");
       ECASE(STYP_TDATA, "tdata");
       ECASE(STYP_TBSS, "tbss");
@@ -1331,7 +1331,7 @@ Expected<XCOFFCsectAuxRef> XCOFFSymbolRef::getXCOFFCsectAuxRef() const {
   }
 
   if (!getObject()->is64Bit()) {
-    // In XCOFF32, the csect auxilliary entry is always the last auxiliary
+    // In XCOFF32, the csect auxiliary entry is always the last auxiliary
     // entry for the symbol.
     uintptr_t AuxAddr = XCOFFObjectFile::getAdvancedSymbolEntryAddress(
         getEntryAddress(), NumberOfAuxEntries);
@@ -1568,7 +1568,7 @@ uint8_t XCOFFTracebackTable::getLanguageID() const {
 }
 
 bool XCOFFTracebackTable::isGlobalLinkage() const {
-  return GETBITWITHMASK(0, IsGlobaLinkageMask);
+  return GETBITWITHMASK(0, IsGlobalLinkageMask);
 }
 
 bool XCOFFTracebackTable::isOutOfLineEpilogOrPrologue() const {

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section-debug.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section-debug.ll
@@ -1,12 +1,12 @@
 ; This file contains exception section testing for when debug information is present.
-; The 32-bit test should not print exception auxilliary entries because they are a 64-bit only feature.
-; Exception auxilliary entries are present in the 64-bit tests because 64-bit && debug enabled are the requirements.
+; The 32-bit test should not print exception auxiliary entries because they are a 64-bit only feature.
+; Exception auxiliary entries are present in the 64-bit tests because 64-bit && debug enabled are the requirements.
 ; RUN: llc -mtriple=powerpc-ibm-aix-xcoff -mcpu=ppc -filetype=obj -o %t_32.o < %s
 ; RUN: llvm-readobj --syms %t_32.o | FileCheck %s --check-prefix=SYMS32
 ; RUN: llc -mtriple=powerpc64-unknown-aix -mcpu=ppc -filetype=obj -o %t_32.o < %s
 ; RUN: llvm-readobj --syms %t_32.o | FileCheck %s --check-prefix=SYMS64
 
-; If any debug information is included in a module and is XCOFF64, exception auxilliary entries are emitted
+; If any debug information is included in a module and is XCOFF64, exception auxiliary entries are emitted
 
 !llvm.module.flags = !{!0, !1}
 !llvm.dbg.cu = !{!2}

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section.ll
@@ -1,4 +1,4 @@
-; Testing 32-bit and 64-bit exception section entries, no exception auxilliary
+; Testing 32-bit and 64-bit exception section entries, no exception auxiliary
 ; entries should be produced as no debug information is specified.
 ; RUN: llc -mtriple=powerpc-ibm-aix-xcoff -mcpu=ppc -filetype=obj -o %t_32.o < %s
 ; RUN: llvm-readobj --exception-section %t_32.o | FileCheck %s --check-prefix=EXCEPT


### PR DESCRIPTION
Corrects multiple instances of the misspelling 'auxilliary' to 'auxiliary' across code, comments, and documentation in XCOFF-related files. Also fixes minor typos such as 'unit64_t' to 'uint64_t' and 'expect' to 'except', and updates a mask name from 'IsGlobaLinkageMask' to 'IsGlobalLinkageMask'.