### PR TITLE
[cmake] disable CMP0179 for gnu-ld 

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -268,6 +268,12 @@ if (NOT DEFINED LLVM_LINKER_DETECTED AND NOT WIN32)
     endif()
   endif()
 
+  if (LLVM_LINKER_IS_GNULD)
+    if(POLICY CMP0179)
+      cmake_policy(SET CMP0179 OLD)
+    endif()
+  endif()
+
   if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     include(CheckLinkerFlag)
     # Linkers that support Darwin allow a setting to internalize all symbol exports,


### PR DESCRIPTION
The gnu-ld resolves archive files (static library in CMake) in order.
Therefore, we should disable CMP0179 so that CMake will generate the
correct order.