### PR TITLE
[clang] Only build clang-tblgen if it is actually needed

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -517,7 +517,9 @@ option(CLANG_ENABLE_HLSL "Include HLSL build products" Off)
 # While HLSL support is experimental this should stay hidden.
 mark_as_advanced(CLANG_ENABLE_HLSL)
 
-add_subdirectory(utils/TableGen)
+if (NOT DEFINED CLANG_TABLEGEN_EXE OR CLANG_INCLUDE_TESTS)
+  add_subdirectory(utils/TableGen)
+endif()
 
 # Export CLANG_TABLEGEN_EXE for use by flang docs.
 set(CLANG_TABLEGEN_EXE "${CLANG_TABLEGEN_EXE}" CACHE INTERNAL "")


### PR DESCRIPTION
It's possible to build clang with an existing clang-tblgen (common when cross-compiling, for instance) by setting CLANG_TABLEGEN_EXE.  If this is the case then building another copy of clang-tblgen that won't be used is pointless.

In Yocto we cross-compile the LLVM projects individually to minimise the amounts of building that is needed (no need to build clang if you just want llvm) and the first step of the build is to build optimised native tablegen binaries so that they're built once and reused often. When a tablegen binary is provided there's no need for clang to setup a native build environment and build the tablegen when the codepaths will all use the provided one and not the freshly built one.

This was discovered whilst chasing down a really horrible build failure where the native binary that clang was building itself in a cross build didn't actually compile, and the realisation that it shouldn't even be building this binary in the first place.