### PR TITLE
Fix typos: 'auxilliary' to 'auxiliary' and 'unit64_t' to 'uint64_t'

### DIFF
--- a/libunwind/test/aix_signal_unwind.pass.sh.S
+++ b/libunwind/test/aix_signal_unwind.pass.sh.S
@@ -168,7 +168,7 @@ L..abc0:
         .vbyte  4, 0x00000000           # Traceback table begin
         .byte   0x00                    # Version = 0
         .byte   0x09                    # Language = CPlusPlus
-        .byte   0x20                    # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+        .byte   0x20                    # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
                                         # +HasTraceBackTableOffset, -IsInternalProcedure
                                         # -HasControlledStorage, -IsTOCless
                                         # -IsFloatingPointPresent
@@ -218,7 +218,7 @@ L..abc0:
         .vbyte  4, 0x00000000           # Traceback table begin
         .byte   0x00                    # Version = 0
         .byte   0x09                    # Language = CPlusPlus
-        .byte   0x20                    # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+        .byte   0x20                    # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
                                         # +HasTraceBackTableOffset, -IsInternalProcedure
                                         # -HasControlledStorage, -IsTOCless
                                         # -IsFloatingPointPresent

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -174,9 +174,9 @@ public:
   /// object files.
   ///
   /// \param comp_unit
-  ///     When this SymbolFile consists of multiple auxilliary
+  ///     When this SymbolFile consists of multiple auxiliary
   ///     SymbolFiles, for example, a Darwin debug map that references
-  ///     multiple .o files, comp_unit helps choose the auxilliary
+  ///     multiple .o files, comp_unit helps choose the auxiliary
   ///     file. In most other cases comp_unit's symbol file is
   ///     identical with *this.
   ///

--- a/llvm/include/llvm/BinaryFormat/XCOFF.h
+++ b/llvm/include/llvm/BinaryFormat/XCOFF.h
@@ -412,7 +412,7 @@ struct TracebackTable {
   static constexpr uint8_t LanguageIdShift = 16;
 
   // Byte 3
-  static constexpr uint32_t IsGlobaLinkageMask = 0x0000'8000;
+  static constexpr uint32_t IsGlobalLinkageMask = 0x0000'8000;
   static constexpr uint32_t IsOutOfLineEpilogOrPrologueMask = 0x0000'4000;
   static constexpr uint32_t HasTraceBackTableOffsetMask = 0x0000'2000;
   static constexpr uint32_t IsInternalProcedureMask = 0x0000'1000;

--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -143,7 +143,7 @@ public:
   // PC sections metadata.
   //===------------------------------------------------------------------===//
 
-  /// A pair of PC section name with auxilliary constant data.
+  /// A pair of PC section name with auxiliary constant data.
   using PCSection = std::pair<StringRef, SmallVector<Constant *>>;
 
   /// Return metadata for PC sections.

--- a/llvm/lib/MC/XCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/XCOFFObjectWriter.cpp
@@ -946,15 +946,15 @@ void XCOFFWriter::writeSymbolEntryForCsectMemberLabel(
                      (is64Bit() && ExceptionSection.isDebugEnabled) ? 3 : 2);
     if (is64Bit() && ExceptionSection.isDebugEnabled) {
       // On 64 bit with debugging enabled, we have a csect, exception, and
-      // function auxilliary entries, so we must increment symbol index by 4.
+      // function auxiliary entries, so we must increment symbol index by 4.
       writeSymbolAuxExceptionEntry(
           ExceptionSection.FileOffsetToData +
               getExceptionOffset(Entry->second.FunctionSymbol),
           Entry->second.FunctionSize,
           SymbolIndexMap[Entry->second.FunctionSymbol] + 4);
     }
-    // For exception section entries, csect and function auxilliary entries
-    // must exist. On 64-bit there is also an exception auxilliary entry.
+    // For exception section entries, csect and function auxiliary entries
+    // must exist. On 64-bit there is also an exception auxiliary entry.
     writeSymbolAuxFunctionEntry(
         ExceptionSection.FileOffsetToData +
             getExceptionOffset(Entry->second.FunctionSymbol),
@@ -1015,7 +1015,7 @@ void XCOFFWriter::writeSymbolAuxFunctionEntry(uint32_t EntryOffset,
 void XCOFFWriter::writeSymbolAuxExceptionEntry(uint64_t EntryOffset,
                                                uint32_t FunctionSize,
                                                uint32_t EndIndex) {
-  assert(is64Bit() && "Exception auxilliary entries are 64-bit only.");
+  assert(is64Bit() && "Exception auxiliary entries are 64-bit only.");
   W.write<uint64_t>(EntryOffset);
   W.write<uint32_t>(FunctionSize);
   W.write<uint32_t>(EndIndex);
@@ -1348,7 +1348,7 @@ void XCOFFWriter::addExceptionEntry(const MCSymbol *Symbol,
                                     unsigned ReasonCode, unsigned FunctionSize,
                                     bool hasDebug) {
   // If a module had debug info, debugging is enabled and XCOFF emits the
-  // exception auxilliary entry.
+  // exception auxiliary entry.
   if (hasDebug)
     ExceptionSection.isDebugEnabled = true;
   auto Entry = ExceptionSection.ExceptionTable.find(Symbol->getName());
@@ -1474,8 +1474,8 @@ void XCOFFWriter::assignAddressesAndIndices(MCAssembler &Asm) {
           SymbolIndexMap[Sym.MCSym] = Sym.SymbolTableIndex;
           // 1 main and 1 auxiliary symbol table entry for each contained
           // symbol. For symbols with exception section entries, a function
-          // auxilliary entry is needed, and on 64-bit XCOFF with debugging
-          // enabled, an additional exception auxilliary entry is needed.
+          // auxiliary entry is needed, and on 64-bit XCOFF with debugging
+          // enabled, an additional exception auxiliary entry is needed.
           SymbolTableIndex += 2;
           if (hasExceptionSection() && hasExceptEntry) {
             if (is64Bit() && ExceptionSection.isDebugEnabled)

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -379,7 +379,7 @@ Expected<StringRef> XCOFFObjectFile::getSectionName(DataRefImpl Sec) const {
 }
 
 uint64_t XCOFFObjectFile::getSectionAddress(DataRefImpl Sec) const {
-  // Avoid ternary due to failure to convert the ubig32_t value to a unit64_t
+  // Avoid ternary due to failure to convert the ubig32_t value to a uint64_t
   // with MSVC.
   if (is64Bit())
     return toSection64(Sec)->VirtualAddress;
@@ -397,7 +397,7 @@ uint64_t XCOFFObjectFile::getSectionIndex(DataRefImpl Sec) const {
 }
 
 uint64_t XCOFFObjectFile::getSectionSize(DataRefImpl Sec) const {
-  // Avoid ternary due to failure to convert the ubig32_t value to a unit64_t
+  // Avoid ternary due to failure to convert the ubig32_t value to a uint64_t
   // with MSVC.
   if (is64Bit())
     return toSection64(Sec)->SectionSize;

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1568,7 +1568,7 @@ uint8_t XCOFFTracebackTable::getLanguageID() const {
 }
 
 bool XCOFFTracebackTable::isGlobalLinkage() const {
-  return GETBITWITHMASK(0, IsGlobaLinkageMask);
+  return GETBITWITHMASK(0, IsGlobalLinkageMask);
 }
 
 bool XCOFFTracebackTable::isOutOfLineEpilogOrPrologue() const {

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1331,7 +1331,7 @@ Expected<XCOFFCsectAuxRef> XCOFFSymbolRef::getXCOFFCsectAuxRef() const {
   }
 
   if (!getObject()->is64Bit()) {
-    // In XCOFF32, the csect auxilliary entry is always the last auxiliary
+    // In XCOFF32, the csect auxiliary entry is always the last auxiliary
     // entry for the symbol.
     uintptr_t AuxAddr = XCOFFObjectFile::getAdvancedSymbolEntryAddress(
         getEntryAddress(), NumberOfAuxEntries);

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -473,7 +473,7 @@ Expected<uintptr_t> XCOFFObjectFile::getSectionFileOffsetToRawData(
       ECASE(STYP_TEXT, "text");
       ECASE(STYP_DATA, "data");
       ECASE(STYP_BSS, "bss");
-      ECASE(STYP_EXCEPT, "expect");
+      ECASE(STYP_EXCEPT, "except");
       ECASE(STYP_INFO, "info");
       ECASE(STYP_TDATA, "tdata");
       ECASE(STYP_TBSS, "tbss");

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2404,7 +2404,7 @@ void PPCAIXAsmPrinter::emitTracebackTable() {
             << static_cast<unsigned>(((V) & (TracebackTable::Field##Mask)) >>  \
                                      (TracebackTable::Field##Shift))
 
-  GENBOOLCOMMENT("", FirstHalfOfMandatoryField, IsGlobaLinkage);
+  GENBOOLCOMMENT("", FirstHalfOfMandatoryField, IsGlobalLinkage);
   GENBOOLCOMMENT(", ", FirstHalfOfMandatoryField, IsOutOfLineEpilogOrPrologue);
   EmitComment();
 

--- a/llvm/test/CodeGen/PowerPC/aix-alloca-r31.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-alloca-r31.ll
@@ -31,7 +31,7 @@ define i32 @varalloca() local_unnamed_addr {
 ; CHECK-ASM32-NEXT:    	.vbyte	4, 0x00000000                   # Traceback table begin
 ; CHECK-ASM32-NEXT:    	.byte	0x00                            # Version = 0
 ; CHECK-ASM32-NEXT:    	.byte	0x09                            # Language = CPlusPlus
-; CHECK-ASM32-NEXT:    	.byte	0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-ASM32-NEXT:    	.byte	0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-ASM32-NEXT:                                            # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-ASM32-NEXT:                                            # -HasControlledStorage, -IsTOCless
 ; CHECK-ASM32-NEXT:                                            # -IsFloatingPointPresent
@@ -70,7 +70,7 @@ define i32 @varalloca() local_unnamed_addr {
 ; CHECK-ASM64-NEXT:    	.vbyte	4, 0x00000000                   # Traceback table begin
 ; CHECK-ASM64-NEXT:    	.byte	0x00                            # Version = 0
 ; CHECK-ASM64-NEXT:    	.byte	0x09                            # Language = CPlusPlus
-; CHECK-ASM64-NEXT:    	.byte	0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-ASM64-NEXT:    	.byte	0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-ASM64-NEXT:                                            # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-ASM64-NEXT:                                            # -HasControlledStorage, -IsTOCless
 ; CHECK-ASM64-NEXT:                                            # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
@@ -49,7 +49,7 @@ entry:
 ; COMMON:       .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -70,7 +70,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                         # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-redzone-boundary.mir
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-redzone-boundary.mir
@@ -25,7 +25,7 @@ body: |
   ; CHECK:              .vbyte  4, 0x00000000                   # Traceback table begin
   ; CHECK-NEXT:         .byte   0x00                            # Version = 0
   ; CHECK-NEXT:         .byte   0x09                            # Language = CPlusPlus
-  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
   ; CHECK-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
   ; CHECK-NEXT:                                         # -HasControlledStorage, -IsTOCless
   ; CHECK-NEXT:                                         # -IsFloatingPointPresent
@@ -43,7 +43,7 @@ body: |
   ; CHECK:              .vbyte  4, 0x00000000                   # Traceback table begin
   ; CHECK-NEXT:         .byte   0x00                            # Version = 0
   ; CHECK-NEXT:         .byte   0x09                            # Language = CPlusPlus
-  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
   ; CHECK-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
   ; CHECK-NEXT:                                         # -HasControlledStorage, -IsTOCless
   ; CHECK-NEXT:                                         # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo.ll
@@ -82,7 +82,7 @@ declare <4 x float> @llvm.fabs.v4f32(<4 x float>) #1
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                         # +IsFloatingPointPresent
@@ -107,7 +107,7 @@ declare <4 x float> @llvm.fabs.v4f32(<4 x float>) #1
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                         # +IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo_hasvarg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo_hasvarg.ll
@@ -15,7 +15,7 @@ entry:
 ;CHECK-ASM:             .vbyte  4, 0x00000000                   # Traceback table begin
 ;CHECK-ASM-NEXT:        .byte   0x00                            # Version = 0
 ;CHECK-ASM-NEXT:        .byte   0x09                            # Language = CPlusPlus
-;CHECK-ASM-NEXT:        .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+;CHECK-ASM-NEXT:        .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ;CHECK-ASM-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ;CHECK-ASM-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ;CHECK-ASM-NEXT:                                         # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable.ll
@@ -138,7 +138,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -167,7 +167,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -190,7 +190,7 @@ entry:
 ; COMMON:       .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -217,7 +217,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-exception.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-exception.ll
@@ -113,7 +113,7 @@ eh.resume:                                        ; preds = %catch.dispatch
 ; ASM:    .vbyte  4, 0x00000000                   # Traceback table begin
 ; ASM:    .byte   0x00                            # Version = 0
 ; ASM:    .byte   0x09                            # Language = CPlusPlus
-; ASM:    .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; ASM:    .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; ASM:                                    # +HasTraceBackTableOffset, -IsInternalProcedure
 ; ASM:                                    # -HasControlledStorage, -IsTOCless
 ; ASM:                                    # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section-debug.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section-debug.ll
@@ -1,12 +1,12 @@
 ; This file contains exception section testing for when debug information is present.
-; The 32-bit test should not print exception auxilliary entries because they are a 64-bit only feature.
-; Exception auxilliary entries are present in the 64-bit tests because 64-bit && debug enabled are the requirements.
+; The 32-bit test should not print exception auxiliary entries because they are a 64-bit only feature.
+; Exception auxiliary entries are present in the 64-bit tests because 64-bit && debug enabled are the requirements.
 ; RUN: llc -mtriple=powerpc-ibm-aix-xcoff -mcpu=ppc -filetype=obj -o %t_32.o < %s
 ; RUN: llvm-readobj --syms %t_32.o | FileCheck %s --check-prefix=SYMS32
 ; RUN: llc -mtriple=powerpc64-unknown-aix -mcpu=ppc -filetype=obj -o %t_32.o < %s
 ; RUN: llvm-readobj --syms %t_32.o | FileCheck %s --check-prefix=SYMS64
 
-; If any debug information is included in a module and is XCOFF64, exception auxilliary entries are emitted
+; If any debug information is included in a module and is XCOFF64, exception auxiliary entries are emitted
 
 !llvm.module.flags = !{!0, !1}
 !llvm.dbg.cu = !{!2}

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-exception-section.ll
@@ -1,4 +1,4 @@
-; Testing 32-bit and 64-bit exception section entries, no exception auxilliary
+; Testing 32-bit and 64-bit exception section entries, no exception auxiliary
 ; entries should be produced as no debug information is specified.
 ; RUN: llc -mtriple=powerpc-ibm-aix-xcoff -mcpu=ppc -filetype=obj -o %t_32.o < %s
 ; RUN: llvm-readobj --exception-section %t_32.o | FileCheck %s --check-prefix=EXCEPT

--- a/llvm/test/DebugInfo/XCOFF/empty.ll
+++ b/llvm/test/DebugInfo/XCOFF/empty.ll
@@ -61,7 +61,7 @@ entry:
 ; ASM32-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; ASM32-NEXT:          .byte   0x00                            # Version = 0
 ; ASM32-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; ASM32-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; ASM32-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; ASM32-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; ASM32-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; ASM32-NEXT:                                          # -IsFloatingPointPresent
@@ -264,7 +264,7 @@ entry:
 ; ASM64-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; ASM64-NEXT:          .byte   0x00                            # Version = 0
 ; ASM64-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; ASM64-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; ASM64-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; ASM64-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; ASM64-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; ASM64-NEXT:                                          # -IsFloatingPointPresent

--- a/llvm/test/DebugInfo/XCOFF/explicit-section.ll
+++ b/llvm/test/DebugInfo/XCOFF/explicit-section.ll
@@ -65,7 +65,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent
@@ -113,7 +113,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent

--- a/llvm/test/DebugInfo/XCOFF/function-sections.ll
+++ b/llvm/test/DebugInfo/XCOFF/function-sections.ll
@@ -60,7 +60,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent
@@ -95,7 +95,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent

--- a/openmp/runtime/src/z_AIX_asm.S
+++ b/openmp/runtime/src/z_AIX_asm.S
@@ -367,7 +367,7 @@
     .vbyte  4, 0x00000000           # Traceback table begin
     .byte   0x00                    # Version = 0
     .byte   0x09                    # Language = CPlusPlus
-    .byte   0x20                    # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+    .byte   0x20                    # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
                                     # +HasTraceBackTableOffset, -IsInternalProcedure
                                     # -HasControlledStorage, -IsTOCless
                                     # -IsFloatingPointPresent


### PR DESCRIPTION
Corrects multiple instances of the misspelling 'auxilliary' to 'auxiliary' 
across code, comments, and documentation in XCOFF-related files. 
Also fixes a minor typo in comments within XCOFFObjectFile.cpp 
where 'unit64_t' was written instead of 'uint64_t'.
