### PR TITLE
Fix typo: IsGlobaLinkage -> IsGlobalLinkage in XCOFF

### DIFF
--- a/libunwind/test/aix_signal_unwind.pass.sh.S
+++ b/libunwind/test/aix_signal_unwind.pass.sh.S
@@ -168,7 +168,7 @@ L..abc0:
         .vbyte  4, 0x00000000           # Traceback table begin
         .byte   0x00                    # Version = 0
         .byte   0x09                    # Language = CPlusPlus
-        .byte   0x20                    # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+        .byte   0x20                    # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
                                         # +HasTraceBackTableOffset, -IsInternalProcedure
                                         # -HasControlledStorage, -IsTOCless
                                         # -IsFloatingPointPresent
@@ -218,7 +218,7 @@ L..abc0:
         .vbyte  4, 0x00000000           # Traceback table begin
         .byte   0x00                    # Version = 0
         .byte   0x09                    # Language = CPlusPlus
-        .byte   0x20                    # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+        .byte   0x20                    # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
                                         # +HasTraceBackTableOffset, -IsInternalProcedure
                                         # -HasControlledStorage, -IsTOCless
                                         # -IsFloatingPointPresent

--- a/llvm/include/llvm/BinaryFormat/XCOFF.h
+++ b/llvm/include/llvm/BinaryFormat/XCOFF.h
@@ -412,7 +412,7 @@ struct TracebackTable {
   static constexpr uint8_t LanguageIdShift = 16;
 
   // Byte 3
-  static constexpr uint32_t IsGlobaLinkageMask = 0x0000'8000;
+  static constexpr uint32_t IsGlobalLinkageMask = 0x0000'8000;
   static constexpr uint32_t IsOutOfLineEpilogOrPrologueMask = 0x0000'4000;
   static constexpr uint32_t HasTraceBackTableOffsetMask = 0x0000'2000;
   static constexpr uint32_t IsInternalProcedureMask = 0x0000'1000;

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1568,7 +1568,7 @@ uint8_t XCOFFTracebackTable::getLanguageID() const {
 }
 
 bool XCOFFTracebackTable::isGlobalLinkage() const {
-  return GETBITWITHMASK(0, IsGlobaLinkageMask);
+  return GETBITWITHMASK(0, IsGlobalLinkageMask);
 }
 
 bool XCOFFTracebackTable::isOutOfLineEpilogOrPrologue() const {

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2404,7 +2404,7 @@ void PPCAIXAsmPrinter::emitTracebackTable() {
             << static_cast<unsigned>(((V) & (TracebackTable::Field##Mask)) >>  \
                                      (TracebackTable::Field##Shift))
 
-  GENBOOLCOMMENT("", FirstHalfOfMandatoryField, IsGlobaLinkage);
+  GENBOOLCOMMENT("", FirstHalfOfMandatoryField, IsGlobalLinkage);
   GENBOOLCOMMENT(", ", FirstHalfOfMandatoryField, IsOutOfLineEpilogOrPrologue);
   EmitComment();
 

--- a/llvm/test/CodeGen/PowerPC/aix-alloca-r31.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-alloca-r31.ll
@@ -31,7 +31,7 @@ define i32 @varalloca() local_unnamed_addr {
 ; CHECK-ASM32-NEXT:    	.vbyte	4, 0x00000000                   # Traceback table begin
 ; CHECK-ASM32-NEXT:    	.byte	0x00                            # Version = 0
 ; CHECK-ASM32-NEXT:    	.byte	0x09                            # Language = CPlusPlus
-; CHECK-ASM32-NEXT:    	.byte	0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-ASM32-NEXT:    	.byte	0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-ASM32-NEXT:                                            # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-ASM32-NEXT:                                            # -HasControlledStorage, -IsTOCless
 ; CHECK-ASM32-NEXT:                                            # -IsFloatingPointPresent
@@ -70,7 +70,7 @@ define i32 @varalloca() local_unnamed_addr {
 ; CHECK-ASM64-NEXT:    	.vbyte	4, 0x00000000                   # Traceback table begin
 ; CHECK-ASM64-NEXT:    	.byte	0x00                            # Version = 0
 ; CHECK-ASM64-NEXT:    	.byte	0x09                            # Language = CPlusPlus
-; CHECK-ASM64-NEXT:    	.byte	0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-ASM64-NEXT:    	.byte	0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-ASM64-NEXT:                                            # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-ASM64-NEXT:                                            # -HasControlledStorage, -IsTOCless
 ; CHECK-ASM64-NEXT:                                            # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
@@ -49,7 +49,7 @@ entry:
 ; COMMON:       .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -70,7 +70,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                         # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-redzone-boundary.mir
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-redzone-boundary.mir
@@ -25,7 +25,7 @@ body: |
   ; CHECK:              .vbyte  4, 0x00000000                   # Traceback table begin
   ; CHECK-NEXT:         .byte   0x00                            # Version = 0
   ; CHECK-NEXT:         .byte   0x09                            # Language = CPlusPlus
-  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
   ; CHECK-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
   ; CHECK-NEXT:                                         # -HasControlledStorage, -IsTOCless
   ; CHECK-NEXT:                                         # -IsFloatingPointPresent
@@ -43,7 +43,7 @@ body: |
   ; CHECK:              .vbyte  4, 0x00000000                   # Traceback table begin
   ; CHECK-NEXT:         .byte   0x00                            # Version = 0
   ; CHECK-NEXT:         .byte   0x09                            # Language = CPlusPlus
-  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+  ; CHECK-NEXT:         .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
   ; CHECK-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
   ; CHECK-NEXT:                                         # -HasControlledStorage, -IsTOCless
   ; CHECK-NEXT:                                         # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo.ll
@@ -82,7 +82,7 @@ declare <4 x float> @llvm.fabs.v4f32(<4 x float>) #1
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                         # +IsFloatingPointPresent
@@ -107,7 +107,7 @@ declare <4 x float> @llvm.fabs.v4f32(<4 x float>) #1
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                         # +IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo_hasvarg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-vectorinfo_hasvarg.ll
@@ -15,7 +15,7 @@ entry:
 ;CHECK-ASM:             .vbyte  4, 0x00000000                   # Traceback table begin
 ;CHECK-ASM-NEXT:        .byte   0x00                            # Version = 0
 ;CHECK-ASM-NEXT:        .byte   0x09                            # Language = CPlusPlus
-;CHECK-ASM-NEXT:        .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+;CHECK-ASM-NEXT:        .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ;CHECK-ASM-NEXT:                                         # +HasTraceBackTableOffset, -IsInternalProcedure
 ;CHECK-ASM-NEXT:                                         # -HasControlledStorage, -IsTOCless
 ;CHECK-ASM-NEXT:                                         # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable.ll
@@ -138,7 +138,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -167,7 +167,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -190,7 +190,7 @@ entry:
 ; COMMON:       .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x22                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x22                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # +IsFloatingPointPresent
@@ -217,7 +217,7 @@ entry:
 ; COMMON-NEXT:  .vbyte  4, 0x00000000                   # Traceback table begin
 ; COMMON-NEXT:  .byte   0x00                            # Version = 0
 ; COMMON-NEXT:  .byte   0x09                            # Language = CPlusPlus
-; COMMON-NEXT:  .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; COMMON-NEXT:  .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; COMMON-NEXT:                                        # +HasTraceBackTableOffset, -IsInternalProcedure
 ; COMMON-NEXT:                                        # -HasControlledStorage, -IsTOCless
 ; COMMON-NEXT:                                        # -IsFloatingPointPresent

--- a/llvm/test/CodeGen/PowerPC/aix-exception.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-exception.ll
@@ -113,7 +113,7 @@ eh.resume:                                        ; preds = %catch.dispatch
 ; ASM:    .vbyte  4, 0x00000000                   # Traceback table begin
 ; ASM:    .byte   0x00                            # Version = 0
 ; ASM:    .byte   0x09                            # Language = CPlusPlus
-; ASM:    .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; ASM:    .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; ASM:                                    # +HasTraceBackTableOffset, -IsInternalProcedure
 ; ASM:                                    # -HasControlledStorage, -IsTOCless
 ; ASM:                                    # -IsFloatingPointPresent

--- a/llvm/test/DebugInfo/XCOFF/empty.ll
+++ b/llvm/test/DebugInfo/XCOFF/empty.ll
@@ -61,7 +61,7 @@ entry:
 ; ASM32-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; ASM32-NEXT:          .byte   0x00                            # Version = 0
 ; ASM32-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; ASM32-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; ASM32-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; ASM32-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; ASM32-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; ASM32-NEXT:                                          # -IsFloatingPointPresent
@@ -264,7 +264,7 @@ entry:
 ; ASM64-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; ASM64-NEXT:          .byte   0x00                            # Version = 0
 ; ASM64-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; ASM64-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; ASM64-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; ASM64-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; ASM64-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; ASM64-NEXT:                                          # -IsFloatingPointPresent

--- a/llvm/test/DebugInfo/XCOFF/explicit-section.ll
+++ b/llvm/test/DebugInfo/XCOFF/explicit-section.ll
@@ -65,7 +65,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent
@@ -113,7 +113,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent

--- a/llvm/test/DebugInfo/XCOFF/function-sections.ll
+++ b/llvm/test/DebugInfo/XCOFF/function-sections.ll
@@ -60,7 +60,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent
@@ -95,7 +95,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, 0x00000000                   # Traceback table begin
 ; CHECK-NEXT:          .byte   0x00                            # Version = 0
 ; CHECK-NEXT:          .byte   0x09                            # Language = CPlusPlus
-; CHECK-NEXT:          .byte   0x20                            # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+; CHECK-NEXT:          .byte   0x20                            # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
 ; CHECK-NEXT:                                          # +HasTraceBackTableOffset, -IsInternalProcedure
 ; CHECK-NEXT:                                          # -HasControlledStorage, -IsTOCless
 ; CHECK-NEXT:                                          # -IsFloatingPointPresent

--- a/openmp/runtime/src/z_AIX_asm.S
+++ b/openmp/runtime/src/z_AIX_asm.S
@@ -367,7 +367,7 @@
     .vbyte  4, 0x00000000           # Traceback table begin
     .byte   0x00                    # Version = 0
     .byte   0x09                    # Language = CPlusPlus
-    .byte   0x20                    # -IsGlobaLinkage, -IsOutOfLineEpilogOrPrologue
+    .byte   0x20                    # -IsGlobalLinkage, -IsOutOfLineEpilogOrPrologue
                                     # +HasTraceBackTableOffset, -IsInternalProcedure
                                     # -HasControlledStorage, -IsTOCless
                                     # -IsFloatingPointPresent


### PR DESCRIPTION
Corrects the spelling of 'IsGlobaLinkage' to 'IsGlobalLinkage' in XCOFF-related code, comments, and tests across the codebase.