### PR TITLE
[NFC] Fix memory leak in IR2Vec tests

### DIFF
--- a/llvm/unittests/Analysis/FunctionPropertiesAnalysisTest.cpp
+++ b/llvm/unittests/Analysis/FunctionPropertiesAnalysisTest.cpp
@@ -59,6 +59,11 @@ public:
     ir2vec::ArgWeight = 1.0;
   }
 
+  ~FunctionPropertiesAnalysisTest() override {
+    delete IR2VecVocab;
+    IR2VecVocab = nullptr;
+  }
+
 private:
   float OriginalOpcWeight = ir2vec::OpcWeight;
   float OriginalTypeWeight = ir2vec::TypeWeight;

--- a/llvm/unittests/Analysis/IR2VecTest.cpp
+++ b/llvm/unittests/Analysis/IR2VecTest.cpp
@@ -319,6 +319,10 @@ protected:
     AddInst = BinaryOperator::CreateAdd(Arg, Const, "add", BB);
     RetInst = ReturnInst::Create(Ctx, AddInst, BB);
   }
+  void TearDown() override {
+    delete V ;
+    V = nullptr;
+  }
 };
 
 TEST_F(IR2VecTestFixture, GetInstVecMap_Symbolic) {

--- a/llvm/unittests/Analysis/IR2VecTest.cpp
+++ b/llvm/unittests/Analysis/IR2VecTest.cpp
@@ -320,7 +320,7 @@ protected:
     RetInst = ReturnInst::Create(Ctx, AddInst, BB);
   }
   void TearDown() override {
-    delete V ;
+    delete V;
     V = nullptr;
   }
 };


### PR DESCRIPTION
After refactoring in ed1d9548b5c0, VocabStorage are being leaked.
