### PR TITLE
[mlir][docs] Fix typo: 'DDR' → 'DRR' in Creating a Dialect tutorial

### DIFF
--- a/mlir/docs/Tutorials/CreatingADialect.md
+++ b/mlir/docs/Tutorials/CreatingADialect.md
@@ -22,7 +22,7 @@ typically defined in FooDialect.cpp, which includes FooOps.cpp.inc and
 FooOpsInterfaces.h.inc.
 
 The 'Transforms' directory contains rewrite rules for the dialect,
-typically described in TableGen file using the [DDR
+typically described in TableGen file using the [DRR
 format](../DeclarativeRewrites.md).
 
 Note that dialect names should not generally be suffixed with “Ops”,


### PR DESCRIPTION
Fixes a small typo in the Creating a Dialect tutorial.

The rewrite rules format should be DRR (Declarative Rewrite Rules), not DDR.