### PR TITLE
[ADT] Add `DefaultUnreachable("msg")` to TypeSwitch

### DIFF
--- a/llvm/unittests/ADT/TypeSwitchTest.cpp
+++ b/llvm/unittests/ADT/TypeSwitchTest.cpp
@@ -124,7 +124,7 @@ TEST(TypeSwitchTest, DefaultUnreachableWithValue) {
   EXPECT_EQ(0, translate(DerivedA()));
 
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
-  EXPECT_DEATH((void)translate(DerivedD(DerivedD())), "Unhandled type");
+  EXPECT_DEATH((void)translate(DerivedD()), "Unhandled type");
 #endif
 }
 
@@ -139,6 +139,6 @@ TEST(TypeSwitchTest, DefaultUnreachableWithVoid) {
   EXPECT_EQ(0, translate(DerivedA()));
 
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
-  EXPECT_DEATH((void)translate(DerivedD(DerivedD())), "Unhandled type");
+  EXPECT_DEATH((void)translate(DerivedD()), "Unhandled type");
 #endif
 }

--- a/llvm/unittests/ADT/TypeSwitchTest.cpp
+++ b/llvm/unittests/ADT/TypeSwitchTest.cpp
@@ -114,3 +114,31 @@ TEST(TypeSwitchTest, CasesOptional) {
   EXPECT_EQ(std::nullopt, translate(DerivedC()));
   EXPECT_EQ(-1, translate(DerivedD()));
 }
+
+TEST(TypeSwitchTest, DefaultUnreachableWithValue) {
+  auto translate = [](auto value) {
+    return TypeSwitch<Base *, int>(&value)
+        .Case([](DerivedA *) { return 0; })
+        .DefaultUnreachable("Unhandled type");
+  };
+  EXPECT_EQ(0, translate(DerivedA()));
+
+#if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
+  EXPECT_DEATH((void)translate(DerivedD(DerivedD())), "Unhandled type");
+#endif
+}
+
+TEST(TypeSwitchTest, DefaultUnreachableWithVoid) {
+  auto translate = [](auto value) {
+    int result = -1;
+    TypeSwitch<Base *>(&value)
+        .Case([&result](DerivedA *) { result = 0; })
+        .DefaultUnreachable("Unhandled type");
+    return result;
+  };
+  EXPECT_EQ(0, translate(DerivedA()));
+
+#if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
+  EXPECT_DEATH((void)translate(DerivedD(DerivedD())), "Unhandled type");
+#endif
+}


### PR DESCRIPTION
This is to allow making it explicit that all the cases must be handled. The error message is customizable.

Something similar was already supported using the conversion operator for the typed case but less explicit. In the `void` case when `TypeSwitch` doesn't return anything, this was not possible without a custom lambda.