### PR TITLE
[ADT] Add `DefaultUnreachable("msg")` to StringSwitch

### DIFF
--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -14,6 +14,7 @@
 #define LLVM_ADT_STRINGSWITCH_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstring>
 #include <optional>
@@ -180,10 +181,14 @@ public:
     return Value;
   }
 
-  [[nodiscard]] operator R() {
-    assert(Result && "Fell off the end of a string-switch");
-    return std::move(*Result);
+  [[nodiscard]] R DefaultUnreachable(
+      const char *Message = "Fell off the end of a string-switch") {
+    if (Result)
+      return std::move(*Result);
+    llvm_unreachable(Message);
   }
+
+  [[nodiscard]] operator R() { return DefaultUnreachable(); }
 
 private:
   // Returns true when `Str` matches the `S` argument, and stores the result.

--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -181,6 +181,7 @@ public:
     return Value;
   }
 
+  /// Declare default as unreachable, making sure that all cases were handled.
   [[nodiscard]] R DefaultUnreachable(
       const char *Message = "Fell off the end of a string-switch") {
     if (Result)

--- a/llvm/unittests/ADT/StringSwitchTest.cpp
+++ b/llvm/unittests/ADT/StringSwitchTest.cpp
@@ -230,3 +230,19 @@ TEST(StringSwitchTest, CasesCopies) {
       "Foo", "Bar", "Baz", "Qux", Copyable{NumCopies});
   EXPECT_EQ(NumCopies, 1u);
 }
+
+TEST(StringSwitchTest, DefaultUnreachable) {
+  auto Translate = [](StringRef S) {
+    return llvm::StringSwitch<int>(S)
+        .Case("A", 0)
+        .Case("B", 1)
+        .DefaultUnreachable("Unhandled case");
+  };
+
+  EXPECT_EQ(0, Translate("A"));
+  EXPECT_EQ(1, Translate("B"));
+
+#if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
+  EXPECT_DEATH((void)Translate("C"), "Unhandled case");
+#endif
+}


### PR DESCRIPTION
Similar to TypeSwitch (#161970), allow for explicit unreachable default case with a custom error message on unhandled cases.

StringSwitch already allowed for checking if any of the cases matched with the conversion operator, but `DefaultUnreachable` is more explicit and allows for a custom message.