### PR TITLE
[SelectionDAG] add cli option to write SelectionDAG graphviz to file

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -530,6 +530,9 @@ public:
 
   /// Pop up a GraphViz/gv window with the DAG rendered using 'dot'.
   LLVM_ABI void viewGraph(const std::string &Title);
+  /// Pop up a GraphViz/gv window with the DAG rendered using 'dot', or write
+  /// the file out instead.
+  LLVM_ABI void viewGraph(const std::string &Title, const bool WriteFile);
   LLVM_ABI void viewGraph();
 
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -175,8 +175,12 @@ static cl::opt<bool>
 ViewISelDAGs("view-isel-dags", cl::Hidden,
           cl::desc("Pop up a window to show isel dags as they are selected"));
 static cl::opt<bool>
-ViewSchedDAGs("view-sched-dags", cl::Hidden,
-          cl::desc("Pop up a window to show sched dags as they are processed"));
+    WriteDAGsToFile("write-dags-to-file", cl::Hidden,
+                    cl::desc("Write dags as they are selected to DOT files "
+                             "instead of opening viewer"));
+static cl::opt<bool> ViewSchedDAGs(
+    "view-sched-dags", cl::Hidden,
+    cl::desc("Pop up a window to show sched dags as they are processed"));
 static cl::opt<bool>
 ViewSUnitDAGs("view-sunit-dags", cl::Hidden,
       cl::desc("Pop up a window to show SUnit dags after they are processed"));
@@ -184,7 +188,8 @@ ViewSUnitDAGs("view-sunit-dags", cl::Hidden,
 static const bool ViewDAGCombine1 = false, ViewLegalizeTypesDAGs = false,
                   ViewDAGCombineLT = false, ViewLegalizeDAGs = false,
                   ViewDAGCombine2 = false, ViewISelDAGs = false,
-                  ViewSchedDAGs = false, ViewSUnitDAGs = false;
+                  WriteDAGsToFile = false, ViewSchedDAGs = false,
+                  ViewSUnitDAGs = false;
 #endif
 
 #ifndef NDEBUG
@@ -957,7 +962,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
 #endif
 
   if (ViewDAGCombine1 && MatchFilterBB)
-    CurDAG->viewGraph("dag-combine1 input for " + BlockName);
+    CurDAG->viewGraph("dag-combine1 input for " + BlockName, WriteDAGsToFile);
 
   // Run the DAG combiner in pre-legalize mode.
   {
@@ -979,7 +984,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
   // Second step, hack on the DAG until it only uses operations and types that
   // the target supports.
   if (ViewLegalizeTypesDAGs && MatchFilterBB)
-    CurDAG->viewGraph("legalize-types input for " + BlockName);
+    CurDAG->viewGraph("legalize-types input for " + BlockName, WriteDAGsToFile);
 
   bool Changed;
   {
@@ -1003,7 +1008,8 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
 
   if (Changed) {
     if (ViewDAGCombineLT && MatchFilterBB)
-      CurDAG->viewGraph("dag-combine-lt input for " + BlockName);
+      CurDAG->viewGraph("dag-combine-lt input for " + BlockName,
+                        WriteDAGsToFile);
 
     // Run the DAG combiner in post-type-legalize mode.
     {
@@ -1057,7 +1063,8 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
 #endif
 
     if (ViewDAGCombineLT && MatchFilterBB)
-      CurDAG->viewGraph("dag-combine-lv input for " + BlockName);
+      CurDAG->viewGraph("dag-combine-lv input for " + BlockName,
+                        WriteDAGsToFile);
 
     // Run the DAG combiner in post-type-legalize mode.
     {
@@ -1078,7 +1085,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
   }
 
   if (ViewLegalizeDAGs && MatchFilterBB)
-    CurDAG->viewGraph("legalize input for " + BlockName);
+    CurDAG->viewGraph("legalize input for " + BlockName, WriteDAGsToFile);
 
   {
     NamedRegionTimer T("legalize", "DAG Legalization", GroupName,
@@ -1097,7 +1104,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
 #endif
 
   if (ViewDAGCombine2 && MatchFilterBB)
-    CurDAG->viewGraph("dag-combine2 input for " + BlockName);
+    CurDAG->viewGraph("dag-combine2 input for " + BlockName, WriteDAGsToFile);
 
   // Run the DAG combiner in post-legalize mode.
   {
@@ -1120,7 +1127,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
     ComputeLiveOutVRegInfo();
 
   if (ViewISelDAGs && MatchFilterBB)
-    CurDAG->viewGraph("isel input for " + BlockName);
+    CurDAG->viewGraph("isel input for " + BlockName, WriteDAGsToFile);
 
   // Third, instruction select all of the operations to machine code, adding the
   // code to the MachineBasicBlock.
@@ -1136,7 +1143,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
             CurDAG->dump(DumpSortedDAG));
 
   if (ViewSchedDAGs && MatchFilterBB)
-    CurDAG->viewGraph("scheduler input for " + BlockName);
+    CurDAG->viewGraph("scheduler input for " + BlockName, WriteDAGsToFile);
 
   // Schedule machine code.
   ScheduleDAGSDNodes *Scheduler = CreateScheduler();

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGPrinter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGPrinter.cpp
@@ -154,6 +154,23 @@ void SelectionDAG::viewGraph(const std::string &Title) {
 #endif  // NDEBUG
 }
 
+/// viewGraph - Pop up a ghostview window with the reachable parts of the DAG
+/// rendered using 'dot' if not writing to file. Otherwise, just write it out.
+///
+void SelectionDAG::viewGraph(const std::string &Title, const bool WriteFile) {
+// This code is only for debugging!
+#ifndef NDEBUG
+  std::string GraphName = "dag." + getMachineFunction().getName().str();
+  if (WriteFile)
+    WriteGraph(this, Twine(GraphName), false, Title);
+  else
+    ViewGraph(this, Twine(GraphName), false, Title);
+#else
+  errs() << "SelectionDAG::viewGraph is only available in debug builds on "
+         << "systems with Graphviz or gv!\n";
+#endif // NDEBUG
+}
+
 // This overload is defined out-of-line here instead of just using a
 // default parameter because this is easiest for gdb to call.
 void SelectionDAG::viewGraph() {


### PR DESCRIPTION
Adds a `write-dags-to-file` CLI option that uses the same internals as `view-isel-dags` but does not attempt to open the graphviz window. 

Allows the graphviz files to more easily be generated on systems which do not have a viewer installed so they can be copied elsewhere