### PR TITLE
[libc][math] Refactor exp2f implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -48,6 +48,7 @@
 #include "math/exp10m1f.h"
 #include "math/exp10m1f16.h"
 #include "math/exp2.h"
+#include "math/exp2f.h"
 #include "math/expf.h"
 #include "math/expf16.h"
 #include "math/frexpf.h"

--- a/libc/shared/math/exp2f.h
+++ b/libc/shared/math/exp2f.h
@@ -1,4 +1,4 @@
-//===-- Single-precision 2^x function -------------------------------------===//
+//===-- Shared exp2f function -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/exp2f.h"
-#include "src/__support/common.h" // for LLVM_LIBC_FUNCTION
-#include "src/__support/macros/config.h"
+#ifndef LLVM_LIBC_SHARED_MATH_EXP2F_H
+#define LLVM_LIBC_SHARED_MATH_EXP2F_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/exp2f.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, exp2f, (float x)) { return math::exp2f(x); }
+using math::exp2f;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_EXP2F_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -736,6 +736,24 @@ add_header_library(
 )
 
 add_header_library(
+  exp2f
+  HDRS
+    exp2f.h
+  DEPENDS
+    .exp10f_utils
+    libc.src.__support.FPUtil.except_value_utils
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.multiply_add
+    libc.src.__support.FPUtil.nearest_integer
+    libc.src.__support.FPUtil.polyeval
+    libc.src.__support.FPUtil.rounding_mode
+    libc.src.__support.macros.optimization
+    libc.src.__support.common
+    libc.src.errno.errno
+)
+
+add_header_library(
   exp10
   HDRS
     exp10.h

--- a/libc/src/__support/math/exp2f.h
+++ b/libc/src/__support/math/exp2f.h
@@ -1,4 +1,4 @@
-//===-- Single-precision 2^x function -------------------------------------===//
+//===-- Implementation header for exp2f -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_MATH_GENERIC_EXP2F_IMPL_H
-#define LLVM_LIBC_SRC_MATH_GENERIC_EXP2F_IMPL_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_EXP2F_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_EXP2F_H
 
+#include "exp10f_utils.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/PolyEval.h"
@@ -20,12 +21,12 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 #include "src/__support/macros/properties/cpu_features.h"
-#include "src/__support/math/exp10f_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
-namespace generic {
 
-LIBC_INLINE float exp2f(float x) {
+namespace math {
+
+LIBC_INLINE static constexpr float exp2f(float x) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
 
@@ -120,8 +121,8 @@ LIBC_INLINE float exp2f(float x) {
   // of 2^mid.
 
   // kf = (hi + mid) * 2^5 = round(x * 2^5)
-  float kf;
-  int k;
+  float kf = 0;
+  int k = 0;
 #ifdef LIBC_TARGET_CPU_HAS_NEAREST_INT
   kf = fputil::nearest_integer(x * 32.0f);
   k = static_cast<int>(kf);
@@ -161,7 +162,8 @@ LIBC_INLINE float exp2f(float x) {
   return static_cast<float>(fputil::multiply_add(p, dx_sq * mh, c1 * mh));
 }
 
-} // namespace generic
+} // namespace math
+
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_MATH_GENERIC_EXP2F_IMPL_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_EXP2F_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1451,24 +1451,6 @@ add_entrypoint_object(
     libc.src.__support.math.exp2
 )
 
-add_header_library(
-  exp2f_impl
-  HDRS
-    exp2f_impl.h
-  DEPENDS
-    libc.src.__support.FPUtil.except_value_utils
-    libc.src.__support.FPUtil.fenv_impl
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.FPUtil.nearest_integer
-    libc.src.__support.FPUtil.polyeval
-    libc.src.__support.FPUtil.rounding_mode
-    libc.src.__support.macros.optimization
-    libc.src.__support.math.exp10f_utils
-    libc.src.__support.common
-    libc.src.errno.errno
-)
-
 add_entrypoint_object(
   exp2f
   SRCS
@@ -1476,7 +1458,7 @@ add_entrypoint_object(
   HDRS
     ../exp2f.h
   DEPENDS
-    .exp2f_impl
+    libc.src.__support.math.exp2f
 )
 
 add_entrypoint_object(
@@ -1659,8 +1641,8 @@ add_entrypoint_object(
   HDRS
     ../powf.h
   DEPENDS
-    .exp2f_impl
     libc.src.__support.math.exp10f
+    libc.src.__support.math.exp2f
     libc.src.__support.CPP.bit
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -20,9 +20,8 @@
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 #include "src/__support/math/common_constants.h" // Lookup tables EXP_M1 and EXP_M2.
 #include "src/__support/math/exp10f.h" // Speedup for powf(10, y) = exp10f(y)
+#include "src/__support/math/exp2f.h"  // Speedup for powf(2, y) = exp2f(y)
 #include "src/__support/math/exp_constants.h"
-
-#include "exp2f_impl.h"  // Speedup for powf(2, y) = exp2f(y)
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -779,7 +778,7 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
 #ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
     case 0x4000'0000: // x = 2.0f
       // pow(2, y) = exp2(y)
-      return generic::exp2f(y);
+      return math::exp2f(y);
     case 0x4120'0000: // x = 10.0f
       // pow(10, y) = exp10(y)
       return math::exp10f(y);

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -41,6 +41,7 @@ add_fp_unittest(
     libc.src.__support.math.erff
     libc.src.__support.math.exp
     libc.src.__support.math.exp2
+    libc.src.__support.math.exp2f
     libc.src.__support.math.exp10
     libc.src.__support.math.exp10f
     libc.src.__support.math.exp10f16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -62,6 +62,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::erff(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp10f(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::expf(0.0f));
+  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp2f(0.0f));
 
   EXPECT_FP_EQ_ALL_ROUNDING(0.75f,
                             LIBC_NAMESPACE::shared::frexpf(24.0f, &exponent));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2168,22 +2168,6 @@ libc_support_library(
 )
 
 libc_support_library(
-    name = "exp2f_impl",
-    hdrs = ["src/math/generic/exp2f_impl.h"],
-    deps = [
-        ":__support_fputil_except_value_utils",
-        ":__support_fputil_fma",
-        ":__support_fputil_multiply_add",
-        ":__support_fputil_nearest_integer",
-        ":__support_fputil_polyeval",
-        ":__support_fputil_rounding_mode",
-        ":__support_macros_optimization",
-        ":__support_math_common_constants",
-        ":__support_math_exp10f_utils",
-    ],
-)
-
-libc_support_library(
     name = "__support_math_acos",
     hdrs = ["src/__support/math/acos.h"],
     deps = [
@@ -2892,6 +2876,22 @@ libc_support_library(
         ":__support_macros_optimization",
         ":__support_math_common_constants",
         ":__support_math_exp_utils",
+    ],
+)
+
+libc_support_library(
+    name = "__support_math_exp2f",
+    hdrs = ["src/__support/math/exp2f.h"],
+    deps = [
+        ":__support_fputil_except_value_utils",
+        ":__support_fputil_fma",
+        ":__support_fputil_multiply_add",
+        ":__support_fputil_nearest_integer",
+        ":__support_fputil_polyeval",
+        ":__support_fputil_rounding_mode",
+        ":__support_macros_optimization",
+        ":__support_math_common_constants",
+        ":__support_math_exp10f_utils",
     ],
 )
 
@@ -3676,7 +3676,7 @@ libc_math_function(
 libc_math_function(
     name = "exp2f",
     additional_deps = [
-        ":exp2f_impl",
+        ":__support_math_exp2f",
     ],
 )
 
@@ -4511,7 +4511,7 @@ libc_math_function(
         ":__support_macros_optimization",
         ":__support_math_exp10f",
         ":__support_math_common_constants",
-        ":exp2f_impl",
+        ":__support_math_exp2f",
     ],
 )
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450