### PR TITLE
[NFC][clang][AST] Add compile-time dispatch for random access iterators in append()

### DIFF
--- a/clang/include/clang/AST/ASTVector.h
+++ b/clang/include/clang/AST/ASTVector.h
@@ -182,8 +182,6 @@ public:
   /// append - Add the specified range to the end of the SmallVector.
   template <typename in_iter>
   void append(const ASTContext &C, in_iter in_start, in_iter in_end) {
-    using size_type =
-        typename std::remove_reference_t<decltype(*this)>::size_type;
     using iterator_category =
         typename std::iterator_traits<in_iter>::iterator_category;
 


### PR DESCRIPTION
This patch improves the `append()` implementation by introducing a compile-time dispatch between random access and non-random access iterators.