### PR TITLE
[compiler-rt][asan][tests] Reland: Stabilize wchar tests on Darwin/Android (test-only)

### DIFF
--- a/compiler-rt/test/asan/TestCases/wcscat.cpp
+++ b/compiler-rt/test/asan/TestCases/wcscat.cpp
@@ -16,10 +16,10 @@ int main() {
   wchar_t badDst[9];
   wcscpy(badDst, start);
   fprintf(stderr, "Good so far.\n");
-  // CHECK: Good so far.
+  // CHECK-DAG: Good so far.
   fflush(stderr);
   wcscat(badDst, append); // Boom!
-  // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
+  // CHECK-DAG: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
   // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
   // CHECK: #0 {{0x[0-9a-f]+}} in wcscat
   printf("Should have failed with ASAN error.\n");

--- a/compiler-rt/test/asan/TestCases/wcscpy.cpp
+++ b/compiler-rt/test/asan/TestCases/wcscpy.cpp
@@ -13,10 +13,10 @@ int main() {
 
   wchar_t badDst[7];
   fprintf(stderr, "Good so far.\n");
-  // CHECK: Good so far.
+  // CHECK-DAG: Good so far.
   fflush(stderr);
   wcscpy(badDst, src); // Boom!
-  // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
+  // CHECK-DAG: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
   // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
   // CHECK: #0 {{0x[0-9a-f]+}} in wcscpy
   printf("Should have failed with ASAN error.\n");

--- a/compiler-rt/test/asan/TestCases/wcsncat.cpp
+++ b/compiler-rt/test/asan/TestCases/wcsncat.cpp
@@ -17,10 +17,10 @@ int main() {
   wcscpy(badDst, start);
   wcsncat(badDst, append, 1);
   fprintf(stderr, "Good so far.\n");
-  // CHECK: Good so far.
+  // CHECK-DAG: Good so far.
   fflush(stderr);
   wcsncat(badDst, append, 3); // Boom!
-  // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
+  // CHECK-DAG: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
   // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
   // CHECK: #0 {{0x[0-9a-f]+}} in wcsncat
   printf("Should have failed with ASAN error.\n");

--- a/compiler-rt/test/asan/TestCases/wcsncpy.cpp
+++ b/compiler-rt/test/asan/TestCases/wcsncpy.cpp
@@ -14,11 +14,11 @@ int main() {
   wchar_t badDst[7];
   wcsncpy(badDst, src, 7); // This should still work.
   fprintf(stderr, "Good so far.\n");
-  // CHECK: Good so far.
+  // CHECK-DAG: Good so far.
   fflush(stderr);
 
   wcsncpy(badDst, src, 15); // Boom!
-  // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
+  // CHECK-DAG: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:0x[0-9a-f]+]] at pc {{0x[0-9a-f]+}} bp {{0x[0-9a-f]+}} sp {{0x[0-9a-f]+}}
   // CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0
   // CHECK: #0 {{0x[0-9a-f]+}} in wcsncpy
   printf("Should have failed with ASAN error.\n");


### PR DESCRIPTION
Reland of #161624, depends on revert [#162001](https://github.com/llvm/llvm-project/pull/162001). NFC: test-only.

- Android: keep `%env_asan_opts=log_to_stderr=1` to route the ASan header to stderr.
- Darwin: use a DAG group for the two potentially reordered lines:
  - `// CHECK-DAG: Good so far.`
  - `// CHECK-DAG: ERROR: AddressSanitizer: stack-buffer-overflow on address [[ADDR:...]] at pc {{...}} bp {{...}} sp {{...}}`
- Then enforce strict order:
  - `// CHECK: WRITE of size {{[0-9]+}} at [[ADDR]] thread T0`
  - `// CHECK: #0 {{0x[0-9a-f]+}} in <func>`