### PR TITLE
[clang][bytecode] interp__builtin_ia32_pshuf - modulo lane index to allow reuse of PSHUFD/LW/HW mask decode. NFC

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2796,7 +2796,7 @@ static bool interp__builtin_ia32_pshuf(InterpState &S, CodePtr OpPC,
     unsigned LaneBase = (Idx / LaneElts) * LaneElts;
     unsigned LaneIdx = Idx % LaneElts;
     unsigned SrcIdx = Idx;
-    unsigned Sel = (Ctl >> (2 * LaneIdx)) & 0x3;
+    unsigned Sel = (Ctl >> (2 * (LaneIdx & 0x3))) & 0x3;
     if (ElemBits == 32) {
       SrcIdx = LaneBase + Sel;
     } else {
@@ -2805,8 +2805,6 @@ static bool interp__builtin_ia32_pshuf(InterpState &S, CodePtr OpPC,
       if (!IsShufHW && !InHigh) {
         SrcIdx = LaneBase + Sel;
       } else if (IsShufHW && InHigh) {
-        unsigned Rel = LaneIdx - HalfSize;
-        Sel = (Ctl >> (2 * Rel)) & 0x3;
         SrcIdx = LaneBase + HalfSize + Sel;
       }
     }


### PR DESCRIPTION
Removes need to offset PSHUFHW land index to extract the shuffle mask element