### PR TITLE
[Github][Docker] Remove 'docker.io/library' from image name

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:24.04 AS base
+FROM ubuntu:24.04 AS base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base AS stage1-toolchain


### PR DESCRIPTION
Based on https://github.com/llvm/llvm-project/pull/161083#discussion_r2404139880, we don't specify explicitly `docker.io/library/`, this is the only violation I could find.