### PR TITLE
[mlir][spirv] Simplify unreachable default cases in type switch. NFC.

### DIFF
--- a/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
@@ -1118,10 +1118,7 @@ StringRef getTypeMangling(Type type, bool isSigned) {
           llvm_unreachable("Unsupported integer width");
         }
       })
-      .Default([](auto) {
-        llvm_unreachable("No mangling defined");
-        return "";
-      });
+      .DefaultUnreachable("No mangling defined");
 }
 
 template <typename ReduceOp>

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -987,7 +987,7 @@ void SPIRVDialect::printType(Type type, DialectAsmPrinter &os) const {
       .Case<ArrayType, CooperativeMatrixType, PointerType, RuntimeArrayType,
             ImageType, SampledImageType, StructType, MatrixType, TensorArmType>(
           [&](auto type) { print(type, os); })
-      .Default([](Type) { llvm_unreachable("unhandled SPIR-V type"); });
+      .DefaultUnreachable("Unhandled SPIR-V type");
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
@@ -57,7 +57,7 @@ public:
           for (Type elementType : concreteType.getElementTypes())
             add(elementType);
         })
-        .Default([](SPIRVType) { llvm_unreachable("Unhandled type"); });
+        .DefaultUnreachable("Unhandled type");
   }
 
   void add(Type type) { add(cast<SPIRVType>(type)); }
@@ -107,7 +107,7 @@ public:
           for (Type elementType : concreteType.getElementTypes())
             add(elementType);
         })
-        .Default([](SPIRVType) { llvm_unreachable("Unhandled type"); });
+        .DefaultUnreachable("Unhandled type");
   }
 
   void add(Type type) { add(cast<SPIRVType>(type)); }
@@ -198,8 +198,7 @@ Type CompositeType::getElementType(unsigned index) const {
       .Case<MatrixType>([](MatrixType type) { return type.getColumnType(); })
       .Case<StructType>(
           [index](StructType type) { return type.getElementType(index); })
-      .Default(
-          [](Type) -> Type { llvm_unreachable("invalid composite type"); });
+      .DefaultUnreachable("Invalid composite type");
 }
 
 unsigned CompositeType::getNumElements() const {
@@ -207,9 +206,7 @@ unsigned CompositeType::getNumElements() const {
       .Case<ArrayType, StructType, TensorArmType, VectorType>(
           [](auto type) { return type.getNumElements(); })
       .Case<MatrixType>([](MatrixType type) { return type.getNumColumns(); })
-      .Default([](SPIRVType) -> unsigned {
-        llvm_unreachable("Invalid type for number of elements query");
-      });
+      .DefaultUnreachable("Invalid type for number of elements query");
 }
 
 bool CompositeType::hasCompileTimeKnownNumElements() const {

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -622,7 +622,7 @@ static spirv::Dim convertRank(int64_t rank) {
 }
 
 static spirv::ImageFormat getImageFormat(Type elementType) {
-  return llvm::TypeSwitch<Type, spirv::ImageFormat>(elementType)
+  return TypeSwitch<Type, spirv::ImageFormat>(elementType)
       .Case<Float16Type>([](Float16Type) { return spirv::ImageFormat::R16f; })
       .Case<Float32Type>([](Float32Type) { return spirv::ImageFormat::R32f; })
       .Case<IntegerType>([](IntegerType intType) {
@@ -639,11 +639,7 @@ static spirv::ImageFormat getImageFormat(Type elementType) {
           llvm_unreachable("Unhandled integer type!");
         }
       })
-      .Default([](Type) {
-        llvm_unreachable("Unhandled element type!");
-        // We need to return something here to satisfy the type switch.
-        return spirv::ImageFormat::R32f;
-      });
+      .DefaultUnreachable("Unhandled element type!");
 #undef BIT_WIDTH_CASE
 }
 


### PR DESCRIPTION
Use `DefaultUnreachable` from https://github.com/llvm/llvm-project/pull/161970.