### PR TITLE
[clang-tidy] Deprecate 'zircon' module

### DIFF
--- a/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
@@ -10,6 +10,7 @@ add_clang_library(clangTidyFuchsiaModule STATIC
   MultipleInheritanceCheck.cpp
   OverloadedOperatorCheck.cpp
   StaticallyConstructedObjectsCheck.cpp
+  TemporaryObjectsCheck.cpp
   TrailingReturnCheck.cpp
   VirtualInheritanceCheck.cpp
 

--- a/clang-tools-extra/clang-tidy/fuchsia/FuchsiaTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/FuchsiaTidyModule.cpp
@@ -15,6 +15,7 @@
 #include "MultipleInheritanceCheck.h"
 #include "OverloadedOperatorCheck.h"
 #include "StaticallyConstructedObjectsCheck.h"
+#include "TemporaryObjectsCheck.h"
 #include "TrailingReturnCheck.h"
 #include "VirtualInheritanceCheck.h"
 
@@ -39,6 +40,8 @@ public:
         "fuchsia-overloaded-operator");
     CheckFactories.registerCheck<StaticallyConstructedObjectsCheck>(
         "fuchsia-statically-constructed-objects");
+    CheckFactories.registerCheck<TemporaryObjectsCheck>(
+        "fuchsia-temporary-objects");
     CheckFactories.registerCheck<TrailingReturnCheck>(
         "fuchsia-trailing-return");
     CheckFactories.registerCheck<VirtualInheritanceCheck>(

--- a/clang-tools-extra/clang-tidy/fuchsia/TemporaryObjectsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/TemporaryObjectsCheck.cpp
@@ -15,7 +15,7 @@
 
 using namespace clang::ast_matchers;
 
-namespace clang::tidy::zircon {
+namespace clang::tidy::fuchsia {
 
 namespace {
 
@@ -55,4 +55,4 @@ void TemporaryObjectsCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "Names", utils::options::serializeStringList(Names));
 }
 
-} // namespace clang::tidy::zircon
+} // namespace clang::tidy::fuchsia

--- a/clang-tools-extra/clang-tidy/fuchsia/TemporaryObjectsCheck.h
+++ b/clang-tools-extra/clang-tidy/fuchsia/TemporaryObjectsCheck.h
@@ -6,19 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ZIRCON_TEMPORARYOBJECTSCHECK_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ZIRCON_TEMPORARYOBJECTSCHECK_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_FUCHSIA_TEMPORARYOBJECTSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_FUCHSIA_TEMPORARYOBJECTSCHECK_H
 
 #include "../ClangTidyCheck.h"
 #include "../utils/OptionsUtils.h"
 
-namespace clang::tidy::zircon {
+namespace clang::tidy::fuchsia {
 
 /// Construction of specific temporary objects in the Zircon kernel is
 /// discouraged.
 ///
 /// For the user-facing documentation see:
-/// https://clang.llvm.org/extra/clang-tidy/checks/zircon/temporary-objects.html
+/// https://clang.llvm.org/extra/clang-tidy/checks/fuchsia/temporary-objects.html
 class TemporaryObjectsCheck : public ClangTidyCheck {
 public:
   TemporaryObjectsCheck(StringRef Name, ClangTidyContext *Context)
@@ -35,6 +35,6 @@ private:
   std::vector<StringRef> Names;
 };
 
-} // namespace clang::tidy::zircon
+} // namespace clang::tidy::fuchsia
 
-#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ZIRCON_TEMPORARYOBJECTSCHECK_H
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_FUCHSIA_TEMPORARYOBJECTSCHECK_H

--- a/clang-tools-extra/clang-tidy/zircon/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/zircon/CMakeLists.txt
@@ -4,11 +4,11 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangTidyZirconModule STATIC
-  TemporaryObjectsCheck.cpp
   ZirconTidyModule.cpp
 
   LINK_LIBS
   clangTidy
+  clangTidyFuchsiaModule
   clangTidyUtils
 
   DEPENDS

--- a/clang-tools-extra/clang-tidy/zircon/ZirconTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/zircon/ZirconTidyModule.cpp
@@ -9,9 +9,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
-#include "TemporaryObjectsCheck.h"
-
-using namespace clang::ast_matchers;
+#include "../fuchsia/TemporaryObjectsCheck.h"
 
 namespace clang::tidy {
 namespace zircon {
@@ -20,14 +18,14 @@ namespace zircon {
 class ZirconModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
-    CheckFactories.registerCheck<TemporaryObjectsCheck>(
+    CheckFactories.registerCheck<fuchsia::TemporaryObjectsCheck>(
         "zircon-temporary-objects");
   }
 };
 
 // Register the ZirconTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<ZirconModule>
-    X("zircon-module", "Adds Zircon kernel checks.");
+    X("zircon-module", "Adds Zircon kernel checks (deprecated in LLVM 24).");
 } // namespace zircon
 
 // This anchor is used to force the linker to link in the generated object file

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -49,6 +49,10 @@ Major New Features
 Potentially Breaking Changes
 ----------------------------
 
+- Deprecated the :program:`clang-tidy` ``zircon`` module. All checks have been
+  moved to the ``fuchsia`` module instead. The ``zircon`` module will be removed
+  in the 24th release.
+
 - Removed :program:`clang-tidy`'s global options `IgnoreMacros` and
   `StrictMode`, which were documented as deprecated since
   :program:`clang-tidy-20`. Users should use the check-specific options of the
@@ -157,6 +161,10 @@ Improvements to clang-tidy
 - Improved :program:`run-clang-tidy.py` and :program:`clang-tidy-diff.py`
   scripts by adding the `-hide-progress` option to suppress progress and
   informational messages.
+
+- Deprecated the :program:`clang-tidy` ``zircon`` module. All checks have been
+  moved to the ``fuchsia`` module instead. The ``zircon`` module will be removed
+  in the 24th release.
 
 New checks
 ^^^^^^^^^^

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/temporary-objects.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/temporary-objects.rst
@@ -1,0 +1,53 @@
+.. title:: clang-tidy - fuchsia-temporary-objects
+
+fuchsia-temporary-objects
+=========================
+
+Warns on construction of specific temporary objects in the Zircon kernel.
+If the object should be flagged, the fully qualified type name must be
+explicitly passed to the check.
+
+For example, given the list of classes "Foo" and "NS::Bar", all of the
+following will trigger the warning:
+
+.. code-block:: c++
+
+  Foo();
+  Foo F = Foo();
+  func(Foo());
+
+  namespace NS {
+
+  Bar();
+
+  }
+
+With the same list, the following will not trigger the warning:
+
+.. code-block:: c++
+
+  Foo F;                 // Non-temporary construction okay
+  Foo F(param);          // Non-temporary construction okay
+  Foo *F = new Foo();    // New construction okay
+
+  Bar();                 // Not NS::Bar, so okay
+  NS::Bar B;             // Non-temporary construction okay
+
+Note that objects must be explicitly specified in order to be flagged,
+and so objects that inherit a specified object will not be flagged.
+
+This check matches temporary objects without regard for inheritance and so a
+prohibited base class type does not similarly prohibit derived class types.
+
+.. code-block:: c++
+
+  class Derived : Foo {} // Derived is not explicitly disallowed
+  Derived();             // and so temporary construction is okay
+
+Options
+-------
+
+.. option:: Names
+
+   A semi-colon-separated list of fully-qualified names of C++ classes that
+   should not be constructed as temporaries. Default is empty.

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/temporary-objects.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/temporary-objects.rst
@@ -50,4 +50,4 @@ Options
 .. option:: Names
 
    A semi-colon-separated list of fully-qualified names of C++ classes that
-   should not be constructed as temporaries. Default is empty.
+   should not be constructed as temporaries. Default is empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -222,6 +222,7 @@ Clang-Tidy Checks
    :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`,
    :doc:`fuchsia-overloaded-operator <fuchsia/overloaded-operator>`,
    :doc:`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>`,
+   :doc:`fuchsia-temporary-objects <fuchsia/temporary-objects>`,
    :doc:`fuchsia-trailing-return <fuchsia/trailing-return>`,
    :doc:`fuchsia-virtual-inheritance <fuchsia/virtual-inheritance>`,
    :doc:`google-build-explicit-make-pair <google/build-explicit-make-pair>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/zircon/temporary-objects.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/zircon/temporary-objects.rst
@@ -5,6 +5,6 @@ zircon-temporary-objects
 
 .. note::
 
-  The `zircon-temporary-objects`` check has been deprecated and will be removed
-  in a 24th release. Please use
+  The `zircon-temporary-objects` check has been deprecated and will be removed
+  in 24th release of LLVM. Please use
   :doc:`fuchsia-temporary-objects <../fuchsia/temporary-objects>` instead.

--- a/clang-tools-extra/docs/clang-tidy/checks/zircon/temporary-objects.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/zircon/temporary-objects.rst
@@ -3,51 +3,8 @@
 zircon-temporary-objects
 ========================
 
-Warns on construction of specific temporary objects in the Zircon kernel.
-If the object should be flagged, If the object should be flagged, the fully
-qualified type name must be explicitly passed to the check.
+.. note::
 
-For example, given the list of classes "Foo" and "NS::Bar", all of the
-following will trigger the warning:
-
-.. code-block:: c++
-
-  Foo();
-  Foo F = Foo();
-  func(Foo());
-
-  namespace NS {
-
-  Bar();
-
-  }
-
-With the same list, the following will not trigger the warning:
-
-.. code-block:: c++
-
-  Foo F;                 // Non-temporary construction okay
-  Foo F(param);          // Non-temporary construction okay
-  Foo *F = new Foo();    // New construction okay
-
-  Bar();                 // Not NS::Bar, so okay
-  NS::Bar B;             // Non-temporary construction okay
-
-Note that objects must be explicitly specified in order to be flagged,
-and so objects that inherit a specified object will not be flagged.
-
-This check matches temporary objects without regard for inheritance and so a
-prohibited base class type does not similarly prohibit derived class types.
-
-.. code-block:: c++
-
-  class Derived : Foo {} // Derived is not explicitly disallowed
-  Derived();             // and so temporary construction is okay
-
-Options
--------
-
-.. option:: Names
-
-   A semi-colon-separated list of fully-qualified names of C++ classes that
-   should not be constructed as temporaries. Default is empty.
+  The `zircon-temporary-objects`` check has been deprecated and will be removed
+  in a 24th release. Please use
+  :doc:`fuchsia-temporary-objects <../fuchsia/temporary-objects>` instead.

--- a/clang-tools-extra/test/clang-tidy/checkers/fuchsia/temporary-objects.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/fuchsia/temporary-objects.cpp
@@ -1,5 +1,5 @@
-// RUN: %check_clang_tidy %s zircon-temporary-objects %t -- \
-// RUN:   -config="{CheckOptions: {zircon-temporary-objects.Names: 'Foo;NS::Bar'}}" \
+// RUN: %check_clang_tidy %s fuchsia-temporary-objects %t -- \
+// RUN:   -config="{CheckOptions: {fuchsia-temporary-objects.Names: 'Foo;NS::Bar'}}" \
 // RUN:   -header-filter=.*
 
 // Should flag instances of Foo, NS::Bar.


### PR DESCRIPTION
As for [RFC](https://discourse.llvm.org/t/rfc-deprecate-and-remove-zircon-module-moving-its-only-check-to-fuchsia-module/88208/2), deprecate `zircon` module and remove eventually in LLVM-24.