### PR TITLE
[NFC][MLIR][TableGen] Change `emitSummaryAndDescComments` to write to os directly

### DIFF
--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -864,11 +864,8 @@ bool DefGenerator::emitDecls(StringRef selectedDialect) {
 
     // Declare all the def classes first (in case they reference each other).
     for (const AttrOrTypeDef &def : defs) {
-      std::string comments = tblgen::emitSummaryAndDescComments(
-          def.getSummary(), def.getDescription());
-      if (!comments.empty()) {
-        os << comments << "\n";
-      }
+      tblgen::emitSummaryAndDescComments(os, def.getSummary(),
+                                         def.getDescription());
       os << "class " << def.getCppClassName() << ";\n";
     }
 

--- a/mlir/tools/mlir-tblgen/CppGenUtilities.cpp
+++ b/mlir/tools/mlir-tblgen/CppGenUtilities.cpp
@@ -14,26 +14,31 @@
 #include "CppGenUtilities.h"
 #include "mlir/Support/IndentedOstream.h"
 
-std::string
-mlir::tblgen::emitSummaryAndDescComments(llvm::StringRef summary,
-                                         llvm::StringRef description) {
+void mlir::tblgen::emitSummaryAndDescComments(llvm::raw_ostream &os,
+                                              llvm::StringRef summary,
+                                              llvm::StringRef description,
+                                              bool terminateComment) {
 
   std::string comments = "";
   StringRef trimmedSummary = summary.trim();
   StringRef trimmedDesc = description.trim();
-  llvm::raw_string_ostream os(comments);
   raw_indented_ostream ros(os);
 
+  bool empty = true;
   if (!trimmedSummary.empty()) {
     ros.printReindented(trimmedSummary, "/// ");
+    empty = false;
   }
 
   if (!trimmedDesc.empty()) {
-    if (!trimmedSummary.empty()) {
+    if (!empty) {
       // If there is a summary, add a newline after it.
       ros << "\n";
     }
     ros.printReindented(trimmedDesc, "/// ");
+    empty = false;
   }
-  return comments;
+
+  if (!empty && terminateComment)
+    ros << "\n";
 }

--- a/mlir/tools/mlir-tblgen/CppGenUtilities.h
+++ b/mlir/tools/mlir-tblgen/CppGenUtilities.h
@@ -15,14 +15,16 @@
 #define MLIR_TOOLS_MLIRTBLGEN_CPPGENUTILITIES_H_
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace mlir {
 namespace tblgen {
 
-// Emit the summary and description as a C++ comment, perperly aligned placed
-// adjacent to the class declaration of generated classes.
-std::string emitSummaryAndDescComments(llvm::StringRef summary,
-                                       llvm::StringRef description);
+// Emit the summary and description as a C++ comment. If `terminateComment` is
+// true, terminates the comment with a `\n`.
+void emitSummaryAndDescComments(llvm::raw_ostream &os, llvm::StringRef summary,
+                                llvm::StringRef description,
+                                bool terminateComment = true);
 } // namespace tblgen
 } // namespace mlir
 

--- a/mlir/tools/mlir-tblgen/DialectGen.cpp
+++ b/mlir/tools/mlir-tblgen/DialectGen.cpp
@@ -109,9 +109,7 @@ tblgen::findDialectToGenerate(ArrayRef<Dialect> dialects) {
 /// {0}: The name of the dialect class.
 /// {1}: The dialect namespace.
 /// {2}: The dialect parent class.
-/// {3}: The summary and description comments.
 static const char *const dialectDeclBeginStr = R"(
-{3}
 class {0} : public ::mlir::{2} {
   explicit {0}(::mlir::MLIRContext *context);
 
@@ -249,10 +247,11 @@ static void emitDialectDecl(Dialect &dialect, raw_ostream &os) {
     StringRef superClassName =
         dialect.isExtensible() ? "ExtensibleDialect" : "Dialect";
 
-    std::string comments = tblgen::emitSummaryAndDescComments(
-        dialect.getSummary(), dialect.getDescription());
+    tblgen::emitSummaryAndDescComments(os, dialect.getSummary(),
+                                       dialect.getDescription(),
+                                       /*terminateCmment=*/false);
     os << llvm::formatv(dialectDeclBeginStr, cppName, dialect.getName(),
-                        superClassName, comments);
+                        superClassName);
 
     // If the dialect requested the default attribute printer and parser, emit
     // the declarations for the hooks.

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -4847,11 +4847,8 @@ static void emitOpClassDecls(const RecordKeeper &records,
   for (auto *def : defs) {
     Operator op(*def);
     NamespaceEmitter emitter(os, op.getCppNamespace());
-    std::string comments = tblgen::emitSummaryAndDescComments(
-        op.getSummary(), op.getDescription());
-    if (!comments.empty()) {
-      os << comments << "\n";
-    }
+    tblgen::emitSummaryAndDescComments(os, op.getSummary(),
+                                       op.getDescription());
     os << "class " << op.getCppClassName() << ";\n";
   }
 

--- a/mlir/tools/mlir-tblgen/OpInterfacesGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpInterfacesGen.cpp
@@ -536,11 +536,8 @@ void InterfaceGenerator::forwardDeclareInterface(const Interface &interface) {
 
   // Emit a forward declaration of the interface class so that it becomes usable
   // in the signature of its methods.
-  std::string comments = tblgen::emitSummaryAndDescComments(
-      "", interface.getDescription().value_or(""));
-  if (!comments.empty()) {
-    os << comments << "\n";
-  }
+  tblgen::emitSummaryAndDescComments(os, "",
+                                     interface.getDescription().value_or(""));
 
   StringRef interfaceName = interface.getName();
   os << "class " << interfaceName << ";\n";
@@ -560,11 +557,8 @@ void InterfaceGenerator::emitInterfaceDecl(const Interface &interface) {
 
   // Emit a forward declaration of the interface class so that it becomes usable
   // in the signature of its methods.
-  std::string comments = tblgen::emitSummaryAndDescComments(
-      "", interface.getDescription().value_or(""));
-  if (!comments.empty()) {
-    os << comments << "\n";
-  }
+  tblgen::emitSummaryAndDescComments(os, "",
+                                     interface.getDescription().value_or(""));
 
   // Emit the traits struct containing the concept and model declarations.
   os << "namespace detail {\n"


### PR DESCRIPTION
Change `emitSummaryAndDescComments` to directly write to the output stream, avoiding creating large intermediate strings.