### PR TITLE
[libc++][string] Assert resize_and_overwrite operation returns integer-like type

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1312,6 +1312,8 @@ public:
 #  if _LIBCPP_STD_VER >= 23
   template <class _Op>
   _LIBCPP_HIDE_FROM_ABI constexpr void resize_and_overwrite(size_type __n, _Op __op) {
+    using __result_type = decltype(std::move(__op)(data(), auto(__n)));
+    static_assert(__integer_like<__result_type>, "Operation return type must be integer-like");
     size_type __sz  = size();
     size_type __cap = capacity();
     if (__n > __cap)

--- a/libcxx/test/std/strings/basic.string/string.capacity/resize_and_overwrite.verify.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/resize_and_overwrite.verify.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++23
+
+// <string>
+
+// template<class Operation>
+// void resize_and_overwrite(size_type n, Operation op)
+
+// Verify that the operation's return type must be integer-like
+
+#include <string>
+
+void test_bool_return_type() {
+  std::string s;
+  s.resize_and_overwrite(10, [](char*, std::size_t) {
+    return true; // expected-error-re@*:* {{{{(static_assertion|static assertion)}}{{.*}}integer-like}}
+  });
+}
+
+void test_pointer_return_type() {
+  std::string s;
+  s.resize_and_overwrite(10, [](char* p, std::size_t) {
+    return p; // expected-error-re@*:* {{{{(static_assertion|static assertion)}}{{.*}}integer-like}}
+              // expected-error@*:* {{cannot initialize}}
+  });
+}
+
+void test_float_return_type() {
+  std::string s;
+  s.resize_and_overwrite(10, [](char*, std::size_t) {
+    return 5.0f; // expected-error-re@*:* {{{{(static_assertion|static assertion)}}{{.*}}integer-like}}
+  });
+}


### PR DESCRIPTION
Verify that the operation passed to resize_and_overwrite returns an integer-like type, matching the behavior of other standard library implementations like GCC's libstdc++

Fixes #160577