### PR TITLE
[lldb][Language] Make SourceLanguage::GetDescription for language version

### DIFF
--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -582,7 +582,7 @@ lldb::LanguageType SourceLanguage::AsLanguageType() const {
 
 llvm::StringRef SourceLanguage::GetDescription() const {
   return llvm::dwarf::LanguageDescription(
-      static_cast<llvm::dwarf::SourceLanguageName>(name));
+      static_cast<llvm::dwarf::SourceLanguageName>(name), version);
 }
 bool SourceLanguage::IsC() const { return name == llvm::dwarf::DW_LNAME_C; }
 

--- a/lldb/unittests/Target/LanguageTest.cpp
+++ b/lldb/unittests/Target/LanguageTest.cpp
@@ -36,9 +36,14 @@ TEST_F(LanguageTest, SourceLanguage_GetDescription) {
   EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus).GetDescription(),
             "ISO C++");
   EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus_17).GetDescription(),
-            "ISO C++");
+            "C++17");
   EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus_20).GetDescription(),
-            "ISO C++");
+            "C++20");
+
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC).GetDescription(),
+            "C (K&R and ISO)");
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC89).GetDescription(),
+            "C89");
 
   EXPECT_EQ(SourceLanguage(eLanguageTypeObjC).GetDescription(), "Objective C");
   EXPECT_EQ(SourceLanguage(eLanguageTypeMipsAssembler).GetDescription(),

--- a/lldb/unittests/Target/LanguageTest.cpp
+++ b/lldb/unittests/Target/LanguageTest.cpp
@@ -40,10 +40,8 @@ TEST_F(LanguageTest, SourceLanguage_GetDescription) {
   EXPECT_EQ(SourceLanguage(eLanguageTypeC_plus_plus_20).GetDescription(),
             "C++20");
 
-  EXPECT_EQ(SourceLanguage(eLanguageTypeC).GetDescription(),
-            "C (K&R and ISO)");
-  EXPECT_EQ(SourceLanguage(eLanguageTypeC89).GetDescription(),
-            "C89");
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC).GetDescription(), "C (K&R and ISO)");
+  EXPECT_EQ(SourceLanguage(eLanguageTypeC89).GetDescription(), "C89");
 
   EXPECT_EQ(SourceLanguage(eLanguageTypeObjC).GetDescription(), "Objective C");
   EXPECT_EQ(SourceLanguage(eLanguageTypeMipsAssembler).GetDescription(),


### PR DESCRIPTION
Depends on https://github.com/llvm/llvm-project/pull/162048

This makes sure we also include the version number in the description.

For `C++17`, this would, e.g., now return `"C++17"` instead of `"ISO C++"`.