### PR TITLE
[OpenCL] Allow undefining cl_khr_integer_dot_product features macros

### DIFF
--- a/clang/lib/Headers/opencl-c-base.h
+++ b/clang/lib/Headers/opencl-c-base.h
@@ -53,13 +53,6 @@
 #define __opencl_c_kernel_clock_scope_work_group 1
 #define __opencl_c_kernel_clock_scope_sub_group 1
 
-#ifdef __undef___opencl_c_integer_dot_product_input_4x8bit
-#undef __opencl_c_integer_dot_product_input_4x8bit
-#endif
-#ifdef __undef___opencl_c_integer_dot_product_input_4x8bit_packed
-#undef __opencl_c_integer_dot_product_input_4x8bit_packed
-#endif
-
 #endif // defined(__SPIR__) || defined(__SPIRV__)
 #endif // (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
 
@@ -89,6 +82,8 @@
 #define __opencl_c_read_write_images 1
 #endif // defined(__SPIR__)
 
+#endif // (__OPENCL_CPP_VERSION__ == 202100 || __OPENCL_C_VERSION__ == 300)
+
 // Undefine any feature macros that have been explicitly disabled using
 // an __undef_<feature> macro.
 #ifdef __undef___opencl_c_work_group_collective_functions
@@ -106,8 +101,12 @@
 #ifdef __undef___opencl_c_read_write_images
 #undef __opencl_c_read_write_images
 #endif
-
-#endif // (__OPENCL_CPP_VERSION__ == 202100 || __OPENCL_C_VERSION__ == 300)
+#ifdef __undef___opencl_c_integer_dot_product_input_4x8bit
+#undef __opencl_c_integer_dot_product_input_4x8bit
+#endif
+#ifdef __undef___opencl_c_integer_dot_product_input_4x8bit_packed
+#undef __opencl_c_integer_dot_product_input_4x8bit_packed
+#endif
 
 #if !defined(__opencl_c_generic_address_space)
 // Internal feature macro to provide named (global, local, private) address

--- a/clang/lib/Headers/opencl-c-base.h
+++ b/clang/lib/Headers/opencl-c-base.h
@@ -53,6 +53,13 @@
 #define __opencl_c_kernel_clock_scope_work_group 1
 #define __opencl_c_kernel_clock_scope_sub_group 1
 
+#ifdef __undef___opencl_c_integer_dot_product_input_4x8bit
+#undef __opencl_c_integer_dot_product_input_4x8bit
+#endif
+#ifdef __undef___opencl_c_integer_dot_product_input_4x8bit_packed
+#undef __opencl_c_integer_dot_product_input_4x8bit_packed
+#endif
+
 #endif // defined(__SPIR__) || defined(__SPIRV__)
 #endif // (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
 

--- a/clang/test/SemaOpenCL/features.cl
+++ b/clang/test/SemaOpenCL/features.cl
@@ -26,6 +26,12 @@
 // RUN: %clang_cc1 -triple spir-unknown-unknown %s -E -dM -o - -x cl -cl-std=clc++1.0 \
 // RUN:   | FileCheck -match-full-lines %s  --check-prefix=NO-FEATURES
 
+// For OpenCL C 2.0, header-only features can be disabled using macros.
+// RUN: %clang_cc1 -triple spir-unknown-unknown %s -E -dM -o - -x cl -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header \
+// RUN:    -D__undef___opencl_c_integer_dot_product_input_4x8bit \
+// RUN:    -D__undef___opencl_c_integer_dot_product_input_4x8bit_packed \
+// RUN:   | FileCheck %s --check-prefix=NO-HEADERONLY-FEATURES-CL20
+
 // For OpenCL C 3.0, header-only features can be disabled using macros.
 // RUN: %clang_cc1 -triple spir-unknown-unknown %s -E -dM -o - -x cl -cl-std=CL3.0 -fdeclare-opencl-builtins -finclude-default-header \
 // RUN:    -D__undef___opencl_c_work_group_collective_functions=1 \
@@ -63,6 +69,9 @@
 // NO-FEATURES-NOT: #define __opencl_c_program_scope_global_variables
 // NO-FEATURES-NOT: #define __opencl_c_read_write_images
 // NO-FEATURES-NOT: #define __opencl_c_subgroups
+
+// NO-HEADERONLY-FEATURES-CL20-NOT: #define __opencl_c_integer_dot_product_input_4x8bit
+// NO-HEADERONLY-FEATURES-CL20-NOT: #define __opencl_c_integer_dot_product_input_4x8bit_packed
 
 // NO-HEADERONLY-FEATURES-NOT: #define __opencl_c_work_group_collective_functions
 // NO-HEADERONLY-FEATURES-NOT: #define __opencl_c_atomic_order_seq_cst


### PR DESCRIPTION
Add header-side undef hooks for:
  __opencl_c_integer_dot_product_input_4x8bit
  __opencl_c_integer_dot_product_input_4x8bit_packed

Motivation: our downstream legacy targets lack cl_khr_integer_dot_product builtins (similar to a60b8f468119). Providing __undef__* macros lets users suppress the feature macros without patching headers.

Fix https://github.com/intel/intel-graphics-compiler/issues/394