### PR TITLE
[lldb][docs] DW_AT_APPLE_major_runtime_version -> DW_AT_APPLE_major_runtime_vers

### DIFF
--- a/lldb/docs/resources/extensions.rst
+++ b/lldb/docs/resources/extensions.rst
@@ -134,5 +134,5 @@ Objective-C runtime
 
 Clang emits the Objective-C runtime version into the
 ``DW_TAG_compile_unit`` using the
-``DW_AT_APPLE_major_runtime_version`` attribute. The value 2 stands
+``DW_AT_APPLE_major_runtime_vers`` attribute. The value 2 stands
 for Objective-C 2.0.


### PR DESCRIPTION
`DW_AT_APPLE_major_runtime_version` doesn't exist. This should be `DW_AT_APPLE_major_runtime_vers`.