### PR TITLE
[clang-tidy] [misc-const-correctness] fix fake positive when pointer is returned as non const

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-pointers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-pointers.cpp
@@ -48,3 +48,33 @@ void ignore_const_alias() {
   p_local0 = &a[1];
 }
 
+void* ignore_const_return(){
+  void* const p = nullptr;
+  return p;
+}
+
+void const* const_return(){
+  void * p = nullptr;
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: pointee of variable 'p' of type 'void *' can be declared 'const'
+  // CHECK-FIXES: void  const* p
+  return p;
+}
+
+template<typename T>
+T* ignore_const_return_template(){
+  T* const p = nullptr;
+  return p;
+}
+
+template<typename T>
+T const* const_return_template(){
+  T * p = nullptr;
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: pointee of variable 'p' of type 'int *' can be declared 'const'
+  // CHECK-FIXES: T  const* p
+  return p;
+}
+
+void instantiate_return_templates() {
+  ignore_const_return_template<int>();
+  const_return_template<int>();
+}

--- a/clang/lib/Analysis/ExprMutationAnalyzer.cpp
+++ b/clang/lib/Analysis/ExprMutationAnalyzer.cpp
@@ -787,10 +787,16 @@ ExprMutationAnalyzer::Analyzer::findPointeeToNonConst(const Expr *Exp) {
   // FIXME: false positive if the pointee does not change in lambda
   const auto CaptureNoConst = lambdaExpr(hasCaptureInit(Exp));
 
+  // Return statement in function with non-const pointer return type
+  const auto ReturnAsNonConst = returnStmt(
+      hasDescendant(equalsNode(Exp)), 
+      hasAncestor(functionDecl(returns(NonConstPointerOrDependentType))));
+
   const auto Matches =
       match(stmt(anyOf(forEachDescendant(
                            stmt(anyOf(AssignToNonConst, PassAsNonConstArg,
-                                      CastToNonConst, CaptureNoConst))
+                                      CastToNonConst, CaptureNoConst,
+                                      ReturnAsNonConst))
                                .bind("stmt")),
                        forEachDescendant(InitToNonConst))),
             Stm, Context);


### PR DESCRIPTION
```cpp
void* ignore_const_return(){
  void* const p = nullptr;
  return p;
}
```
misc-const-correctness give fake positive when a pointer is not modified but returned as non-const type
```
test.cpp:7:3: warning: pointee of variable 'p' of type 'void *' can be declared 'const' [misc-const-correctness]
    7 |   void * p = nullptr;
```