### PR TITLE
[libclc] Remove -fno-builtin from compile options

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -353,7 +353,7 @@ function(add_libclc_builtin_set)
       TRIPLE ${ARG_TRIPLE}
       INPUT ${input_file}
       OUTPUT ${output_file}
-      EXTRA_OPTS -fno-builtin -nostdlib "${ARG_COMPILE_FLAGS}"
+      EXTRA_OPTS -nostdlib "${ARG_COMPILE_FLAGS}"
         "${file_specific_compile_options}"
         -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
       DEPENDENCIES ${input_file_dep}


### PR DESCRIPTION
The flag was added in 8ef48d07efa3 to suppress build warning and is no
longer needed.

It adds "no-builtins" attribute, which prevents libclc functions from
being inlined into caller that don't have the attribute.

The flag is meant to prevent folding standard library calls into optimized implementations. For libclc device targets, however, such target‑driven folding is desirable.

llvm-diff shows no change to amdgcn--amdhsa.bc and nvptx--nvidiacl.bc.