### PR TITLE
[IR] Handle addrspacecast in findBaseObject()

### DIFF
--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -419,6 +419,7 @@ findBaseObject(const Constant *C, DenseSet<const GlobalAlias *> &Aliases,
     case Instruction::PtrToAddr:
     case Instruction::PtrToInt:
     case Instruction::BitCast:
+    case Instruction::AddrSpaceCast:
     case Instruction::GetElementPtr:
       return findBaseObject(CE->getOperand(0), Aliases, Op);
     default:

--- a/llvm/test/Bitcode/thinlto-alias-addrspacecast.ll
+++ b/llvm/test/Bitcode/thinlto-alias-addrspacecast.ll
@@ -1,0 +1,7 @@
+; RUN: opt -module-summary < %s | llvm-dis | FileCheck %s
+
+@__oclc_ABI_version = linkonce_odr hidden addrspace(4) constant i32 500, align 4
+@_ZL20__oclc_ABI_version__ = internal alias i32, addrspacecast (ptr addrspace(4) @__oclc_ABI_version to ptr)
+
+; CHECK: ^1 = gv: (name: "__oclc_ABI_version", summaries: (variable: (module: ^0, flags: {{.*}})))
+; CHECK: ^2 = gv: (name: "_ZL20__oclc_ABI_version__", summaries: (alias: (module: ^0, flags: {{.*}}, aliasee: ^1)))


### PR DESCRIPTION
Make findBaseObject() look through addrspacecast, so that getAliaseeObject() works with an aliasee that uses and addrspacecast. This fixes a crash during module summary index emission.

Fixes https://github.com/llvm/llvm-project/issues/161646.