### PR TITLE
[SPIRV] Support -fembed-bitcode=marker for non-shader modules

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -236,7 +236,7 @@ class SPIRVEmitIntrinsics
 
   Instruction *buildLogicalAccessChainFromGEP(GetElementPtrInst &GEP);
 
-  bool promoteEmbddedBitcodeMarker(Module &M) const;
+  bool promoteEmbeddedBitcodeMarkear(Module &M) const;
 
 public:
   static char ID;
@@ -3007,7 +3007,7 @@ void SPIRVEmitIntrinsics::parseFunDeclarations(Module &M) {
   }
 }
 
-bool SPIRVEmitIntrinsics::promoteEmbddedBitcodeMarker(Module &M) const {
+bool SPIRVEmitIntrinsics::promoteEmbeddedBitcodeMarkear(Module &M) const {
   const SPIRVSubtarget *STI = TM->getSubtargetImpl();
   if (STI->isShader())
     return false;
@@ -3016,18 +3016,18 @@ bool SPIRVEmitIntrinsics::promoteEmbddedBitcodeMarker(Module &M) const {
   if (!EmbeddedBitcode)
     return false;
 
-  ArrayType *AT = cast<ArrayType>(EmbeddedBitcode->getValueType());
-  if (AT->getNumElements() != 0)
+  ArrayType *ArrTy = cast<ArrayType>(EmbeddedBitcode->getValueType());
+  if (ArrTy->getNumElements() != 0)
     return false;
 
   // When compiling with -fembed-bitcode=marker, LLVM generates a [0 x i8]
   // zeroinitialized global variable containing the bitcode. This results in an
   // assert outside of shaders. As a workaround, we replace this global with a
   // zeroinitialized [1 x i8].
-  ArrayType *AT1 = ArrayType::get(AT->getElementType(), 1);
-  Constant *ZeroInit = Constant::getNullValue(AT1);
+  ArrayType *ArrTyOneElt = ArrayType::get(ArrTy->getElementType(), 1);
+  Constant *ZeroInit = Constant::getNullValue(ArrTyOneElt);
   GlobalVariable *NewEmbeddedBitcode = new GlobalVariable(
-      AT1, EmbeddedBitcode->isConstant(), EmbeddedBitcode->getLinkage(),
+      ArrTyOneElt, EmbeddedBitcode->isConstant(), EmbeddedBitcode->getLinkage(),
       ZeroInit, "", EmbeddedBitcode->getThreadLocalMode(),
       EmbeddedBitcode->getAddressSpace(),
       EmbeddedBitcode->isExternallyInitialized());
@@ -3043,7 +3043,7 @@ bool SPIRVEmitIntrinsics::promoteEmbddedBitcodeMarker(Module &M) const {
 bool SPIRVEmitIntrinsics::runOnModule(Module &M) {
   bool Changed = false;
 
-  Changed |= promoteEmbddedBitcodeMarker(M);
+  Changed |= promoteEmbeddedBitcodeMarkear(M);
   parseFunDeclarations(M);
   insertConstantsForFPFastMathDefault(M);
 

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker-shader.ll
@@ -1,0 +1,21 @@
+; RUN: llc -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
+
+@llvm.embedded.module = private constant [0 x i8] zeroinitializer, section ".llvmbc", align 1
+@llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1
+@llvm.compiler.used = appending global [2 x ptr] [ptr @llvm.embedded.module, ptr @llvm.cmdline], section "llvm.metadata"
+
+; CHECK-DAG: OpName [[FOO:%[0-9]+]] "foo"
+; CHECK-DAG: OpName [[MODULE:%[0-9]+]] "llvm.embedded.module"
+; CHECK-DAG: [[INT8:%[0-9]+]] = OpTypeInt 8 0
+; CHECK-DAG: [[RUNTIME_ARRAY_INT8x1:%[0-9]+]] = OpTypeRuntimeArray [[INT8]]
+; CHECK-DAG: [[POINTER:%[0-9]+]] = OpTypePointer Function [[RUNTIME_ARRAY_INT8x1]]
+; CHECK-DAG: [[EMBEDDED_MODULE_INIT:%[0-9]+]] = OpConstantNull [[RUNTIME_ARRAY_INT8x1]]
+; CHECK: [[FOO]] = OpFunction {{.*}} None {{.*}} 
+; CHECK-DAG: {{%[0-9]+}} = OpVariable [[POINTER]] Function [[EMBEDDED_MODULE_INIT]]
+
+define void @foo() #1 {
+entry:
+  ret void
+}
+
+attributes #1 = { "hlsl.numthreads"="4,8,16" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker-shader.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 @llvm.embedded.module = private constant [0 x i8] zeroinitializer, section ".llvmbc", align 1
 @llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker.ll
@@ -1,10 +1,20 @@
-; XFAIL: *
 ; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 @llvm.embedded.module = private constant [0 x i8] zeroinitializer, section ".llvmbc", align 1
 @llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1
 @llvm.compiler.used = appending global [2 x ptr] [ptr @llvm.embedded.module, ptr @llvm.cmdline], section "llvm.metadata"
+
+; CHECK-DAG: OpName [[FOO:%[0-9]+]] "foo"
+; CHECK-DAG: OpName [[MODULE:%[0-9]+]] "llvm.embedded.module"
+; CHECK-DAG: [[INT8:%[0-9]+]] = OpTypeInt 8 0
+; CHECK-DAG: [[INT32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[CONST_1_32:%[0-9]+]] = OpConstant [[INT32]] 1
+; CHECK-DAG: [[ARRAY_INT8x1:%[0-9]+]] = OpTypeArray [[INT8]] [[CONST_1_32]]
+; CHECK-DAG: [[POINTER:%[0-9]+]] = OpTypePointer Function [[ARRAY_INT8x1]]
+; CHECK-DAG: [[EMBEDDED_MODULE_INIT:%[0-9]+]] = OpConstantNull [[ARRAY_INT8x1]]
+; CHECK: [[FOO]] = OpFunction {{.*}} None {{.*}}
+; CHECK-DAG: {{%[0-9]+}} = OpVariable [[POINTER]] Function [[EMBEDDED_MODULE_INIT]]
 
 define spir_kernel void @foo() {
 entry:

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker.ll
@@ -1,0 +1,11 @@
+; XFAIL: *
+; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+
+@llvm.embedded.module = private constant [0 x i8] zeroinitializer, section ".llvmbc", align 1
+@llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1
+@llvm.compiler.used = appending global [2 x ptr] [ptr @llvm.embedded.module, ptr @llvm.cmdline], section "llvm.metadata"
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode-marker.ll
@@ -1,5 +1,6 @@
 ; XFAIL: *
 ; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 @llvm.embedded.module = private constant [0 x i8] zeroinitializer, section ".llvmbc", align 1
 @llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 @llvm.embedded.module = private constant [4 x i8] c"BC\C0\DE", section ".llvmbc", align 1
 @llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1

--- a/llvm/test/CodeGen/SPIRV/fembed-bitcode.ll
+++ b/llvm/test/CodeGen/SPIRV/fembed-bitcode.ll
@@ -1,0 +1,25 @@
+; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+
+@llvm.embedded.module = private constant [4 x i8] c"BC\C0\DE", section ".llvmbc", align 1
+@llvm.cmdline = private constant [5 x i8] c"-cc1\00", section ".llvmcmd", align 1
+@llvm.compiler.used = appending global [2 x ptr] [ptr @llvm.embedded.module, ptr @llvm.cmdline], section "llvm.metadata"
+
+; CHECK-DAG: OpName [[FOO:%[0-9]+]] "foo"
+; CHECK-DAG: OpName [[MODULE:%[0-9]+]] "llvm.embedded.module"
+; CHECK-DAG: [[INT8:%[0-9]+]] = OpTypeInt 8 0
+; CHECK-DAG: [[INT32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[CONST_4_32:%[0-9]+]] = OpConstant [[INT32]] 4
+; CHECK-DAG: [[ARRAY_INT8x4:%[0-9]+]] = OpTypeArray [[INT8]] [[CONST_4_32]]
+; CHECK-DAG: [[POINTER:%[0-9]+]] = OpTypePointer Function [[ARRAY_INT8x4]]
+; CHECK-DAG: [[CONST_B_8:%[0-9]+]] = OpConstant [[INT8]] 66
+; CHECK-DAG: [[CONST_C_8:%[0-9]+]] = OpConstant [[INT8]] 67
+; CHECK-DAG: [[CONST_0xC0_8:%[0-9]+]] = OpConstant [[INT8]] 192
+; CHECK-DAG: [[CONST_0xDE_8:%[0-9]+]] = OpConstant [[INT8]] 222
+; CHECK-DAG: [[EMBEDDED_MODULE_INIT:%[0-9]+]] = OpConstantComposite [[ARRAY_INT8x4]] [[CONST_B_8]] [[CONST_C_8]] [[CONST_0xC0_8]] [[CONST_0xDE_8]]
+; CHECK: [[FOO]] = OpFunction {{.*}} None {{.*}} 
+; CHECK-DAG: {{%[0-9]+}} = OpVariable [[POINTER]] Function [[EMBEDDED_MODULE_INIT]]
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}


### PR DESCRIPTION
-fembed-bitcode=marker gets lowered as a [0 x i8] zeroinitialized global
variable. This is interpreted as a runtime-array and is not supported in
non-shaders.

To work around this, we replace the [0 x i8] by a zeroinitialized
single-element array.

I'm not sure this is the way we want to support this, neither for shaders (using runtime arrays) nor for kernels (using the 1-sized zeroinitialized array).
A part of me would like to just delete the variable since we do not really need the delimiter.

Depends on https://github.com/llvm/llvm-project/pull/162081