### PR TITLE
[AMDGPU][True16] si-fold-operand selecting srcidx for v_mov_b16_t16_e64

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -932,7 +932,7 @@ static MachineOperand *lookUpCopyChain(const SIInstrInfo &TII,
   for (MachineInstr *SubDef = MRI.getVRegDef(SrcReg);
        SubDef && TII.isFoldableCopy(*SubDef);
        SubDef = MRI.getVRegDef(Sub->getReg())) {
-    unsigned SrcIdx = TII.getFoldableCopySrcIdx(*SubDef);
+    const int SrcIdx = SubDef->getOpcode() == AMDGPU::V_MOV_B16_t16_e64 ? 2 : 1;
     MachineOperand &SrcOp = SubDef->getOperand(SrcIdx);
 
     if (SrcOp.isImm())

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -416,8 +416,12 @@ public:
   areMemAccessesTriviallyDisjoint(const MachineInstr &MIa,
                                   const MachineInstr &MIb) const override;
 
-  static bool isFoldableCopy(const MachineInstr &MI);
-  static unsigned getFoldableCopySrcIdx(const MachineInstr &MI);
+  bool isFoldableCopy(const MachineInstr &MI) const;
+
+  bool getFoldableImm(Register Reg, const MachineRegisterInfo &MRI,
+                      int64_t &Imm, MachineInstr **DefMI) const;
+  bool getFoldableImm(const MachineOperand *MO, int64_t &Imm,
+                      MachineInstr **DefMI) const;
 
   void removeModOperands(MachineInstr &MI) const;
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -416,12 +416,8 @@ public:
   areMemAccessesTriviallyDisjoint(const MachineInstr &MIa,
                                   const MachineInstr &MIb) const override;
 
-  bool isFoldableCopy(const MachineInstr &MI) const;
-
-  bool getFoldableImm(Register Reg, const MachineRegisterInfo &MRI,
-                      int64_t &Imm, MachineInstr **DefMI) const;
-  bool getFoldableImm(const MachineOperand *MO, int64_t &Imm,
-                      MachineInstr **DefMI) const;
+  static bool isFoldableCopy(const MachineInstr &MI);
+  static unsigned getFoldableCopySrcIdx(const MachineInstr &MI);
 
   void removeModOperands(MachineInstr &MI) const;
 
@@ -1258,8 +1254,8 @@ public:
   ///  e.g. src[012]_mod, omod, clamp.
   bool hasModifiers(unsigned Opcode) const;
 
-  bool hasModifiersSet(const MachineInstr &MI, AMDGPU::OpName OpName) const;
-  bool hasAnyModifiersSet(const MachineInstr &MI) const;
+  static bool hasModifiersSet(const MachineInstr &MI, AMDGPU::OpName OpName);
+  static bool hasAnyModifiersSet(const MachineInstr &MI);
 
   bool canShrink(const MachineInstr &MI,
                  const MachineRegisterInfo &MRI) const;
@@ -1435,12 +1431,12 @@ public:
   /// Returns the operand named \p Op.  If \p MI does not have an
   /// operand named \c Op, this function returns nullptr.
   LLVM_READONLY
-  MachineOperand *getNamedOperand(MachineInstr &MI,
-                                  AMDGPU::OpName OperandName) const;
+  static MachineOperand *getNamedOperand(MachineInstr &MI,
+                                         AMDGPU::OpName OperandName);
 
   LLVM_READONLY
-  const MachineOperand *getNamedOperand(const MachineInstr &MI,
-                                        AMDGPU::OpName OperandName) const {
+  static const MachineOperand *getNamedOperand(const MachineInstr &MI,
+                                               AMDGPU::OpName OperandName) {
     return getNamedOperand(const_cast<MachineInstr &>(MI), OperandName);
   }
 


### PR DESCRIPTION
This is a follow up patch from https://github.com/llvm/llvm-project/pull/161764

This
1. revert previous patch that the v_mov_b16_t16_e32 should still select idx 1 while only e64 should select idx 2
2. revert the utility function added in previous patch
3. added a src modifier check in isFoldCopyable check for v_mov_b16_t16_e64 (we never set the src mod so far, but it's a correct change)