### PR TITLE
cmse: emit `__acle_se_` symbol for aliases to entry functions

### DIFF
--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -102,6 +102,35 @@ void ARMAsmPrinter::emitXXStructor(const DataLayout &DL, const Constant *CV) {
   OutStreamer->emitValue(E, Size);
 }
 
+// An alias to a cmse entry function should also emit a `__acle_se_` symbol.
+void ARMAsmPrinter::emitCMSEVeneerAlias(const GlobalAlias &GA) {
+  const Function *BaseFn = dyn_cast_or_null<Function>(GA.getAliaseeObject());
+  if (!BaseFn || !BaseFn->hasFnAttribute("cmse_nonsecure_entry"))
+    return;
+
+  MCSymbol *AliasSym = getSymbol(&GA);
+  MCSymbol *FnSym = getSymbol(BaseFn);
+
+  MCSymbol *SEAliasSym =
+      OutContext.getOrCreateSymbol(Twine("__acle_se_") + AliasSym->getName());
+  MCSymbol *SEBaseSym =
+      OutContext.getOrCreateSymbol(Twine("__acle_se_") + FnSym->getName());
+
+  // Mirror alias linkage/visibility onto the veneer-alias symbol.
+  emitLinkage(&GA, SEAliasSym);
+  OutStreamer->emitSymbolAttribute(SEAliasSym, MCSA_ELF_TypeFunction);
+  emitVisibility(SEAliasSym, GA.getVisibility());
+
+  // emit "__acle_se_<alias> = __acle_se_<aliasee>"
+  const MCExpr *SEExpr = MCSymbolRefExpr::create(SEBaseSym, OutContext);
+  OutStreamer->emitAssignment(SEAliasSym, SEExpr);
+}
+
+void ARMAsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
+  AsmPrinter::emitGlobalAlias(M, GA);
+  emitCMSEVeneerAlias(GA);
+}
+
 void ARMAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   if (PromotedGlobals.count(GV))
     // The global was promoted into a constant pool. It should not be emitted.

--- a/llvm/lib/Target/ARM/ARMAsmPrinter.h
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.h
@@ -108,6 +108,7 @@ public:
   void emitEndOfAsmFile(Module &M) override;
   void emitXXStructor(const DataLayout &DL, const Constant *CV) override;
   void emitGlobalVariable(const GlobalVariable *GV) override;
+  void emitGlobalAlias(const Module &M, const GlobalAlias &GA) override;
 
   MCSymbol *GetCPISymbol(unsigned CPID) const override;
 
@@ -151,6 +152,8 @@ private:
   MCSymbol *GetARMJTIPICJumpTableLabel(unsigned uid) const;
 
   MCSymbol *GetARMGVSymbol(const GlobalValue *GV, unsigned char TargetFlags);
+
+  void emitCMSEVeneerAlias(const GlobalAlias &GA);
 
 public:
   /// EmitMachineConstantPoolValue - Print a machine constantpool value to

--- a/llvm/test/CodeGen/ARM/cmse-entry-alias.ll
+++ b/llvm/test/CodeGen/ARM/cmse-entry-alias.ll
@@ -1,0 +1,17 @@
+; RUN: llc -mtriple=thumbv8.1m.main %s -o - | FileCheck %s
+
+@foo = unnamed_addr alias void (), ptr @bar
+
+; CHECK: .globl bar 
+; CHECK: .globl __acle_se_bar @ @bar 
+; CHECK: .globl foo 
+; CHECK: foo = bar
+; CHECK: __acle_se_foo = __acle_se_bar
+
+define dso_local void @bar() unnamed_addr #0 {
+start:
+  ret void
+}
+
+attributes #0 = { nounwind "cmse_nonsecure_entry" }
+


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/162084

Emitting the symbol in `emitGlobalAlias` seemed most efficient, otherwise I think you'd have to traverse all aliases. I have verified that the additional symbol is picked up by `arm-none-eabi-ld` and correctly generates an entry in `veneers.o`.



