### PR TITLE
[clang][NFC] Format DeclPrinterTest partially

### DIFF
--- a/clang/unittests/AST/DeclPrinterTest.cpp
+++ b/clang/unittests/AST/DeclPrinterTest.cpp
@@ -1022,91 +1022,91 @@ TEST(DeclPrinter, TestFieldDecl2) {
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl1) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<typename T>"
-    "struct A { T a; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <typename T> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("template<typename T>"
+                              "struct A { T a; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <typename T> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl2) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<typename T = int>"
-    "struct A { T a; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <typename T = int> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("template<typename T = int>"
+                              "struct A { T a; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <typename T = int> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl3) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<class T>"
-    "struct A { T a; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <class T> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("template<class T>"
+                              "struct A { T a; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <class T> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl4) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<typename T, typename U>"
-    "struct A { T a; U b; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <typename T, typename U> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("template<typename T, typename U>"
+                              "struct A { T a; U b; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <typename T, typename U> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl5) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<int N>"
-    "struct A { int a[N]; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <int N> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("template<int N>"
+                              "struct A { int a[N]; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <int N> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl6) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<int N = 42>"
-    "struct A { int a[N]; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <int N = 42> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("template<int N = 42>"
+                              "struct A { int a[N]; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <int N = 42> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl7) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "typedef int MyInt;"
-    "template<MyInt N>"
-    "struct A { int a[N]; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <MyInt N> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX98Matches("typedef int MyInt;"
+                              "template<MyInt N>"
+                              "struct A { int a[N]; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <MyInt N> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl8) {
   ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<template<typename U> class T> struct A { };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <template <typename U> class T> struct A {}"));
+      "template<template<typename U> class T> struct A { };",
+      classTemplateDecl(hasName("A")).bind("id"),
+      "template <template <typename U> class T> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl9) {
   ASSERT_TRUE(PrintedDeclCXX98Matches(
-    "template<typename T> struct Z { };"
-    "template<template<typename U> class T = Z> struct A { };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <template <typename U> class T> struct A {}"));
+      "template<typename T> struct Z { };"
+      "template<template<typename U> class T = Z> struct A { };",
+      classTemplateDecl(hasName("A")).bind("id"),
+      "template <template <typename U> class T> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl10) {
-  ASSERT_TRUE(PrintedDeclCXX11Matches(
-    "template<typename... T>"
-    "struct A { int a; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <typename ...T> struct A {}"));
+  ASSERT_TRUE(
+      PrintedDeclCXX11Matches("template<typename... T>"
+                              "struct A { int a; };",
+                              classTemplateDecl(hasName("A")).bind("id"),
+                              "template <typename ...T> struct A {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplateDecl11) {
   ASSERT_TRUE(PrintedDeclCXX11Matches(
-    "template<typename... T>"
-    "struct A : public T... { int a; };",
-    classTemplateDecl(hasName("A")).bind("id"),
-    "template <typename ...T> struct A : public T... {}"));
+      "template<typename... T>"
+      "struct A : public T... { int a; };",
+      classTemplateDecl(hasName("A")).bind("id"),
+      "template <typename ...T> struct A : public T... {}"));
 }
 
 TEST(DeclPrinter, TestClassTemplatePartialSpecializationDecl1) {


### PR DESCRIPTION
Only `TestClassTemplateDecl*` tests have been formatted because `TestClassTemplateDecl9` is affected in #162134, and because clang-format makes the code worse for some other test cases.