### PR TITLE
[flang][mlir] Cleaning up the atomic-control testcase

### DIFF
--- a/flang/test/Lower/OpenMP/atomic-control-options.f90
+++ b/flang/test/Lower/OpenMP/atomic-control-options.f90
@@ -8,25 +8,17 @@ program test
     threads = 128
     A = 0
     B = 0
-    !UNSAFE-FP-ATOMICS: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !UNSAFE-FP-ATOMICS: } {atomic_control = #omp.atomic_control<ignore_denormal_mode = true>}
-    !IGNORE-DENORMAL: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !IGNORE-DENORMAL: } {atomic_control = #omp.atomic_control<ignore_denormal_mode = true>}
-    !FINE-GRAINED-MEMORY: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !FINE-GRAINED-MEMORY: } {atomic_control = #omp.atomic_control<fine_grained_memory = true>}
-    !REMOTE-MEMORY: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !REMOTE-MEMORY: } {atomic_control = #omp.atomic_control<remote_memory = true>}
     !$omp target parallel num_threads(threads)
     !$omp atomic
     A =  A + 1
     !$omp end target parallel
-    !UNSAFE-FP-ATOMICS: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !UNSAFE-FP-ATOMICS: } {atomic_control = #omp.atomic_control<ignore_denormal_mode = true>}
-    !IGNORE-DENORMAL: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !IGNORE-DENORMAL: } {atomic_control = #omp.atomic_control<ignore_denormal_mode = true>}
-    !FINE-GRAINED-MEMORY: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !FINE-GRAINED-MEMORY: } {atomic_control = #omp.atomic_control<fine_grained_memory = true>}
-    !REMOTE-MEMORY: omp.atomic.update %{{.*}} : !fir.ref<i32> {
     !REMOTE-MEMORY: } {atomic_control = #omp.atomic_control<remote_memory = true>}
     !$omp target parallel num_threads(threads)
     !$omp atomic capture


### PR DESCRIPTION
The testcase tests atomicupdate header which is not required for testing atomic control attributes. This induces failures due to unrelated changes (like changes in atomic update clauses). This PR removes the unrelated test to keep it minimal.