### PR TITLE
[RISCV][TableGen] Correct vTtoGetLlvmTyString for RISC-V tuples.

### DIFF
--- a/llvm/utils/TableGen/Basic/VTEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/VTEmitter.cpp
@@ -33,11 +33,11 @@ static void vTtoGetLlvmTyString(raw_ostream &OS, const Record *VT) {
   bool IsRISCVVecTuple = VT->getValueAsBit("isRISCVVecTuple");
 
   if (IsRISCVVecTuple) {
-    unsigned NElem = VT->getValueAsInt("nElem");
+    unsigned NF = VT->getValueAsInt("NF");
     unsigned Sz = VT->getValueAsInt("Size");
     OS << "TargetExtType::get(Context, \"riscv.vector.tuple\", "
           "ScalableVectorType::get(Type::getInt8Ty(Context), "
-       << (Sz / (NElem * 8)) << "), " << NElem << ")";
+       << (Sz / (NF * 8)) << "), " << NF << ")";
     return;
   }
 


### PR DESCRIPTION
RISC-V tuples use "NF" not "nElem" to store the number of fields in the segment.

This fixes a crash when lowering a function with tuple return. getReturnInfo in CallLowering.cpp does Type*->EVT->Type* and we were incorrectly converting EVT to Type*.