### PR TITLE
[Clang] Fix another parameter mapping substitution bug

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -277,8 +277,12 @@ public:
   bool VisitTemplateTypeParmType(TemplateTypeParmType *T) {
     // A lambda expression can introduce template parameters that don't have
     // corresponding template arguments yet.
-    if (T->getDepth() >= TemplateArgs.getNumLevels() ||
-        !TemplateArgs.hasTemplateArgument(T->getDepth(), T->getIndex()))
+    if (T->getDepth() >= TemplateArgs.getNumLevels())
+      return true;
+
+    // There might not be a corresponding template argument before substituting
+    // into the parameter mapping, e.g. a sizeof... expression.
+    if (!TemplateArgs.hasTemplateArgument(T->getDepth(), T->getIndex()))
       return true;
 
     TemplateArgument Arg = TemplateArgs(T->getDepth(), T->getIndex());

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -277,8 +277,8 @@ public:
   bool VisitTemplateTypeParmType(TemplateTypeParmType *T) {
     // A lambda expression can introduce template parameters that don't have
     // corresponding template arguments yet.
-    if (T->getDepth() >= TemplateArgs.getNumLevels()
-        || !TemplateArgs.hasTemplateArgument(T->getDepth(), T->getIndex()))
+    if (T->getDepth() >= TemplateArgs.getNumLevels() ||
+        !TemplateArgs.hasTemplateArgument(T->getDepth(), T->getIndex()))
       return true;
 
     TemplateArgument Arg = TemplateArgs(T->getDepth(), T->getIndex());

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -277,7 +277,8 @@ public:
   bool VisitTemplateTypeParmType(TemplateTypeParmType *T) {
     // A lambda expression can introduce template parameters that don't have
     // corresponding template arguments yet.
-    if (T->getDepth() >= TemplateArgs.getNumLevels())
+    if (T->getDepth() >= TemplateArgs.getNumLevels()
+        || !TemplateArgs.hasTemplateArgument(T->getDepth(), T->getIndex()))
       return true;
 
     TemplateArgument Arg = TemplateArgs(T->getDepth(), T->getIndex());

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1434,7 +1434,7 @@ template<typename, typename... Ts>
 concept true_types = true_int<sizeof...(Ts), void>;
 
 template<typename, typename... Ts>
-concept true_types2 = true_int<Ts...[0]{1}, void>;
+concept true_types2 = true_int<Ts...[0]{1}, void>; // cxx20-warning {{pack indexing is a C++2c extension}}
 
 template<typename... Ts>
 struct s {

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -std=c++20 -ferror-limit 0 -verify %s
+// RUN: %clang_cc1 -std=c++20 -ferror-limit 0 -verify=expected,cxx20 %s
+// RUN: %clang_cc1 -std=c++2c -ferror-limit 0 -verify=expected %s
 
 namespace PR47043 {
   template<typename T> concept True = true;
@@ -1404,4 +1405,42 @@ static_assert(!std::is_constructible_v<span<4>, array<int, 3>>);
 
 }
 
+}
+
+
+namespace GH162125 {
+template<typename, int size>
+concept true_int = (size, true);
+
+template<typename, typename... Ts>
+concept true_types = true_int<void, sizeof...(Ts)>;
+
+template<typename, typename... Ts>
+concept true_types2 = true_int<void, Ts...[0]{1}>; // cxx20-warning {{pack indexing is a C++2c extension}}
+
+template<typename... Ts>
+struct s {
+  template<typename T> requires true_types<T, Ts...> && true_types2<T, Ts...>
+  static void f(T);
+};
+void(*test)(int) = &s<bool>::f<int>;
+}
+
+namespace GH162125_reversed {
+template<int size, typename>
+concept true_int = (size, true);
+
+template<typename, typename... Ts>
+concept true_types = true_int<sizeof...(Ts), void>;
+
+template<typename, typename... Ts>
+concept true_types2 = true_int<Ts...[0]{1}, void>;
+
+template<typename... Ts>
+struct s {
+  template<typename T> requires true_types<T, Ts...> && true_types2<T, Ts...>
+  static void f(T);
+};
+
+void(*test)(int) = &s<bool>::f<int>;
 }


### PR DESCRIPTION
When a template parameter pack is named before
it can be substituted, it might not have a corresponding mapping.

Fixes #162125