### PR TITLE
[clang-tidy] Add more constexpr options to `readability-identifier-naming`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -83,14 +83,18 @@ namespace readability {
     m(Member) \
     m(ClassConstant) \
     m(ClassMember) \
+    m(ClassConstexpr) \
+    m(GlobalConstexprVariable) \
     m(GlobalConstant) \
     m(GlobalConstantPointer) \
     m(GlobalPointer) \
     m(GlobalVariable) \
+    m(LocalConstexprVariable) \
     m(LocalConstant) \
     m(LocalConstantPointer) \
     m(LocalPointer) \
     m(LocalVariable) \
+    m(StaticConstexprVariable) \
     m(StaticConstant) \
     m(StaticVariable) \
     m(Constant) \
@@ -1497,8 +1501,22 @@ StyleKind IdentifierNamingCheck::findStyleKindForField(
 StyleKind IdentifierNamingCheck::findStyleKindForVar(
     const VarDecl *Var, QualType Type,
     ArrayRef<std::optional<NamingStyle>> NamingStyles) const {
-  if (Var->isConstexpr() && NamingStyles[SK_ConstexprVariable])
-    return SK_ConstexprVariable;
+  if (Var->isConstexpr()) {
+    if (Var->isStaticDataMember() && NamingStyles[SK_ClassConstexpr])
+      return SK_ClassConstexpr;
+
+    if (Var->isFileVarDecl() && NamingStyles[SK_GlobalConstexprVariable])
+      return SK_GlobalConstexprVariable;
+
+    if (Var->isStaticLocal() && NamingStyles[SK_StaticConstexprVariable])
+      return SK_StaticConstexprVariable;
+
+    if (Var->isLocalVarDecl() && NamingStyles[SK_LocalConstexprVariable])
+      return SK_LocalConstexprVariable;
+
+    if (NamingStyles[SK_ConstexprVariable])
+      return SK_ConstexprVariable;
+  }
 
   if (!Type.isNull() && Type.isConstQualified()) {
     if (Var->isStaticDataMember() && NamingStyles[SK_ClassConstant])

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -396,7 +396,8 @@ Changes in existing checks
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check by ignoring
   declarations and macros in system headers. The documentation is also improved
-  to differentiate the general options from the specific ones.
+  to differentiate the general options from the specific ones. Options for
+  fine-grained control over ``constexpr`` variables were added.
 
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -59,6 +59,7 @@ The available options are summarized below:
 
  - :option:`AbstractClassCase`, :option:`AbstractClassPrefix`, :option:`AbstractClassSuffix`, :option:`AbstractClassIgnoredRegexp`, :option:`AbstractClassHungarianPrefix`
  - :option:`ClassCase`, :option:`ClassPrefix`, :option:`ClassSuffix`, :option:`ClassIgnoredRegexp`, :option:`ClassHungarianPrefix`
+ - :option:`ClassConstexprCase`, :option:`ClassConstexprPrefix`, :option:`ClassConstexprSuffix`, :option:`ClassConstexprIgnoredRegexp`, :option:`ClassConstexprHungarianPrefix`
  - :option:`ClassConstantCase`, :option:`ClassConstantPrefix`, :option:`ClassConstantSuffix`, :option:`ClassConstantIgnoredRegexp`, :option:`ClassConstantHungarianPrefix`
  - :option:`ClassMemberCase`, :option:`ClassMemberPrefix`, :option:`ClassMemberSuffix`, :option:`ClassMemberIgnoredRegexp`, :option:`ClassMemberHungarianPrefix`
  - :option:`ClassMethodCase`, :option:`ClassMethodPrefix`, :option:`ClassMethodSuffix`, :option:`ClassMethodIgnoredRegexp`
@@ -73,12 +74,14 @@ The available options are summarized below:
  - :option:`EnumCase`, :option:`EnumPrefix`, :option:`EnumSuffix`, :option:`EnumIgnoredRegexp`
  - :option:`EnumConstantCase`, :option:`EnumConstantPrefix`, :option:`EnumConstantSuffix`, :option:`EnumConstantIgnoredRegexp`, :option:`EnumConstantHungarianPrefix`
  - :option:`FunctionCase`, :option:`FunctionPrefix`, :option:`FunctionSuffix`, :option:`FunctionIgnoredRegexp`
+ - :option:`GlobalConstexprVariableCase`, :option:`GlobalConstexprVariablePrefix`, :option:`GlobalConstexprVariableSuffix`, :option:`GlobalConstexprVariableIgnoredRegexp`, :option:`GlobalConstexprVariableHungarianPrefix`
  - :option:`GlobalConstantCase`, :option:`GlobalConstantPrefix`, :option:`GlobalConstantSuffix`, :option:`GlobalConstantIgnoredRegexp`, :option:`GlobalConstantHungarianPrefix`
  - :option:`GlobalConstantPointerCase`, :option:`GlobalConstantPointerPrefix`, :option:`GlobalConstantPointerSuffix`, :option:`GlobalConstantPointerIgnoredRegexp`, :option:`GlobalConstantPointerHungarianPrefix`
  - :option:`GlobalFunctionCase`, :option:`GlobalFunctionPrefix`, :option:`GlobalFunctionSuffix`, :option:`GlobalFunctionIgnoredRegexp`
  - :option:`GlobalPointerCase`, :option:`GlobalPointerPrefix`, :option:`GlobalPointerSuffix`, :option:`GlobalPointerIgnoredRegexp`, :option:`GlobalPointerHungarianPrefix`
  - :option:`GlobalVariableCase`, :option:`GlobalVariablePrefix`, :option:`GlobalVariableSuffix`, :option:`GlobalVariableIgnoredRegexp`, :option:`GlobalVariableHungarianPrefix`
  - :option:`InlineNamespaceCase`, :option:`InlineNamespacePrefix`, :option:`InlineNamespaceSuffix`, :option:`InlineNamespaceIgnoredRegexp`
+ - :option:`LocalConstexprVariableCase`, :option:`LocalConstexprVariablePrefix`, :option:`LocalConstexprVariableSuffix`, :option:`LocalConstexprVariableIgnoredRegexp`, :option:`LocalConstexprVariableHungarianPrefix`
  - :option:`LocalConstantCase`, :option:`LocalConstantPrefix`, :option:`LocalConstantSuffix`, :option:`LocalConstantIgnoredRegexp`, :option:`LocalConstantHungarianPrefix`
  - :option:`LocalConstantPointerCase`, :option:`LocalConstantPointerPrefix`, :option:`LocalConstantPointerSuffix`, :option:`LocalConstantPointerIgnoredRegexp`, :option:`LocalConstantPointerHungarianPrefix`
  - :option:`LocalPointerCase`, :option:`LocalPointerPrefix`, :option:`LocalPointerSuffix`, :option:`LocalPointerIgnoredRegexp`, :option:`LocalPointerHungarianPrefix`
@@ -97,6 +100,7 @@ The available options are summarized below:
  - :option:`PublicMemberCase`, :option:`PublicMemberPrefix`, :option:`PublicMemberSuffix`, :option:`PublicMemberIgnoredRegexp`, :option:`PublicMemberHungarianPrefix`
  - :option:`PublicMethodCase`, :option:`PublicMethodPrefix`, :option:`PublicMethodSuffix`, :option:`PublicMethodIgnoredRegexp`
  - :option:`ScopedEnumConstantCase`, :option:`ScopedEnumConstantPrefix`, :option:`ScopedEnumConstantSuffix`, :option:`ScopedEnumConstantIgnoredRegexp`
+ - :option:`StaticConstexprVariableCase`, :option:`StaticConstexprVariablePrefix`, :option:`StaticConstexprVariableSuffix`, :option:`StaticConstexprVariableIgnoredRegexp`, :option:`StaticConstexprVariableHungarianPrefix`
  - :option:`StaticConstantCase`, :option:`StaticConstantPrefix`, :option:`StaticConstantSuffix`, :option:`StaticConstantIgnoredRegexp`, :option:`StaticConstantHungarianPrefix`
  - :option:`StaticVariableCase`, :option:`StaticVariablePrefix`, :option:`StaticVariableSuffix`, :option:`StaticVariableIgnoredRegexp`, :option:`StaticVariableHungarianPrefix`
  - :option:`StructCase`, :option:`StructPrefix`, :option:`StructSuffix`, :option:`StructIgnoredRegexp`
@@ -305,6 +309,58 @@ After:
     public:
       pre_foo_post();
       ~pre_foo_post();
+    };
+
+.. option:: ClassConstexprCase
+
+    When defined, the check will ensure class ``constexpr`` names conform to
+    the selected casing.
+
+.. option:: ClassConstexprPrefix
+
+    When defined, the check will ensure class ``constexpr`` names will add the
+    prefixed with the given value (regardless of casing).
+
+.. option:: ClassConstexprIgnoredRegexp
+
+    Identifier naming checks won't be enforced for class ``constexpr`` names
+    matching this regular expression.
+
+.. option:: ClassConstexprSuffix
+
+    When defined, the check will ensure class ``constexpr`` names will add the
+    suffix with the given value (regardless of casing).
+
+.. option:: ClassConstexprHungarianPrefix
+
+    When enabled, the check ensures that the declared identifier will have a
+    Hungarian notation prefix based on the declared type.
+
+For example using values of:
+
+   - ClassConstexprCase of ``lower_case``
+   - ClassConstexprPrefix of ``pre_``
+   - ClassConstexprSuffix of ``_post``
+   - ClassConstexprHungarianPrefix of ``On``
+
+Identifies and/or transforms class ``constexpr`` variable names as follows:
+
+Before:
+
+.. code-block:: c++
+
+    class FOO {
+    public:
+      static constexpr int CLASS_CONSTEXPR;
+    };
+
+After:
+
+.. code-block:: c++
+
+    class FOO {
+    public:
+      static const int pre_class_constexpr_post;
     };
 
 .. option:: ClassConstantCase
@@ -950,6 +1006,52 @@ After:
     different style.
     Default value is `true`.
 
+.. option:: GlobalConstexprVariableCase
+
+    When defined, the check will ensure global ``constexpr`` variable names
+    conform to the selected casing.
+
+.. option:: GlobalConstexprVariablePrefix
+
+    When defined, the check will ensure global ``constexpr`` variable names
+    will add the prefixed with the given value (regardless of casing).
+
+.. option:: GlobalConstexprVariableIgnoredRegexp
+
+    Identifier naming checks won't be enforced for global ``constexpr``
+    variable names matching this regular expression.
+
+.. option:: GlobalConstexprVariableSuffix
+
+    When defined, the check will ensure global ``constexpr`` variable names
+    will add the suffix with the given value (regardless of casing).
+
+.. option:: GlobalConstexprVariableHungarianPrefix
+
+    When enabled, the check ensures that the declared identifier will have a
+    Hungarian notation prefix based on the declared type.
+
+For example using values of:
+
+   - GlobalConstexprVariableCase of ``lower_case``
+   - GlobalConstexprVariablePrefix of ``pre_``
+   - GlobalConstexprVariableSuffix of ``_post``
+   - GlobalConstexprVariableHungarianPrefix of ``On``
+
+Identifies and/or transforms global ``constexpr`` variable names as follows:
+
+Before:
+
+.. code-block:: c++
+
+    constexpr unsigned ImportantValue = 69;
+
+After:
+
+.. code-block:: c++
+
+    constexpr unsigned pre_important_value_post = 69;
+
 .. option:: GlobalConstantCase
 
     When defined, the check will ensure global constant names conform to the
@@ -1227,6 +1329,52 @@ After:
     ...
     }
     } // namespace FOO_NS
+
+.. option:: LocalConstexprVariableCase
+
+    When defined, the check will ensure local ``constexpr`` variable names
+    conform to the selected casing.
+
+.. option:: LocalConstexprVariablePrefix
+
+    When defined, the check will ensure local ``constexpr`` variable names will
+    add the prefixed with the given value (regardless of casing).
+
+.. option:: LocalConstexprVariableIgnoredRegexp
+
+    Identifier naming checks won't be enforced for local ``constexpr`` variable
+    names matching this regular expression.
+
+.. option:: LocalConstexprVariableSuffix
+
+    When defined, the check will ensure local ``constexpr`` variable names will
+    add the suffix with the given value (regardless of casing).
+
+.. option:: LocalConstexprVariableHungarianPrefix
+
+    When enabled, the check ensures that the declared identifier will have a
+    Hungarian notation prefix based on the declared type.
+
+For example using values of:
+
+   - LocalConstexprVariableCase of ``lower_case``
+   - LocalConstexprVariablePrefix of ``pre_``
+   - LocalConstexprVariableSuffix of ``_post``
+   - LocalConstexprVariableHungarianPrefix of ``On``
+
+Identifies and/or transforms local ``constexpr`` variable names as follows:
+
+Before:
+
+.. code-block:: c++
+
+    void foo() { int const local_Constexpr = 420; }
+
+After:
+
+.. code-block:: c++
+
+    void foo() { int const pre_local_constexpr_post = 420; }
 
 .. option:: LocalConstantCase
 
@@ -2076,6 +2224,52 @@ After:
 .. code-block:: c++
 
     enum class FOO { pre_One_post, pre_Two_post, pre_Three_post };
+
+.. option:: StaticConstexprVariableCase
+
+    When defined, the check will ensure static ``constexpr`` variable names
+    conform to the selected casing.
+
+.. option:: StaticConstexprVariablePrefix
+
+    When defined, the check will ensure static ``constexpr`` variable names
+    will add the prefixed with the given value (regardless of casing).
+
+.. option:: StaticConstexprVariableIgnoredRegexp
+
+    Identifier naming checks won't be enforced for static ``constexpr``
+    variable names matching this regular expression.
+
+.. option:: StaticConstexprVariableSuffix
+
+    When defined, the check will ensure static ``constexpr`` variable names
+    will add the suffix with the given value (regardless of casing).
+
+.. option:: StaticConstexprVariableHungarianPrefix
+
+    When enabled, the check ensures that the declared identifier will have a
+    Hungarian notation prefix based on the declared type.
+
+For example using values of:
+
+   - StaticConstexprVariableCase of ``lower_case``
+   - StaticConstexprVariablePrefix of ``pre_``
+   - StaticConstexprVariableSuffix of ``_post``
+   - StaticConstexprVariableHungarianPrefix of ``On``
+
+Identifies and/or transforms static ``constexpr`` variable names as follows:
+
+Before:
+
+.. code-block:: c++
+
+    static unsigned constexpr MyConstexprStatic_array[] = {1, 2, 3};
+
+After:
+
+.. code-block:: c++
+
+    static unsigned constexpr pre_my_constexpr_static_array_post[] = {1, 2, 3};
 
 .. option:: StaticConstantCase
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -10,6 +10,8 @@
 // RUN:     readability-identifier-naming.ClassConstantCase: CamelCase, \
 // RUN:     readability-identifier-naming.ClassConstantPrefix: 'k', \
 // RUN:     readability-identifier-naming.ClassMemberCase: CamelCase, \
+// RUN:     readability-identifier-naming.ClassConstexprCase: CamelCase, \
+// RUN:     readability-identifier-naming.GlobalConstexprVariableCase: UPPER_CASE, \
 // RUN:     readability-identifier-naming.ClassMethodCase: camelBack, \
 // RUN:     readability-identifier-naming.ConceptCase: CamelCase, \
 // RUN:     readability-identifier-naming.ConstantCase: UPPER_CASE, \
@@ -27,6 +29,7 @@
 // RUN:     readability-identifier-naming.GlobalVariableCase: lower_case, \
 // RUN:     readability-identifier-naming.GlobalVariablePrefix: 'g_', \
 // RUN:     readability-identifier-naming.InlineNamespaceCase: lower_case, \
+// RUN:     readability-identifier-naming.LocalConstexprVariableCase: CamelCase, \
 // RUN:     readability-identifier-naming.LocalConstantCase: CamelCase, \
 // RUN:     readability-identifier-naming.LocalConstantPrefix: 'k', \
 // RUN:     readability-identifier-naming.LocalVariableCase: lower_case, \
@@ -47,6 +50,7 @@
 // RUN:     readability-identifier-naming.ParameterPackCase: camelBack, \
 // RUN:     readability-identifier-naming.PureFunctionCase: lower_case, \
 // RUN:     readability-identifier-naming.PureMethodCase: camelBack, \
+// RUN:     readability-identifier-naming.StaticConstexprVariableCase: UPPER_CASE, \
 // RUN:     readability-identifier-naming.StaticConstantCase: UPPER_CASE, \
 // RUN:     readability-identifier-naming.StaticVariableCase: camelBack, \
 // RUN:     readability-identifier-naming.StaticVariablePrefix: 's_', \
@@ -186,8 +190,8 @@ enum class EMyEnumeration {
 };
 
 constexpr int ConstExpr_variable = MyConstant;
-// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for constexpr variable 'ConstExpr_variable'
-// CHECK-FIXES: constexpr int const_expr_variable = MY_CONSTANT;
+// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global constexpr variable 'ConstExpr_variable'
+// CHECK-FIXES: constexpr int CONST_EXPR_VARIABLE = MY_CONSTANT;
 
 class my_class {
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'my_class'
@@ -208,7 +212,7 @@ public:
 private:
   const int MEMBER_one_1 = ConstExpr_variable;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for constant member 'MEMBER_one_1'
-// CHECK-FIXES: const int member_one_1 = const_expr_variable;
+// CHECK-FIXES: const int member_one_1 = CONST_EXPR_VARIABLE;
   int member2 = 2;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for private member 'member2'
 // CHECK-FIXES: int __member2 = 2;
@@ -276,6 +280,9 @@ class CMyWellNamedClass2 : public my_class {
   int my_Other_Bad_Member = 42;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for private member 'my_Other_Bad_Member'
   // CHECK-FIXES: int __my_Other_Bad_Member = 42;
+  static constexpr int my_Other_Other_Bad_Member = 69;
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for class constexpr 'my_Other_Other_Bad_Member'
+  // CHECK-FIXES: static constexpr int MyOtherOtherBadMember = 69;
 public:
   CMyWellNamedClass2() = default;
   CMyWellNamedClass2(CMyWellNamedClass2 const&) = default;
@@ -447,12 +454,18 @@ void global_function(int PARAMETER_1, int const CONST_parameter) {
     static const int THIS_static_ConsTant = 4;
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: invalid case style for static constant 'THIS_static_ConsTant'
 // CHECK-FIXES: static const int THIS_STATIC_CONS_TANT = 4;
+    static constexpr int THIS_static_ConstExpr = 4;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: invalid case style for static constexpr variable 'THIS_static_ConstExpr'
+// CHECK-FIXES: static constexpr int THIS_STATIC_CONST_EXPR = 4;
     static int THIS_static_variable;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for static variable 'THIS_static_variable'
 // CHECK-FIXES: static int s_thisStaticVariable;
     int const local_Constant = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for local constant 'local_Constant'
 // CHECK-FIXES: int const kLocalConstant = 3;
+    int constexpr local_Constexpr = 3;
+// CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for local constexpr variable 'local_Constexpr'
+// CHECK-FIXES: int constexpr LocalConstexpr = 3;
     int LOCAL_VARIABLE;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for local variable 'LOCAL_VARIABLE'
 // CHECK-FIXES: int local_variable;


### PR DESCRIPTION
Add more constexpr options to `readability-identifier-naming` check such as:
- `ClassConstexpr*`
- `GlobalConstexprVariable*`
- `LocalConstexprVariable*`
-  `StaticConstexprVariable*`

closes #54110