### PR TITLE
[Flang][Docs] Clean up flang/docs/IntrinsicTypes.md documentation

### DIFF
--- a/flang/docs/IntrinsicTypes.md
+++ b/flang/docs/IntrinsicTypes.md
@@ -34,7 +34,7 @@ f18 supports the following type and kind combinations:
 | INTEGER(KIND=4) | 32-bit two's-complement integer |
 | INTEGER(KIND=8) | 64-bit two's-complement integer |
 | INTEGER(KIND=16) | 128-bit two's-complement integer |
-| REAL(KIND=2) | 16-bit IEEE 754 binary16 (5e11m) |  
+| REAL(KIND=2) | 16-bit IEEE 754 binary16 (5e11m) |
 | REAL(KIND=3) | 16-bit upper half of 32-bit IEEE 754 binary32 (8e8m) |
 | REAL(KIND=4) | 32-bit IEEE 754 binary32 (8e24m) |
 | REAL(KIND=8) | 64-bit IEEE 754 binary64 (11e53m) |
@@ -43,13 +43,13 @@ f18 supports the following type and kind combinations:
 | COMPLEX(KIND=2) | Two 16-bit IEEE 754 binary16 |
 | COMPLEX(KIND=3) | Two 16-bit upper half of 32-bit IEEE 754 binary32 |
 | COMPLEX(KIND=4) | Two 32-bit IEEE 754 binary32 |
-| COMPLEX(KIND=8) | Two 64-bit IEEE 754 binary64 | 
+| COMPLEX(KIND=8) | Two 64-bit IEEE 754 binary64 |
 | COMPLEX(KIND=10) | Two 80-bit extended precisions values |
 | COMPLEX(KIND=16) | Two 128-bit IEEE 754 binary128 |
 | LOGICAL(KIND=1) | 8-bit integer |
-| LOGICAL(KIND=2) | 16-bit integer | 
+| LOGICAL(KIND=2) | 16-bit integer |
 | LOGICAL(KIND=4) | 32-bit integer |
-| LOGICAL(KIND=8) | 64-bit integer | 
+| LOGICAL(KIND=8) | 64-bit integer |
 
 * No [double-double](https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format)
 quad precision type is supported.
@@ -59,9 +59,9 @@ quad precision type is supported.
 
 f18 defaults to the following kinds for these types:
 
-* `INTEGER` 4  
-* `REAL` 4 
-* `COMPLEX` 4   
+* `INTEGER` 4
+* `REAL` 4
+* `COMPLEX` 4
 * `DOUBLE PRECISION` 8
 * `LOGICAL` 4
 
@@ -70,8 +70,8 @@ may be freely mixed. Module files encode the kind value for every entity.
 
 #### Modifying the default kind with default-real-8.  
 
-* `REAL` 8  
-* `DOUBLE PRECISION` 8   
+* `REAL` 8
+* `DOUBLE PRECISION` 8
 * `COMPLEX` 8
 
 #### Modifying the default kind with default-integer-8:  

--- a/flang/docs/IntrinsicTypes.md
+++ b/flang/docs/IntrinsicTypes.md
@@ -30,7 +30,7 @@ f18 supports the following type and kind combinations:
 | Type | Description |
 | :--: | :---------: |
 | INTEGER(KIND=1) | 8-bit two's-complement integer |
-| INTEGER(KIND=2) | 16-bit two's-complement integer | 
+| INTEGER(KIND=2) | 16-bit two's-complement integer |
 | INTEGER(KIND=4) | 32-bit two's-complement integer |
 | INTEGER(KIND=8) | 64-bit two's-complement integer |
 | INTEGER(KIND=16) | 128-bit two's-complement integer |
@@ -106,13 +106,13 @@ to interface with other languages.
 
 * `.TRUE.` is `-1_kind`.
 * `.FALSE.` is `0_kind`.
-* Any other values result in undefined behavior.  
-* Values with a low-bit set are treated as `.TRUE.`.  
-* Values with a low-bit clear are treated as `.FALSE.`.  
+* Any other values result in undefined behavior.
+* Values with a low-bit set are treated as `.TRUE.`.
+* Values with a low-bit clear are treated as `.FALSE.`.
 
 #### IBM XLF
 
 * `.TRUE.` is `1_kind`.
 * `.FALSE.` is `0_kind`.
-* Values with a low-bit set are treated as `.TRUE.`.  
-* Values with a low-bit clear are treated as `.FALSE.`.  
+* Values with a low-bit set are treated as `.TRUE.`.
+* Values with a low-bit clear are treated as `.FALSE.`.

--- a/flang/docs/IntrinsicTypes.md
+++ b/flang/docs/IntrinsicTypes.md
@@ -25,90 +25,94 @@ in [Character.md](Character.md).
 
 ## Supported TYPES and KINDS
 
-Here are the type and kind combinations supported in f18:
+f18 supports the following type and kind combinations:
 
-INTEGER(KIND=1) 8-bit two's-complement integer  
-INTEGER(KIND=2) 16-bit two's-complement integer  
-INTEGER(KIND=4) 32-bit two's-complement integer  
-INTEGER(KIND=8) 64-bit two's-complement integer  
-INTEGER(KIND=16) 128-bit two's-complement integer  
+| Type | Description |
+| :--: | :---------: |
+| INTEGER(KIND=1) | 8-bit two's-complement integer |
+| INTEGER(KIND=2) | 16-bit two's-complement integer | 
+| INTEGER(KIND=4) | 32-bit two's-complement integer |
+| INTEGER(KIND=8) | 64-bit two's-complement integer |
+| INTEGER(KIND=16) | 128-bit two's-complement integer |
+| REAL(KIND=2) | 16-bit IEEE 754 binary16 (5e11m) |  
+| REAL(KIND=3) | 16-bit upper half of 32-bit IEEE 754 binary32 (8e8m) |
+| REAL(KIND=4) | 32-bit IEEE 754 binary32 (8e24m) |
+| REAL(KIND=8) | 64-bit IEEE 754 binary64 (11e53m) |
+| REAL(KIND=10) | 80-bit extended precision with explicit normalization bit (15e64m) |
+| REAL(KIND=16) | 128-bit IEEE 754 binary128 (15e113m) |
+| COMPLEX(KIND=2) | Two 16-bit IEEE 754 binary16 |
+| COMPLEX(KIND=3) | Two 16-bit upper half of 32-bit IEEE 754 binary32 |
+| COMPLEX(KIND=4) | Two 32-bit IEEE 754 binary32 |
+| COMPLEX(KIND=8) | Two 64-bit IEEE 754 binary64 | 
+| COMPLEX(KIND=10) | Two 80-bit extended precisions values |
+| COMPLEX(KIND=16) | Two 128-bit IEEE 754 binary128 |
+| LOGICAL(KIND=1) | 8-bit integer |
+| LOGICAL(KIND=2) | 16-bit integer | 
+| LOGICAL(KIND=4) | 32-bit integer |
+| LOGICAL(KIND=8) | 64-bit integer | 
 
-REAL(KIND=2) 16-bit IEEE 754 binary16 (5e11m)  
-REAL(KIND=3) 16-bit upper half of 32-bit IEEE 754 binary32 (8e8m)  
-REAL(KIND=4) 32-bit IEEE 754 binary32 (8e24m)  
-REAL(KIND=8) 64-bit IEEE 754 binary64 (11e53m)  
-REAL(KIND=10) 80-bit extended precision with explicit normalization bit (15e64m)  
-REAL(KIND=16) 128-bit IEEE 754 binary128 (15e113m)  
-
-COMPLEX(KIND=2) Two 16-bit IEEE 754 binary16  
-COMPLEX(KIND=3) Two 16-bit upper half of 32-bit IEEE 754 binary32  
-COMPLEX(KIND=4) Two 32-bit IEEE 754 binary32  
-COMPLEX(KIND=8) Two 64-bit IEEE 754 binary64  
-COMPLEX(KIND=10) Two 80-bit extended precisions values  
-COMPLEX(KIND=16) Two 128-bit IEEE 754 binary128  
-
-No
-[double-double
-](https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format)
+* No [double-double](https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format)
 quad precision type is supported.
-
-LOGICAL(KIND=1) 8-bit integer  
-LOGICAL(KIND=2) 16-bit integer  
-LOGICAL(KIND=4) 32-bit integer  
-LOGICAL(KIND=8) 64-bit integer  
-
-No 128-bit logical support.
+* No 128-bit logical support.
 
 ### Defaults kinds
 
-INTEGER 4  
-REAL 4  
-COMPLEX 4  
-DOUBLE PRECISION 8  
-LOGICAL 4  
+f18 defaults to the following kinds for these types:
 
-#### Modifying the default kind with default-real-8.  
-REAL 8  
-DOUBLE PRECISION  8  
-COMPLEX 8  
-
-#### Modifying the default kind with default-integer-8:  
-INTEGER 8
-LOGICAL 8
+* `INTEGER` 4  
+* `REAL` 4 
+* `COMPLEX` 4   
+* `DOUBLE PRECISION` 8
+* `LOGICAL` 4
 
 Modules compiled with different default-real and default-integer kinds
-may be freely mixed.
-Module files encode the kind value for every entity.
+may be freely mixed. Module files encode the kind value for every entity.
+
+#### Modifying the default kind with default-real-8.  
+
+* `REAL` 8  
+* `DOUBLE PRECISION` 8   
+* `COMPLEX` 8
+
+#### Modifying the default kind with default-integer-8:  
+
+* `INTEGER` 8
+* `LOGICAL` 8
 
 ## Representation of LOGICAL variables
 
-The default logical is `LOGICAL(KIND=4)`.
+The Fortran standard specifies that a logical has two values, `.TRUE.` and
+`.FALSE.`, but does not specify their internal representation.
 
-Logical literal constants with kind 1, 2, 4, and 8
-share the following characteristics:   
-.TRUE. is represented as 1_kind  
-.FALSE. is represented as 0_kind  
+Flang specifies that logical literal constants with `KIND=[1|2|4|8]` share the
+following characteristics:
 
-Tests for true is *integer value is not zero*.
+* `.TRUE.` is `1_kind`.
+* `.FALSE.` is `0_kind`.
+* A true test is `<integer value> .NE. 0_kind`.
 
-The implementation matches gfortran.
-
-Programs should not use integer values in LOGICAL contexts or
-use LOGICAL values to interface with other languages.
+Programs should not use integer values in LOGICAL contexts or use LOGICAL values
+to interface with other languages.
 
 ### Representations of LOGICAL variables in other compilers
 
-#### Intel ifort / NVIDA nvfortran / PGI pgf90
-.TRUE. is represented as -1_kind  
-.FALSE. is represented as 0_kind  
-Any other values result in undefined behavior.  
+#### GNU gfortran
 
-Values with a low-bit set are treated as .TRUE..  
-Values with a low-bit clear are treated as .FALSE..  
+* `.TRUE.` is `1_kind`.
+* `.FALSE.` is `0_kind`.
+* A true test is `<integer value> .NE. 0_kind`.
+
+#### Intel ifort / NVIDA nvfortran / PGI pgf90
+
+* `.TRUE.` is `-1_kind`.
+* `.FALSE.` is `0_kind`.
+* Any other values result in undefined behavior.  
+* Values with a low-bit set are treated as `.TRUE.`.  
+* Values with a low-bit clear are treated as `.FALSE.`.  
 
 #### IBM XLF
-.TRUE. is represented as 1_kind  
-.FALSE. is represented as 0_kind  
 
-Values with a low-bit set are treated as .TRUE..  
-Values with a low-bit clear are treated as .FALSE..  
+* `.TRUE.` is `1_kind`.
+* `.FALSE.` is `0_kind`.
+* Values with a low-bit set are treated as `.TRUE.`.  
+* Values with a low-bit clear are treated as `.FALSE.`.  

--- a/flang/docs/IntrinsicTypes.md
+++ b/flang/docs/IntrinsicTypes.md
@@ -14,13 +14,13 @@ local:
 ---
 ```
 
-Intrinsic types are integer, real, complex, character, and logical.
-All intrinsic types have a kind type parameter called KIND,
+Intrinsic types are `INTEGER`, `REAL`, `COMPLEX`, `CHARACTER`, and `LOGICAL`.
+All intrinsic types have a kind type parameter called `KIND`,
 which determines the representation method for the specified type.
-The intrinsic type character also has a length type parameter called LEN,
+The intrinsic type character also has a length type parameter called `LEN`,
 which determines the length of the character string.
 
-The implementation of `CHARACTER` type in f18 is described
+The implementation of the `CHARACTER` type in f18 is described
 in [Character.md](Character.md).
 
 ## Supported TYPES and KINDS
@@ -65,16 +65,17 @@ f18 defaults to the following kinds for these types:
 * `DOUBLE PRECISION` 8
 * `LOGICAL` 4
 
-Modules compiled with different default-real and default-integer kinds
-may be freely mixed. Module files encode the kind value for every entity.
+Modules compiled with different `-fdefault-real-<kind>` and
+`-f-default-integer-<kind>` may be freely mixed. Module files encode the kind
+value for every entity.
 
-#### Modifying the default kind with default-real-8.  
+#### Modifying the default kind with -fdefault-real-8:
 
 * `REAL` 8
 * `DOUBLE PRECISION` 8
 * `COMPLEX` 8
 
-#### Modifying the default kind with default-integer-8:  
+#### Modifying the default kind with -fdefault-integer-8:
 
 * `INTEGER` 8
 * `LOGICAL` 8


### PR DESCRIPTION
Light cleanup of the IntrinsicTypes.md documentation:

  - Don't rely on GFortran for description of `LOGICAL` implementation.
  - Highlight some keywords.
  - Add a table for the supported `TYPES` and `KINDS`.
  - Spell out `-fdefault-[real|integer]-<kind>`.
