### PR TITLE
[NFC][clang] Prefer triple overload of lookupTarget

### DIFF
--- a/clang/lib/Testing/CommandLineArgs.cpp
+++ b/clang/lib/Testing/CommandLineArgs.cpp
@@ -103,7 +103,8 @@ std::string getAnyTargetForTesting() {
     StringRef TargetName(Target.getName());
     if (TargetName == "x86-64")
       TargetName = "x86_64";
-    if (llvm::TargetRegistry::lookupTarget(llvm::Triple(TargetName), Error) == &Target) {
+    if (llvm::TargetRegistry::lookupTarget(llvm::Triple(TargetName), Error) ==
+        &Target) {
       return std::string(TargetName);
     }
   }

--- a/clang/lib/Testing/CommandLineArgs.cpp
+++ b/clang/lib/Testing/CommandLineArgs.cpp
@@ -103,7 +103,7 @@ std::string getAnyTargetForTesting() {
     StringRef TargetName(Target.getName());
     if (TargetName == "x86-64")
       TargetName = "x86_64";
-    if (llvm::TargetRegistry::lookupTarget(TargetName, Error) == &Target) {
+    if (llvm::TargetRegistry::lookupTarget(llvm::Triple(TargetName), Error) == &Target) {
       return std::string(TargetName);
     }
   }

--- a/clang/unittests/Driver/ToolChainTest.cpp
+++ b/clang/unittests/Driver/ToolChainTest.cpp
@@ -442,7 +442,7 @@ TEST(ToolChainTest, ParsedClangName) {
 TEST(ToolChainTest, GetTargetAndMode) {
   llvm::InitializeAllTargets();
   std::string IgnoredError;
-  if (!llvm::TargetRegistry::lookupTarget("x86_64", IgnoredError))
+  if (!llvm::TargetRegistry::lookupTarget(llvm::Triple("x86_64"), IgnoredError))
     GTEST_SKIP();
 
   ParsedClangName Res = ToolChain::getTargetAndModeFromProgramName("clang");


### PR DESCRIPTION
The string overload will be deprecated soon, similar to other functions in TargetRegistry.