### PR TITLE
[NFC][Flang] Prefer triple overloads of lookupTarget

### DIFF
--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -344,9 +344,10 @@ bool CompilerInstance::setUpTargetMachine() {
   const std::string &theTriple = targetOpts.triple;
 
   // Create `Target`
+  const llvm::Triple triple(theTriple);
   std::string error;
   const llvm::Target *theTarget =
-      llvm::TargetRegistry::lookupTarget(theTriple, error);
+      llvm::TargetRegistry::lookupTarget(triple, error);
   if (!theTarget) {
     getDiagnostics().Report(clang::diag::err_fe_unable_to_create_target)
         << error;
@@ -365,13 +366,12 @@ bool CompilerInstance::setUpTargetMachine() {
   tOpts.EnableAIXExtendedAltivecABI = targetOpts.EnableAIXExtendedAltivecABI;
 
   targetMachine.reset(theTarget->createTargetMachine(
-      llvm::Triple(theTriple), /*CPU=*/targetOpts.cpu,
+      triple, /*CPU=*/targetOpts.cpu,
       /*Features=*/featuresStr, /*Options=*/tOpts,
       /*Reloc::Model=*/CGOpts.getRelocationModel(),
       /*CodeModel::Model=*/cm, OptLevel));
   assert(targetMachine && "Failed to create TargetMachine");
   if (cm.has_value()) {
-    const llvm::Triple triple(theTriple);
     if ((cm == llvm::CodeModel::Medium || cm == llvm::CodeModel::Large) &&
         triple.getArch() == llvm::Triple::x86_64) {
       targetMachine->setLargeDataThreshold(CGOpts.LargeDataThreshold);

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -316,13 +316,14 @@ createTargetMachine(llvm::StringRef targetTriple, std::string &error) {
   std::string triple{targetTriple};
   if (triple.empty())
     triple = llvm::sys::getDefaultTargetTriple();
+  llvm::Triple parsedTriple(triple);
 
   const llvm::Target *theTarget =
-      llvm::TargetRegistry::lookupTarget(triple, error);
+      llvm::TargetRegistry::lookupTarget(parsedTriple, error);
   if (!theTarget)
     return nullptr;
   return std::unique_ptr<llvm::TargetMachine>{
-      theTarget->createTargetMachine(llvm::Triple(triple), /*CPU=*/"",
+      theTarget->createTargetMachine(parsedTriple, /*CPU=*/"",
                                      /*Features=*/"", llvm::TargetOptions(),
                                      /*Reloc::Model=*/std::nullopt)};
 }

--- a/flang/tools/flang-driver/fc1_main.cpp
+++ b/flang/tools/flang-driver/fc1_main.cpp
@@ -46,8 +46,8 @@ static int printSupportedCPUs(llvm::StringRef triple) {
   // the target machine will handle the mcpu printing
   llvm::TargetOptions targetOpts;
   std::unique_ptr<llvm::TargetMachine> targetMachine(
-      target->createTargetMachine(parsedTriple, "", "+cpuhelp",
-                                  targetOpts, std::nullopt));
+      target->createTargetMachine(parsedTriple, "", "+cpuhelp", targetOpts,
+                                  std::nullopt));
   return 0;
 }
 

--- a/flang/tools/flang-driver/fc1_main.cpp
+++ b/flang/tools/flang-driver/fc1_main.cpp
@@ -34,9 +34,10 @@ using namespace Fortran::frontend;
 
 /// Print supported cpus of the given target.
 static int printSupportedCPUs(llvm::StringRef triple) {
+  llvm::Triple parsedTriple(triple);
   std::string error;
   const llvm::Target *target =
-      llvm::TargetRegistry::lookupTarget(triple, error);
+      llvm::TargetRegistry::lookupTarget(parsedTriple, error);
   if (!target) {
     llvm::errs() << error;
     return 1;
@@ -45,7 +46,7 @@ static int printSupportedCPUs(llvm::StringRef triple) {
   // the target machine will handle the mcpu printing
   llvm::TargetOptions targetOpts;
   std::unique_ptr<llvm::TargetMachine> targetMachine(
-      target->createTargetMachine(llvm::Triple(triple), "", "+cpuhelp",
+      target->createTargetMachine(parsedTriple, "", "+cpuhelp",
                                   targetOpts, std::nullopt));
   return 0;
 }


### PR DESCRIPTION
The overloads accepting a string will be deprecated soon, like other functions in TargetRegistry.