### PR TITLE
[NFC][MLIR] Prefer triple overload of lookupTarget

### DIFF
--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -66,8 +66,8 @@ ModuleToObject::getOrCreateTargetMachine() {
   }
 
   // Create the target machine using the target.
-  targetMachine.reset(target->createTargetMachine(parsedTriple, chip,
-                                                  features, {}, {}));
+  targetMachine.reset(
+      target->createTargetMachine(parsedTriple, chip, features, {}, {}));
   if (!targetMachine)
     return std::nullopt;
   return targetMachine.get();

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -56,8 +56,9 @@ ModuleToObject::getOrCreateTargetMachine() {
     return targetMachine.get();
   // Load the target.
   std::string error;
+  llvm::Triple parsedTriple(triple);
   const llvm::Target *target =
-      llvm::TargetRegistry::lookupTarget(triple, error);
+      llvm::TargetRegistry::lookupTarget(parsedTriple, error);
   if (!target) {
     getOperation().emitError()
         << "Failed to lookup target for triple '" << triple << "' " << error;
@@ -65,7 +66,7 @@ ModuleToObject::getOrCreateTargetMachine() {
   }
 
   // Create the target machine using the target.
-  targetMachine.reset(target->createTargetMachine(llvm::Triple(triple), chip,
+  targetMachine.reset(target->createTargetMachine(parsedTriple, chip,
                                                   features, {}, {}));
   if (!targetMachine)
     return std::nullopt;

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -289,7 +289,7 @@ SerializeGPUModuleBase::assembleIsa(StringRef isa) {
   llvm::Triple triple(llvm::Triple::normalize(targetTriple));
   std::string error;
   const llvm::Target *target =
-      llvm::TargetRegistry::lookupTarget(triple.normalize(), error);
+      llvm::TargetRegistry::lookupTarget(triple, error);
   if (!target) {
     emitError(loc, Twine("failed to lookup target: ") + error);
     return std::nullopt;

--- a/mlir/lib/Target/LLVMIR/Transforms/TargetUtils.cpp
+++ b/mlir/lib/Target/LLVMIR/Transforms/TargetUtils.cpp
@@ -43,16 +43,17 @@ getTargetMachine(mlir::LLVM::TargetAttrInterface attr) {
       llvm::cast_if_present<LLVM::TargetFeaturesAttr>(attr.getFeatures());
   std::string features = featuresAttr ? featuresAttr.getFeaturesString() : "";
 
+  llvm::Triple parsedTriple(triple);
   std::string error;
   const llvm::Target *target =
-      llvm::TargetRegistry::lookupTarget(triple, error);
+      llvm::TargetRegistry::lookupTarget(parsedTriple, error);
   if (!target || !error.empty()) {
     LDBG() << "Looking up target '" << triple << "' failed: " << error << "\n";
     return failure();
   }
 
   return std::unique_ptr<llvm::TargetMachine>(target->createTargetMachine(
-      llvm::Triple(triple), chipAKAcpu, features, {}, {}));
+      parsedTriple, chipAKAcpu, features, {}, {}));
 }
 
 FailureOr<llvm::DataLayout>

--- a/mlir/lib/Target/LLVMIR/Transforms/TargetUtils.cpp
+++ b/mlir/lib/Target/LLVMIR/Transforms/TargetUtils.cpp
@@ -52,8 +52,8 @@ getTargetMachine(mlir::LLVM::TargetAttrInterface attr) {
     return failure();
   }
 
-  return std::unique_ptr<llvm::TargetMachine>(target->createTargetMachine(
-      parsedTriple, chipAKAcpu, features, {}, {}));
+  return std::unique_ptr<llvm::TargetMachine>(
+      target->createTargetMachine(parsedTriple, chipAKAcpu, features, {}, {}));
 }
 
 FailureOr<llvm::DataLayout>


### PR DESCRIPTION
The overloads accepting a string will be deprecated soon, similar to other functions in TargetRegistry.