### PR TITLE
[llvm-driver] Remove llvm-profdata from the driver

### DIFF
--- a/llvm/tools/llvm-profdata/CMakeLists.txt
+++ b/llvm/tools/llvm-profdata/CMakeLists.txt
@@ -10,9 +10,6 @@ add_llvm_tool(llvm-profdata
 
   DEPENDS
   intrinsics_gen
-  GENERATE_DRIVER
   )
 
-if(NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
-  target_link_libraries(llvm-profdata PRIVATE LLVMDebuginfod)
-endif()
+target_link_libraries(llvm-profdata PRIVATE LLVMDebuginfod)

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -3464,10 +3464,7 @@ static int order_main() {
   return 0;
 }
 
-int llvm_profdata_main(int argc, char **argvNonConst,
-                       const llvm::ToolContext &) {
-  const char **argv = const_cast<const char **>(argvNonConst);
-
+int main(int argc, const char *argv[]) {
   StringRef ProgName(sys::path::filename(argv[0]));
 
   if (argc < 2) {


### PR DESCRIPTION
llvm-profdata uses cl tool for command line parsing which declares
global options which can clash in a multicall driver build. Removing
llvm-profdata from the driver.
