### PR TITLE
[clang-tidy] Correctly add parentheses in `readability-implicit-bool-conversion`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -89,7 +89,8 @@ static void fixGenericExprCastToBool(DiagnosticBuilder &Diag,
 
   const Expr *SubExpr = Cast->getSubExpr();
 
-  bool NeedInnerParens = utils::fixit::areParensNeededForStatement(*SubExpr);
+  bool NeedInnerParens =
+      utils::fixit::areParensNeededForStatement(*SubExpr->IgnoreImpCasts());
   bool NeedOuterParens =
       Parent != nullptr && utils::fixit::areParensNeededForStatement(*Parent);
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -381,6 +381,11 @@ Changes in existing checks
   declarations and macros in system headers. The documentation is also improved
   to differentiate the general options from the specific ones.
 
+- Improved :doc:`readability-implicit-bool-conversion
+  <clang-tidy/checks/readability/implicit-bool-conversion>` check by correctly
+  adding parentheses when the inner expression are implicitly converted
+  multiple times.
+
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option
   `IgnoreAliasing`, that allows not looking at underlying types of type aliases.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -547,3 +547,13 @@ namespace PR71848 {
 // CHECK-FIXES: return static_cast<int>( foo );
   }
 }
+
+namespace PR161318 {  
+  int AddParenOutsideOfCompoundAssignOp() {
+    int val = -1;
+    while(val >>= 7) {
+    // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: implicit conversion 'int' -> 'bool' [readability-implicit-bool-conversion]
+    // CHECK-FIXES: while((val >>= 7) != 0) {
+    }
+  }
+}


### PR DESCRIPTION
For `CompoundAssignOperator` in condition, there will be two layers of `ImplicitCastExpr`, for code:
```
int val = -1;
while(val >>= 7) {
}
```
While statement's AST:
```
WhileStmt <line:4:5, line:5:5>
      |-ImplicitCastExpr <line:4:11, col:18> 'bool' <IntegralToBoolean>
      | `-ImplicitCastExpr <col:11, col:18> 'int' <LValueToRValue>
      |   `-CompoundAssignOperator <col:11, col:18> 'int' lvalue '>>=' ComputeLHSTy='int' ComputeResultTy='int'
      |     |-DeclRefExpr <col:11> 'int' lvalue Var 0x20290cb8 'val' 'int'
      |     `-IntegerLiteral <col:18> 'int' 7
      `-CompoundStmt <col:21, line:5:5>
```
This is not taken into account by the check when determining whether brackets need to be added.

Closes #161318.