### PR TITLE
[clang-tidy] Fix insertion location for certain function pointers in `cppcoreguidelines-init-variables`

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/InitVariablesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/InitVariablesCheck.cpp
@@ -108,7 +108,7 @@ void InitVariablesCheck::check(const MatchFinder::MatchResult &Result) {
         << MatchedDecl;
     if (*InitializationString != nullptr)
       Diagnostic << FixItHint::CreateInsertion(
-          utils::lexer::findNextTerminator(MatchedDecl->getLocation(),
+          utils::lexer::findNextTerminator(MatchedDecl->getEndLoc(),
                                            *Result.SourceManager,
                                            Result.Context->getLangOpts()),
           *InitializationString);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -299,6 +299,10 @@ Changes in existing checks
   an additional matcher that generalizes the copy-and-swap idiom pattern
   detection.
 
+- Improved :doc:`cppcoreguidelines-init-variables
+  <clang-tidy/checks/cppcoreguidelines/init-variables>` check by fixing the
+  insertion location for function pointers with multiple parameters.
+
 - Improved :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>` check to
   avoid false positives on inherited members in class templates.

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
@@ -151,16 +151,16 @@ namespace gh112089 {
 namespace gh161978 {
   void test() {
     bool (*fp1)(int);
-    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp1' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'fp1' is not initialized [cppcoreguidelines-init-variables]
     // CHECK-FIXES: bool (*fp1)(int) = nullptr;
     bool (*fp2)(int, int);
-    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp2' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'fp2' is not initialized [cppcoreguidelines-init-variables]
     // CHECK-FIXES: bool (*fp2)(int, int) = nullptr;
     bool (*fp3)(int, int, int);
-    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp3' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'fp3' is not initialized [cppcoreguidelines-init-variables]
     // CHECK-FIXES: bool (*fp3)(int, int, int) = nullptr;
     bool (*fp4)(int, int, int, ...);
-    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp4' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'fp4' is not initialized [cppcoreguidelines-init-variables]
     // CHECK-FIXES: bool (*fp4)(int, int, int, ...) = nullptr;
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
@@ -148,3 +148,19 @@ namespace gh112089 {
     }
 } // namespace gh112089
 
+namespace gh161978 {
+  void test() {
+    bool (*fp1)(int);
+    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp1' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-FIXES: bool (*fp1)(int) = nullptr;
+    bool (*fp2)(int, int);
+    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp2' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-FIXES: bool (*fp2)(int, int) = nullptr;
+    bool (*fp3)(int, int, int);
+    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp3' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-FIXES: bool (*fp3)(int, int, int) = nullptr;
+    bool (*fp4)(int, int, int, ...);
+    // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: variable 'fp4' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-FIXES: bool (*fp4)(int, int, int, ...) = nullptr;
+  }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
@@ -162,5 +162,9 @@ namespace gh161978 {
     bool (*fp4)(int, int, int, ...);
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'fp4' is not initialized [cppcoreguidelines-init-variables]
     // CHECK-FIXES: bool (*fp4)(int, int, int, ...) = nullptr;
+    bool (*fp5)(int, int), (*fp6)(int, int);
+    // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'fp5' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-MESSAGES: :[[@LINE-2]]:30: warning: variable 'fp6' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-FIXES: bool (*fp5)(int, int) = nullptr, (*fp6)(int, int) = nullptr;
   }
 }


### PR DESCRIPTION
This patch starts to find terminator from `VarDecl`'s end location rather than it's `getLocation()` to ignore terminator(`,`) in function paramaters list.

Kind of follow up to #112091 

Closes #161978 .