### PR TITLE
[NFC] Fix deprecated use of lookupTarget in Kaleidoscope

### DIFF
--- a/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
@@ -1228,7 +1228,8 @@ int main() {
   TheModule->setTargetTriple(Triple(TargetTriple));
 
   std::string Error;
-  auto Target = TargetRegistry::lookupTarget(TargetTriple, Error);
+  auto Target =
+      TargetRegistry::lookupTarget(TheModule->getTargetTriple(), Error);
 
   // Print an error and exit if we couldn't find the requested target.
   // This generally occurs if we've forgotten to initialise the


### PR DESCRIPTION
Related: https://github.com/llvm/llvm-project/commit/009da92e19aa7536daee1553cc65e40e1bb60372