### PR TITLE
[mlir][bufferization][NFC] Rename `resultBufferizesToMemoryWrite`

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
@@ -720,10 +720,10 @@ defaultGetBufferType(Value value, const BufferizationOptions &options,
                      SmallVector<Value> &invocationStack);
 
 /// This is the default implementation of
-/// BufferizableOpInterface::resultBufferizesToMemoryWrite. Should not be called
+/// BufferizableOpInterface::bufferizesToMemoryWrite. Should not be called
 /// from other places.
-bool defaultResultBufferizesToMemoryWrite(OpResult opResult,
-                                          const AnalysisState &state);
+bool defaultBufferizesToMemoryWrite(OpResult opResult,
+                                    const AnalysisState &state);
 
 /// This is the default implementation of
 /// BufferizableOpInterface::isRepetitiveRegion. Should not be called from other

--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td
@@ -148,8 +148,8 @@ def BufferizableOpInterface : OpInterface<"BufferizableOpInterface"> {
       InterfaceMethod<
         /*desc=*/[{
           Return `true` if the given OpResult bufferizes to a memory write.
-          This is the same property as `bufferizesToMemoryWrite`, but from The
-          perspective of OpResults.
+          This is the same property as `bufferizesToMemoryWrite(OpOperand &)`,
+          but from the perspective of OpResults.
 
           This method will never be called on OpResults that do not have a
           tensor type.
@@ -165,7 +165,7 @@ def BufferizableOpInterface : OpInterface<"BufferizableOpInterface"> {
 
              Counter-example: bufferization.alloc_tensor
              The op just allocates and does not specify the data of the tensor,
-             so resultBufferizesToMemoryWrite is overridden to return false.
+             so `bufferizesToMemoryWrite` is overridden to return false.
 
           2. At least one aliasing OpOperand bufferizes to a memory write.
 
@@ -192,14 +192,14 @@ def BufferizableOpInterface : OpInterface<"BufferizableOpInterface"> {
              write.
           }],
         /*retType=*/"bool",
-        /*methodName=*/"resultBufferizesToMemoryWrite",
+        /*methodName=*/"bufferizesToMemoryWrite",
         /*args=*/(ins "::mlir::OpResult":$opResult,
                       "const ::mlir::bufferization::AnalysisState &":$state),
         /*methodBody=*/"",
         /*defaultImplementation=*/[{
           assert(opResult.getDefiningOp() == $_op.getOperation() &&
                  "invalid OpResult");
-          return ::mlir::bufferization::detail::defaultResultBufferizesToMemoryWrite(
+          return ::mlir::bufferization::detail::defaultBufferizesToMemoryWrite(
               opResult, state);
         }]
       >,

--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationOps.td
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationOps.td
@@ -96,8 +96,8 @@ def Bufferization_AllocTensorOp : Bufferization_Op<"alloc_tensor",
                             const BufferizationOptions &options,
                             BufferizationState &state);
 
-    bool resultBufferizesToMemoryWrite(OpResult opResult,
-                                       const AnalysisState &state);
+    bool bufferizesToMemoryWrite(OpResult opResult,
+                                 const AnalysisState &state);
 
     bool bufferizesToAllocation(Value value) { return true; }
 

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -496,7 +496,7 @@ bool AnalysisState::bufferizesToMemoryWrite(Value value) const {
   auto bufferizableOp = getOptions().dynCastBufferizableOp(value);
   if (!bufferizableOp)
     return true;
-  return bufferizableOp.resultBufferizesToMemoryWrite(opResult, *this);
+  return bufferizableOp.bufferizesToMemoryWrite(opResult, *this);
 }
 
 /// Return true if the given value is read by an op that bufferizes to a memory
@@ -882,7 +882,7 @@ bufferization::getMemRefTypeWithStaticIdentityLayout(TensorType tensorType,
 // Default implementations of interface methods
 //===----------------------------------------------------------------------===//
 
-bool bufferization::detail::defaultResultBufferizesToMemoryWrite(
+bool bufferization::detail::defaultBufferizesToMemoryWrite(
     OpResult opResult, const AnalysisState &state) {
   auto bufferizableOp = cast<BufferizableOpInterface>(opResult.getDefiningOp());
   AliasingOpOperandList opOperands =

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
@@ -195,8 +195,8 @@ LogicalResult AllocTensorOp::bufferize(RewriterBase &rewriter,
   return success();
 }
 
-bool AllocTensorOp::resultBufferizesToMemoryWrite(OpResult opResult,
-                                                  const AnalysisState &state) {
+bool AllocTensorOp::bufferizesToMemoryWrite(OpResult opResult,
+                                            const AnalysisState &state) {
   // AllocTensorOps do not write unless they have a `copy` value.
   return static_cast<bool>(getCopy());
 }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -112,8 +112,8 @@ struct LoadOpInterface
 struct NewOpInterface
     : public SparseBufferizableOpInterfaceExternalModel<NewOpInterface,
                                                         sparse_tensor::NewOp> {
-  bool resultBufferizesToMemoryWrite(Operation *op, OpResult opResult,
-                                     const AnalysisState &state) const {
+  bool bufferizesToMemoryWrite(Operation *op, OpResult opResult,
+                               const AnalysisState &state) const {
     // NewOps allocate but do not write.
     return false;
   }

--- a/mlir/lib/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -272,8 +272,8 @@ struct EmptyOpInterface
                                                     tensor::EmptyOp> {
   bool bufferizesToAllocation(Operation *op, Value value) const { return true; }
 
-  bool resultBufferizesToMemoryWrite(Operation *op, OpResult opResult,
-                                     const AnalysisState &state) const {
+  bool bufferizesToMemoryWrite(Operation *op, OpResult opResult,
+                               const AnalysisState &state) const {
     // The returned tensor does not have specified contents.
     return false;
   }


### PR DESCRIPTION
Since #161828, interface methods can be overloaded. This commit renames `resultBufferizesToMemoryWrite` to `bufferizesToMemoryWrite`, which was not possible before.
