### PR TITLE
[flang][OpenMP] Add semantics test: named COMMON + member with firstprivate+lastprivate is valid

### DIFF
--- a/flang/test/Semantics/OpenMP/omp-common-fp-lp.f90
+++ b/flang/test/Semantics/OpenMP/omp-common-fp-lp.f90
@@ -1,0 +1,20 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=51 -fsyntax-only %s 2>&1 | FileCheck %s --allow-empty
+! CHECK-NOT: error:
+
+! Regression test for issue #162033.
+! Verify that a named COMMON block can appear in a data-sharing clause together
+! with one of its members in another clause on the same construct. This is valid
+! in OpenMP >= 5.1 because:
+!  - A named COMMON in a clause is equivalent to listing all its explicit members
+!  - A list item may appear in both FIRSTPRIVATE and LASTPRIVATE on the same directive
+! OpenMP 5.0 explicitly forbade this combination.
+
+subroutine sub1()
+  common /com/ j
+  j = 10
+!$omp parallel do firstprivate(j) lastprivate(/com/)
+  do i = 1, 10
+     j = j + 1
+  end do
+!$omp end parallel do
+end


### PR DESCRIPTION
This adds a positive semantics test showing that:

- A named COMMON block in a clause is equivalent to listing all explicit members.
- The same list item may appear in both firstprivate and lastprivate on the same construct.

The reporter example in #162033 therefore conforms to OpenMP and Flang is correct to accept it. This test documents and locks in that behavior to avoid regressions.
<img width="1606" height="350" alt="image" src="https://github.com/user-attachments/assets/0b464c58-b9cc-43e0-8d1f-1c5a5b993bf6" />
