### PR TITLE
[LLVM-C] Upstream `LLVMGetOrInsertFunction` from rustc

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -146,6 +146,8 @@ Changes to the Python bindings
 Changes to the C API
 --------------------
 
+* Add `LLVMGetOrInsertFunction` to get or insert a function, replacing the combination of `LLVMGetNamedFunction` and `LLVMAddFunction`.
+
 Changes to the CodeGen infrastructure
 -------------------------------------
 

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -1207,6 +1207,22 @@ LLVM_C_ABI LLVMValueRef LLVMAddFunction(LLVMModuleRef M, const char *Name,
                                         LLVMTypeRef FunctionTy);
 
 /**
+ * Obtain or insert a function into a module.
+ *
+ * If a function with the specified name already exists in the module, it
+ * is returned. Otherwise, a new function is created in the module with the
+ * specified name and type and is returned.
+ *
+ * The returned value corresponds to a llvm::Function instance.
+ *
+ * @see llvm::Module::getOrInsertFunction()
+ */
+LLVM_C_ABI LLVMValueRef LLVMGetOrInsertFunction(LLVMModuleRef M,
+                                                const char *Name,
+                                                size_t NameLen,
+                                                LLVMTypeRef FunctionTy);
+
+/**
  * Obtain a Function value from a Module by its name.
  *
  * The returned value corresponds to a llvm::Function value.

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -2403,6 +2403,14 @@ LLVMValueRef LLVMAddFunction(LLVMModuleRef M, const char *Name,
                                GlobalValue::ExternalLinkage, Name, unwrap(M)));
 }
 
+LLVMValueRef LLVMGetOrInsertFunction(LLVMModuleRef M, const char *Name,
+                                     size_t NameLen, LLVMTypeRef FunctionTy) {
+  return wrap(unwrap(M)
+                  ->getOrInsertFunction(StringRef(Name, NameLen),
+                                        unwrap<FunctionType>(FunctionTy))
+                  .getCallee());
+}
+
 LLVMValueRef LLVMGetNamedFunction(LLVMModuleRef M, const char *Name) {
   return wrap(unwrap(M)->getFunction(Name));
 }

--- a/llvm/unittests/IR/FunctionTest.cpp
+++ b/llvm/unittests/IR/FunctionTest.cpp
@@ -625,4 +625,23 @@ TEST(FunctionTest, Personality) {
   EXPECT_FALSE(LLVMHasPersonalityFn(wrap(F)));
 }
 
+TEST(FunctionTest, LLVMGetOrInsertFunction) {
+  LLVMContext Ctx;
+  Module M("test", Ctx);
+  Type *Int8Ty = Type::getInt8Ty(Ctx);
+  FunctionType *FTy = FunctionType::get(Int8Ty, false);
+
+  // Create the function using the C API
+  LLVMValueRef FuncRef = LLVMGetOrInsertFunction(wrap(&M), "F", 1, wrap(FTy));
+
+  // Verify that the returned value is a function and has the correct type
+  Function *Func = unwrap<Function>(FuncRef);
+  EXPECT_EQ(Func->getName(), "F");
+  EXPECT_EQ(Func->getFunctionType(), FTy);
+
+  // Call LLVMGetOrInsertFunction again to ensure it returns the same function
+  LLVMValueRef FuncRef2 = LLVMGetOrInsertFunction(wrap(&M), "F", 1, wrap(FTy));
+  EXPECT_EQ(FuncRef, FuncRef2);
+}
+
 } // end namespace


### PR DESCRIPTION
Add `LLVMGetOrInsertFunction` to the C API as a thin wrapper over `Module::getOrInsertFunction`, upstreamed from [rustc](https://github.com/rust-lang/rust/blob/d773bd07d63a74adcf25ea5f4aae986be94cac5e/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp#L203).
It provides a single-call way to get or create a function declaration, avoiding `LLVMGetNamedFunction` + `LLVMAddFunction` and is more idiomatic.
