### PR TITLE
[DFAJumpThreading] Set MadeChanges only if threading happened

### DIFF
--- a/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
@@ -820,11 +820,14 @@ struct TransformDFA {
       : SwitchPaths(SwitchPaths), DT(DT), AC(AC), TTI(TTI), ORE(ORE),
         EphValues(EphValues) {}
 
-  void run() {
+  bool run() {
+    bool MadeChange = false;
     if (isLegalAndProfitableToTransform()) {
       createAllExitPaths();
+      MadeChange = true;
       NumTransforms++;
     }
+    return MadeChange;
   }
 
 private:
@@ -1426,9 +1429,8 @@ bool DFAJumpThreading::run(Function &F) {
 
   for (AllSwitchPaths SwitchPaths : ThreadableLoops) {
     TransformDFA Transform(&SwitchPaths, DT, AC, TTI, ORE, EphValues);
-    Transform.run();
-    MadeChanges = true;
-    LoopInfoBroken = true;
+    if (Transform.run())
+      MadeChanges = LoopInfoBroken = true;
   }
 
 #ifdef EXPENSIVE_CHECKS

--- a/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
@@ -821,13 +821,12 @@ struct TransformDFA {
         EphValues(EphValues) {}
 
   bool run() {
-    bool MadeChange = false;
     if (isLegalAndProfitableToTransform()) {
       createAllExitPaths();
-      MadeChange = true;
       NumTransforms++;
+      return true;
     }
-    return MadeChange;
+    return false;
   }
 
 private:


### PR DESCRIPTION
Threading may fail due to legality and profitability checks. This patch preserves the analysis if no threading happens.