### PR TITLE
Use ScaledThreshold to calculate Unroll count

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -574,6 +574,9 @@ public:
     /// The cost threshold for the unrolled loop, like Threshold, but used
     /// for partial/runtime unrolling (set to UINT_MAX to disable).
     unsigned PartialThreshold;
+    /// The cost threshold for the unrolled loop, like Threshold, but used
+    /// for calculating unroll count for loop.
+    unsigned ScaledThreshold;
     /// The cost threshold for the unrolled loop when optimizing for size, like
     /// OptSizeThreshold, but used for partial/runtime unrolling (set to
     /// UINT_MAX to disable).

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -201,6 +201,7 @@ TargetTransformInfo::UnrollingPreferences llvm::gatherUnrollingPreferences(
   UP.MaxPercentThresholdBoost = 400;
   UP.OptSizeThreshold = UnrollOptSizeThreshold;
   UP.PartialThreshold = 150;
+  UP.ScaledThreshold = 100;
   UP.PartialOptSizeThreshold = UnrollOptSizeThreshold;
   UP.Count = 0;
   UP.DefaultUnrollRuntimeCount = 8;
@@ -884,8 +885,8 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
   if (UP.PartialThreshold != NoThreshold) {
     // Reduce unroll count to be modulo of TripCount for partial unrolling.
     if (UCE.getUnrolledLoopSize(UP, count) > UP.PartialThreshold)
-      count = (std::max(UP.PartialThreshold, UP.BEInsns + 1) - UP.BEInsns) /
-        (LoopSize - UP.BEInsns);
+      count = (std::max(UP.ScaledThreshold, UP.BEInsns + 1) - UP.BEInsns) /
+              (LoopSize - UP.BEInsns);
     if (count > UP.MaxCount)
       count = UP.MaxCount;
     while (count != 0 && TripCount % count != 0)


### PR DESCRIPTION
Earlier we were using partial threshold to calculate unroll count for loop but for small loops it is giving more unroll count which is degrading the performance.Using Scaled Threshold improves the performance.