### PR TITLE
[AArch64][SVE] Share code across SVE prologue/epilogue implementations (NFCI)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -315,6 +315,8 @@ public:
   }
 
   void setStackSizeSVE(uint64_t ZPR, uint64_t PPR) {
+    assert(isAligned(Align(16), ZPR) && isAligned(Align(16), PPR) &&
+           "expected SVE stack sizes to be aligned to 16-bytes");
     StackSizeZPR = ZPR;
     StackSizePPR = PPR;
     HasCalculatedStackSizeSVE = true;
@@ -425,6 +427,8 @@ public:
 
   // Saves the CalleeSavedStackSize for SVE vectors in 'scalable bytes'
   void setSVECalleeSavedStackSize(unsigned ZPR, unsigned PPR) {
+    assert(isAligned(Align(16), ZPR) && isAligned(Align(16), PPR) &&
+           "expected SVE callee-save sizes to be aligned to 16-bytes");
     ZPRCalleeSavedStackSize = ZPR;
     PPRCalleeSavedStackSize = PPR;
     HasSVECalleeSavedStackSize = true;

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
@@ -1446,8 +1446,7 @@ void AArch64EpilogueEmitter::emitEpilogue() {
 
   auto SVECSPartitions = partitionSVECS(
       MBB,
-      SVECalleeSavesSize &&
-              SVELayout == SVEStackLayout::CalleeSavesAboveFrameRecord
+      SVELayout == SVEStackLayout::CalleeSavesAboveFrameRecord
           ? MBB.getFirstTerminator()
           : FirstGPRRestoreI,
       PPRCalleeSavesSize, ZPRCalleeSavesSize, /*IsEpilogue=*/true);

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
@@ -97,11 +97,11 @@ AArch64PrologueEpilogueCommon::AArch64PrologueEpilogueCommon(
   NeedsWinCFI = AFL.needsWinCFI(MF);
 
   // Windows unwind can't represent the required stack adjustments if we have
-  // both SVE callee-saves and dynamic stack allocations, and the frame
-  // pointer is before the SVE spills.  The allocation of the frame pointer
-  // must be the last instruction in the prologue so the unwinder can restore
-  // the stack pointer correctly. (And there isn't any unwind opcode for
-  // `addvl sp, x29, -17`.)
+  // both SVE callee-saves and dynamic stack allocations, and the frame pointer
+  // is before the SVE spills.  The allocation of the frame pointer must be the
+  // last instruction in the prologue so the unwinder can restore the stack
+  // pointer correctly. (And there isn't any unwind opcode for `addvl sp, x29,
+  // -17`.)
   //
   // Because of this, we do spills in the opposite order on Windows: first SVE,
   // then GPRs. The main side-effect of this is that it makes accessing

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
@@ -60,7 +60,6 @@ static bool isPartOfZPRCalleeSaves(MachineBasicBlock::iterator I) {
   case AArch64::PTRUE_C_B:
     return I->getFlag(MachineInstr::FrameSetup) ||
            I->getFlag(MachineInstr::FrameDestroy);
-  case AArch64::SEH_SavePReg:
   case AArch64::SEH_SaveZReg:
     return true;
   }
@@ -75,6 +74,8 @@ static bool isPartOfPPRCalleeSaves(MachineBasicBlock::iterator I) {
   case AArch64::LDR_PXI:
     return I->getFlag(MachineInstr::FrameSetup) ||
            I->getFlag(MachineInstr::FrameDestroy);
+  case AArch64::SEH_SavePReg:
+    return true;
   }
 }
 
@@ -1475,8 +1476,7 @@ void AArch64EpilogueEmitter::emitEpilogue() {
 
   // Process the SVE callee-saves to determine what space needs to be
   // deallocated.
-  auto SVEPartitions = partitionSVEEpilogue(
-      MBB,
+  auto SVEPartitions = partitionSVEEpilogue(MBB,
       SVECalleeSavedSize &&
               SVELayout == SVEStackLayout::CalleeSavesAboveFrameRecord
           ? MBB.getFirstTerminator()

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
@@ -28,8 +28,9 @@ class AArch64FunctionInfo;
 class AArch64FrameLowering;
 
 struct SVEFrameSizes {
-  StackOffset PPRCalleeSavesSize, ZPRCalleeSavesSize;
-  StackOffset PPRLocalsSize, ZPRLocalsSize;
+  struct {
+    StackOffset CalleeSavesSize, LocalsSize;
+  } PPR, ZPR;
 };
 
 class AArch64PrologueEpilogueCommon {

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
@@ -31,6 +31,7 @@ struct SVEFrameSizes {
   StackOffset PPRCalleeSavesSize, ZPRCalleeSavesSize;
   StackOffset PPRLocalsSize, ZPRLocalsSize;
 };
+
 class AArch64PrologueEpilogueCommon {
 public:
   AArch64PrologueEpilogueCommon(MachineFunction &MF, MachineBasicBlock &MBB,

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
@@ -27,6 +27,10 @@ class AArch64Subtarget;
 class AArch64FunctionInfo;
 class AArch64FrameLowering;
 
+struct SVEFrameSizes {
+  StackOffset PPRCalleeSavesSize, ZPRCalleeSavesSize;
+  StackOffset PPRLocalsSize, ZPRLocalsSize;
+};
 class AArch64PrologueEpilogueCommon {
 public:
   AArch64PrologueEpilogueCommon(MachineFunction &MF, MachineBasicBlock &MBB,
@@ -58,6 +62,8 @@ protected:
                                          uint64_t LocalStackSize) const;
 
   bool shouldCombineCSRLocalStackBump(uint64_t StackBumpBytes) const;
+
+  SVEFrameSizes getSVEStackFrameSizes() const;
 
   MachineFunction &MF;
   MachineBasicBlock &MBB;

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
@@ -32,6 +32,12 @@ public:
   AArch64PrologueEpilogueCommon(MachineFunction &MF, MachineBasicBlock &MBB,
                                 const AArch64FrameLowering &AFL);
 
+  enum class SVEStackLayout {
+    Default,
+    Split,
+    CalleeSavesAboveFrameRecord,
+  };
+
 protected:
   bool requiresGetVGCall() const;
 
@@ -68,6 +74,7 @@ protected:
   bool IsFunclet = false;   // Note: Set in derived constructors.
   bool NeedsWinCFI = false; // Note: Can be changed in emitFramePointerSetup.
   bool HomPrologEpilog = false; // Note: Set in derived constructors.
+  SVEStackLayout SVELayout = SVEStackLayout::Default;
 
   // Note: "HasWinCFI" is mutable as it can change in any "emit" function.
   mutable bool HasWinCFI = false;


### PR DESCRIPTION
This patch refactors the SVE prologue and epilogue to use a common code path for both the "Default" and "Split" SVE layouts. 

This also factors some code into common helpers, such as:
- `partitionSVECS()` (which returns the MI ranges of the PPR/ZPR callee-saves) 
- `getSVEStackFrameSizes()` (which returns the sizes of the PPR/ZPR locals/callee-saves)

Since most split-SVE layout code is now shared with the default path, there should be much less code that is only tested when split-SVE is enabled. 

This patch was prepared in a number of small steps (that should build alone). I've kept these as commits in the PR, as it may help with review. 