### PR TITLE
[libcxx] Map Windows ERROR_NETNAME_DELETED to no_such_file_or_directory

### DIFF
--- a/libcxx/src/system_error.cpp
+++ b/libcxx/src/system_error.cpp
@@ -95,6 +95,8 @@ std::optional<errc> __win_err_to_errc(int err) {
     return errc::no_lock_available;
   case ERROR_NEGATIVE_SEEK:
     return errc::invalid_argument;
+  case ERROR_NETNAME_DELETED:
+    return errc::no_such_file_or_directory;
   case ERROR_NOACCESS:
     return errc::permission_denied;
   case ERROR_NOT_ENOUGH_MEMORY:


### PR DESCRIPTION
This fixes spurious failures in
std/input.output/filesystems/fs.op.funcs/fs.op.proximate/proximate.pass.cpp on Windows.

As part of that test, libcxx tries to open a fake network path such as "//foo/a". Normally, this sets the error ERROR_BAD_NETPATH, which is mapped to no_such_file_or_directory. However occasionally, it can end up setting the error ERROR_NETNAME_DELETED instead.

Map ERROR_NETNAME_DELETED to no_such_file_or_directory just like ERROR_BAD_NETPATH is mapped. This makes these cases be treated equally within the create_file_status function in
src/filesystem/file_descriptor.h, causing the __weakly_canonical function in operations.cpp to keep iterating, rather than erroring out.