### PR TITLE
[HIP][SPIRV] Use OPT_fembed_bitcode_EQ instead of the alias OPT_fembed_bitcode_marker

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -259,7 +259,7 @@ void HIPAMDToolChain::addClangTargetOptions(
     // For SPIR-V we embed the command-line into the generated binary, in order
     // to retrieve it at JIT time and be able to do target specific compilation
     // with options that match the user-supplied ones.
-    if (!DriverArgs.hasArg(options::OPT_fembed_bitcode_marker))
+    if (!DriverArgs.hasArg(options::OPT_fembed_bitcode_EQ))
       CC1Args.push_back("-fembed-bitcode=marker");
     // For SPIR-V we want to retain the pristine output of Clang CodeGen, since
     // optimizations might lose structure / information that is necessary for

--- a/clang/test/Driver/hip-toolchain-no-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-no-rdc.hip
@@ -41,6 +41,18 @@
 // RUN:   %s -nogpuinc -nogpulib \
 // RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV %s
 
+// Only the first case where -fembed-bitcode-marker is used is relevant.
+// The next 2 cases only verify that the user's will is respected.
+// RUN: %clang -### --target=x86_64-linux-gnu \
+// RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 -fembed-bitcode=all \
+// RUN:   %s -nogpuinc -nogpulib \
+// RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV-EMBED %s
+
+// RUN: %clang -### --target=x86_64-linux-gnu \
+// RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 -fembed-bitcode=off \
+// RUN:   %s -nogpuinc -nogpulib \
+// RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV %s
+
 //
 // Compile device code in a.cu to code object for gfx803.
 //
@@ -214,3 +226,7 @@
 // AMDGCNSPIRV: {{".*clang-offload-bundler.*"}} "-type=o"
 // AMDGCNSPIRV-SAME: "-targets={{.*}}hipv4-spirv64-amd-amdhsa--amdgcnspirv,hipv4-amdgcn-amd-amdhsa--gfx900"
 // AMDGCNSPIRV-SAME: "-input=[[AMDGCNSPV_CO]]" "-input=[[GFX900_CO]]"
+
+// Only check that no confliction options are passed
+// AMDGCNSPIRV-EMBED: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-emit-llvm-bc" {{.*}}"-fembed-bitcode=marker" "-disable-llvm-passes" {{.*}} "-o" "[[AMDGCNSPV_MARKER_BC:.*bc]]"
+// AMDGCNSPIRV-EMBED: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-emit-llvm-bc" {{.*}}"-fembed-bitcode=all"{{.*}}"-fembed-bitcode=marker" {{.*}} "-o" "[[AMDGCNSPV_BC:.*bc]]" "-x" "ir" "[[AMDGCNSPV_MARKER_BC]]"

--- a/clang/test/Driver/hip-toolchain-no-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-no-rdc.hip
@@ -46,12 +46,12 @@
 // RUN: %clang -### --target=x86_64-linux-gnu \
 // RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 -fembed-bitcode=all \
 // RUN:   %s -nogpuinc -nogpulib \
-// RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV-EMBED %s
+// RUN: 2>&1 | FileCheck -check-prefixes="AMDGCNSPIRV-EMBED,AMDGCNSPIRV-NOMARKER" %s
 
 // RUN: %clang -### --target=x86_64-linux-gnu \
 // RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 -fembed-bitcode=off \
 // RUN:   %s -nogpuinc -nogpulib \
-// RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV %s
+// RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV-NOMARKER %s
 
 //
 // Compile device code in a.cu to code object for gfx803.
@@ -228,5 +228,7 @@
 // AMDGCNSPIRV-SAME: "-input=[[AMDGCNSPV_CO]]" "-input=[[GFX900_CO]]"
 
 // Only check that no confliction options are passed
-// AMDGCNSPIRV-EMBED: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-emit-llvm-bc" {{.*}}"-fembed-bitcode=marker" "-disable-llvm-passes" {{.*}} "-o" "[[AMDGCNSPV_MARKER_BC:.*bc]]"
-// AMDGCNSPIRV-EMBED: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-emit-llvm-bc" {{.*}}"-fembed-bitcode=all"{{.*}}"-fembed-bitcode=marker" {{.*}} "-o" "[[AMDGCNSPV_BC:.*bc]]" "-x" "ir" "[[AMDGCNSPV_MARKER_BC]]"
+// AMDGCNSPIRV-NOMARKER-NOT: "-fembed-bitcode=marker"
+// AMDGCNSPIRV-NOMARKER-NOT: "-fembed-bitcode-marker"
+// AMDGCNSPIRV-EMBED: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-emit-llvm-bc" {{.*}} "-disable-llvm-passes" {{.*}} "-o" "[[AMDGCNSPV_FIRST_BC:.*bc]]"
+// AMDGCNSPIRV-EMBED: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-emit-llvm-bc" {{.*}}"-fembed-bitcode=all"{{.*}} "-o" "[[AMDGCNSPV_BC:.*bc]]" "-x" "ir" "[[AMDGCNSPV_FIRST_BC]]"


### PR DESCRIPTION
This helps avoid passing conflicting options if the user specified
-fembed-bitcode= .

OPT_fembed_bitcode_marker only matches -fembed-bitcode-marker.
-fembed-bitcode=all/marker/none do not match.

If the user specifies -fembed-bitcode=all/none, we should respect it,
even if it may not make sense to us.