### PR TITLE
[clang] Mark `OverloadCandidateSet::OperatorRewriteInfo` methods as const

### DIFF
--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -1202,12 +1202,12 @@ class Sema;
 
       /// Would use of this function result in a rewrite using a different
       /// operator?
-      bool isRewrittenOperator(const FunctionDecl *FD) {
+      bool isRewrittenOperator(const FunctionDecl *FD) const {
         return OriginalOperator &&
                FD->getDeclName().getCXXOverloadedOperator() != OriginalOperator;
       }
 
-      bool isAcceptableCandidate(const FunctionDecl *FD) {
+      bool isAcceptableCandidate(const FunctionDecl *FD) const {
         if (!OriginalOperator)
           return true;
 
@@ -1234,7 +1234,7 @@ class Sema;
       }
       /// Determines whether this operator could be implemented by a function
       /// with reversed parameter order.
-      bool isReversible() {
+      bool isReversible() const {
         return AllowRewrittenCandidates && OriginalOperator &&
                (getRewrittenOverloadedOperator(OriginalOperator) != OO_None ||
                 allowsReversed(OriginalOperator));
@@ -1242,13 +1242,13 @@ class Sema;
 
       /// Determine whether reversing parameter order is allowed for operator
       /// Op.
-      bool allowsReversed(OverloadedOperatorKind Op);
+      bool allowsReversed(OverloadedOperatorKind Op) const;
 
       /// Determine whether we should add a rewritten candidate for \p FD with
       /// reversed parameter order.
       /// \param OriginalArgs are the original non reversed arguments.
       bool shouldAddReversed(Sema &S, ArrayRef<Expr *> OriginalArgs,
-                             FunctionDecl *FD);
+                             FunctionDecl *FD) const;
     };
 
   private:

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1087,14 +1087,14 @@ static bool shouldAddReversedEqEq(Sema &S, SourceLocation OpLoc,
 }
 
 bool OverloadCandidateSet::OperatorRewriteInfo::allowsReversed(
-    OverloadedOperatorKind Op) {
+    OverloadedOperatorKind Op) const {
   if (!AllowRewrittenCandidates)
     return false;
   return Op == OO_EqualEqual || Op == OO_Spaceship;
 }
 
 bool OverloadCandidateSet::OperatorRewriteInfo::shouldAddReversed(
-    Sema &S, ArrayRef<Expr *> OriginalArgs, FunctionDecl *FD) {
+    Sema &S, ArrayRef<Expr *> OriginalArgs, FunctionDecl *FD) const {
   auto Op = FD->getOverloadedOperator();
   if (!allowsReversed(Op))
     return false;


### PR DESCRIPTION
They don't mutate the object and this makes them easier to use and allows better const correctness when using Clang as a library.