### PR TITLE
[lldb] Fix TypeSystemClang::GetBasicTypeEnumeration for 128-bit int types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -849,8 +849,8 @@ lldb::BasicType TypeSystemClang::GetBasicTypeEnumeration(llvm::StringRef name) {
       {"unsigned long long int", eBasicTypeUnsignedLongLong},
 
       // "int128"
-      {"__int128_t", eBasicTypeInt128},
-      {"__uint128_t", eBasicTypeUnsignedInt128},
+      {"__int128", eBasicTypeInt128},
+      {"unsigned __int128", eBasicTypeUnsignedInt128},
 
       // "bool"
       {"bool", eBasicTypeBool},

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -849,6 +849,8 @@ lldb::BasicType TypeSystemClang::GetBasicTypeEnumeration(llvm::StringRef name) {
       {"unsigned long long int", eBasicTypeUnsignedLongLong},
 
       // "int128"
+      {"__int128_t", eBasicTypeInt128},
+      {"__uint128_t", eBasicTypeUnsignedInt128},
       {"__int128", eBasicTypeInt128},
       {"unsigned __int128", eBasicTypeUnsignedInt128},
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -849,8 +849,18 @@ lldb::BasicType TypeSystemClang::GetBasicTypeEnumeration(llvm::StringRef name) {
       {"unsigned long long int", eBasicTypeUnsignedLongLong},
 
       // "int128"
+      //
+      // The following two lines are here only
+      // for the sake of backward-compatibility.
+      // Neither "__int128_t", nor "__uint128_t" are basic-types.
+      // They are typedefs.
       {"__int128_t", eBasicTypeInt128},
       {"__uint128_t", eBasicTypeUnsignedInt128},
+      // In order to be consistent with:
+      // - gcc's C programming language extension related to 128-bit integers
+      //   https://gcc.gnu.org/onlinedocs/gcc/_005f_005fint128.html
+      // - the "BuiltinType::getName" method in LLVM
+      // the following two lines must be present:
       {"__int128", eBasicTypeInt128},
       {"unsigned __int128", eBasicTypeUnsignedInt128},
 

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -10,7 +10,7 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
 
-    def testTypedefUnwrapping(self):
+    def test(self):
         """Test that SBType.GetBasicType unwraps typedefs."""
 
         a = self.frame().FindVariable("a")
@@ -32,7 +32,5 @@ class TestCase(TestBase):
         self.assertEqual(c.GetType().GetBasicType(), int_basic_type)
         self.assertEqual(d.GetType().GetBasicType(), int_basic_type)
 
-    def testBasicTypeSize(self):
-        """Check the size of the chosen basic types."""
         self.assertEqual(self.target().FindFirstType("__int128").size, 16)
         self.assertEqual(self.target().FindFirstType("unsigned __int128").size, 16)

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -5,13 +5,10 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    def setUp(self):
-        TestBase.setUp(self)
-        self.build()
-        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
-
     def test(self):
         """Test that SBType.GetBasicType unwraps typedefs."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
 
         a = self.frame().FindVariable("a")
         self.assertTrue(a)

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -35,3 +35,7 @@ class TestCase(TestBase):
         # Check the size of the chosen basic types.
         self.assertEqual(self.target().FindFirstType("__int128").size, 16)
         self.assertEqual(self.target().FindFirstType("unsigned __int128").size, 16)
+
+        # Check the size of the chosen aliases of basic types.
+        self.assertEqual(self.target().FindFirstType("__int128_t").size, 16)
+        self.assertEqual(self.target().FindFirstType("__uint128_t").size, 16)

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -32,5 +32,6 @@ class TestCase(TestBase):
         self.assertEqual(c.GetType().GetBasicType(), int_basic_type)
         self.assertEqual(d.GetType().GetBasicType(), int_basic_type)
 
+        # Check the size of the chosen basic types.
         self.assertEqual(self.target().FindFirstType("__int128").size, 16)
         self.assertEqual(self.target().FindFirstType("unsigned __int128").size, 16)

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -5,10 +5,13 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    def test(self):
-        """Test that SBType.GetBasicType unwraps typedefs."""
+    def setUp(self):
+        TestBase.setUp(self)
         self.build()
         lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
+
+    def testTypedefUnwrapping(self):
+        """Test that SBType.GetBasicType unwraps typedefs."""
 
         a = self.frame().FindVariable("a")
         self.assertTrue(a)
@@ -28,3 +31,8 @@ class TestCase(TestBase):
         self.assertEqual(b.GetType().GetBasicType(), int_basic_type)
         self.assertEqual(c.GetType().GetBasicType(), int_basic_type)
         self.assertEqual(d.GetType().GetBasicType(), int_basic_type)
+
+    def testBasicTypeSize(self):
+        """Check the size of the chosen basic types."""
+        self.assertEqual(self.target().FindFirstType("__int128").size, 16)
+        self.assertEqual(self.target().FindFirstType("unsigned __int128").size, 16)

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -159,9 +159,9 @@ TEST_F(TestTypeSystemClang, TestGetBasicTypeFromName) {
             GetBasicQualType("unsigned long long"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeUnsignedLongLong),
             GetBasicQualType("unsigned long long int"));
-  EXPECT_EQ(GetBasicQualType(eBasicTypeInt128), GetBasicQualType("__int128_t"));
+  EXPECT_EQ(GetBasicQualType(eBasicTypeInt128), GetBasicQualType("__int128"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeUnsignedInt128),
-            GetBasicQualType("__uint128_t"));
+            GetBasicQualType("unsigned __int128"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeVoid), GetBasicQualType("void"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeBool), GetBasicQualType("bool"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeFloat), GetBasicQualType("float"));

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -159,6 +159,9 @@ TEST_F(TestTypeSystemClang, TestGetBasicTypeFromName) {
             GetBasicQualType("unsigned long long"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeUnsignedLongLong),
             GetBasicQualType("unsigned long long int"));
+  EXPECT_EQ(GetBasicQualType(eBasicTypeInt128), GetBasicQualType("__int128_t"));
+  EXPECT_EQ(GetBasicQualType(eBasicTypeUnsignedInt128),
+            GetBasicQualType("__uint128_t"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeInt128), GetBasicQualType("__int128"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeUnsignedInt128),
             GetBasicQualType("unsigned __int128"));


### PR DESCRIPTION
When we take the following C program:
```
int main() {
  return 0;
}
```
and create a statically-linked executable from it:
```
clang -static -g -o main main.c
```
Then we can observe the following `lldb` behavior:
```
$ lldb
(lldb) target create main
Current executable set to '.../main' (x86_64).
(lldb) breakpoint set --name main
Breakpoint 1: where = main`main + 11 at main.c:2:3, address = 0x000000000022aa7b
(lldb) process launch
Process 3773637 launched: '/home/me/tmp/built-in/main' (x86_64)
Process 3773637 stopped
* thread #1, name = 'main', stop reason = breakpoint 1.1
    frame #0: 0x000000000022aa7b main`main at main.c:2:3
   1   	int main() {
-> 2   	  return 0;
   3   	}
(lldb) script lldb.debugger.GetSelectedTarget().FindFirstType("__int128").size
0
(lldb) script lldb.debugger.GetSelectedTarget().FindFirstType("unsigned __int128").size
0
(lldb) quit
```
The value return by the `SBTarget::FindFirstType` method is wrong for the `__int128` and `unsigned __int128` basic types.

The proposed changes make the `TypeSystemClang::GetBasicTypeEnumeration` method consistent with `gcc` and `clang` C [language extension](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fint128.html) related to 128-bit integer types as well as with the `BuiltinType::getName` method in the LLVM codebase itself.

When the above change is applied, the behavior of the `lldb` changes in the following (desired) way:
```
$ lldb
(lldb) target create main
Current executable set to '.../main' (x86_64).
(lldb) breakpoint set --name main
Breakpoint 1: where = main`main + 11 at main.c:2:3, address = 0x000000000022aa7b
(lldb) process launch
Process 3773637 launched: '/home/me/tmp/built-in/main' (x86_64)
Process 3773637 stopped
* thread #1, name = 'main', stop reason = breakpoint 1.1
    frame #0: 0x000000000022aa7b main`main at main.c:2:3
   1   	int main() {
-> 2   	  return 0;
   3   	}
(lldb) script lldb.debugger.GetSelectedTarget().FindFirstType("__int128").size
16
(lldb) script lldb.debugger.GetSelectedTarget().FindFirstType("unsigned __int128").size
16
(lldb) quit
```