### PR TITLE
[GlobalIsel] Add failure memory order to LegalityQuery (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -115,14 +115,17 @@ struct LegalityQuery {
   struct MemDesc {
     LLT MemoryTy;
     uint64_t AlignInBits;
-    AtomicOrdering Ordering;
+    AtomicOrdering Ordering; //< For cmpxchg this is the success ordering.
+    AtomicOrdering FailureOrdering; //< For cmpxchg, otherwise NotAtomic.
 
     MemDesc() = default;
-    MemDesc(LLT MemoryTy, uint64_t AlignInBits, AtomicOrdering Ordering)
-        : MemoryTy(MemoryTy), AlignInBits(AlignInBits), Ordering(Ordering) {}
+    MemDesc(LLT MemoryTy, uint64_t AlignInBits, AtomicOrdering Ordering,
+            AtomicOrdering FailureOrdering)
+        : MemoryTy(MemoryTy), AlignInBits(AlignInBits), Ordering(Ordering),
+          FailureOrdering(FailureOrdering) {}
     MemDesc(const MachineMemOperand &MMO)
         : MemDesc(MMO.getMemoryType(), MMO.getAlign().value() * 8,
-                  MMO.getSuccessOrdering()) {}
+                  MMO.getSuccessOrdering(), MMO.getFailureOrdering()) {}
   };
 
   /// Operations which require memory can use this to place requirements on the

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -1215,7 +1215,7 @@ bool CombinerHelper::isIndexedLoadStoreLegal(GLoadStore &LdSt) const {
   LLT MemTy = LdSt.getMMO().getMemoryType();
   SmallVector<LegalityQuery::MemDesc, 2> MemDescrs(
       {{MemTy, MemTy.getSizeInBits().getKnownMinValue(),
-        AtomicOrdering::NotAtomic}});
+        AtomicOrdering::NotAtomic, AtomicOrdering::NotAtomic}});
   unsigned IndexedOpc = getIndexedOpc(LdSt.getOpcode());
   SmallVector<LLT> OpTys;
   if (IndexedOpc == TargetOpcode::G_INDEXED_STORE)

--- a/llvm/lib/CodeGen/GlobalISel/LoadStoreOpt.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LoadStoreOpt.cpp
@@ -958,7 +958,8 @@ void LoadStoreOpt::initializeStoreMergeTargetInfo(unsigned AddrSpace) {
   for (unsigned Size = 2; Size <= MaxStoreSizeToForm; Size *= 2) {
     LLT Ty = LLT::scalar(Size);
     SmallVector<LegalityQuery::MemDesc, 2> MemDescrs(
-        {{Ty, Ty.getSizeInBits(), AtomicOrdering::NotAtomic}});
+        {{Ty, Ty.getSizeInBits(), AtomicOrdering::NotAtomic,
+          AtomicOrdering::NotAtomic}});
     SmallVector<LLT> StoreTys({Ty, PtrTy});
     LegalityQuery Q(TargetOpcode::G_STORE, StoreTys, MemDescrs);
     LegalizeActionStep ActionStep = LI.getAction(Q);

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
@@ -480,18 +480,21 @@ TEST(LegalizerInfoTest, MMOAlignment) {
 
     LegacyInfo.computeTables();
 
-    EXPECT_ACTION(Legal, 0, LLT(),
-                  LegalityQuery(G_LOAD, {s32, p0},
-                                LegalityQuery::MemDesc{
-                                  s32, 32, AtomicOrdering::NotAtomic}));
-    EXPECT_ACTION(Unsupported, 0, LLT(),
-                  LegalityQuery(G_LOAD, {s32, p0},
-                                LegalityQuery::MemDesc{
-                                  s32, 16, AtomicOrdering::NotAtomic }));
-    EXPECT_ACTION(Unsupported, 0, LLT(),
-                  LegalityQuery(G_LOAD, {s32, p0},
-                                LegalityQuery::MemDesc{
-                                  s32, 8, AtomicOrdering::NotAtomic}));
+    EXPECT_ACTION(
+        Legal, 0, LLT(),
+        LegalityQuery(G_LOAD, {s32, p0},
+                      LegalityQuery::MemDesc{s32, 32, AtomicOrdering::NotAtomic,
+                                             AtomicOrdering::NotAtomic}));
+    EXPECT_ACTION(
+        Unsupported, 0, LLT(),
+        LegalityQuery(G_LOAD, {s32, p0},
+                      LegalityQuery::MemDesc{s32, 16, AtomicOrdering::NotAtomic,
+                                             AtomicOrdering::NotAtomic}));
+    EXPECT_ACTION(
+        Unsupported, 0, LLT(),
+        LegalityQuery(G_LOAD, {s32, p0},
+                      LegalityQuery::MemDesc{s32, 8, AtomicOrdering::NotAtomic,
+                                             AtomicOrdering::NotAtomic}));
   }
 
   // Test that the maximum supported alignment value isn't truncated
@@ -506,14 +509,17 @@ TEST(LegalizerInfoTest, MMOAlignment) {
 
     LegacyInfo.computeTables();
 
-    EXPECT_ACTION(Legal, 0, LLT(),
-                  LegalityQuery(G_LOAD, {s32, p0},
-                                LegalityQuery::MemDesc{s32,
-                                    MaxAlignInBits, AtomicOrdering::NotAtomic}));
-    EXPECT_ACTION(Unsupported, 0, LLT(),
-                  LegalityQuery(G_LOAD, {s32, p0},
-                                LegalityQuery::MemDesc{
-                                  s32, 8, AtomicOrdering::NotAtomic }));
+    EXPECT_ACTION(
+        Legal, 0, LLT(),
+        LegalityQuery(G_LOAD, {s32, p0},
+                      LegalityQuery::MemDesc{s32, MaxAlignInBits,
+                                             AtomicOrdering::NotAtomic,
+                                             AtomicOrdering::NotAtomic}));
+    EXPECT_ACTION(
+        Unsupported, 0, LLT(),
+        LegalityQuery(G_LOAD, {s32, p0},
+                      LegalityQuery::MemDesc{s32, 8, AtomicOrdering::NotAtomic,
+                                             AtomicOrdering::NotAtomic}));
   }
 }
 


### PR DESCRIPTION
The `cmpxchg` instruction has two memory orders, one for success and one for failure.
Prior to this patch LegalityQuery only exposed a single memory order, that of the success case. This meant that it was not generally possible to legalize `cmpxchg` instructions based on their memory orders.

Add a `FailureOrdering` field to `LegalityQuery::MemDesc`, it is only set for `cmpxchg` instructions, otherwise it is `NotAtomic`. I didn't rename `Ordering` to `SuccessOrdering` or similar to avoid breaking changes for out of tree targets.
The new field does not increase `sizeof(MemDesc)`, it falls into previous padding bits due to alignment, so I'd expect there to be no performance impact for this change.

Verified via check-llvm in build with AMDGPU, AArch64, and X86 targets enabled.