### PR TITLE
[clang-tidy][NFC] Remove regex hacks to match full lines in tests

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/cleanup-ctad.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/cleanup-ctad.cpp
@@ -79,27 +79,27 @@ absl::Cleanup<cleanup_internal::Tag, Callback> MakeCleanup(Callback callback) {
 void test() {
   auto a = absl::MakeCleanup([] {});
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: prefer absl::Cleanup's class template argument deduction pattern in C++17 and higher
-  // CHECK-FIXES: {{^}}  absl::Cleanup a = [] {};{{$}}
+  // CHECK-FIXES: absl::Cleanup a = [] {};
 
   auto b = absl::MakeCleanup(std::function<void()>([] {}));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: prefer absl::Cleanup{{.*}}C++17 and higher
-  // CHECK-FIXES: {{^}}  absl::Cleanup b = std::function<void()>([] {});{{$}}
+  // CHECK-FIXES: absl::Cleanup b = std::function<void()>([] {});
 
   const auto c = absl::MakeCleanup([] {});
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: prefer absl::Cleanup{{.*}}C++17 and higher
-  // CHECK-FIXES: {{^}}  const absl::Cleanup c = [] {};{{$}}
+  // CHECK-FIXES: const absl::Cleanup c = [] {};
 
   const auto d = absl::MakeCleanup(std::function<void()>([] {}));
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: prefer absl::Cleanup{{.*}}C++17 and higher
-  // CHECK-FIXES: {{^}}  const absl::Cleanup d = std::function<void()>([] {});{{$}}
+  // CHECK-FIXES: const absl::Cleanup d = std::function<void()>([] {});
 
   // Preserves extra parens
   auto e = absl::MakeCleanup(([] {}));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: prefer absl::Cleanup{{.*}}C++17 and higher
-  // CHECK-FIXES: {{^}}  absl::Cleanup e = ([] {});{{$}}
+  // CHECK-FIXES: absl::Cleanup e = ([] {});
 
   // Preserves comments
   auto f = /* a */ absl::MakeCleanup(/* b */ [] { /* c */ } /* d */) /* e */;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: prefer absl::Cleanup{{.*}}C++17 and higher
-  // CHECK-FIXES: {{^}}  absl::Cleanup f = /* a */ /* b */ [] { /* c */ } /* d */ /* e */;{{$}}
+  // CHECK-FIXES: absl::Cleanup f = /* a */ /* b */ [] { /* c */ } /* d */ /* e */;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/str-cat-append.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/str-cat-append.cpp
@@ -97,7 +97,7 @@ void Bar() {
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: call to 'absl::StrCat' has no effect
   A = StrCat(A, B);
 // CHECK-MESSAGES: [[@LINE-1]]:3: warning: call 'absl::StrAppend' instead of 'absl::StrCat' when appending to a string to avoid a performance penalty
-// CHECK-FIXES: {{^}}  absl::StrAppend(&A, B);
+// CHECK-FIXES: absl::StrAppend(&A, B);
   B = StrCat(A, B);
 
 #define M(X) X = StrCat(X, A)
@@ -117,7 +117,7 @@ void OutsideAbsl() {
   std::string A, B;
   A = absl::StrCat(A, B);
 // CHECK-MESSAGES: [[@LINE-1]]:3: warning: call 'absl::StrAppend' instead of 'absl::StrCat' when appending to a string to avoid a performance penalty
-// CHECK-FIXES: {{^}}  absl::StrAppend(&A, B);
+// CHECK-FIXES: absl::StrAppend(&A, B);
 }
 
 void OutsideUsingAbsl() {
@@ -125,5 +125,5 @@ void OutsideUsingAbsl() {
   using absl::StrCat;
   A = StrCat(A, B);
 // CHECK-MESSAGES: [[@LINE-1]]:3: warning: call 'absl::StrAppend' instead of 'absl::StrCat' when appending to a string to avoid a performance penalty
-// CHECK-FIXES: {{^}}  absl::StrAppend(&A, B);
+// CHECK-FIXES: absl::StrAppend(&A, B);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/string-find-str-contains.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/string-find-str-contains.cpp
@@ -70,41 +70,41 @@ void basic_tests() {
   std::string ss;
   ss.find("a") == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of find() == npos
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ss, "a");{{$}}
+  // CHECK-FIXES: !absl::StrContains(ss, "a");
 
   ss.find("a") != std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of find() != npos
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ss, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(ss, "a");
 
   std::string::npos != ss.find("a");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ss, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(ss, "a");
 
   std::string_view ssv;
   ssv.find("a") == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ssv, "a");{{$}}
+  // CHECK-FIXES: !absl::StrContains(ssv, "a");
 
   ssv.find("a") != std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ssv, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(ssv, "a");
 
   std::string_view::npos != ssv.find("a");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ssv, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(ssv, "a");
 
   absl::string_view asv;
   asv.find("a") == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(asv, "a");{{$}}
+  // CHECK-FIXES: !absl::StrContains(asv, "a");
 
   asv.find("a") != absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(asv, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(asv, "a");
 
   absl::string_view::npos != asv.find("a");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(asv, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(asv, "a");
 }
 
 // Confirms that it works even if you mix-and-match the type for find and for
@@ -115,29 +115,29 @@ void mismatched_npos() {
   std::string ss;
   ss.find("a") == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ss, "a");{{$}}
+  // CHECK-FIXES: !absl::StrContains(ss, "a");
 
   ss.find("a") != absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ss, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(ss, "a");
 
   std::string_view ssv;
   ssv.find("a") == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ssv, "a");{{$}}
+  // CHECK-FIXES: !absl::StrContains(ssv, "a");
 
   ssv.find("a") != std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ssv, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(ssv, "a");
 
   absl::string_view asv;
   asv.find("a") == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(asv, "a");{{$}}
+  // CHECK-FIXES: !absl::StrContains(asv, "a");
 
   asv.find("a") != std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(asv, "a");{{$}}
+  // CHECK-FIXES: absl::StrContains(asv, "a");
 }
 
 // Confirms that it works even when the needle or the haystack are more
@@ -146,41 +146,41 @@ void subexpression_tests() {
   std::string ss, ss2;
   foo_ss(ss).find(ss2) == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(foo_ss(ss), ss2);{{$}}
+  // CHECK-FIXES: !absl::StrContains(foo_ss(ss), ss2);
 
   ss.find(foo_ss(ss2)) != std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ss, foo_ss(ss2));{{$}}
+  // CHECK-FIXES: absl::StrContains(ss, foo_ss(ss2));
 
   foo_ss(bar_ss()).find(foo_ss(ss2)) != std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(foo_ss(bar_ss()), foo_ss(ss2));{{$}}
+  // CHECK-FIXES: absl::StrContains(foo_ss(bar_ss()), foo_ss(ss2));
 
   std::string_view ssv, ssv2;
   foo_ssv(ssv).find(ssv2) == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(foo_ssv(ssv), ssv2);{{$}}
+  // CHECK-FIXES: !absl::StrContains(foo_ssv(ssv), ssv2);
 
   ssv.find(foo_ssv(ssv2)) != std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(ssv, foo_ssv(ssv2));{{$}}
+  // CHECK-FIXES: absl::StrContains(ssv, foo_ssv(ssv2));
 
   foo_ssv(bar_ssv()).find(foo_ssv(ssv2)) != std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(foo_ssv(bar_ssv()), foo_ssv(ssv2));{{$}}
+  // CHECK-FIXES: absl::StrContains(foo_ssv(bar_ssv()), foo_ssv(ssv2));
 
   absl::string_view asv, asv2;
   foo_asv(asv).find(asv2) == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(foo_asv(asv), asv2);{{$}}
+  // CHECK-FIXES: !absl::StrContains(foo_asv(asv), asv2);
 
   asv.find(foo_asv(asv2)) != absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(asv, foo_asv(asv2));{{$}}
+  // CHECK-FIXES: absl::StrContains(asv, foo_asv(asv2));
 
   foo_asv(bar_asv()).find(foo_asv(asv2)) != absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StrContains(foo_asv(bar_asv()), foo_asv(asv2));{{$}}
+  // CHECK-FIXES: absl::StrContains(foo_asv(bar_asv()), foo_asv(asv2));
 }
 
 // Confirms that it works with string literal, char* and const char* parameters.
@@ -191,58 +191,58 @@ void string_literal_and_char_ptr_tests() {
   std::string ss;
   ss.find("c") == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ss, "c");{{$}}
+  // CHECK-FIXES: !absl::StrContains(ss, "c");
 
   ss.find(c) == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ss, c);{{$}}
+  // CHECK-FIXES: !absl::StrContains(ss, c);
 
   ss.find(cc) == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ss, cc);{{$}}
+  // CHECK-FIXES: !absl::StrContains(ss, cc);
 
   std::string_view ssv;
   ssv.find("c") == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ssv, "c");{{$}}
+  // CHECK-FIXES: !absl::StrContains(ssv, "c");
 
   ssv.find(c) == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ssv, c);{{$}}
+  // CHECK-FIXES: !absl::StrContains(ssv, c);
 
   ssv.find(cc) == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ssv, cc);{{$}}
+  // CHECK-FIXES: !absl::StrContains(ssv, cc);
 
   absl::string_view asv;
   asv.find("c") == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(asv, "c");{{$}}
+  // CHECK-FIXES: !absl::StrContains(asv, "c");
 
   asv.find(c) == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(asv, c);{{$}}
+  // CHECK-FIXES: !absl::StrContains(asv, c);
 
   asv.find(cc) == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(asv, cc);{{$}}
+  // CHECK-FIXES: !absl::StrContains(asv, cc);
 }
 
 void char_param_tests() {
   std::string ss;
   ss.find('c') == std::string::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ss, 'c');{{$}}
+  // CHECK-FIXES: !absl::StrContains(ss, 'c');
 
   std::string_view ssv;
   ssv.find('c') == std::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(ssv, 'c');{{$}}
+  // CHECK-FIXES: !absl::StrContains(ssv, 'c');
 
   absl::string_view asv;
   asv.find('c') == absl::string_view::npos;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StrContains instead of
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StrContains(asv, 'c');{{$}}
+  // CHECK-FIXES: !absl::StrContains(asv, 'c');
 }
 
 #define FOO(a, b, c, d) ((a).find(b) == std::string::npos ? (c) : (d))

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment.cpp
@@ -12,7 +12,7 @@ void g() {
   // CHECK-NOTES: [[@LINE+2]]:14: warning: argument name 'z' in comment does not match parameter name 'y'
   // CHECK-NOTES: [[@LINE-5]]:19: note: 'y' declared here
   f(/*y=*/0, /*z=*/0);
-  // CHECK-FIXES: {{^}}  f(/*y=*/0, /*z=*/0);
+  // CHECK-FIXES: f(/*y=*/0, /*z=*/0);
 
   f(/*x=*/1, /*y=*/1);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.c
@@ -30,19 +30,19 @@ void numericConversion1(int I, double D) { numericConversion1(D, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion1' of convertible types are easily swapped by mistake [bugprone-easily-swappable-parameters]
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:39: note: the last parameter in the range is 'D'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted{{$}}
 
 void numericConversion2(int I, short S) { numericConversion2(S, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion2' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:38: note: the last parameter in the range is 'S'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted{{$}}
 
 void numericConversion3(float F, unsigned long UL) { numericConversion3(UL, F); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion3' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:31: note: the first parameter in the range is 'F'
 // CHECK-MESSAGES: :[[@LINE-3]]:48: note: the last parameter in the range is 'UL'
-// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long' may be implicitly converted{{$}}
 
 enum Unscoped { U_A,
                 U_B };
@@ -53,25 +53,25 @@ void numericConversion4(int I, enum Unscoped U) { numericConversion4(U, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion4' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:46: note: the last parameter in the range is 'U'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum Unscoped' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum Unscoped' may be implicitly converted{{$}}
 
 void numericConversion5(int I, enum UnscopedFixed UF) { numericConversion5(UF, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion5' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:51: note: the last parameter in the range is 'UF'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum UnscopedFixed' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum UnscopedFixed' may be implicitly converted{{$}}
 
 void numericConversion7(double D, enum Unscoped U) { numericConversion7(U, D); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion7' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:32: note: the first parameter in the range is 'D'
 // CHECK-MESSAGES: :[[@LINE-3]]:49: note: the last parameter in the range is 'U'
-// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum Unscoped' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum Unscoped' may be implicitly converted{{$}}
 
 void numericConversion8(double D, enum UnscopedFixed UF) { numericConversion8(UF, D); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion8' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:32: note: the first parameter in the range is 'D'
 // CHECK-MESSAGES: :[[@LINE-3]]:54: note: the last parameter in the range is 'UF'
-// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum UnscopedFixed' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum UnscopedFixed' may be implicitly converted{{$}}
 
 void pointeeConversion(int *IP, double *DP) { pointeeConversion(DP, IP); }
 // NO-WARN: Even though this is possible in C, a swap is diagnosed by the compiler.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.c
@@ -30,19 +30,19 @@ void numericConversion1(int I, double D) { numericConversion1(D, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion1' of convertible types are easily swapped by mistake [bugprone-easily-swappable-parameters]
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:39: note: the last parameter in the range is 'D'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted
 
 void numericConversion2(int I, short S) { numericConversion2(S, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion2' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:38: note: the last parameter in the range is 'S'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted
 
 void numericConversion3(float F, unsigned long UL) { numericConversion3(UL, F); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion3' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:31: note: the first parameter in the range is 'F'
 // CHECK-MESSAGES: :[[@LINE-3]]:48: note: the last parameter in the range is 'UL'
-// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long' may be implicitly converted
 
 enum Unscoped { U_A,
                 U_B };
@@ -53,25 +53,25 @@ void numericConversion4(int I, enum Unscoped U) { numericConversion4(U, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion4' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:46: note: the last parameter in the range is 'U'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum Unscoped' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum Unscoped' may be implicitly converted
 
 void numericConversion5(int I, enum UnscopedFixed UF) { numericConversion5(UF, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion5' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:51: note: the last parameter in the range is 'UF'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum UnscopedFixed' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'enum UnscopedFixed' may be implicitly converted
 
 void numericConversion7(double D, enum Unscoped U) { numericConversion7(U, D); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion7' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:32: note: the first parameter in the range is 'D'
 // CHECK-MESSAGES: :[[@LINE-3]]:49: note: the last parameter in the range is 'U'
-// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum Unscoped' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum Unscoped' may be implicitly converted
 
 void numericConversion8(double D, enum UnscopedFixed UF) { numericConversion8(UF, D); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion8' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:32: note: the first parameter in the range is 'D'
 // CHECK-MESSAGES: :[[@LINE-3]]:54: note: the last parameter in the range is 'UF'
-// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum UnscopedFixed' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:35: note: 'double' and 'enum UnscopedFixed' may be implicitly converted
 
 void pointeeConversion(int *IP, double *DP) { pointeeConversion(DP, IP); }
 // NO-WARN: Even though this is possible in C, a swap is diagnosed by the compiler.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.cpp
@@ -74,19 +74,19 @@ void numericConversion1(int I, double D) { numericConversion1(D, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion1' of convertible types are easily swapped by mistake [bugprone-easily-swappable-parameters]
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:39: note: the last parameter in the range is 'D'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted{{$}}
 
 void numericConversion2(int I, short S) { numericConversion2(S, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion2' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:38: note: the last parameter in the range is 'S'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted{{$}}
 
 void numericConversion3(float F, unsigned long long ULL) { numericConversion3(ULL, F); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion3' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:31: note: the first parameter in the range is 'F'
 // CHECK-MESSAGES: :[[@LINE-3]]:53: note: the last parameter in the range is 'ULL'
-// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long long' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long long' may be implicitly converted{{$}}
 
 enum Unscoped { U_A,
                 U_B };
@@ -111,7 +111,7 @@ void numericConversionMultiUnique(int I, double D1, double D2) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: 3 adjacent parameters of 'numericConversionMultiUnique' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:39: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:60: note: the last parameter in the range is 'D2'
-// CHECK-MESSAGES: :[[@LINE-4]]:42: note: 'int' and 'double' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:42: note: 'int' and 'double' may be implicitly converted{{$}}
 // (Note: int<->double conversion for I<->D2 not diagnosed again.)
 
 typedef int MyInt;
@@ -176,7 +176,7 @@ void userDefinedConversion1(int I1, Integer I2) { userDefinedConversion1(I2, I1)
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: 2 adjacent parameters of 'userDefinedConversion1' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:33: note: the first parameter in the range is 'I1'
 // CHECK-MESSAGES: :[[@LINE-3]]:45: note: the last parameter in the range is 'I2'
-// CHECK-MESSAGES: :[[@LINE-4]]:37: note: 'int' and 'Integer' may be implicitly converted
+// CHECK-MESSAGES: :[[@LINE-4]]:37: note: 'int' and 'Integer' may be implicitly converted{{$}}
 // CHECK-MESSAGES: :[[@LINE-9]]:3: note: the implicit conversion involves the converting constructor declared here
 // CHECK-MESSAGES: :[[@LINE-9]]:3: note: the implicit conversion involves the conversion operator declared here
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/easily-swappable-parameters-implicits.cpp
@@ -74,19 +74,19 @@ void numericConversion1(int I, double D) { numericConversion1(D, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion1' of convertible types are easily swapped by mistake [bugprone-easily-swappable-parameters]
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:39: note: the last parameter in the range is 'D'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'double' may be implicitly converted
 
 void numericConversion2(int I, short S) { numericConversion2(S, I); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion2' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:29: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:38: note: the last parameter in the range is 'S'
-// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:32: note: 'int' and 'short' may be implicitly converted
 
 void numericConversion3(float F, unsigned long long ULL) { numericConversion3(ULL, F); }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: 2 adjacent parameters of 'numericConversion3' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:31: note: the first parameter in the range is 'F'
 // CHECK-MESSAGES: :[[@LINE-3]]:53: note: the last parameter in the range is 'ULL'
-// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long long' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:34: note: 'float' and 'unsigned long long' may be implicitly converted
 
 enum Unscoped { U_A,
                 U_B };
@@ -111,7 +111,7 @@ void numericConversionMultiUnique(int I, double D1, double D2) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: 3 adjacent parameters of 'numericConversionMultiUnique' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:39: note: the first parameter in the range is 'I'
 // CHECK-MESSAGES: :[[@LINE-3]]:60: note: the last parameter in the range is 'D2'
-// CHECK-MESSAGES: :[[@LINE-4]]:42: note: 'int' and 'double' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:42: note: 'int' and 'double' may be implicitly converted
 // (Note: int<->double conversion for I<->D2 not diagnosed again.)
 
 typedef int MyInt;
@@ -176,7 +176,7 @@ void userDefinedConversion1(int I1, Integer I2) { userDefinedConversion1(I2, I1)
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: 2 adjacent parameters of 'userDefinedConversion1' of convertible types
 // CHECK-MESSAGES: :[[@LINE-2]]:33: note: the first parameter in the range is 'I1'
 // CHECK-MESSAGES: :[[@LINE-3]]:45: note: the last parameter in the range is 'I2'
-// CHECK-MESSAGES: :[[@LINE-4]]:37: note: 'int' and 'Integer' may be implicitly converted{{$}}
+// CHECK-MESSAGES: :[[@LINE-4]]:37: note: 'int' and 'Integer' may be implicitly converted
 // CHECK-MESSAGES: :[[@LINE-9]]:3: note: the implicit conversion involves the converting constructor declared here
 // CHECK-MESSAGES: :[[@LINE-9]]:3: note: the implicit conversion involves the conversion operator declared here
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/inaccurate-erase.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/inaccurate-erase.cpp
@@ -51,12 +51,12 @@ struct custom_container {
 template <typename T> void g() {
   T t;
   t.erase(std::remove(t.begin(), t.end(), 10));
-  // CHECK-FIXES: {{^  }}t.erase(std::remove(t.begin(), t.end(), 10));{{$}}
+  // CHECK-FIXES: t.erase(std::remove(t.begin(), t.end(), 10));
 
   std::vector<int> v;
   v.erase(remove(v.begin(), v.end(), 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this call will remove at most one
-  // CHECK-FIXES: {{^  }}v.erase(remove(v.begin(), v.end(), 10), v.end());{{$}}
+  // CHECK-FIXES: v.erase(remove(v.begin(), v.end(), 10), v.end());
 }
 
 #define ERASE(x, y) x.erase(remove(x.begin(), x.end(), y))
@@ -67,34 +67,34 @@ int main() {
 
   v.erase(remove(v.begin(), v.end(), 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this call will remove at most one item even when multiple items should be removed [bugprone-inaccurate-erase]
-  // CHECK-FIXES: {{^  }}v.erase(remove(v.begin(), v.end(), 10), v.end());{{$}}
+  // CHECK-FIXES: v.erase(remove(v.begin(), v.end(), 10), v.end());
   v.erase(remove(v.begin(), v.end(), 20), v.end());
 
   auto *p = &v;
   p->erase(remove(p->begin(), p->end(), 11));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this call will remove at most one
-  // CHECK-FIXES: {{^  }}p->erase(remove(p->begin(), p->end(), 11), p->end());{{$}}
+  // CHECK-FIXES: p->erase(remove(p->begin(), p->end(), 11), p->end());
 
   std::vector_with_const_iterator<int> v2;
   v2.erase(remove(v2.begin(), v2.end(), 12));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this call will remove at most one
-  // CHECK-FIXES: {{^  }}v2.erase(remove(v2.begin(), v2.end(), 12), v2.end());{{$}}
+  // CHECK-FIXES: v2.erase(remove(v2.begin(), v2.end(), 12), v2.end());
 
   // Fix is not trivial.
   auto it = v.end();
   v.erase(remove(v.begin(), it, 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this call will remove at most one
-  // CHECK-FIXES: {{^  }}v.erase(remove(v.begin(), it, 10));{{$}}
+  // CHECK-FIXES: v.erase(remove(v.begin(), it, 10));
 
   g<std::vector<int>>();
   g<custom_container>();
 
   ERASE(v, 15);
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: this call will remove at most one
-  // CHECK-FIXES: {{^  }}ERASE(v, 15);{{$}}
+  // CHECK-FIXES: ERASE(v, 15);
 
   std::vector<std::unique_ptr<int>> vupi;
   auto iter = vupi.begin();
   vupi.erase(iter++);
-  // CHECK-FIXES: {{^  }}vupi.erase(iter++);{{$}}
+  // CHECK-FIXES: vupi.erase(iter++);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc.cpp
@@ -17,7 +17,7 @@ size_t strlen(const char *);
 void bad_std_malloc_std_strlen(char *name) {
   char *new_name = (char *)std::malloc(std::strlen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_name = \(char \*\)std::malloc\(}}std::strlen(name) + 1{{\);$}}
+  // CHECK-FIXES: char *new_name = (char *)std::malloc(std::strlen(name) + 1);
 }
 
 void ignore_non_std_malloc_std_strlen(char *name) {
@@ -35,7 +35,7 @@ void ignore_std_malloc_non_std_strlen(char *name) {
 void bad_new_strlen(char *name) {
   char *new_name = new char[std::strlen(name + 1)];
   // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_name = new char\[}}std::strlen(name) + 1{{\];$}}
+  // CHECK-FIXES: char *new_name = new char[std::strlen(name) + 1];
 }
 
 void good_new_strlen(char *name) {
@@ -54,5 +54,5 @@ public:
 void bad_custom_new_strlen(char *name) {
   C *new_name = new C[std::strlen(name + 1)];
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  C \*new_name = new C\[}}std::strlen(name) + 1{{\];$}}
+  // CHECK-FIXES: C *new_name = new C[std::strlen(name) + 1];
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/reserved-identifier-invert.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/reserved-identifier-invert.cpp
@@ -12,16 +12,16 @@ void __f() {}
 
 void f();
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier 'f', which is not a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void __f();{{$}}
+// CHECK-FIXES: void __f();
 struct helper {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: declaration uses identifier 'helper', which is not a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}struct __helper {};{{$}}
+// CHECK-FIXES: struct __helper {};
 struct Helper {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: declaration uses identifier 'Helper', which is not a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}struct _Helper {};{{$}}
+// CHECK-FIXES: struct _Helper {};
 struct _helper2 {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: declaration uses identifier '_helper2', which is not a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}struct __helper2 {};{{$}}
+// CHECK-FIXES: struct __helper2 {};
 
 template <class _Tp>
 class reference_wrapper {
@@ -53,11 +53,11 @@ ref(reference_wrapper<_Tp> __t) noexcept {
 
 template <class Up>
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: declaration uses identifier 'Up', which is not a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}template <class _Up>{{$}}
+// CHECK-FIXES: template <class _Up>
 inline reference_wrapper<const Up>
 cref(const Up &u) noexcept {
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: declaration uses identifier 'u', which is not a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}cref(const _Up &__u) noexcept {{{$}}
+  // CHECK-FIXES: cref(const _Up &__u) noexcept {
   return reference_wrapper<const Up>(u);
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/string-integer-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/string-integer-assignment.cpp
@@ -33,26 +33,26 @@ int main() {
 
   s = 6;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: an integer is interpreted as a character code when assigning {{.*}} [bugprone-string-integer-assignment]
-// CHECK-FIXES: {{^}}  s = '6';{{$}}
+// CHECK-FIXES: s = '6';
   s = 66;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: an integer is interpreted as a chara
-// CHECK-FIXES: {{^}}  s = "66";{{$}}
+// CHECK-FIXES: s = "66";
   s = x;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: an integer is interpreted as a chara
-// CHECK-FIXES: {{^}}  s = std::to_string(x);{{$}}
+// CHECK-FIXES: s = std::to_string(x);
   s = 'c';
   s = static_cast<char>(6);
 
 // +=
   ws += 6;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: an integer is interpreted as a chara
-// CHECK-FIXES: {{^}}  ws += L'6';{{$}}
+// CHECK-FIXES: ws += L'6';
   ws += 66;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: an integer is interpreted as a chara
-// CHECK-FIXES: {{^}}  ws += L"66";{{$}}
+// CHECK-FIXES: ws += L"66";
   ws += x;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: an integer is interpreted as a chara
-// CHECK-FIXES: {{^}}  ws += std::to_wstring(x);{{$}}
+// CHECK-FIXES: ws += std::to_wstring(x);
   ws += L'c';
   ws += (wchar_t)6;
 
@@ -79,11 +79,11 @@ int main() {
   s += x % 26;
   s += 26 % x;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: an integer is interpreted as a chara
-  // CHECK-FIXES: {{^}}  s += std::to_string(26 % x);{{$}}
+  // CHECK-FIXES: s += std::to_string(26 % x);
   s += c | 0x80;
   s += c | 0x8000;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: an integer is interpreted as a chara
-  // CHECK-FIXES: {{^}}  s += std::to_string(c | 0x8000);{{$}}
+  // CHECK-FIXES: s += std::to_string(c | 0x8000);
   as += c | 0x8000;
 
   s += 'a' + (x % 26);
@@ -94,7 +94,7 @@ int main() {
   s += x > 255 ? c : x;
   s += x > 255 ? 12 : x;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: an integer is interpreted as a chara
-  // CHECK-FIXES: {{^}}  s += std::to_string(x > 255 ? 12 : x);{{$}}
+  // CHECK-FIXES: s += std::to_string(x > 255 ? 12 : x);
 }
 
 namespace instantiation_dependent_exprs {
@@ -104,7 +104,7 @@ struct S {
   std::string s;
   void f(char c) { s += c | static_cast<int>(t); }
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: an integer is interpreted as a chara
-  // CHECK-FIXES: {{^}}  void f(char c) { s += std::to_string(c | static_cast<int>(t)); } 
+  // CHECK-FIXES: void f(char c) { s += std::to_string(c | static_cast<int>(t)); } 
 };
 
 template struct S<int>;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/stringview-nullptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/stringview-nullptr.cpp
@@ -134,124 +134,124 @@ void temporary_construction() /* a */ {
   {
     (void)(std::string_view(nullptr)) /* a1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing basic_string_view from null is undefined; replace with the default constructor
-    // CHECK-FIXES: {{^}}    (void)(std::string_view()) /* a1 */;
+    // CHECK-FIXES: (void)(std::string_view()) /* a1 */;
 
     (void)(std::string_view((nullptr))) /* a2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view()) /* a2 */;
+    // CHECK-FIXES: (void)(std::string_view()) /* a2 */;
 
     (void)(std::string_view({nullptr})) /* a3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view()) /* a3 */;
+    // CHECK-FIXES: (void)(std::string_view()) /* a3 */;
 
     (void)(std::string_view({(nullptr)})) /* a4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view()) /* a4 */;
+    // CHECK-FIXES: (void)(std::string_view()) /* a4 */;
 
     (void)(std::string_view({})) /* a5 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view()) /* a5 */;
+    // CHECK-FIXES: (void)(std::string_view()) /* a5 */;
   }
 
   // Temporary Object
   {
     (void)(std::string_view{nullptr}) /* a6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view{}) /* a6 */;
+    // CHECK-FIXES: (void)(std::string_view{}) /* a6 */;
 
     (void)(std::string_view{(nullptr)}) /* a7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view{}) /* a7 */;
+    // CHECK-FIXES: (void)(std::string_view{}) /* a7 */;
 
     (void)(std::string_view{{nullptr}}) /* a8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view{}) /* a8 */;
+    // CHECK-FIXES: (void)(std::string_view{}) /* a8 */;
 
     (void)(std::string_view{{(nullptr)}}) /* a9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view{}) /* a9 */;
+    // CHECK-FIXES: (void)(std::string_view{}) /* a9 */;
 
     (void)(std::string_view{{}}) /* a10 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(std::string_view{}) /* a10 */;
+    // CHECK-FIXES: (void)(std::string_view{}) /* a10 */;
   }
 
   // C-Style Cast && Compound Literal
   {
     (void)((std::string_view) nullptr) /* a11 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view) {}) /* a11 */;
+    // CHECK-FIXES: (void)((std::string_view) {}) /* a11 */;
 
     (void)((std::string_view)(nullptr)) /* a12 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view){}) /* a12 */;
+    // CHECK-FIXES: (void)((std::string_view){}) /* a12 */;
 
     (void)((std::string_view){nullptr}) /* a13 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view){}) /* a13 */;
+    // CHECK-FIXES: (void)((std::string_view){}) /* a13 */;
 
     (void)((std::string_view){(nullptr)}) /* a14 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view){}) /* a14 */;
+    // CHECK-FIXES: (void)((std::string_view){}) /* a14 */;
 
     (void)((std::string_view){{nullptr}}) /* a15 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view){}) /* a15 */;
+    // CHECK-FIXES: (void)((std::string_view){}) /* a15 */;
 
     (void)((std::string_view){{(nullptr)}}) /* a16 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view){}) /* a16 */;
+    // CHECK-FIXES: (void)((std::string_view){}) /* a16 */;
 
     (void)((std::string_view){{}}) /* a17 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((std::string_view){}) /* a17 */;
+    // CHECK-FIXES: (void)((std::string_view){}) /* a17 */;
 
     (void)((const std::string_view) nullptr) /* a18 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view) {}) /* a18 */;
+    // CHECK-FIXES: (void)((const std::string_view) {}) /* a18 */;
 
     (void)((const std::string_view)(nullptr)) /* a19 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view){}) /* a19 */;
+    // CHECK-FIXES: (void)((const std::string_view){}) /* a19 */;
 
     (void)((const std::string_view){nullptr}) /* a20 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view){}) /* a20 */;
+    // CHECK-FIXES: (void)((const std::string_view){}) /* a20 */;
 
     (void)((const std::string_view){(nullptr)}) /* a21 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view){}) /* a21 */;
+    // CHECK-FIXES: (void)((const std::string_view){}) /* a21 */;
 
     (void)((const std::string_view){{nullptr}}) /* a22 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view){}) /* a22 */;
+    // CHECK-FIXES: (void)((const std::string_view){}) /* a22 */;
 
     (void)((const std::string_view){{(nullptr)}}) /* a23 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view){}) /* a23 */;
+    // CHECK-FIXES: (void)((const std::string_view){}) /* a23 */;
 
     (void)((const std::string_view){{}}) /* a24 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)((const std::string_view){}) /* a24 */;
+    // CHECK-FIXES: (void)((const std::string_view){}) /* a24 */;
   }
 
   // Static Cast
   {
     (void)(static_cast<std::string_view>(nullptr)) /* a25 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: casting to basic_string_view from null is undefined; replace with the empty string
-    // CHECK-FIXES: {{^}}    (void)(static_cast<std::string_view>("")) /* a25 */;
+    // CHECK-FIXES: (void)(static_cast<std::string_view>("")) /* a25 */;
 
     (void)(static_cast<std::string_view>((nullptr))) /* a26 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(static_cast<std::string_view>("")) /* a26 */;
+    // CHECK-FIXES: (void)(static_cast<std::string_view>("")) /* a26 */;
 
     (void)(static_cast<const std::string_view>(nullptr)) /* a27 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(static_cast<const std::string_view>("")) /* a27 */;
+    // CHECK-FIXES: (void)(static_cast<const std::string_view>("")) /* a27 */;
 
     (void)(static_cast<const std::string_view>((nullptr))) /* a28 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(static_cast<const std::string_view>("")) /* a28 */;
+    // CHECK-FIXES: (void)(static_cast<const std::string_view>("")) /* a28 */;
   }
 }
 
@@ -260,240 +260,240 @@ void stack_construction() /* b */ {
   {
     std::string_view b1 = nullptr;
     // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b1 = {};
+    // CHECK-FIXES: std::string_view b1 = {};
 
     std::string_view b2 = (nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b2 = {};
+    // CHECK-FIXES: std::string_view b2 = {};
 
     const std::string_view b3 = nullptr;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b3 = {};
+    // CHECK-FIXES: const std::string_view b3 = {};
 
     const std::string_view b4 = (nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b4 = {};
+    // CHECK-FIXES: const std::string_view b4 = {};
   }
 
   // Copy Initialization With Temporary
   {
     std::string_view b5 = std::string_view(nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b5 = std::string_view();
+    // CHECK-FIXES: std::string_view b5 = std::string_view();
 
     std::string_view b6 = std::string_view{nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b6 = std::string_view{};
+    // CHECK-FIXES: std::string_view b6 = std::string_view{};
 
     std::string_view b7 = (std::string_view) nullptr;
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b7 = (std::string_view) {};
+    // CHECK-FIXES: std::string_view b7 = (std::string_view) {};
 
     std::string_view b8 = (std::string_view){nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b8 = (std::string_view){};
+    // CHECK-FIXES: std::string_view b8 = (std::string_view){};
 
     std::string_view b9 = static_cast<SV>(nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view b9 = static_cast<SV>("");
+    // CHECK-FIXES: std::string_view b9 = static_cast<SV>("");
   }
 
   // Copy List Initialization
   {
     std::string_view b10 = {nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b10 = {};
+    // CHECK-FIXES: std::string_view b10 = {};
 
     std::string_view b11 = {(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b11 = {};
+    // CHECK-FIXES: std::string_view b11 = {};
 
     std::string_view b12 = {{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b12 = {};
+    // CHECK-FIXES: std::string_view b12 = {};
 
     std::string_view b13 = {{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b13 = {};
+    // CHECK-FIXES: std::string_view b13 = {};
 
     std::string_view b14 = {{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b14 = {};
+    // CHECK-FIXES: std::string_view b14 = {};
 
     const std::string_view b15 = {nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b15 = {};
+    // CHECK-FIXES: const std::string_view b15 = {};
 
     const std::string_view b16 = {(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b16 = {};
+    // CHECK-FIXES: const std::string_view b16 = {};
 
     const std::string_view b17 = {{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b17 = {};
+    // CHECK-FIXES: const std::string_view b17 = {};
 
     const std::string_view b18 = {{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b18 = {};
+    // CHECK-FIXES: const std::string_view b18 = {};
 
     const std::string_view b19 = {{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b19 = {};
+    // CHECK-FIXES: const std::string_view b19 = {};
   }
 
   // Copy List Initialization With Temporary
   {
     std::string_view b20 = {std::string_view(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b20 = {std::string_view()};
+    // CHECK-FIXES: std::string_view b20 = {std::string_view()};
 
     std::string_view b21 = {std::string_view{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b21 = {std::string_view{}};
+    // CHECK-FIXES: std::string_view b21 = {std::string_view{}};
 
     std::string_view b22 = {(std::string_view) nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b22 = {(std::string_view) {}};
+    // CHECK-FIXES: std::string_view b22 = {(std::string_view) {}};
 
     std::string_view b23 = {(std::string_view){nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b23 = {(std::string_view){}};
+    // CHECK-FIXES: std::string_view b23 = {(std::string_view){}};
 
     std::string_view b24 = {static_cast<SV>(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view b24 = {static_cast<SV>("")};
+    // CHECK-FIXES: std::string_view b24 = {static_cast<SV>("")};
   }
 
   // Direct Initialization
   {
     std::string_view b25(nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b25;
+    // CHECK-FIXES: std::string_view b25;
 
     std::string_view b26((nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b26;
+    // CHECK-FIXES: std::string_view b26;
 
     std::string_view b27({nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b27;
+    // CHECK-FIXES: std::string_view b27;
 
     std::string_view b28({(nullptr)});
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b28;
+    // CHECK-FIXES: std::string_view b28;
 
     std::string_view b29({}); // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b29;
+    // CHECK-FIXES: std::string_view b29;
 
     const std::string_view b30(nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b30;
+    // CHECK-FIXES: const std::string_view b30;
 
     const std::string_view b31((nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b31;
+    // CHECK-FIXES: const std::string_view b31;
 
     const std::string_view b32({nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b32;
+    // CHECK-FIXES: const std::string_view b32;
 
     const std::string_view b33({(nullptr)});
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b33;
+    // CHECK-FIXES: const std::string_view b33;
 
     const std::string_view b34({}); // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b34;
+    // CHECK-FIXES: const std::string_view b34;
   }
 
   // Direct Initialization With Temporary
   {
     std::string_view b35(std::string_view(nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b35(std::string_view());
+    // CHECK-FIXES: std::string_view b35(std::string_view());
 
     std::string_view b36(std::string_view{nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b36(std::string_view{});
+    // CHECK-FIXES: std::string_view b36(std::string_view{});
 
     std::string_view b37((std::string_view) nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b37((std::string_view) {});
+    // CHECK-FIXES: std::string_view b37((std::string_view) {});
 
     std::string_view b38((std::string_view){nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b38((std::string_view){});
+    // CHECK-FIXES: std::string_view b38((std::string_view){});
 
     std::string_view b39(static_cast<SV>(nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view b39(static_cast<SV>(""));
+    // CHECK-FIXES: std::string_view b39(static_cast<SV>(""));
   }
 
   // Direct List Initialization
   {
     std::string_view b40{nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b40{};
+    // CHECK-FIXES: std::string_view b40{};
 
     std::string_view b41{(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b41{};
+    // CHECK-FIXES: std::string_view b41{};
 
     std::string_view b42{{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b42{};
+    // CHECK-FIXES: std::string_view b42{};
 
     std::string_view b43{{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b43{};
+    // CHECK-FIXES: std::string_view b43{};
 
     std::string_view b44{{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b44{};
+    // CHECK-FIXES: std::string_view b44{};
 
     const std::string_view b45{nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b45{};
+    // CHECK-FIXES: const std::string_view b45{};
 
     const std::string_view b46{(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b46{};
+    // CHECK-FIXES: const std::string_view b46{};
 
     const std::string_view b47{{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b47{};
+    // CHECK-FIXES: const std::string_view b47{};
 
     const std::string_view b48{{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b48{};
+    // CHECK-FIXES: const std::string_view b48{};
 
     const std::string_view b49{{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view b49{};
+    // CHECK-FIXES: const std::string_view b49{};
   }
 
   // Direct List Initialization With Temporary
   {
     std::string_view b50{std::string_view(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b50{std::string_view()};
+    // CHECK-FIXES: std::string_view b50{std::string_view()};
 
     std::string_view b51{std::string_view{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b51{std::string_view{}};
+    // CHECK-FIXES: std::string_view b51{std::string_view{}};
 
     std::string_view b52{(std::string_view) nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b52{(std::string_view) {}};
+    // CHECK-FIXES: std::string_view b52{(std::string_view) {}};
 
     std::string_view b53{(std::string_view){nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view b53{(std::string_view){}};
+    // CHECK-FIXES: std::string_view b53{(std::string_view){}};
 
     std::string_view b54{static_cast<SV>(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view b54{static_cast<SV>("")};
+    // CHECK-FIXES: std::string_view b54{static_cast<SV>("")};
   }
 }
 
@@ -503,169 +503,169 @@ void field_construction() /* c */ {
   struct DMICopyInitialization {
     std::string_view c1 = nullptr;
     // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c1 = {};
+    // CHECK-FIXES: std::string_view c1 = {};
 
     std::string_view c2 = (nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c2 = {};
+    // CHECK-FIXES: std::string_view c2 = {};
 
     const std::string_view c3 = nullptr;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c3 = {};
+    // CHECK-FIXES: const std::string_view c3 = {};
 
     const std::string_view c4 = (nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c4 = {};
+    // CHECK-FIXES: const std::string_view c4 = {};
   };
 
   struct DMICopyInitializationWithTemporary {
     std::string_view c5 = std::string_view(nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c5 = std::string_view();
+    // CHECK-FIXES: std::string_view c5 = std::string_view();
 
     std::string_view c6 = std::string_view{nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c6 = std::string_view{};
+    // CHECK-FIXES: std::string_view c6 = std::string_view{};
 
     std::string_view c7 = (std::string_view) nullptr;
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c7 = (std::string_view) {};
+    // CHECK-FIXES: std::string_view c7 = (std::string_view) {};
 
     std::string_view c8 = (std::string_view){nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c8 = (std::string_view){};
+    // CHECK-FIXES: std::string_view c8 = (std::string_view){};
 
     std::string_view c9 = static_cast<SV>(nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view c9 = static_cast<SV>("");
+    // CHECK-FIXES: std::string_view c9 = static_cast<SV>("");
   };
 
   struct DMICopyListInitialization {
     std::string_view c10 = {nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c10 = {};
+    // CHECK-FIXES: std::string_view c10 = {};
 
     std::string_view c11 = {(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c11 = {};
+    // CHECK-FIXES: std::string_view c11 = {};
 
     std::string_view c12 = {{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c12 = {};
+    // CHECK-FIXES: std::string_view c12 = {};
 
     std::string_view c13 = {{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c13 = {};
+    // CHECK-FIXES: std::string_view c13 = {};
 
     std::string_view c14 = {{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c14 = {};
+    // CHECK-FIXES: std::string_view c14 = {};
 
     const std::string_view c15 = {nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c15 = {};
+    // CHECK-FIXES: const std::string_view c15 = {};
 
     const std::string_view c16 = {(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c16 = {};
+    // CHECK-FIXES: const std::string_view c16 = {};
 
     const std::string_view c17 = {{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c17 = {};
+    // CHECK-FIXES: const std::string_view c17 = {};
 
     const std::string_view c18 = {{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c18 = {};
+    // CHECK-FIXES: const std::string_view c18 = {};
 
     const std::string_view c19 = {{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c19 = {};
+    // CHECK-FIXES: const std::string_view c19 = {};
   };
 
   struct DMICopyListInitializationWithTemporary {
     std::string_view c20 = {std::string_view(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c20 = {std::string_view()};
+    // CHECK-FIXES: std::string_view c20 = {std::string_view()};
 
     std::string_view c21 = {std::string_view{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c21 = {std::string_view{}};
+    // CHECK-FIXES: std::string_view c21 = {std::string_view{}};
 
     std::string_view c22 = {(std::string_view) nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c22 = {(std::string_view) {}};
+    // CHECK-FIXES: std::string_view c22 = {(std::string_view) {}};
 
     std::string_view c23 = {(std::string_view){nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c23 = {(std::string_view){}};
+    // CHECK-FIXES: std::string_view c23 = {(std::string_view){}};
 
     std::string_view c24 = {static_cast<SV>(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view c24 = {static_cast<SV>("")};
+    // CHECK-FIXES: std::string_view c24 = {static_cast<SV>("")};
   };
 
   struct DMIDirectListInitialization {
     std::string_view c25{nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c25{};
+    // CHECK-FIXES: std::string_view c25{};
 
     std::string_view c26{(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c26{};
+    // CHECK-FIXES: std::string_view c26{};
 
     std::string_view c27{{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c27{};
+    // CHECK-FIXES: std::string_view c27{};
 
     std::string_view c28{{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c28{};
+    // CHECK-FIXES: std::string_view c28{};
 
     std::string_view c29{{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c29{};
+    // CHECK-FIXES: std::string_view c29{};
 
     const std::string_view c30{nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c30{};
+    // CHECK-FIXES: const std::string_view c30{};
 
     const std::string_view c31{(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c31{};
+    // CHECK-FIXES: const std::string_view c31{};
 
     const std::string_view c32{{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c32{};
+    // CHECK-FIXES: const std::string_view c32{};
 
     const std::string_view c33{{(nullptr)}};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c33{};
+    // CHECK-FIXES: const std::string_view c33{};
 
     const std::string_view c34{{}}; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    const std::string_view c34{};
+    // CHECK-FIXES: const std::string_view c34{};
   };
 
   struct DMIDirectListInitializationWithTemporary {
     std::string_view c35{std::string_view(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c35{std::string_view()};
+    // CHECK-FIXES: std::string_view c35{std::string_view()};
 
     std::string_view c36{std::string_view{nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c36{std::string_view{}};
+    // CHECK-FIXES: std::string_view c36{std::string_view{}};
 
     std::string_view c37{(std::string_view) nullptr};
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c37{(std::string_view) {}};
+    // CHECK-FIXES: std::string_view c37{(std::string_view) {}};
 
     std::string_view c38{(std::string_view){nullptr}};
     // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    std::string_view c38{(std::string_view){}};
+    // CHECK-FIXES: std::string_view c38{(std::string_view){}};
 
     std::string_view c39{static_cast<SV>(nullptr)};
     // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    std::string_view c39{static_cast<SV>("")};
+    // CHECK-FIXES: std::string_view c39{static_cast<SV>("")};
   };
 
   // Constructor Initializers
@@ -680,23 +680,23 @@ void field_construction() /* c */ {
     CIDirectInitialization()
         : c40(nullptr),
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}        : c40(),
+          // CHECK-FIXES: : c40(),
 
           c41((nullptr)),
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c41(),
+          // CHECK-FIXES: c41(),
 
           c42({nullptr}),
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c42(),
+          // CHECK-FIXES: c42(),
 
           c43({(nullptr)}),
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c43(),
+          // CHECK-FIXES: c43(),
 
           c44({}) { // Default `const CharT*`
       // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-      // CHECK-FIXES: {{^}}          c44() {
+      // CHECK-FIXES: c44() {
     }
   };
 
@@ -710,23 +710,23 @@ void field_construction() /* c */ {
     CIDirectInitializationWithTemporary()
         : c45(std::string_view(nullptr)),
           // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}        : c45(std::string_view()),
+          // CHECK-FIXES: : c45(std::string_view()),
 
           c46(std::string_view{nullptr}),
           // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c46(std::string_view{}),
+          // CHECK-FIXES: c46(std::string_view{}),
 
           c47((std::string_view) nullptr),
           // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c47((std::string_view) {}),
+          // CHECK-FIXES: c47((std::string_view) {}),
 
           c48((std::string_view){nullptr}),
           // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c48((std::string_view){}),
+          // CHECK-FIXES: c48((std::string_view){}),
 
           c49(static_cast<SV>(nullptr)) {
       // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: casting{{.*}}empty string
-      // CHECK-FIXES: {{^}}          c49(static_cast<SV>("")) {
+      // CHECK-FIXES: c49(static_cast<SV>("")) {
     }
   };
 
@@ -740,23 +740,23 @@ void field_construction() /* c */ {
     CIDirectListInitialization()
         : c50{nullptr},
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}        : c50{},
+          // CHECK-FIXES: : c50{},
 
           c51{(nullptr)},
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c51{},
+          // CHECK-FIXES: c51{},
 
           c52{{nullptr}},
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c52{},
+          // CHECK-FIXES: c52{},
 
           c53{{(nullptr)}},
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c53{},
+          // CHECK-FIXES: c53{},
 
           c54{{}} { // Default `const CharT*`
       // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
-      // CHECK-FIXES: {{^}}          c54{} {
+      // CHECK-FIXES: c54{} {
     }
   };
 
@@ -770,23 +770,23 @@ void field_construction() /* c */ {
     CIDirectListInitializationWithTemporary()
         : c55{std::string_view(nullptr)},
           // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}        : c55{std::string_view()},
+          // CHECK-FIXES: : c55{std::string_view()},
 
           c56{std::string_view{nullptr}},
           // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c56{std::string_view{}},
+          // CHECK-FIXES: c56{std::string_view{}},
 
           c57{(std::string_view) nullptr},
           // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c57{(std::string_view) {}},
+          // CHECK-FIXES: c57{(std::string_view) {}},
 
           c58{(std::string_view){nullptr}},
           // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-          // CHECK-FIXES: {{^}}          c58{(std::string_view){}},
+          // CHECK-FIXES: c58{(std::string_view){}},
 
           c59{static_cast<SV>(nullptr)} {
       // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: casting{{.*}}empty string
-      // CHECK-FIXES: {{^}}          c59{static_cast<SV>("")} {
+      // CHECK-FIXES: c59{static_cast<SV>("")} {
     }
   };
 }
@@ -796,108 +796,108 @@ void default_argument_construction() /* d */ {
   {
     void d1(std::string_view sv = nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d1(std::string_view sv = {});
+    // CHECK-FIXES: void d1(std::string_view sv = {});
 
     void d2(std::string_view sv = (nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d2(std::string_view sv = {});
+    // CHECK-FIXES: void d2(std::string_view sv = {});
 
     void d3(const std::string_view sv = nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d3(const std::string_view sv = {});
+    // CHECK-FIXES: void d3(const std::string_view sv = {});
 
     void d4(const std::string_view sv = (nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d4(const std::string_view sv = {});
+    // CHECK-FIXES: void d4(const std::string_view sv = {});
   }
 
   // Copy Initialization With Temporary
   {
     void d5(std::string_view sv = std::string_view(nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d5(std::string_view sv = std::string_view());
+    // CHECK-FIXES: void d5(std::string_view sv = std::string_view());
 
     void d6(std::string_view sv = std::string_view{nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d6(std::string_view sv = std::string_view{});
+    // CHECK-FIXES: void d6(std::string_view sv = std::string_view{});
 
     void d7(std::string_view sv = (std::string_view) nullptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:54: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d7(std::string_view sv = (std::string_view) {});
+    // CHECK-FIXES: void d7(std::string_view sv = (std::string_view) {});
 
     void d8(std::string_view sv = (std::string_view){nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:54: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d8(std::string_view sv = (std::string_view){});
+    // CHECK-FIXES: void d8(std::string_view sv = (std::string_view){});
 
     void d9(std::string_view sv = static_cast<SV>(nullptr));
     // CHECK-MESSAGES: :[[@LINE-1]]:51: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    void d9(std::string_view sv = static_cast<SV>(""));
+    // CHECK-FIXES: void d9(std::string_view sv = static_cast<SV>(""));
   }
 
   // Copy List Initialization
   {
     void d10(std::string_view sv = {nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d10(std::string_view sv = {});
+    // CHECK-FIXES: void d10(std::string_view sv = {});
 
     void d11(std::string_view sv = {(nullptr)});
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d11(std::string_view sv = {});
+    // CHECK-FIXES: void d11(std::string_view sv = {});
 
     void d12(std::string_view sv = {{nullptr}});
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d12(std::string_view sv = {});
+    // CHECK-FIXES: void d12(std::string_view sv = {});
 
     void d13(std::string_view sv = {{(nullptr)}});
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d13(std::string_view sv = {});
+    // CHECK-FIXES: void d13(std::string_view sv = {});
 
     void d14(std::string_view sv = {{}}); // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d14(std::string_view sv = {});
+    // CHECK-FIXES: void d14(std::string_view sv = {});
 
     void d15(const std::string_view sv = {nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d15(const std::string_view sv = {});
+    // CHECK-FIXES: void d15(const std::string_view sv = {});
 
     void d16(const std::string_view sv = {(nullptr)});
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d16(const std::string_view sv = {});
+    // CHECK-FIXES: void d16(const std::string_view sv = {});
 
     void d17(const std::string_view sv = {{nullptr}});
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d17(const std::string_view sv = {});
+    // CHECK-FIXES: void d17(const std::string_view sv = {});
 
     void d18(const std::string_view sv = {{(nullptr)}});
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d18(const std::string_view sv = {});
+    // CHECK-FIXES: void d18(const std::string_view sv = {});
 
     void d19(const std::string_view sv = {{}}); // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d19(const std::string_view sv = {});
+    // CHECK-FIXES: void d19(const std::string_view sv = {});
   }
 
   // Copy List Initialization With Temporary
   {
     void d20(std::string_view sv = {std::string_view(nullptr)});
     // CHECK-MESSAGES: :[[@LINE-1]]:54: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d20(std::string_view sv = {std::string_view()});
+    // CHECK-FIXES: void d20(std::string_view sv = {std::string_view()});
 
     void d21(std::string_view sv = {std::string_view{nullptr}});
     // CHECK-MESSAGES: :[[@LINE-1]]:54: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d21(std::string_view sv = {std::string_view{}});
+    // CHECK-FIXES: void d21(std::string_view sv = {std::string_view{}});
 
     void d22(std::string_view sv = {(std::string_view) nullptr});
     // CHECK-MESSAGES: :[[@LINE-1]]:56: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d22(std::string_view sv = {(std::string_view) {}});
+    // CHECK-FIXES: void d22(std::string_view sv = {(std::string_view) {}});
 
     void d23(std::string_view sv = {(std::string_view){nullptr}});
     // CHECK-MESSAGES: :[[@LINE-1]]:56: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    void d23(std::string_view sv = {(std::string_view){}});
+    // CHECK-FIXES: void d23(std::string_view sv = {(std::string_view){}});
 
     void d24(std::string_view sv = {static_cast<SV>(nullptr)});
     // CHECK-MESSAGES: :[[@LINE-1]]:53: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    void d24(std::string_view sv = {static_cast<SV>("")});
+    // CHECK-FIXES: void d24(std::string_view sv = {static_cast<SV>("")});
   }
 }
 
@@ -906,132 +906,132 @@ void heap_construction() /* e */ {
   {
     (void)(new std::string_view(nullptr)) /* e1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view()) /* e1 */;
+    // CHECK-FIXES: (void)(new std::string_view()) /* e1 */;
 
     (void)(new std::string_view((nullptr))) /* e2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view()) /* e2 */;
+    // CHECK-FIXES: (void)(new std::string_view()) /* e2 */;
 
     (void)(new std::string_view({nullptr})) /* e3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view()) /* e3 */;
+    // CHECK-FIXES: (void)(new std::string_view()) /* e3 */;
 
     (void)(new std::string_view({(nullptr)})) /* e4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view()) /* e4 */;
+    // CHECK-FIXES: (void)(new std::string_view()) /* e4 */;
 
     (void)(new std::string_view({})) /* e5 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view()) /* e5 */;
+    // CHECK-FIXES: (void)(new std::string_view()) /* e5 */;
 
     (void)(new const std::string_view(nullptr)) /* e6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view()) /* e6 */;
+    // CHECK-FIXES: (void)(new const std::string_view()) /* e6 */;
 
     (void)(new const std::string_view((nullptr))) /* e7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view()) /* e7 */;
+    // CHECK-FIXES: (void)(new const std::string_view()) /* e7 */;
 
     (void)(new const std::string_view({nullptr})) /* e8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view()) /* e8 */;
+    // CHECK-FIXES: (void)(new const std::string_view()) /* e8 */;
 
     (void)(new const std::string_view({(nullptr)})) /* e9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view()) /* e9 */;
+    // CHECK-FIXES: (void)(new const std::string_view()) /* e9 */;
 
     (void)(new const std::string_view({})) /* e10 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view()) /* e10 */;
+    // CHECK-FIXES: (void)(new const std::string_view()) /* e10 */;
   }
 
   // Direct Initialization With Temporary
   {
     (void)(new std::string_view(std::string_view(nullptr))) /* e11 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view(std::string_view())) /* e11 */;
+    // CHECK-FIXES: (void)(new std::string_view(std::string_view())) /* e11 */;
 
     (void)(new std::string_view(std::string_view{nullptr})) /* e12 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view(std::string_view{})) /* e12 */;
+    // CHECK-FIXES: (void)(new std::string_view(std::string_view{})) /* e12 */;
 
     (void)(new std::string_view((std::string_view) nullptr)) /* e13 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view((std::string_view) {})) /* e13 */;
+    // CHECK-FIXES: (void)(new std::string_view((std::string_view) {})) /* e13 */;
 
     (void)(new std::string_view((std::string_view){nullptr})) /* e14 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view((std::string_view){})) /* e14 */;
+    // CHECK-FIXES: (void)(new std::string_view((std::string_view){})) /* e14 */;
 
     (void)(new std::string_view(static_cast<SV>(nullptr))) /* e15 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view(static_cast<SV>(""))) /* e15 */;
+    // CHECK-FIXES: (void)(new std::string_view(static_cast<SV>(""))) /* e15 */;
   }
 
   // Direct List Initialization
   {
     (void)(new std::string_view{nullptr}) /* e16 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{}) /* e16 */;
+    // CHECK-FIXES: (void)(new std::string_view{}) /* e16 */;
 
     (void)(new std::string_view{(nullptr)}) /* e17 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{}) /* e17 */;
+    // CHECK-FIXES: (void)(new std::string_view{}) /* e17 */;
 
     (void)(new std::string_view{{nullptr}}) /* e18 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{}) /* e18 */;
+    // CHECK-FIXES: (void)(new std::string_view{}) /* e18 */;
 
     (void)(new std::string_view{{(nullptr)}}) /* e19 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{}) /* e19 */;
+    // CHECK-FIXES: (void)(new std::string_view{}) /* e19 */;
 
     (void)(new std::string_view{{}}) /* e20 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{}) /* e20 */;
+    // CHECK-FIXES: (void)(new std::string_view{}) /* e20 */;
 
     (void)(new const std::string_view{nullptr}) /* e21 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view{}) /* e21 */;
+    // CHECK-FIXES: (void)(new const std::string_view{}) /* e21 */;
 
     (void)(new const std::string_view{(nullptr)}) /* e22 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view{}) /* e22 */;
+    // CHECK-FIXES: (void)(new const std::string_view{}) /* e22 */;
 
     (void)(new const std::string_view{{nullptr}}) /* e23 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view{}) /* e23 */;
+    // CHECK-FIXES: (void)(new const std::string_view{}) /* e23 */;
 
     (void)(new const std::string_view{{(nullptr)}}) /* e24 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view{}) /* e24 */;
+    // CHECK-FIXES: (void)(new const std::string_view{}) /* e24 */;
 
     (void)(new const std::string_view{{}}) /* e25 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new const std::string_view{}) /* e25 */;
+    // CHECK-FIXES: (void)(new const std::string_view{}) /* e25 */;
   }
 
   // Direct List Initialization With Temporary
   {
     (void)(new std::string_view{std::string_view(nullptr)}) /* e26 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{std::string_view()}) /* e26 */;
+    // CHECK-FIXES: (void)(new std::string_view{std::string_view()}) /* e26 */;
 
     (void)(new std::string_view{std::string_view{nullptr}}) /* e27 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{std::string_view{}}) /* e27 */;
+    // CHECK-FIXES: (void)(new std::string_view{std::string_view{}}) /* e27 */;
 
     (void)(new std::string_view{(std::string_view) nullptr}) /* e28 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{(std::string_view) {}}) /* e28 */;
+    // CHECK-FIXES: (void)(new std::string_view{(std::string_view) {}}) /* e28 */;
 
     (void)(new std::string_view{(std::string_view){nullptr}}) /* e29 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{(std::string_view){}}) /* e29 */;
+    // CHECK-FIXES: (void)(new std::string_view{(std::string_view){}}) /* e29 */;
 
     (void)(new std::string_view{static_cast<SV>(nullptr)}) /* e30 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(new std::string_view{static_cast<SV>("")}) /* e30 */;
+    // CHECK-FIXES: (void)(new std::string_view{static_cast<SV>("")}) /* e30 */;
   }
 }
 
@@ -1040,46 +1040,46 @@ void function_argument_initialization() /* f */ {
   {
     function(nullptr) /* f1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing null as basic_string_view is undefined; replace with the empty string
-    // CHECK-FIXES: {{^}}    function("") /* f1 */;
+    // CHECK-FIXES: function("") /* f1 */;
 
     function((nullptr)) /* f2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    function("") /* f2 */;
+    // CHECK-FIXES: function("") /* f2 */;
 
     function({nullptr}) /* f3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    function("") /* f3 */;
+    // CHECK-FIXES: function("") /* f3 */;
 
     function({(nullptr)}) /* f4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    function("") /* f4 */;
+    // CHECK-FIXES: function("") /* f4 */;
 
     function({{}}) /* f5 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    function("") /* f5 */;
+    // CHECK-FIXES: function("") /* f5 */;
   }
 
   // Function Argument Initialization With Temporary
   {
     function(std::string_view(nullptr)) /* f6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    function(std::string_view()) /* f6 */;
+    // CHECK-FIXES: function(std::string_view()) /* f6 */;
 
     function(std::string_view{nullptr}) /* f7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    function(std::string_view{}) /* f7 */;
+    // CHECK-FIXES: function(std::string_view{}) /* f7 */;
 
     function((std::string_view) nullptr) /* f8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    function((std::string_view) {}) /* f8 */;
+    // CHECK-FIXES: function((std::string_view) {}) /* f8 */;
 
     function((std::string_view){nullptr}) /* f9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    function((std::string_view){}) /* f9 */;
+    // CHECK-FIXES: function((std::string_view){}) /* f9 */;
 
     function(static_cast<SV>(nullptr)) /* f10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    function(static_cast<SV>("")) /* f10 */;
+    // CHECK-FIXES: function(static_cast<SV>("")) /* f10 */;
   }
 }
 
@@ -1088,46 +1088,46 @@ void assignment(std::string_view sv) /* g */ {
   {
     sv = nullptr /* g1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment to basic_string_view from null is undefined; replace with the default constructor
-    // CHECK-FIXES: {{^}}    sv = {} /* g1 */;
+    // CHECK-FIXES: sv = {} /* g1 */;
 
     sv = (nullptr) /* g2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = {} /* g2 */;
+    // CHECK-FIXES: sv = {} /* g2 */;
 
     sv = {nullptr} /* g3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = {} /* g3 */;
+    // CHECK-FIXES: sv = {} /* g3 */;
 
     sv = {(nullptr)} /* g4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = {} /* g4 */;
+    // CHECK-FIXES: sv = {} /* g4 */;
 
     sv = {{}} /* g5 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = {} /* g5 */;
+    // CHECK-FIXES: sv = {} /* g5 */;
   }
 
   // Assignment With Temporary
   {
     sv = std::string_view(nullptr) /* g6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = std::string_view() /* g6 */;
+    // CHECK-FIXES: sv = std::string_view() /* g6 */;
 
     sv = std::string_view{nullptr} /* g7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = std::string_view{} /* g7 */;
+    // CHECK-FIXES: sv = std::string_view{} /* g7 */;
 
     sv = (std::string_view) nullptr /* g8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = (std::string_view) {} /* g8 */;
+    // CHECK-FIXES: sv = (std::string_view) {} /* g8 */;
 
     sv = (std::string_view){nullptr} /* g9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    sv = (std::string_view){} /* g9 */;
+    // CHECK-FIXES: sv = (std::string_view){} /* g9 */;
 
     sv = static_cast<SV>(nullptr) /* g10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    sv = static_cast<SV>("") /* g10 */;
+    // CHECK-FIXES: sv = static_cast<SV>("") /* g10 */;
   }
 }
 
@@ -1136,46 +1136,46 @@ void pointer_assignment(std::string_view *sv_ptr) /* h */ {
   {
     *sv_ptr = nullptr /* h1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = {} /* h1 */;
+    // CHECK-FIXES: *sv_ptr = {} /* h1 */;
 
     *sv_ptr = (nullptr) /* h2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = {} /* h2 */;
+    // CHECK-FIXES: *sv_ptr = {} /* h2 */;
 
     *sv_ptr = {nullptr} /* h3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = {} /* h3 */;
+    // CHECK-FIXES: *sv_ptr = {} /* h3 */;
 
     *sv_ptr = {(nullptr)} /* h4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = {} /* h4 */;
+    // CHECK-FIXES: *sv_ptr = {} /* h4 */;
 
     *sv_ptr = {{}} /* h5 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = {} /* h5 */;
+    // CHECK-FIXES: *sv_ptr = {} /* h5 */;
   }
 
   // Assignment With Temporary
   {
     *sv_ptr = std::string_view(nullptr) /* h6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = std::string_view() /* h6 */;
+    // CHECK-FIXES: *sv_ptr = std::string_view() /* h6 */;
 
     *sv_ptr = std::string_view{nullptr} /* h7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = std::string_view{} /* h7 */;
+    // CHECK-FIXES: *sv_ptr = std::string_view{} /* h7 */;
 
     *sv_ptr = (std::string_view) nullptr /* h8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = (std::string_view) {} /* h8 */;
+    // CHECK-FIXES: *sv_ptr = (std::string_view) {} /* h8 */;
 
     *sv_ptr = (std::string_view){nullptr} /* h9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    *sv_ptr = (std::string_view){} /* h9 */;
+    // CHECK-FIXES: *sv_ptr = (std::string_view){} /* h9 */;
 
     *sv_ptr = static_cast<SV>(nullptr) /* h10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    *sv_ptr = static_cast<SV>("") /* h10 */;
+    // CHECK-FIXES: *sv_ptr = static_cast<SV>("") /* h10 */;
   }
 }
 
@@ -1184,38 +1184,38 @@ void lesser_comparison(std::string_view sv) /* i */ {
   {
     (void)(sv < nullptr) /* i1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: comparing basic_string_view to null is undefined; replace with the empty string
-    // CHECK-FIXES: {{^}}    (void)(sv < "") /* i1 */;
+    // CHECK-FIXES: (void)(sv < "") /* i1 */;
 
     (void)(sv < (nullptr)) /* i2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv < "") /* i2 */;
+    // CHECK-FIXES: (void)(sv < "") /* i2 */;
 
     (void)(nullptr < sv) /* i3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" < sv) /* i3 */;
+    // CHECK-FIXES: (void)("" < sv) /* i3 */;
 
     (void)((nullptr) < sv) /* i4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" < sv) /* i4 */;
+    // CHECK-FIXES: (void)("" < sv) /* i4 */;
   }
 
   // With Equality
   {
     (void)(sv <= nullptr) /* i5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv <= "") /* i5 */;
+    // CHECK-FIXES: (void)(sv <= "") /* i5 */;
 
     (void)(sv <= (nullptr)) /* i6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv <= "") /* i6 */;
+    // CHECK-FIXES: (void)(sv <= "") /* i6 */;
 
     (void)(nullptr <= sv) /* i7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" <= sv) /* i7 */;
+    // CHECK-FIXES: (void)("" <= sv) /* i7 */;
 
     (void)((nullptr) <= sv) /* i8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" <= sv) /* i8 */;
+    // CHECK-FIXES: (void)("" <= sv) /* i8 */;
   }
 }
 
@@ -1224,38 +1224,38 @@ void pointer_lesser_comparison(std::string_view *sv_ptr) /* j */ {
   {
     (void)(*sv_ptr < nullptr) /* j1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr < "") /* j1 */;
+    // CHECK-FIXES: (void)(*sv_ptr < "") /* j1 */;
 
     (void)(*sv_ptr < (nullptr)) /* j2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr < "") /* j2 */;
+    // CHECK-FIXES: (void)(*sv_ptr < "") /* j2 */;
 
     (void)(nullptr < *sv_ptr) /* j3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" < *sv_ptr) /* j3 */;
+    // CHECK-FIXES: (void)("" < *sv_ptr) /* j3 */;
 
     (void)((nullptr) < *sv_ptr) /* j4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" < *sv_ptr) /* j4 */;
+    // CHECK-FIXES: (void)("" < *sv_ptr) /* j4 */;
   }
 
   // With Equality
   {
     (void)(*sv_ptr <= nullptr) /* j5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr <= "") /* j5 */;
+    // CHECK-FIXES: (void)(*sv_ptr <= "") /* j5 */;
 
     (void)(*sv_ptr <= (nullptr)) /* j6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr <= "") /* j6 */;
+    // CHECK-FIXES: (void)(*sv_ptr <= "") /* j6 */;
 
     (void)(nullptr <= *sv_ptr) /* j7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" <= *sv_ptr) /* j7 */;
+    // CHECK-FIXES: (void)("" <= *sv_ptr) /* j7 */;
 
     (void)((nullptr) <= *sv_ptr) /* j8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" <= *sv_ptr) /* j8 */;
+    // CHECK-FIXES: (void)("" <= *sv_ptr) /* j8 */;
   }
 }
 
@@ -1264,38 +1264,38 @@ void greater_comparison(std::string_view sv) /* k */ {
   {
     (void)(sv > nullptr) /* k1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv > "") /* k1 */;
+    // CHECK-FIXES: (void)(sv > "") /* k1 */;
 
     (void)(sv > (nullptr)) /* k2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv > "") /* k2 */;
+    // CHECK-FIXES: (void)(sv > "") /* k2 */;
 
     (void)(nullptr > sv) /* k3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" > sv) /* k3 */;
+    // CHECK-FIXES: (void)("" > sv) /* k3 */;
 
     (void)((nullptr) > sv) /* k4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" > sv) /* k4 */;
+    // CHECK-FIXES: (void)("" > sv) /* k4 */;
   }
 
   // With Equality
   {
     (void)(sv >= nullptr) /* k5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv >= "") /* k5 */;
+    // CHECK-FIXES: (void)(sv >= "") /* k5 */;
 
     (void)(sv >= (nullptr)) /* k6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(sv >= "") /* k6 */;
+    // CHECK-FIXES: (void)(sv >= "") /* k6 */;
 
     (void)(nullptr >= sv) /* k7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" >= sv) /* k7 */;
+    // CHECK-FIXES: (void)("" >= sv) /* k7 */;
 
     (void)((nullptr) >= sv) /* k8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" >= sv) /* k8 */;
+    // CHECK-FIXES: (void)("" >= sv) /* k8 */;
   }
 }
 
@@ -1304,61 +1304,61 @@ void pointer_greater_comparison(std::string_view *sv_ptr) /* l */ {
   {
     (void)(*sv_ptr > nullptr) /* l1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr > "") /* l1 */;
+    // CHECK-FIXES: (void)(*sv_ptr > "") /* l1 */;
 
     (void)(*sv_ptr > (nullptr)) /* l2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr > "") /* l2 */;
+    // CHECK-FIXES: (void)(*sv_ptr > "") /* l2 */;
 
     (void)(nullptr > *sv_ptr) /* l3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" > *sv_ptr) /* l3 */;
+    // CHECK-FIXES: (void)("" > *sv_ptr) /* l3 */;
 
     (void)((nullptr) > *sv_ptr) /* l4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" > *sv_ptr) /* l4 */;
+    // CHECK-FIXES: (void)("" > *sv_ptr) /* l4 */;
   }
 
   // With Equality
   {
     (void)(*sv_ptr >= nullptr) /* l5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr >= "") /* l5 */;
+    // CHECK-FIXES: (void)(*sv_ptr >= "") /* l5 */;
 
     (void)(*sv_ptr >= (nullptr)) /* l6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)(*sv_ptr >= "") /* l6 */;
+    // CHECK-FIXES: (void)(*sv_ptr >= "") /* l6 */;
 
     (void)(nullptr >= *sv_ptr) /* l7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" >= *sv_ptr) /* l7 */;
+    // CHECK-FIXES: (void)("" >= *sv_ptr) /* l7 */;
 
     (void)((nullptr) >= *sv_ptr) /* l8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}empty string
-    // CHECK-FIXES: {{^}}    (void)("" >= *sv_ptr) /* l8 */;
+    // CHECK-FIXES: (void)("" >= *sv_ptr) /* l8 */;
   }
 }
 
 void relative_comparison_with_temporary(std::string_view sv) /* m */ {
   (void)(sv < std::string_view(nullptr)) /* m1 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv < std::string_view()) /* m1 */;
+  // CHECK-FIXES: (void)(sv < std::string_view()) /* m1 */;
 
   (void)(sv < std::string_view{nullptr}) /* m2 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv < std::string_view{}) /* m2 */;
+  // CHECK-FIXES: (void)(sv < std::string_view{}) /* m2 */;
 
   (void)(sv < (std::string_view) nullptr) /* m3 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv < (std::string_view) {}) /* m3 */;
+  // CHECK-FIXES: (void)(sv < (std::string_view) {}) /* m3 */;
 
   (void)(sv < (std::string_view){nullptr}) /* m4 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv < (std::string_view){}) /* m4 */;
+  // CHECK-FIXES: (void)(sv < (std::string_view){}) /* m4 */;
 
   (void)(sv < static_cast<SV>(nullptr)) /* m5 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: casting{{.*}}empty string
-  // CHECK-FIXES: {{^}}  (void)(sv < static_cast<SV>("")) /* m5 */;
+  // CHECK-FIXES: (void)(sv < static_cast<SV>("")) /* m5 */;
 }
 
 void equality_comparison(std::string_view sv) /* n */ {
@@ -1366,76 +1366,76 @@ void equality_comparison(std::string_view sv) /* n */ {
   {
     (void)(sv == nullptr) /* n1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing basic_string_view to null is undefined; replace with the emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n1 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n1 */;
 
     (void)(sv == (nullptr)) /* n2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n2 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n2 */;
 
     (void)(nullptr == sv) /* n3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n3 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n3 */;
 
     (void)((nullptr) == sv) /* n4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n4 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n4 */;
   }
 
   // Empty With Parens
   {
     (void)((sv) == nullptr) /* n5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing basic_string_view to null is undefined; replace with the emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n5 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n5 */;
 
     (void)((sv) == (nullptr)) /* n6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n6 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n6 */;
 
     (void)(nullptr == (sv)) /* n7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n7 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n7 */;
 
     (void)((nullptr) == (sv)) /* n8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv.empty()) /* n8 */;
+    // CHECK-FIXES: (void)(sv.empty()) /* n8 */;
   }
 
   // Non-Empty Without Parens
   {
     (void)((sv) != nullptr) /* n9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n9 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n9 */;
 
     (void)((sv) != (nullptr)) /* n10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n10 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n10 */;
 
     (void)(nullptr != (sv)) /* n11 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n11 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n11 */;
 
     (void)((nullptr) != (sv)) /* n12 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n12 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n12 */;
   }
 
   // Non-Empty With Parens
   {
     (void)((sv) != nullptr) /* n13 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n13 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n13 */;
 
     (void)((sv) != (nullptr)) /* n14 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n14 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n14 */;
 
     (void)(nullptr != (sv)) /* n15 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n15 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n15 */;
 
     (void)((nullptr) != (sv)) /* n16 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv.empty()) /* n16 */;
+    // CHECK-FIXES: (void)(!sv.empty()) /* n16 */;
   }
 }
 
@@ -1444,99 +1444,99 @@ void pointer_equality_comparison(std::string_view *sv_ptr) /* o */ {
   {
     (void)(*sv_ptr == nullptr) /* o1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o1 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o1 */;
 
     (void)(*sv_ptr == (nullptr)) /* o2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o2 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o2 */;
 
     (void)(nullptr == *sv_ptr) /* o3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o3 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o3 */;
 
     (void)((nullptr) == *sv_ptr) /* o4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o4 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o4 */;
   }
 
   // Empty With Parens
   {
     (void)((*sv_ptr) == nullptr) /* o5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o5 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o5 */;
 
     (void)((*sv_ptr) == (nullptr)) /* o6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o6 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o6 */;
 
     (void)(nullptr == (*sv_ptr)) /* o7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o7 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o7 */;
 
     (void)((nullptr) == (*sv_ptr)) /* o8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(sv_ptr->empty()) /* o8 */;
+    // CHECK-FIXES: (void)(sv_ptr->empty()) /* o8 */;
   }
 
   // Non-Empty With Parens
   {
     (void)((*sv_ptr) != nullptr) /* o9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o9 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o9 */;
 
     (void)((*sv_ptr) != (nullptr)) /* o10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o10 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o10 */;
 
     (void)(nullptr != (*sv_ptr)) /* o11 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o11 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o11 */;
 
     (void)((nullptr) != (*sv_ptr)) /* o12 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o12 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o12 */;
   }
 
   // Non-Empty Without Parens
   {
     (void)((*sv_ptr) != nullptr) /* o13 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o13 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o13 */;
 
     (void)((*sv_ptr) != (nullptr)) /* o14 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o14 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o14 */;
 
     (void)(nullptr != (*sv_ptr)) /* o15 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o15 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o15 */;
 
     (void)((nullptr) != (*sv_ptr)) /* o16 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: comparing{{.*}}emptiness query
-    // CHECK-FIXES: {{^}}    (void)(!sv_ptr->empty()) /* o16 */;
+    // CHECK-FIXES: (void)(!sv_ptr->empty()) /* o16 */;
   }
 }
 
 void equality_comparison_with_temporary(std::string_view sv) /* p */ {
   (void)(sv == std::string_view(nullptr)) /* p1 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv == std::string_view()) /* p1 */;
+  // CHECK-FIXES: (void)(sv == std::string_view()) /* p1 */;
 
   (void)(sv == std::string_view{nullptr}) /* p2 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv == std::string_view{}) /* p2 */;
+  // CHECK-FIXES: (void)(sv == std::string_view{}) /* p2 */;
 
   (void)(sv == (std::string_view) nullptr) /* p3 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv == (std::string_view) {}) /* p3 */;
+  // CHECK-FIXES: (void)(sv == (std::string_view) {}) /* p3 */;
 
   (void)(sv == (std::string_view){nullptr}) /* p4 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
-  // CHECK-FIXES: {{^}}  (void)(sv == (std::string_view){}) /* p4 */;
+  // CHECK-FIXES: (void)(sv == (std::string_view){}) /* p4 */;
 
   (void)(sv == static_cast<SV>(nullptr)) /* p5 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: casting{{.*}}empty string
-  // CHECK-FIXES: {{^}}  (void)(sv == static_cast<SV>("")) /* p5 */;
+  // CHECK-FIXES: (void)(sv == static_cast<SV>("")) /* p5 */;
 }
 
 void return_statement() /* q */ {
@@ -1544,54 +1544,54 @@ void return_statement() /* q */ {
   {
     []() -> SV { return nullptr; } /* q1 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q1 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q1 */;
 
     []() -> SV { return (nullptr); } /* q2 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q2 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q2 */;
 
     []() -> SV { return {nullptr}; } /* q3 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q3 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q3 */;
 
     []() -> SV { return {(nullptr)}; } /* q4 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q4 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q4 */;
 
     []() -> SV { return {{nullptr}}; } /* q5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q5 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q5 */;
 
     []() -> SV { return {{(nullptr)}}; } /* q6 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q6 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q6 */;
 
     []() -> SV { return {{}}; } /* q7 */; // Default `const CharT*`
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return {}; } /* q7 */;
+    // CHECK-FIXES: []() -> SV { return {}; } /* q7 */;
   }
 
   // Return Statement With Temporary
   {
     []() -> SV { return SV(nullptr); } /* q8 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return SV(); } /* q8 */;
+    // CHECK-FIXES: []() -> SV { return SV(); } /* q8 */;
 
     []() -> SV { return SV{nullptr}; } /* q9 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return SV{}; } /* q9 */;
+    // CHECK-FIXES: []() -> SV { return SV{}; } /* q9 */;
 
     []() -> SV { return (SV) nullptr; } /* q10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return (SV) {}; } /* q10 */;
+    // CHECK-FIXES: []() -> SV { return (SV) {}; } /* q10 */;
 
     []() -> SV { return (SV){nullptr}; } /* q11 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: constructing{{.*}}default
-    // CHECK-FIXES: {{^}}    []() -> SV { return (SV){}; } /* q11 */;
+    // CHECK-FIXES: []() -> SV { return (SV){}; } /* q11 */;
 
     []() -> SV { return static_cast<SV>(nullptr); } /* q12 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: casting{{.*}}empty string
-    // CHECK-FIXES: {{^}}    []() -> SV { return static_cast<SV>(""); } /* q12 */;
+    // CHECK-FIXES: []() -> SV { return static_cast<SV>(""); } /* q12 */;
   }
 }
 
@@ -1600,13 +1600,13 @@ void constructor_invocation() /* r */ {
     explicit AcceptsSV(std::string_view) {}
   } r1(nullptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: passing{{.*}}empty string
-  // CHECK-FIXES: {{^}}  } r1("");
+  // CHECK-FIXES: } r1("");
 
   (void)(AcceptsSV{nullptr}) /* r2 */;
   // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: passing{{.*}}empty string
-  // CHECK-FIXES: {{^}}  (void)(AcceptsSV{""}) /* r2 */;
+  // CHECK-FIXES: (void)(AcceptsSV{""}) /* r2 */;
 
   AcceptsSV r3{nullptr};
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: passing{{.*}}empty string
-  // CHECK-FIXES: {{^}}  AcceptsSV r3{""};
+  // CHECK-FIXES: AcceptsSV r3{""};
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-semicolon.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-semicolon.cpp
@@ -35,7 +35,7 @@ void fail2()
 	if(x == 5);
 		nop();
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: potentially unintended semicolon [bugprone-suspicious-semicolon]
-  // CHECK-FIXES: if(x == 5){{$}}
+  // CHECK-FIXES: if(x == 5)
 }
 
 void fail3()
@@ -45,7 +45,7 @@ void fail3()
 		nop();
 	}
   // CHECK-MESSAGES: :[[@LINE-4]]:11: warning: potentially unintended semicolon
-  // CHECK-FIXES: if(x < 5){{$}}
+  // CHECK-FIXES: if(x < 5)
 }
 
 void correct4()
@@ -65,7 +65,7 @@ void fail4()
 	for(int i = 0; i < x; ++i);
 		nop();
   // CHECK-MESSAGES: :[[@LINE-2]]:28: warning: potentially unintended semicolon
-  // CHECK-FIXES: for(int i = 0; i < x; ++i){{$}}
+  // CHECK-FIXES: for(int i = 0; i < x; ++i)
 }
 
 void fail5()
@@ -73,7 +73,7 @@ void fail5()
 	if(x % 5 == 1);
 	  nop();
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: potentially unintended semicolon
-  // CHECK-FIXES: if(x % 5 == 1){{$}}
+  // CHECK-FIXES: if(x % 5 == 1)
 }
 
 void fail6() {
@@ -82,7 +82,7 @@ void fail6() {
   } else if (a != 1);
     a = 2;
   // CHECK-MESSAGES: :[[@LINE-2]]:21: warning: potentially unintended semicolon
-  // CHECK-FIXES: } else if (a != 1){{$}}
+  // CHECK-FIXES: } else if (a != 1)
 }
 
 void fail7() {

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables.cpp
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy %s cppcoreguidelines-init-variables -fix-errors %t -- -- -fno-delayed-template-parsing -fexceptions
-// CHECK-FIXES: {{^}}#include <math.h>
+// CHECK-FIXES: #include <math.h>
 
 // Ensure that function declarations are not changed.
 void some_func(int x, double d, bool b, const char *p);
@@ -28,48 +28,48 @@ void template_test_function() {
   T t;
   int uninitialized;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: variable 'uninitialized' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  int uninitialized = 0;{{$}}
+  // CHECK-FIXES: int uninitialized = 0;
 }
 
 void init_unit_tests() {
   int x;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: variable 'x' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  int x = 0;{{$}}
+  // CHECK-FIXES: int x = 0;
   my_int_type myint;
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: variable 'myint' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  my_int_type myint = 0;{{$}}
+  // CHECK-FIXES: my_int_type myint = 0;
 
   MACRO_INT macroint;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: variable 'macroint' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  MACRO_INT macroint = 0;{{$}}
+  // CHECK-FIXES: MACRO_INT macroint = 0;
   FULL_DECLARATION();
 
   int x0 = 1, x1, x2 = 2;
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: variable 'x1' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  int x0 = 1, x1 = 0, x2 = 2;{{$}}
+  // CHECK-FIXES: int x0 = 1, x1 = 0, x2 = 2;
   int y0, y1 = 1, y2;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: variable 'y0' is not initialized [cppcoreguidelines-init-variables]
   // CHECK-MESSAGES: :[[@LINE-2]]:19: warning: variable 'y2' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  int y0 = 0, y1 = 1, y2 = 0;{{$}}
+  // CHECK-FIXES: int y0 = 0, y1 = 1, y2 = 0;
   int hasval = 42;
 
   float f;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: variable 'f' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  float f = NAN;{{$}}
+  // CHECK-FIXES: float f = NAN;
   float fval = 85.0;
   double d;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: variable 'd' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  double d = NAN;{{$}}
+  // CHECK-FIXES: double d = NAN;
   double dval = 99.0;
 
   bool b;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: variable 'b' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  bool b = false;{{$}}
+  // CHECK-FIXES: bool b = false;
   bool bval = true;
 
   const char *ptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: variable 'ptr' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  const char *ptr = nullptr;{{$}}
+  // CHECK-FIXES: const char *ptr = nullptr;
   const char *ptrval = "a string";
 
   UnusedStruct u;
@@ -128,11 +128,11 @@ void uninitialized_enum() {
 void test_clang_diagnostic_error() {
   int a;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: variable 'a' is not initialized [cppcoreguidelines-init-variables]
-  // CHECK-FIXES: {{^}}  int a = 0;{{$}}
+  // CHECK-FIXES: int a = 0;
 
   UnknownType b;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: error: unknown type name 'UnknownType' [clang-diagnostic-error]
-  // CHECK-FIXES-NOT: {{^}}  UnknownType b = 0;{{$}}
+  // CHECK-FIXES-NOT: UnknownType b = 0;
 }
 
 namespace gh112089 {

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-namespace-comments.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-namespace-comments.cpp
@@ -75,7 +75,7 @@ void h();
 // CHECK-MESSAGES: :[[@LINE+2]]:1: warning: anonymous namespace not terminated with
 // CHECK-MESSAGES: :[[@LINE-10]]:26: note: anonymous namespace starts here
 }
-// CHECK-FIXES: }  // namespace{{$}}
+// CHECK-FIXES: }  // namespace
 
 namespace [[]] {
 void hh();
@@ -89,7 +89,7 @@ void hh();
 // CHECK-MESSAGES: :[[@LINE+2]]:1: warning: anonymous namespace not terminated with
 // CHECK-MESSAGES: :[[@LINE-10]]:16: note: anonymous namespace starts here
 }
-// CHECK-FIXES: }  // namespace{{$}}
+// CHECK-FIXES: }  // namespace
 
 namespace short1 {
 namespace short2 {

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/include-cleaner-wrong-config.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/include-cleaner-wrong-config.cpp
@@ -7,4 +7,4 @@
 // CHECK-MESSAGES: warning: The check 'misc-include-cleaner' will not perform any analysis because 'UnusedIncludes' and 'MissingIncludes' are both false. [clang-tidy-config]
 
 #include "bar.h"
-// CHECK-FIXES-NOT: {{^}}#include "baz.h"{{$}}
+// CHECK-FIXES-NOT: #include "baz.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/include-cleaner.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/include-cleaner.cpp
@@ -1,10 +1,10 @@
 // RUN: %check_clang_tidy %s misc-include-cleaner %t -- -- -I%S/Inputs -isystem%S/Inputs/system
 #include "bar.h"
-// CHECK-FIXES: {{^}}#include "baz.h"{{$}}
+// CHECK-FIXES: #include "baz.h"
 #include "foo.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: included header foo.h is not used directly [misc-include-cleaner]
 // CHECK-FIXES: {{^}}
-// CHECK-FIXES: {{^}}#include <string>{{$}}
+// CHECK-FIXES: #include <string>
 #include <vector.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: included header vector.h is not used directly [misc-include-cleaner]
 // CHECK-FIXES: {{^}}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/redundant-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/redundant-expression.cpp
@@ -999,21 +999,21 @@ int TestOperatorConfusion(int X, int Y, long Z)
 
   int K = !(1 | 2 | 4);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: ineffective logical negation operator used; did you mean '~'?
-  // CHECK-FIXES: {{^}}  int K = ~(1 | 2 | 4);{{$}}
+  // CHECK-FIXES: int K = ~(1 | 2 | 4);
   K = !(FLAG1 & FLAG2 & FLAG3);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: ineffective logical negation operator
-  // CHECK-FIXES: {{^}}  K = ~(FLAG1 & FLAG2 & FLAG3);{{$}}
+  // CHECK-FIXES: K = ~(FLAG1 & FLAG2 & FLAG3);
   K = !(3 | 4);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: ineffective logical negation operator
-  // CHECK-FIXES: {{^}}  K = ~(3 | 4);{{$}}
+  // CHECK-FIXES: K = ~(3 | 4);
   int NotFlags = !FLAGS;
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: ineffective logical negation operator
-  // CHECK-FIXES: {{^}}  int NotFlags = ~FLAGS;{{$}}
+  // CHECK-FIXES: int NotFlags = ~FLAGS;
   NotFlags = NOTFLAGS;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: ineffective logical negation operator
   return !(1 | 2 | 4);
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: ineffective logical negation operator
-  // CHECK-FIXES: {{^}}  return ~(1 | 2 | 4);{{$}}
+  // CHECK-FIXES: return ~(1 | 2 | 4);
 }
 
 template <int Shift, int Mask>

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters-strict.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters-strict.cpp
@@ -5,14 +5,14 @@
 namespace strict_mode {
 void f(int foo) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: parameter 'foo' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void f(int  /*foo*/) {}{{$}}
+// CHECK-FIXES: void f(int  /*foo*/) {}
 class E {
   int i;
 
 public:
   E(int j) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: parameter 'j' is unused
-// CHECK-FIXES: {{^}}  E(int  /*j*/) {}{{$}}
+// CHECK-FIXES: E(int  /*j*/) {}
 };
 class F {
   int i;
@@ -20,7 +20,7 @@ class F {
 public:
   F(int j) : i() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: parameter 'j' is unused
-// CHECK-FIXES: {{^}}  F(int  /*j*/) : i() {}{{$}}
+// CHECK-FIXES: F(int  /*j*/) : i() {}
 };
 
 // Do not warn on naked functions.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.c
@@ -4,14 +4,14 @@
 // =============
 void a(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void a(int i) {;}{{$}}
+// CHECK-FIXES: void a(int i) {;}
 
 #if __STDC_VERSION__ < 202311L
 static void b(); // In C before C23, forward declarations can leave out parameters.
 #endif
 static void b(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}static void b() {;}{{$}}
+// CHECK-FIXES: static void b() {;}
 
 // Unchanged cases
 // ===============

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -11,36 +11,36 @@
 // =============
 void a(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void a(int  /*i*/) {;}{{$}}
+// CHECK-FIXES: void a(int  /*i*/) {;}
 
 void b(int i = 1) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void b(int  /*i*/ = 1) {;}{{$}}
+// CHECK-FIXES: void b(int  /*i*/ = 1) {;}
 
 void c(int *i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void c(int * /*i*/) {;}{{$}}
+// CHECK-FIXES: void c(int * /*i*/) {;}
 
 void d(int i[]) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void d(int  /*i*/[]) {;}{{$}}
+// CHECK-FIXES: void d(int  /*i*/[]) {;}
 
 void e(int i[1]) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void e(int  /*i*/[1]) {;}{{$}}
+// CHECK-FIXES: void e(int  /*i*/[1]) {;}
 
 void f(void (*fn)()) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: parameter 'fn' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}void f(void (* /*fn*/)()) {;}{{$}}
+// CHECK-FIXES: void f(void (* /*fn*/)()) {;}
 
 int *k([[clang::lifetimebound]] int *i) { return nullptr; }
 // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}int *k({{\[\[clang::lifetimebound\]\]}} int * /*i*/) { return nullptr; }{{$}}
+// CHECK-FIXES: int *k({{\[\[clang::lifetimebound\]\]}} int * /*i*/) { return nullptr; }
 
 #define ATTR_BEFORE(x) [[clang::lifetimebound]] x
 int* m(ATTR_BEFORE(const int *i)) { return nullptr; }
 // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: parameter 'i' is unused [misc-unused-parameters]
-// CHECK-FIXES: {{^}}int* m(ATTR_BEFORE(const int * /*i*/)) { return nullptr; }{{$}}
+// CHECK-FIXES: int* m(ATTR_BEFORE(const int * /*i*/)) { return nullptr; }
 #undef ATTR_BEFORE
 
 // Unchanged cases
@@ -64,44 +64,44 @@ static bool static_var = useLambda([] (int a) { return a; });
 // Remove parameters of local functions
 // ====================================
 static void staticFunctionA(int i);
-// CHECK-FIXES: {{^}}static void staticFunctionA();
+// CHECK-FIXES: static void staticFunctionA();
 static void staticFunctionA(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: {{^}}static void staticFunctionA()
+// CHECK-FIXES: static void staticFunctionA()
 
 static void staticFunctionB(int i, int j) { (void)i; }
 // CHECK-MESSAGES: :[[@LINE-1]]:40: warning
-// CHECK-FIXES: {{^}}static void staticFunctionB(int i)
+// CHECK-FIXES: static void staticFunctionB(int i)
 
 static void staticFunctionC(int i, int j) { (void)j; }
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: {{^}}static void staticFunctionC(int j)
+// CHECK-FIXES: static void staticFunctionC(int j)
 
 static void staticFunctionD(int i, int j, int k) { (void)i; (void)k; }
 // CHECK-MESSAGES: :[[@LINE-1]]:40: warning
-// CHECK-FIXES: {{^}}static void staticFunctionD(int i, int k)
+// CHECK-FIXES: static void staticFunctionD(int i, int k)
 
 static void staticFunctionE(int i = 4) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: {{^}}static void staticFunctionE()
+// CHECK-FIXES: static void staticFunctionE()
 
 static void staticFunctionF(int i = 4);
-// CHECK-FIXES: {{^}}static void staticFunctionF();
+// CHECK-FIXES: static void staticFunctionF();
 static void staticFunctionF(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: {{^}}static void staticFunctionF()
+// CHECK-FIXES: static void staticFunctionF()
 
 static void staticFunctionG(int i[]);
-// CHECK-FIXES: {{^}}static void staticFunctionG();
+// CHECK-FIXES: static void staticFunctionG();
 static void staticFunctionG(int i[]) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: {{^}}static void staticFunctionG()
+// CHECK-FIXES: static void staticFunctionG()
 
 static void staticFunctionH(void (*fn)());
-// CHECK-FIXES: {{^}}static void staticFunctionH();
+// CHECK-FIXES: static void staticFunctionH();
 static void staticFunctionH(void (*fn)()) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:36: warning
-// CHECK-FIXES: {{^}}static void staticFunctionH()
+// CHECK-FIXES: static void staticFunctionH()
 
 static void someCallSites() {
   staticFunctionA(1);
@@ -136,12 +136,12 @@ static void someCallSites() {
 // =======================================================
 static int variableWithLongName1(int LongName1, int LongName2) {
 // CHECK-MESSAGES: :[[@LINE-1]]:53: warning: parameter 'LongName2' is unused
-// CHECK-FIXES: {{^}}static int variableWithLongName1(int LongName1) {
+// CHECK-FIXES: static int variableWithLongName1(int LongName1) {
   return LongName1;
 }
 static int variableWithLongName2(int LongName1, int LongName2) {
 // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: parameter 'LongName1' is unused
-// CHECK-FIXES: {{^}}static int variableWithLongName2(int LongName2) {
+// CHECK-FIXES: static int variableWithLongName2(int LongName2) {
   return LongName2;
 }
 static void someLongNameCallSites() {
@@ -225,12 +225,12 @@ template <typename T> void someFunctionTemplate(T b, T e) { (void)b; (void)e; }
 
 template <typename T> void someFunctionTemplateOneUnusedParam(T b, T e) { (void)e; }
 // CHECK-MESSAGES: :[[@LINE-1]]:65: warning
-// CHECK-FIXES: {{^}}template <typename T> void someFunctionTemplateOneUnusedParam(T  /*b*/, T e) { (void)e; }
+// CHECK-FIXES: template <typename T> void someFunctionTemplateOneUnusedParam(T  /*b*/, T e) { (void)e; }
 
 template <typename T> void someFunctionTemplateAllUnusedParams(T b, T e) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:66: warning
 // CHECK-MESSAGES: :[[@LINE-2]]:71: warning
-// CHECK-FIXES: {{^}}template <typename T> void someFunctionTemplateAllUnusedParams(T  /*b*/, T  /*e*/) {;}
+// CHECK-FIXES: template <typename T> void someFunctionTemplateAllUnusedParams(T  /*b*/, T  /*e*/) {;}
 
 static void dontGetConfusedByParametersInFunctionTypes() { void (*F)(int i); }
 
@@ -244,7 +244,7 @@ namespace {
 struct a {
   void b(int c) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: parameter 'c' is unused
-// CHECK-FIXES: {{^}}  void b() {;}{{$}}
+// CHECK-FIXES: void b() {;}
 };
 template <class>
 class d {
@@ -262,7 +262,7 @@ void f2(int foo2) {
 }
 void f3(int foo3) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: parameter 'foo3' is unused
-// CHECK-FIXES: {{^}}void f3(int  /*foo3*/) {;}{{$}}
+// CHECK-FIXES: void f3(int  /*foo3*/) {;}
 
 class E {
   int i;
@@ -277,7 +277,7 @@ public:
   // Constructor initializer counts as a non-empty body.
   F(int j) : i() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: parameter 'j' is unused
-// CHECK-FIXES: {{^}}  F(int  /*j*/) : i() {}{{$}}
+// CHECK-FIXES: F(int  /*j*/) : i() {}
 };
 
 class A {
@@ -289,7 +289,7 @@ class B : public A {
 public:
   B(int i) : A() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: parameter 'i' is unused
-// CHECK-FIXES: {{^}}  B(int  /*i*/) : A() {}{{$}}
+// CHECK-FIXES: B(int  /*i*/) : A() {}
 };
 } // namespace strict_mode_off
 
@@ -298,7 +298,7 @@ using fn = void(int);
 void f(fn *);
 void test() {
   // CHECK-MESSAGES: :[[@LINE+2]]:12: warning: parameter 'I' is unused
-  // CHECK-FIXES: {{^}}  f([](int  /*I*/) {
+  // CHECK-FIXES: f([](int  /*I*/) {
   f([](int I) { return; });
 }
 } // namespace lambda

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls-cxx17.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls-cxx17.cpp
@@ -22,7 +22,7 @@ using ns::Bar;
 using ns::Foo;
 using ns::Unused; // Unused
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: using decl 'Unused' is unused
-// CHECK-FIXES: {{^}}// Unused
+// CHECK-FIXES: // Unused
 
 void f() {
   Foo(123);

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-cxx03.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-cxx03.cpp
@@ -2,69 +2,69 @@
 
 #include <assert.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
-// CHECK-FIXES: {{^}}#include <cassert>{{$}}
+// CHECK-FIXES: #include <cassert>
 #include <complex.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'complex.h'; consider using 'complex' instead
-// CHECK-FIXES: {{^}}#include <complex>{{$}}
+// CHECK-FIXES: #include <complex>
 #include <ctype.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'ctype.h'; consider using 'cctype' instead
-// CHECK-FIXES: {{^}}#include <cctype>{{$}}
+// CHECK-FIXES: #include <cctype>
 #include <errno.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno' instead
-// CHECK-FIXES: {{^}}#include <cerrno>{{$}}
+// CHECK-FIXES: #include <cerrno>
 #include <float.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'float.h'; consider using 'cfloat' instead
-// CHECK-FIXES: {{^}}#include <cfloat>{{$}}
+// CHECK-FIXES: #include <cfloat>
 #include <limits.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'limits.h'; consider using 'climits' instead
-// CHECK-FIXES: {{^}}#include <climits>{{$}}
+// CHECK-FIXES: #include <climits>
 #include <locale.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'locale.h'; consider using 'clocale' instead
-// CHECK-FIXES: {{^}}#include <clocale>{{$}}
+// CHECK-FIXES: #include <clocale>
 #include <math.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'math.h'; consider using 'cmath' instead
-// CHECK-FIXES: {{^}}#include <cmath>{{$}}
+// CHECK-FIXES: #include <cmath>
 #include <setjmp.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'setjmp.h'; consider using 'csetjmp' instead
-// CHECK-FIXES: {{^}}#include <csetjmp>{{$}}
+// CHECK-FIXES: #include <csetjmp>
 #include <signal.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'signal.h'; consider using 'csignal' instead
-// CHECK-FIXES: {{^}}#include <csignal>{{$}}
+// CHECK-FIXES: #include <csignal>
 #include <stdarg.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdarg.h'; consider using 'cstdarg' instead
-// CHECK-FIXES: {{^}}#include <cstdarg>{{$}}
+// CHECK-FIXES: #include <cstdarg>
 #include <stddef.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stddef.h'; consider using 'cstddef' instead
-// CHECK-FIXES: {{^}}#include <cstddef>{{$}}
+// CHECK-FIXES: #include <cstddef>
 #include <stdio.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdio.h'; consider using 'cstdio' instead
-// CHECK-FIXES: {{^}}#include <cstdio>{{$}}
+// CHECK-FIXES: #include <cstdio>
 #include <stdlib.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
-// CHECK-FIXES: {{^}}#include <cstdlib>{{$}}
+// CHECK-FIXES: #include <cstdlib>
 #include <string.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'string.h'; consider using 'cstring' instead
-// CHECK-FIXES: {{^}}#include <cstring>{{$}}
+// CHECK-FIXES: #include <cstring>
 #include <time.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'time.h'; consider using 'ctime' instead
-// CHECK-FIXES: {{^}}#include <ctime>{{$}}
+// CHECK-FIXES: #include <ctime>
 #include <wchar.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wchar.h'; consider using 'cwchar' instead
-// CHECK-FIXES: {{^}}#include <cwchar>{{$}}
+// CHECK-FIXES: #include <cwchar>
 #include <wctype.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wctype.h'; consider using 'cwctype' instead
-// CHECK-FIXES: {{^}}#include <cwctype>{{$}}
+// CHECK-FIXES: #include <cwctype>
 
 // Headers that have no effect in C++; remove them
 #include <stdalign.h> // <stdalign.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdalign.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// <stdalign.h>{{$}}
+// CHECK-FIXES: // <stdalign.h>
 #include <stdbool.h> // <stdbool.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdbool.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// <stdbool.h>{{$}}
+// CHECK-FIXES: // <stdbool.h>
 #include <iso646.h> // <iso646.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'iso646.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// <iso646.h>{{$}}
+// CHECK-FIXES: // <iso646.h>
 
 // Headers deprecated since C++11: expect no diagnostics.
 #include <fenv.h>
@@ -76,69 +76,69 @@
 
 #include "assert.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead
-// CHECK-FIXES: {{^}}#include <cassert>{{$}}
+// CHECK-FIXES: #include <cassert>
 #include "complex.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'complex.h'; consider using 'complex' instead
-// CHECK-FIXES: {{^}}#include <complex>{{$}}
+// CHECK-FIXES: #include <complex>
 #include "ctype.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'ctype.h'; consider using 'cctype' instead
-// CHECK-FIXES: {{^}}#include <cctype>{{$}}
+// CHECK-FIXES: #include <cctype>
 #include "errno.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno' instead
-// CHECK-FIXES: {{^}}#include <cerrno>{{$}}
+// CHECK-FIXES: #include <cerrno>
 #include "float.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'float.h'; consider using 'cfloat' instead
-// CHECK-FIXES: {{^}}#include <cfloat>{{$}}
+// CHECK-FIXES: #include <cfloat>
 #include "limits.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'limits.h'; consider using 'climits' instead
-// CHECK-FIXES: {{^}}#include <climits>{{$}}
+// CHECK-FIXES: #include <climits>
 #include "locale.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'locale.h'; consider using 'clocale' instead
-// CHECK-FIXES: {{^}}#include <clocale>{{$}}
+// CHECK-FIXES: #include <clocale>
 #include "math.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'math.h'; consider using 'cmath' instead
-// CHECK-FIXES: {{^}}#include <cmath>{{$}}
+// CHECK-FIXES: #include <cmath>
 #include "setjmp.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'setjmp.h'; consider using 'csetjmp' instead
-// CHECK-FIXES: {{^}}#include <csetjmp>{{$}}
+// CHECK-FIXES: #include <csetjmp>
 #include "signal.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'signal.h'; consider using 'csignal' instead
-// CHECK-FIXES: {{^}}#include <csignal>{{$}}
+// CHECK-FIXES: #include <csignal>
 #include "stdarg.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdarg.h'; consider using 'cstdarg' instead
-// CHECK-FIXES: {{^}}#include <cstdarg>{{$}}
+// CHECK-FIXES: #include <cstdarg>
 #include "stddef.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stddef.h'; consider using 'cstddef' instead
-// CHECK-FIXES: {{^}}#include <cstddef>{{$}}
+// CHECK-FIXES: #include <cstddef>
 #include "stdio.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdio.h'; consider using 'cstdio' instead
-// CHECK-FIXES: {{^}}#include <cstdio>{{$}}
+// CHECK-FIXES: #include <cstdio>
 #include "stdlib.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
-// CHECK-FIXES: {{^}}#include <cstdlib>{{$}}
+// CHECK-FIXES: #include <cstdlib>
 #include "string.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'string.h'; consider using 'cstring' instead
-// CHECK-FIXES: {{^}}#include <cstring>{{$}}
+// CHECK-FIXES: #include <cstring>
 #include "time.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'time.h'; consider using 'ctime' instead
-// CHECK-FIXES: {{^}}#include <ctime>{{$}}
+// CHECK-FIXES: #include <ctime>
 #include "wchar.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wchar.h'; consider using 'cwchar' instead
-// CHECK-FIXES: {{^}}#include <cwchar>{{$}}
+// CHECK-FIXES: #include <cwchar>
 #include "wctype.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wctype.h'; consider using 'cwctype' instead
-// CHECK-FIXES: {{^}}#include <cwctype>
+// CHECK-FIXES: #include <cwctype>
 
 // Headers that have no effect in C++; remove them
 #include "stdalign.h" // "stdalign.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdalign.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// "stdalign.h"{{$}}
+// CHECK-FIXES: // "stdalign.h"
 #include "stdbool.h" // "stdbool.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdbool.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// "stdbool.h"{{$}}
+// CHECK-FIXES: // "stdbool.h"
 #include "iso646.h" // "iso646.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'iso646.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// "iso646.h"{{$}}
+// CHECK-FIXES: // "iso646.h"
 
 // Headers deprecated since C++11; expect no diagnostics
 #include "fenv.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-cxx11.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-cxx11.cpp
@@ -2,162 +2,162 @@
 
 #include <assert.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
-// CHECK-FIXES: {{^}}#include <cassert>{{$}}
+// CHECK-FIXES: #include <cassert>
 #include <complex.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'complex.h'; consider using 'complex' instead
-// CHECK-FIXES: {{^}}#include <complex>{{$}}
+// CHECK-FIXES: #include <complex>
 #include <ctype.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'ctype.h'; consider using 'cctype' instead
-// CHECK-FIXES: {{^}}#include <cctype>{{$}}
+// CHECK-FIXES: #include <cctype>
 #include <errno.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno' instead
-// CHECK-FIXES: {{^}}#include <cerrno>{{$}}
+// CHECK-FIXES: #include <cerrno>
 #include <fenv.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'fenv.h'; consider using 'cfenv' instead
-// CHECK-FIXES: {{^}}#include <cfenv>{{$}}
+// CHECK-FIXES: #include <cfenv>
 #include <float.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'float.h'; consider using 'cfloat' instead
-// CHECK-FIXES: {{^}}#include <cfloat>{{$}}
+// CHECK-FIXES: #include <cfloat>
 #include <inttypes.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'inttypes.h'; consider using 'cinttypes' instead
-// CHECK-FIXES: {{^}}#include <cinttypes>{{$}}
+// CHECK-FIXES: #include <cinttypes>
 #include <limits.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'limits.h'; consider using 'climits' instead
-// CHECK-FIXES: {{^}}#include <climits>{{$}}
+// CHECK-FIXES: #include <climits>
 #include <locale.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'locale.h'; consider using 'clocale' instead
-// CHECK-FIXES: {{^}}#include <clocale>{{$}}
+// CHECK-FIXES: #include <clocale>
 #include <math.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'math.h'; consider using 'cmath' instead
-// CHECK-FIXES: {{^}}#include <cmath>{{$}}
+// CHECK-FIXES: #include <cmath>
 #include <setjmp.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'setjmp.h'; consider using 'csetjmp' instead
-// CHECK-FIXES: {{^}}#include <csetjmp>{{$}}
+// CHECK-FIXES: #include <csetjmp>
 #include <signal.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'signal.h'; consider using 'csignal' instead
-// CHECK-FIXES: {{^}}#include <csignal>{{$}}
+// CHECK-FIXES: #include <csignal>
 #include <stdarg.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdarg.h'; consider using 'cstdarg' instead
-// CHECK-FIXES: {{^}}#include <cstdarg>{{$}}
+// CHECK-FIXES: #include <cstdarg>
 #include <stddef.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stddef.h'; consider using 'cstddef' instead
-// CHECK-FIXES: {{^}}#include <cstddef>{{$}}
+// CHECK-FIXES: #include <cstddef>
 #include <stdint.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdint.h'; consider using 'cstdint' instead
-// CHECK-FIXES: {{^}}#include <cstdint>{{$}}
+// CHECK-FIXES: #include <cstdint>
 #include <stdio.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdio.h'; consider using 'cstdio' instead
-// CHECK-FIXES: {{^}}#include <cstdio>{{$}}
+// CHECK-FIXES: #include <cstdio>
 #include <stdlib.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
-// CHECK-FIXES: {{^}}#include <cstdlib>{{$}}
+// CHECK-FIXES: #include <cstdlib>
 #include <string.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'string.h'; consider using 'cstring' instead
-// CHECK-FIXES: {{^}}#include <cstring>{{$}}
+// CHECK-FIXES: #include <cstring>
 #include <tgmath.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'tgmath.h'; consider using 'ctgmath' instead
-// CHECK-FIXES: {{^}}#include <ctgmath>{{$}}
+// CHECK-FIXES: #include <ctgmath>
 #include <time.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'time.h'; consider using 'ctime' instead
-// CHECK-FIXES: {{^}}#include <ctime>{{$}}
+// CHECK-FIXES: #include <ctime>
 #include <uchar.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'uchar.h'; consider using 'cuchar' instead
-// CHECK-FIXES: {{^}}#include <cuchar>{{$}}
+// CHECK-FIXES: #include <cuchar>
 #include <wchar.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wchar.h'; consider using 'cwchar' instead
-// CHECK-FIXES: {{^}}#include <cwchar>{{$}}
+// CHECK-FIXES: #include <cwchar>
 #include <wctype.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wctype.h'; consider using 'cwctype' instead
-// CHECK-FIXES: {{^}}#include <cwctype>
+// CHECK-FIXES: #include <cwctype>
 
 // Headers that have no effect in C++; remove them
 #include <stdalign.h> // <stdalign.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdalign.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// <stdalign.h>{{$}}
+// CHECK-FIXES: // <stdalign.h>
 #include <stdbool.h> // <stdbool.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdbool.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// <stdbool.h>{{$}}
+// CHECK-FIXES: // <stdbool.h>
 #include <iso646.h> // <iso646.h>
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'iso646.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// <iso646.h>{{$}}
+// CHECK-FIXES: // <iso646.h>
 
 #include "assert.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead
-// CHECK-FIXES: {{^}}#include <cassert>{{$}}
+// CHECK-FIXES: #include <cassert>
 #include "complex.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'complex.h'; consider using 'complex' instead
-// CHECK-FIXES: {{^}}#include <complex>{{$}}
+// CHECK-FIXES: #include <complex>
 #include "ctype.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'ctype.h'; consider using 'cctype' instead
-// CHECK-FIXES: {{^}}#include <cctype>{{$}}
+// CHECK-FIXES: #include <cctype>
 #include "errno.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno' instead
-// CHECK-FIXES: {{^}}#include <cerrno>{{$}}
+// CHECK-FIXES: #include <cerrno>
 #include "fenv.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'fenv.h'; consider using 'cfenv' instead
-// CHECK-FIXES: {{^}}#include <cfenv>{{$}}
+// CHECK-FIXES: #include <cfenv>
 #include "float.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'float.h'; consider using 'cfloat' instead
-// CHECK-FIXES: {{^}}#include <cfloat>{{$}}
+// CHECK-FIXES: #include <cfloat>
 #include "inttypes.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'inttypes.h'; consider using 'cinttypes' instead
-// CHECK-FIXES: {{^}}#include <cinttypes>{{$}}
+// CHECK-FIXES: #include <cinttypes>
 #include "limits.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'limits.h'; consider using 'climits' instead
-// CHECK-FIXES: {{^}}#include <climits>{{$}}
+// CHECK-FIXES: #include <climits>
 #include "locale.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'locale.h'; consider using 'clocale' instead
-// CHECK-FIXES: {{^}}#include <clocale>{{$}}
+// CHECK-FIXES: #include <clocale>
 #include "math.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'math.h'; consider using 'cmath' instead
-// CHECK-FIXES: {{^}}#include <cmath>{{$}}
+// CHECK-FIXES: #include <cmath>
 #include "setjmp.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'setjmp.h'; consider using 'csetjmp' instead
-// CHECK-FIXES: {{^}}#include <csetjmp>{{$}}
+// CHECK-FIXES: #include <csetjmp>
 #include "signal.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'signal.h'; consider using 'csignal' instead
-// CHECK-FIXES: {{^}}#include <csignal>{{$}}
+// CHECK-FIXES: #include <csignal>
 #include "stdarg.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdarg.h'; consider using 'cstdarg' instead
-// CHECK-FIXES: {{^}}#include <cstdarg>{{$}}
+// CHECK-FIXES: #include <cstdarg>
 #include "stddef.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stddef.h'; consider using 'cstddef' instead
-// CHECK-FIXES: {{^}}#include <cstddef>{{$}}
+// CHECK-FIXES: #include <cstddef>
 #include "stdint.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdint.h'; consider using 'cstdint' instead
-// CHECK-FIXES: {{^}}#include <cstdint>{{$}}
+// CHECK-FIXES: #include <cstdint>
 #include "stdio.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdio.h'; consider using 'cstdio' instead
-// CHECK-FIXES: {{^}}#include <cstdio>{{$}}
+// CHECK-FIXES: #include <cstdio>
 #include "stdlib.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
-// CHECK-FIXES: {{^}}#include <cstdlib>{{$}}
+// CHECK-FIXES: #include <cstdlib>
 #include "string.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'string.h'; consider using 'cstring' instead
-// CHECK-FIXES: {{^}}#include <cstring>{{$}}
+// CHECK-FIXES: #include <cstring>
 #include "tgmath.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'tgmath.h'; consider using 'ctgmath' instead
-// CHECK-FIXES: {{^}}#include <ctgmath>{{$}}
+// CHECK-FIXES: #include <ctgmath>
 #include "time.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'time.h'; consider using 'ctime' instead
-// CHECK-FIXES: {{^}}#include <ctime>{{$}}
+// CHECK-FIXES: #include <ctime>
 #include "uchar.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'uchar.h'; consider using 'cuchar' instead
-// CHECK-FIXES: {{^}}#include <cuchar>{{$}}
+// CHECK-FIXES: #include <cuchar>
 #include "wchar.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wchar.h'; consider using 'cwchar' instead
-// CHECK-FIXES: {{^}}#include <cwchar>{{$}}
+// CHECK-FIXES: #include <cwchar>
 #include "wctype.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'wctype.h'; consider using 'cwctype' instead
-// CHECK-FIXES: {{^}}#include <cwctype>
+// CHECK-FIXES: #include <cwctype>
 
 // Headers that have no effect in C++; remove them
 #include "stdalign.h" // "stdalign.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdalign.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// "stdalign.h"{{$}}
+// CHECK-FIXES: // "stdalign.h"
 #include "stdbool.h" // "stdbool.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'stdbool.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// "stdbool.h"{{$}}
+// CHECK-FIXES: // "stdbool.h"
 #include "iso646.h" // "iso646.h"
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: including 'iso646.h' has no effect in C++; consider removing it
-// CHECK-FIXES: {{^}}// "iso646.h"{{$}}
+// CHECK-FIXES: // "iso646.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal.cpp
@@ -2,7 +2,7 @@
 
 char const *const BackSlash("goink\\frob");
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: escaped string literal can be written as a raw string literal [modernize-raw-string-literal]
-// CHECK-FIXES: {{^}}char const *const BackSlash(R"(goink\frob)");{{$}}
+// CHECK-FIXES: char const *const BackSlash(R"(goink\frob)");
 
 char const *const PlainLiteral("plain literal");
 
@@ -41,7 +41,7 @@ char const *const Us("goink\\\037");
 char const *const HexNonPrintable("\\\x03");
 char const *const Delete("\\\177");
 char const *const MultibyteSnowman("\xE2\x98\x83");
-// CHECK-FIXES: {{^}}char const *const MultibyteSnowman("\xE2\x98\x83");{{$}}
+// CHECK-FIXES: char const *const MultibyteSnowman("\xE2\x98\x83");
 
 char const *const TrailingSpace("A line \\with space. \n");
 char const *const TrailingNewLine("A single \\line.\n");
@@ -59,39 +59,39 @@ wchar_t const *const WideRawLiteral(LR"(foobie\\bletch)");
 
 char const *const SingleQuote("goink\'frob");
 // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: {{.*}} can be written as a raw string literal
-// CHECK-XFIXES: {{^}}char const *const SingleQuote(R"(goink'frob)");{{$}}
+// CHECK-XFIXES: char const *const SingleQuote(R"(goink'frob)");
 
 char const *const DoubleQuote("goink\"frob");
 // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const DoubleQuote(R"(goink"frob)");{{$}}
+// CHECK-FIXES: char const *const DoubleQuote(R"(goink"frob)");
 
 char const *const QuestionMark("goink\?frob");
 // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const QuestionMark(R"(goink?frob)");{{$}}
+// CHECK-FIXES: char const *const QuestionMark(R"(goink?frob)");
 
 char const *const RegEx("goink\\(one|two\\)\\\\\\?.*\\nfrob");
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const RegEx(R"(goink\(one|two\)\\\?.*\nfrob)");{{$}}
+// CHECK-FIXES: char const *const RegEx(R"(goink\(one|two\)\\\?.*\nfrob)");
 
 char const *const Path("C:\\Program Files\\Vendor\\Application\\Application.exe");
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const Path(R"(C:\Program Files\Vendor\Application\Application.exe)");{{$}}
+// CHECK-FIXES: char const *const Path(R"(C:\Program Files\Vendor\Application\Application.exe)");
 
 char const *const ContainsSentinel("who\\ops)\"");
 // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const ContainsSentinel(R"lit(who\ops)")lit");{{$}}
+// CHECK-FIXES: char const *const ContainsSentinel(R"lit(who\ops)")lit");
 
 char const *const ContainsDelim("whoops)\")lit\"");
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const ContainsDelim(R"lit1(whoops)")lit")lit1");{{$}}
+// CHECK-FIXES: char const *const ContainsDelim(R"lit1(whoops)")lit")lit1");
 
 char const *const OctalPrintable("\100\\");
 // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const OctalPrintable(R"(@\)");{{$}}
+// CHECK-FIXES: char const *const OctalPrintable(R"(@\)");
 
 char const *const HexPrintable("\x40\\");
 // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const HexPrintable(R"(@\)");{{$}}
+// CHECK-FIXES: char const *const HexPrintable(R"(@\)");
 
 char const *const prettyFunction(__PRETTY_FUNCTION__);
 char const *const function(__FUNCTION__);
@@ -111,23 +111,23 @@ template <typename T>
 void fn(char const *const Arg) {
   char const *const Str("foo\\bar");
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: {{.*}} can be written as a raw string literal
-  // CHECK-FIXES: {{^}}  char const *const Str(R"(foo\bar)");{{$}}
+  // CHECK-FIXES: char const *const Str(R"(foo\bar)");
 }
 
 template <>
 void fn<int>(char const *const Arg) {
   char const *const Str("foo\\bar");
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: {{.*}} can be written as a raw string literal
-  // CHECK-FIXES: {{^}}  char const *const Str(R"(foo\bar)");{{$}}
+  // CHECK-FIXES: char const *const Str(R"(foo\bar)");
 }
 
 void callFn() {
   fn<int>("foo\\bar");
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: {{.*}} can be written as a raw string literal
-  // CHECK-FIXES: {{^}}  fn<int>(R"(foo\bar)");{{$}}
+  // CHECK-FIXES: fn<int>(R"(foo\bar)");
   fn<double>("foo\\bar");
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} can be written as a raw string literal
-  // CHECK-FIXES: {{^}}  fn<double>(R"(foo\bar)");{{$}}
+  // CHECK-FIXES: fn<double>(R"(foo\bar)");
 }
 
 namespace std {
@@ -140,5 +140,5 @@ namespace gh97243 {
 using namespace std::ud;
 auto UserDefinedLiteral = "foo\\bar"_abc;
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}auto UserDefinedLiteral = R"(foo\bar)"_abc;
+// CHECK-FIXES: auto UserDefinedLiteral = R"(foo\bar)"_abc;
 } // namespace gh97243

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg-delayed.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg-delayed.cpp
@@ -2,7 +2,7 @@
 
 int foo(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant void argument list in function definition [modernize-redundant-void-arg]
-// CHECK-FIXES: {{^}}int foo() {{{$}}
+// CHECK-FIXES: int foo() {
     return 0;
 }
 
@@ -10,7 +10,7 @@ template <class T>
 struct MyFoo {
   int foo(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant void argument list in function definition [modernize-redundant-void-arg]
-// CHECK-FIXES: {{^}}  int foo() {{{$}}
+// CHECK-FIXES: int foo() {
     return 0;
   }
 };
@@ -22,7 +22,7 @@ struct MyBar {
   // This declaration isn't instantiated and won't be parsed 'delayed-template-parsing'.
   int foo(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant void argument list in function definition [modernize-redundant-void-arg]
-// CHECK-FIXES: {{^}}  int foo() {{{$}}
+// CHECK-FIXES: int foo() {
     return 0;
   }
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
@@ -19,7 +19,7 @@ int j = 1;
 
 int foo(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant void argument list in function definition [modernize-redundant-void-arg]
-// CHECK-FIXES: {{^}}int foo() {{{$}}
+// CHECK-FIXES: int foo() {
     return 0;
 }
 
@@ -32,23 +32,23 @@ typedef void my_void;
 int (*returns_fn_void_int(void))(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: {{.*}} in function declaration
 // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: {{.*}} in function declaration
-// CHECK-FIXES: {{^}}int (*returns_fn_void_int())();{{$}}
+// CHECK-FIXES: int (*returns_fn_void_int())();
 
 typedef int (*returns_fn_void_int_t(void))(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: {{.*}} in typedef
 // CHECK-MESSAGES: :[[@LINE-2]]:44: warning: {{.*}} in typedef
-// CHECK-FIXES: {{^}}typedef int (*returns_fn_void_int_t())();{{$}}
+// CHECK-FIXES: typedef int (*returns_fn_void_int_t())();
 
 // Should work for type aliases as well as typedef.
 using returns_fn_void_int_t2 = int (*(void))(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: {{.*}} in type alias
 // CHECK-MESSAGES: :[[@LINE-2]]:46: warning: {{.*}} in type alias
-// CHECK-FIXES: {{^}}using returns_fn_void_int_t2 = int (*())();{{$}}
+// CHECK-FIXES: using returns_fn_void_int_t2 = int (*())();
 
 int (*returns_fn_void_int(void))(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: {{.*}} in function definition
 // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}int (*returns_fn_void_int())() {{{$}}
+// CHECK-FIXES: int (*returns_fn_void_int())() {
   return nullptr;
 }
 
@@ -58,25 +58,25 @@ void (*(*returns_fn_returns_fn_void_void(void))(void))(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: {{.*}} in function declaration
 // CHECK-MESSAGES: :[[@LINE-2]]:49: warning: {{.*}} in function declaration
 // CHECK-MESSAGES: :[[@LINE-3]]:56: warning: {{.*}} in function declaration
-// CHECK-FIXES: {{^}}void (*(*returns_fn_returns_fn_void_void())())();{{$}}
+// CHECK-FIXES: void (*(*returns_fn_returns_fn_void_void())())();
 
 typedef void (*(*returns_fn_returns_fn_void_void_t(void))(void))(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: {{.*}} in typedef
 // CHECK-MESSAGES: :[[@LINE-2]]:59: warning: {{.*}} in typedef
 // CHECK-MESSAGES: :[[@LINE-3]]:66: warning: {{.*}} in typedef
-// CHECK-FIXES: {{^}}typedef void (*(*returns_fn_returns_fn_void_void_t())())();{{$}}
+// CHECK-FIXES: typedef void (*(*returns_fn_returns_fn_void_void_t())())();
 
 void (*(*returns_fn_returns_fn_void_void(void))(void))(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: {{.*}} in function definition
 // CHECK-MESSAGES: :[[@LINE-2]]:49: warning: {{.*}} in function definition
 // CHECK-MESSAGES: :[[@LINE-3]]:56: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}void (*(*returns_fn_returns_fn_void_void())())() {{{$}}
+// CHECK-FIXES: void (*(*returns_fn_returns_fn_void_void())())() {
     return nullptr;
 }
 
 void bar(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}void bar() {{{$}}
+// CHECK-FIXES: void bar() {
 }
 
 void op_fn(int i) {
@@ -103,13 +103,13 @@ private:
 
     void (*f1)(void);
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: {{.*}} in field declaration
-    // CHECK-FIXES: {{^    }}void (*f1)();{{$}}
+    // CHECK-FIXES: void (*f1)();
 
   void (*op)(int i);
 
   void (gronk::*p1)(void);
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: {{.*}} in field declaration
-  // CHECK-FIXES: {{^  }}void (gronk::*p1)();{{$}}
+  // CHECK-FIXES: void (gronk::*p1)();
 
   int (gronk::*p_mi);
 
@@ -119,13 +119,13 @@ private:
   // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: {{.*}} in function declaration
   // CHECK-MESSAGES: :[[@LINE-2]]:51: warning: {{.*}} in function declaration
   // CHECK-MESSAGES: :[[@LINE-3]]:58: warning: {{.*}} in function declaration
-  // CHECK-FIXES: {{^}}  void (*(*returns_fn_returns_fn_void_void())())();{{$}}
+  // CHECK-FIXES: void (*(*returns_fn_returns_fn_void_void())())();
 
   void (*(*(gronk::*returns_fn_returns_fn_void_void_mem)(void))(void))(void);
   // CHECK-MESSAGES: :[[@LINE-1]]:58: warning: {{.*}} in field declaration
   // CHECK-MESSAGES: :[[@LINE-2]]:65: warning: {{.*}} in field declaration
   // CHECK-MESSAGES: :[[@LINE-3]]:72: warning: {{.*}} in field declaration
-  // CHECK-FIXES: {{^}}  void (*(*(gronk::*returns_fn_returns_fn_void_void_mem)())())();{{$}}
+  // CHECK-FIXES: void (*(*(gronk::*returns_fn_returns_fn_void_void_mem)())())();
 };
 
 int i;
@@ -138,35 +138,35 @@ double *pd;
 
 void (*f1)(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: {{.*}} in variable declaration
-// CHECK-FIXES: {{^}}void (*f1)();{{$}}
+// CHECK-FIXES: void (*f1)();
 
 void (*f2)(void) = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f2)() = nullptr;{{$}}
+// CHECK-FIXES: void (*f2)() = nullptr;
 
 void (*f2b)(void)(nullptr);
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f2b)()(nullptr);{{$}}
+// CHECK-FIXES: void (*f2b)()(nullptr);
 
 void (*f2c)(void){nullptr};
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f2c)(){nullptr};{{$}}
+// CHECK-FIXES: void (*f2c)(){nullptr};
 
 void (*f2d)(void) = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f2d)() = NULL;{{$}}
+// CHECK-FIXES: void (*f2d)() = NULL;
 
 void (*f2e)(void)(NULL);
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f2e)()(NULL);{{$}}
+// CHECK-FIXES: void (*f2e)()(NULL);
 
 void (*f2f)(void){NULL};
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f2f)(){NULL};{{$}}
+// CHECK-FIXES: void (*f2f)(){NULL};
 
 void (*f3)(void) = bar;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (*f3)() = bar;{{$}}
+// CHECK-FIXES: void (*f3)() = bar;
 
 void (*o1)(int i);
 void (*o2)(int i) = nullptr;
@@ -185,7 +185,7 @@ void (*fc)() = bar;
 
 typedef void (function_ptr)(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: {{.*}} in typedef
-// CHECK-FIXES: {{^}}typedef void (function_ptr)();{{$}}
+// CHECK-FIXES: typedef void (function_ptr)();
 
 // intentionally not LLVM style to check preservation of whitespace
 typedef void (function_ptr2)
@@ -245,15 +245,15 @@ void
 
 void (gronk::*p1)(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: {{.*}} in variable declaration
-// CHECK-FIXES: {{^}}void (gronk::*p1)();{{$}}
+// CHECK-FIXES: void (gronk::*p1)();
 
 void (gronk::*p2)(void) = &gronk::foo;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: {{.*}} in variable declaration with initializer
-// CHECK-FIXES: {{^}}void (gronk::*p2)() = &gronk::foo;{{$}}
+// CHECK-FIXES: void (gronk::*p2)() = &gronk::foo;
 
 typedef void (gronk::*member_function_ptr)(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: {{.*}} in typedef
-// CHECK-FIXES: {{^}}typedef void (gronk::*member_function_ptr)();{{$}}
+// CHECK-FIXES: typedef void (gronk::*member_function_ptr)();
 
 // intentionally not LLVM style to check preservation of whitespace
 typedef void (gronk::*member_function_ptr2)
@@ -269,11 +269,11 @@ typedef void (gronk::*member_function_ptr2)
 void gronk::foo() {
   void (*f1)(void) = &::bar;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} in variable declaration with initializer
-  // CHECK-FIXES: {{^  }}void (*f1)() = &::bar;{{$}}
+  // CHECK-FIXES: void (*f1)() = &::bar;
 
   void (*f2)(void);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} in variable declaration
-  // CHECK-FIXES: {{^  }}void (*f2)();{{$}}
+  // CHECK-FIXES: void (*f2)();
 
   // intentionally not LLVM style to check preservation of whitespace
   void (*f3)
@@ -289,14 +289,14 @@ void gronk::foo() {
 
 void gronk::bar(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}void gronk::bar() {{{$}}
+// CHECK-FIXES: void gronk::bar() {
   void (gronk::*p3)(void) = &gronk::foo;
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: {{.*}} in variable declaration with initializer
-  // CHECK-FIXES: {{^  }}void (gronk::*p3)() = &gronk::foo;{{$}}
+  // CHECK-FIXES: void (gronk::*p3)() = &gronk::foo;
 
   void (gronk::*p4)(void);
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: {{.*}} in variable declaration
-  // CHECK-FIXES: {{^  }}void (gronk::*p4)();{{$}}
+  // CHECK-FIXES: void (gronk::*p4)();
 
   // intentionally not LLVM style to check preservation of whitespace
   void (gronk::*p5)
@@ -325,14 +325,14 @@ void gronk::bar2
 
 gronk::gronk(void)
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}gronk::gronk(){{$}}
+// CHECK-FIXES: gronk::gronk()
   : f1(nullptr),
   p1(nullptr) {
 }
 
 gronk::~gronk(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}gronk::~gronk() {{{$}}
+// CHECK-FIXES: gronk::~gronk() {
 }
 
 class nutter {
@@ -342,21 +342,21 @@ public:
 
 nutter::nutter(void) {
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: {{.*}} in function definition
-// CHECK-FIXES: {{^}}nutter::nutter() {{{$}}
+// CHECK-FIXES: nutter::nutter() {
   void (*f3)(void) = static_cast<void (*)(void)>(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} in variable declaration with initializer
   // CHECK-MESSAGES: :[[@LINE-2]]:43: warning: {{.*}} in named cast
-  // CHECK-FIXES: void (*f3)() = static_cast<void (*)()>(0);{{$}}
+  // CHECK-FIXES: void (*f3)() = static_cast<void (*)()>(0);
 
   void (*f4)(void) = (void (*)(void)) 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} in variable declaration with initializer
   // CHECK-MESSAGES: :[[@LINE-2]]:32: warning: {{.*}} in cast expression
-  // CHECK-FIXES: void (*f4)() = (void (*)()) 0;{{$}}
+  // CHECK-FIXES: void (*f4)() = (void (*)()) 0;
 
   void (*f5)(void) = reinterpret_cast<void (*)(void)>(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: {{.*}} in variable declaration with initializer
   // CHECK-MESSAGES: :[[@LINE-2]]:48: warning: {{.*}} in named cast
-  // CHECK-FIXES: void (*f5)() = reinterpret_cast<void (*)()>(0);{{$}}
+  // CHECK-FIXES: void (*f5)() = reinterpret_cast<void (*)()>(0);
 
   // intentionally not LLVM style to check preservation of whitespace
   void (*f6)(void) = static_cast<void (*)
@@ -403,17 +403,17 @@ class generator {
 public:
   int operator()(void) { return 1; }
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: {{.*}} in function definition
-  // CHECK-FIXES: {{^  }}int operator()() { return 1; }{{$}}
+  // CHECK-FIXES: int operator()() { return 1; }
 };
 
 void test_lambda_functions() {
   auto lamb_duh = [](void (*fn)(void)) { (*fn)(); };
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: {{.*}} in variable declaration
-  // CHECK-FIXES: {{^  }}auto lamb_duh = [](void (*fn)()) { (*fn)(); };{{$}}
+  // CHECK-FIXES: auto lamb_duh = [](void (*fn)()) { (*fn)(); };
 
   auto lambda_generator = [](void) { return 1; };
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: {{.*}} in lambda expression
-  // CHECK-FIXES: {{^  }}auto lambda_generator = []() { return 1; };{{$}}
+  // CHECK-FIXES: auto lambda_generator = []() { return 1; };
 
   auto gen2 = []() { return 1; };
 
@@ -422,7 +422,7 @@ void test_lambda_functions() {
   auto void_returner = [](void) -> void (*)(void) { return f1; };
   // CHECK-MESSAGES: [[@LINE-1]]:27: warning: {{.*}} in lambda expression
   // CHECK-MESSAGES: [[@LINE-2]]:45: warning: {{.*}} in lambda expression
-  // CHECK-FIXES: {{^  }}auto void_returner = []() -> void (*)() { return f1; };{{$}}
+  // CHECK-FIXES: auto void_returner = []() -> void (*)() { return f1; };
 }
 
 #define M(x) x

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-disallow-copy-and-assign-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-disallow-copy-and-assign-macro.cpp
@@ -33,8 +33,8 @@ private:
   DISALLOW_COPY_AND_ASSIGN(TestClass1);
 };
 // CHECK-MESSAGES-DEFAULT: :[[@LINE-2]]:3: warning: prefer deleting copy constructor and assignment operator over using macro 'DISALLOW_COPY_AND_ASSIGN' [modernize-replace-disallow-copy-and-assign-macro]
-// CHECK-FIXES-DEFAULT:      {{^}}  TestClass1(const TestClass1 &) = delete;{{$}}
-// CHECK-FIXES-DEFAULT-NEXT: {{^}}  const TestClass1 &operator=(const TestClass1 &) = delete;{{$}}
+// CHECK-FIXES-DEFAULT: TestClass1(const TestClass1 &) = delete;
+// CHECK-FIXES-DEFAULT-NEXT: const TestClass1 &operator=(const TestClass1 &) = delete;
 
 #define MY_MACRO_NAME(TypeName)
 
@@ -43,8 +43,8 @@ private:
   MY_MACRO_NAME(TestClass2);
 };
 // CHECK-MESSAGES-DIFFERENT-NAME: :[[@LINE-2]]:3: warning: prefer deleting copy constructor and assignment operator over using macro 'MY_MACRO_NAME' [modernize-replace-disallow-copy-and-assign-macro]
-// CHECK-FIXES-DIFFERENT-NAME:      {{^}}  TestClass2(const TestClass2 &) = delete;{{$}}
-// CHECK-FIXES-DIFFERENT-NAME-NEXT: {{^}}  const TestClass2 &operator=(const TestClass2 &) = delete;{{$}}
+// CHECK-FIXES-DIFFERENT-NAME: TestClass2(const TestClass2 &) = delete;
+// CHECK-FIXES-DIFFERENT-NAME-NEXT: const TestClass2 &operator=(const TestClass2 &) = delete;
 
 #define DISALLOW_COPY_AND_ASSIGN_FINALIZE(TypeName) \
   TypeName(const TypeName &) = delete;              \
@@ -58,8 +58,8 @@ private:
   DISALLOW_COPY_AND_ASSIGN_FINALIZE(TestClass3)
 };
 // CHECK-MESSAGES-FINALIZE: :[[@LINE-2]]:3: warning: prefer deleting copy constructor and assignment operator over using macro 'DISALLOW_COPY_AND_ASSIGN_FINALIZE' [modernize-replace-disallow-copy-and-assign-macro]
-// CHECK-FIXES-FINALIZE:      {{^}}  TestClass3(const TestClass3 &) = delete;{{$}}
-// CHECK-FIXES-FINALIZE-NEXT: {{^}}  const TestClass3 &operator=(const TestClass3 &) = delete;{{$}}
+// CHECK-FIXES-FINALIZE: TestClass3(const TestClass3 &) = delete;
+// CHECK-FIXES-FINALIZE-NEXT: const TestClass3 &operator=(const TestClass3 &) = delete;
 
 #define DISALLOW_COPY_AND_ASSIGN_MORE_AGUMENTS(A, B)
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-disallow-copy-and-assign-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-disallow-copy-and-assign-macro.cpp
@@ -33,7 +33,7 @@ private:
   DISALLOW_COPY_AND_ASSIGN(TestClass1);
 };
 // CHECK-MESSAGES-DEFAULT: :[[@LINE-2]]:3: warning: prefer deleting copy constructor and assignment operator over using macro 'DISALLOW_COPY_AND_ASSIGN' [modernize-replace-disallow-copy-and-assign-macro]
-// CHECK-FIXES-DEFAULT: TestClass1(const TestClass1 &) = delete;
+// CHECK-FIXES-DEFAULT:      TestClass1(const TestClass1 &) = delete;
 // CHECK-FIXES-DEFAULT-NEXT: const TestClass1 &operator=(const TestClass1 &) = delete;
 
 #define MY_MACRO_NAME(TypeName)
@@ -43,7 +43,7 @@ private:
   MY_MACRO_NAME(TestClass2);
 };
 // CHECK-MESSAGES-DIFFERENT-NAME: :[[@LINE-2]]:3: warning: prefer deleting copy constructor and assignment operator over using macro 'MY_MACRO_NAME' [modernize-replace-disallow-copy-and-assign-macro]
-// CHECK-FIXES-DIFFERENT-NAME: TestClass2(const TestClass2 &) = delete;
+// CHECK-FIXES-DIFFERENT-NAME:      TestClass2(const TestClass2 &) = delete;
 // CHECK-FIXES-DIFFERENT-NAME-NEXT: const TestClass2 &operator=(const TestClass2 &) = delete;
 
 #define DISALLOW_COPY_AND_ASSIGN_FINALIZE(TypeName) \
@@ -58,7 +58,7 @@ private:
   DISALLOW_COPY_AND_ASSIGN_FINALIZE(TestClass3)
 };
 // CHECK-MESSAGES-FINALIZE: :[[@LINE-2]]:3: warning: prefer deleting copy constructor and assignment operator over using macro 'DISALLOW_COPY_AND_ASSIGN_FINALIZE' [modernize-replace-disallow-copy-and-assign-macro]
-// CHECK-FIXES-FINALIZE: TestClass3(const TestClass3 &) = delete;
+// CHECK-FIXES-FINALIZE:      TestClass3(const TestClass3 &) = delete;
 // CHECK-FIXES-FINALIZE-NEXT: const TestClass3 &operator=(const TestClass3 &) = delete;
 
 #define DISALLOW_COPY_AND_ASSIGN_MORE_AGUMENTS(A, B)

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-bool-literals.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-bool-literals.cpp
@@ -5,43 +5,43 @@
 
 bool IntToTrue = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: converting integer literal to bool, use bool literal instead [modernize-use-bool-literals]
-// CHECK-FIXES: {{^}}bool IntToTrue = true;{{$}}
+// CHECK-FIXES: bool IntToTrue = true;
 
 bool IntToFalse(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool IntToFalse(false);{{$}}
+// CHECK-FIXES: bool IntToFalse(false);
 
 bool LongLongToTrue{0x1LL};
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool LongLongToTrue{true};{{$}}
+// CHECK-FIXES: bool LongLongToTrue{true};
 
 bool ExplicitCStyleIntToFalse = (bool)0;
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ExplicitCStyleIntToFalse = false;{{$}}
+// CHECK-FIXES: bool ExplicitCStyleIntToFalse = false;
 
 bool ExplicitFunctionalIntToFalse = bool(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ExplicitFunctionalIntToFalse = false;{{$}}
+// CHECK-FIXES: bool ExplicitFunctionalIntToFalse = false;
 
 bool ExplicitStaticIntToFalse = static_cast<bool>(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ExplicitStaticIntToFalse = false;{{$}}
+// CHECK-FIXES: bool ExplicitStaticIntToFalse = false;
 
 #define TRUE_MACRO 1
-// CHECK-FIXES: {{^}}#define TRUE_MACRO 1{{$}}
+// CHECK-FIXES: #define TRUE_MACRO 1
 
 bool MacroIntToTrue = TRUE_MACRO;
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool MacroIntToTrue = TRUE_MACRO;{{$}}
+// CHECK-FIXES: bool MacroIntToTrue = TRUE_MACRO;
 
 #define FALSE_MACRO bool(0)
-// CHECK-FIXES: {{^}}#define FALSE_MACRO bool(0){{$}}
+// CHECK-FIXES: #define FALSE_MACRO bool(0)
 
 bool TrueBool = true; // OK
 
 bool FalseBool = bool(FALSE_MACRO);
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool FalseBool = bool(FALSE_MACRO);{{$}}
+// CHECK-FIXES: bool FalseBool = bool(FALSE_MACRO);
 
 void boolFunction(bool bar) {
 
@@ -52,58 +52,58 @@ char Character = 0; // OK
 unsigned long long LongInteger = 1; // OK
 
 #define MACRO_DEPENDENT_CAST(x) static_cast<bool>(x)
-// CHECK-FIXES: {{^}}#define MACRO_DEPENDENT_CAST(x) static_cast<bool>(x){{$}}
+// CHECK-FIXES: #define MACRO_DEPENDENT_CAST(x) static_cast<bool>(x)
 
 bool MacroDependentBool = MACRO_DEPENDENT_CAST(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool MacroDependentBool = MACRO_DEPENDENT_CAST(0);{{$}}
+// CHECK-FIXES: bool MacroDependentBool = MACRO_DEPENDENT_CAST(0);
 
 bool ManyMacrosDependent = MACRO_DEPENDENT_CAST(FALSE_MACRO);
 // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ManyMacrosDependent = MACRO_DEPENDENT_CAST(FALSE_MACRO);{{$}}
+// CHECK-FIXES: bool ManyMacrosDependent = MACRO_DEPENDENT_CAST(FALSE_MACRO);
 
 class FooClass {
   public:
   FooClass() : JustBool(0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}FooClass() : JustBool(false) {}{{$}}
+  // CHECK-FIXES: FooClass() : JustBool(false) {}
   FooClass(int) : JustBool{0} {}
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}FooClass(int) : JustBool{false} {}{{$}}
+  // CHECK-FIXES: FooClass(int) : JustBool{false} {}
   private:
   bool JustBool;
   bool BoolWithBraces{0};
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool BoolWithBraces{false};{{$}}
+  // CHECK-FIXES: bool BoolWithBraces{false};
   bool BoolFromInt = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool BoolFromInt = false;{{$}}
+  // CHECK-FIXES: bool BoolFromInt = false;
   bool SimpleBool = true; // OK
 };
 
 template<typename type>
 void templateFunction(type) {
   type TemplateType = 0;
-  // CHECK-FIXES: {{^ *}}type TemplateType = 0;{{$}}
+  // CHECK-FIXES: type TemplateType = 0;
 }
 
 template<int c>
 void valueDependentTemplateFunction() {
   bool Boolean = c;
-  // CHECK-FIXES: {{^ *}}bool Boolean = c;{{$}}
+  // CHECK-FIXES: bool Boolean = c;
 }
 
 template<typename type>
 void anotherTemplateFunction(type) {
   bool JustBool = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool JustBool = false;{{$}}
+  // CHECK-FIXES: bool JustBool = false;
 }
 
 int main() {
   boolFunction(1);
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}boolFunction(true);{{$}}
+  // CHECK-FIXES: boolFunction(true);
 
   boolFunction(false);
 
@@ -117,7 +117,7 @@ int main() {
 
   IntToTrue = 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}IntToTrue = true;{{$}}
+  // CHECK-FIXES: IntToTrue = true;
 }
 
 static int Value = 1;
@@ -126,7 +126,7 @@ bool Function1() {
   bool Result = Value == 1 ? 1 : 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: converting integer literal to bool
   // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool Result = Value == 1 ? true : false;{{$}}
+  // CHECK-FIXES: bool Result = Value == 1 ? true : false;
   return Result;
 }
 
@@ -134,18 +134,18 @@ bool Function2() {
   return Value == 1 ? 1 : 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: converting integer literal to bool
   // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}return Value == 1 ? true : false;{{$}}
+  // CHECK-FIXES: return Value == 1 ? true : false;
 }
 
 void foo() {
   bool Result;
   Result = Value == 1 ? true : 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}Result = Value == 1 ? true : false;{{$}}
+  // CHECK-FIXES: Result = Value == 1 ? true : false;
   Result = Value == 1 ? false : bool(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}Result = Value == 1 ? false : false;{{$}}
+  // CHECK-FIXES: Result = Value == 1 ? false : false;
   Result = Value == 1 ? (bool)0 : false;
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}Result = Value == 1 ? false : false;{{$}}
+  // CHECK-FIXES: Result = Value == 1 ? false : false;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints-first-greatergreater.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints-first-greatergreater.cpp
@@ -19,4 +19,4 @@ template <typename T, typename = std::enable_if_t<T::some_value>>
 void first_greatergreater_is_enable_if() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void first_greatergreater_is_enable_if() requires T::some_value {{{$}}
+// CHECK-FIXES: void first_greatergreater_is_enable_if() requires T::some_value {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
@@ -33,28 +33,28 @@ typename std::enable_if<T::some_value, Obj>::type basic() {
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj basic() requires T::some_value {{{$}}
+// CHECK-FIXES: Obj basic() requires T::some_value {
 
 template <typename T>
 std::enable_if_t<T::some_value, Obj> basic_t() {
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj basic_t() requires T::some_value {{{$}}
+// CHECK-FIXES: Obj basic_t() requires T::some_value {
 
 template <typename T>
 auto basic_trailing() -> typename std::enable_if<T::some_value, Obj>::type {
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:26: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}auto basic_trailing() -> Obj requires T::some_value {{{$}}
+// CHECK-FIXES: auto basic_trailing() -> Obj requires T::some_value {
 
 template <typename T>
 typename std::enable_if<T::some_value, Obj>::type existing_constraint() requires (T::another_value) {
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}typename std::enable_if<T::some_value, Obj>::type existing_constraint() requires (T::another_value) {{{$}}
+// CHECK-FIXES: typename std::enable_if<T::some_value, Obj>::type existing_constraint() requires (T::another_value) {
 
 template <typename U>
 typename std::enable_if<U::some_value, Obj>::type decl_without_def();
@@ -79,32 +79,32 @@ typename std::enable_if<T::some_value, int>::type* pointer_of_enable_if() {
   return nullptr;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}int* pointer_of_enable_if() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: int* pointer_of_enable_if() requires T::some_value {
 
 template <typename T>
 std::enable_if_t<T::some_value, int>* pointer_of_enable_if_t() {
   return nullptr;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}int* pointer_of_enable_if_t() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: int* pointer_of_enable_if_t() requires T::some_value {
 
 template <typename T>
 const std::enable_if_t<T::some_value, int>* const_pointer_of_enable_if_t() {
   return nullptr;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:7: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}const int* const_pointer_of_enable_if_t() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: const int* const_pointer_of_enable_if_t() requires T::some_value {
 
 template <typename T>
 std::enable_if_t<T::some_value, int> const * const_pointer_of_enable_if_t2() {
   return nullptr;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}int const * const_pointer_of_enable_if_t2() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: int const * const_pointer_of_enable_if_t2() requires T::some_value {
 
 
 template <typename T>
@@ -112,34 +112,34 @@ std::enable_if_t<T::some_value, int>& reference_of_enable_if_t() {
   static int x; return x;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}int& reference_of_enable_if_t() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: int& reference_of_enable_if_t() requires T::some_value {
 
 template <typename T>
 const std::enable_if_t<T::some_value, int>& const_reference_of_enable_if_t() {
   static int x; return x;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:7: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}const int& const_reference_of_enable_if_t() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: const int& const_reference_of_enable_if_t() requires T::some_value {
 
 template <typename T>
 typename std::enable_if<T::some_value>::type enable_if_default_void() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void enable_if_default_void() requires T::some_value {{{$}}
+// CHECK-FIXES: void enable_if_default_void() requires T::some_value {
 
 template <typename T>
 std::enable_if_t<T::some_value> enable_if_t_default_void() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void enable_if_t_default_void() requires T::some_value {{{$}}
+// CHECK-FIXES: void enable_if_t_default_void() requires T::some_value {
 
 template <typename T>
 std::enable_if_t<T::some_value>* enable_if_t_default_void_pointer() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void* enable_if_t_default_void_pointer() requires T::some_value {{{$}}
+// CHECK-FIXES: void* enable_if_t_default_void_pointer() requires T::some_value {
 
 namespace using_namespace_std {
 
@@ -149,25 +149,25 @@ template <typename T>
 typename enable_if<T::some_value>::type with_typename() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void with_typename() requires T::some_value {{{$}}
+// CHECK-FIXES: void with_typename() requires T::some_value {
 
 template <typename T>
 enable_if_t<T::some_value> with_t() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void with_t() requires T::some_value {{{$}}
+// CHECK-FIXES: void with_t() requires T::some_value {
 
 template <typename T>
 typename enable_if<T::some_value, int>::type with_typename_and_type() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}int with_typename_and_type() requires T::some_value {{{$}}
+// CHECK-FIXES: int with_typename_and_type() requires T::some_value {
 
 template <typename T>
 enable_if_t<T::some_value, int> with_t_and_type() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}int with_t_and_type() requires T::some_value {{{$}}
+// CHECK-FIXES: int with_t_and_type() requires T::some_value {
 
 } // namespace using_namespace_std
 
@@ -213,43 +213,43 @@ template <typename T>
 std::enable_if_t<Traits<T>::value> type_trait_value() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void type_trait_value() requires Traits<T>::value {{{$}}
+// CHECK-FIXES: void type_trait_value() requires Traits<T>::value {
 
 template <typename T>
 std::enable_if_t<Traits<T>::member()> type_trait_member_call() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void type_trait_member_call() requires (Traits<T>::member()) {{{$}}
+// CHECK-FIXES: void type_trait_member_call() requires (Traits<T>::member()) {
 
 template <typename T>
 std::enable_if_t<!Traits<T>::value> negate() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void negate() requires (!Traits<T>::value) {{{$}}
+// CHECK-FIXES: void negate() requires (!Traits<T>::value) {
 
 template <typename T>
 std::enable_if_t<Traits<T>::value1 && Traits<T>::value2> conjunction() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void conjunction() requires (Traits<T>::value1 && Traits<T>::value2) {{{$}}
+// CHECK-FIXES: void conjunction() requires (Traits<T>::value1 && Traits<T>::value2) {
 
 template <typename T>
 std::enable_if_t<Traits<T>::value1 || Traits<T>::value2> disjunction() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void disjunction() requires (Traits<T>::value1 || Traits<T>::value2) {{{$}}
+// CHECK-FIXES: void disjunction() requires (Traits<T>::value1 || Traits<T>::value2) {
 
 template <typename T>
 std::enable_if_t<Traits<T>::value1 && !Traits<T>::value2> conjunction_with_negate() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void conjunction_with_negate() requires (Traits<T>::value1 && !Traits<T>::value2) {{{$}}
+// CHECK-FIXES: void conjunction_with_negate() requires (Traits<T>::value1 && !Traits<T>::value2) {
 
 template <typename T>
 std::enable_if_t<Traits<T>::value1 == (Traits<T>::value2 + 5)> complex_operators() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void complex_operators() requires (Traits<T>::value1 == (Traits<T>::value2 + 5)) {{{$}}
+// CHECK-FIXES: void complex_operators() requires (Traits<T>::value1 == (Traits<T>::value2 + 5)) {
 
 } // namespace primary_expression_tests
 
@@ -263,14 +263,14 @@ constexpr typename std::enable_if<T::some_value, int>::type constexpr_decl() {
   return 10;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:11: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}constexpr int constexpr_decl() requires T::some_value {{{$}}
+// CHECK-FIXES: constexpr int constexpr_decl() requires T::some_value {
 
 template <typename T>
 static inline constexpr typename std::enable_if<T::some_value, int>::type static_inline_constexpr_decl() {
   return 10;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}static inline constexpr int static_inline_constexpr_decl() requires T::some_value {{{$}}
+// CHECK-FIXES: static inline constexpr int static_inline_constexpr_decl() requires T::some_value {
 
 template <typename T>
 static
@@ -279,16 +279,16 @@ static_decl() {
   return 10;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}static{{$}}
-// CHECK-FIXES-NEXT: {{^}}int{{$}}
-// CHECK-FIXES-NEXT: {{^}}static_decl() requires T::some_value {{{$}}
+// CHECK-FIXES: static
+// CHECK-FIXES-NEXT: int
+// CHECK-FIXES-NEXT: static_decl() requires T::some_value {
 
 template <typename T>
 constexpr /* comment */ typename std::enable_if<T::some_value, int>::type constexpr_comment_decl() {
   return 10;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}constexpr /* comment */ int constexpr_comment_decl() requires T::some_value {{{$}}
+// CHECK-FIXES: constexpr /* comment */ int constexpr_comment_decl() requires T::some_value {
 
 
 ////////////////////////////////
@@ -302,45 +302,45 @@ struct AClass {
     return Obj{};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:10: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  static Obj static_method() requires T::some_value {{{$}}
+  // CHECK-FIXES: static Obj static_method() requires T::some_value {
 
   template <typename T>
   typename std::enable_if<T::some_value, Obj>::type member() {
     return Obj{};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  Obj member() requires T::some_value {{{$}}
+  // CHECK-FIXES: Obj member() requires T::some_value {
 
   template <typename T>
   typename std::enable_if<T::some_value, Obj>::type const_qualifier() const {
     return Obj{};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  Obj const_qualifier() const requires T::some_value {{{$}}
+  // CHECK-FIXES: Obj const_qualifier() const requires T::some_value {
 
   template <typename T>
   typename std::enable_if<T::some_value, Obj>::type rvalue_ref_qualifier() && {
     return Obj{};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  Obj rvalue_ref_qualifier() && requires T::some_value {{{$}}
+  // CHECK-FIXES: Obj rvalue_ref_qualifier() && requires T::some_value {
 
   template <typename T>
   typename std::enable_if<T::some_value, Obj>::type rvalue_ref_qualifier_comment() /* c1 */ && /* c2 */ {
     return Obj{};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  Obj rvalue_ref_qualifier_comment() /* c1 */ && /* c2 */ requires T::some_value {{{$}}
+  // CHECK-FIXES: Obj rvalue_ref_qualifier_comment() /* c1 */ && /* c2 */ requires T::some_value {
 
   template <typename T>
   std::enable_if_t<T::some_value, AClass&> operator=(T&&) = delete;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  AClass& operator=(T&&) requires T::some_value = delete;
+  // CHECK-FIXES: AClass& operator=(T&&) requires T::some_value = delete;
 
   template<typename T>
   std::enable_if_t<T::some_value, AClass&> operator=(ConsumeVariadic<T>) noexcept(requires (T t) { t = 4; }) = delete;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  AClass& operator=(ConsumeVariadic<T>) noexcept(requires (T t) { t = 4; }) requires T::some_value = delete;
+  // CHECK-FIXES: AClass& operator=(ConsumeVariadic<T>) noexcept(requires (T t) { t = 4; }) requires T::some_value = delete;
 
 };
 
@@ -354,7 +354,7 @@ typename std::enable_if</* check1 */ T::some_value, Obj>::type leading_comment()
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj leading_comment() requires /* check1 */ T::some_value {{{$}}
+// CHECK-FIXES: Obj leading_comment() requires /* check1 */ T::some_value {
 
 template <typename T>
 typename std::enable_if<T::some_value, Obj>::type body_on_next_line()
@@ -362,22 +362,22 @@ typename std::enable_if<T::some_value, Obj>::type body_on_next_line()
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj body_on_next_line(){{$}}
-// CHECK-FIXES-NEXT: {{^}}requires T::some_value {{{$}}
+// CHECK-FIXES: Obj body_on_next_line()
+// CHECK-FIXES-NEXT: requires T::some_value {
 
 template <typename T>
 typename std::enable_if<  /* check1 */ T::some_value, Obj>::type leading_comment_whitespace() {
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj leading_comment_whitespace() requires /* check1 */ T::some_value {{{$}}
+// CHECK-FIXES: Obj leading_comment_whitespace() requires /* check1 */ T::some_value {
 
 template <typename T>
 typename std::enable_if</* check1 */ T::some_value /* check2 */, Obj>::type leading_and_trailing_comment() {
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj leading_and_trailing_comment() requires /* check1 */ T::some_value /* check2 */ {{{$}}
+// CHECK-FIXES: Obj leading_and_trailing_comment() requires /* check1 */ T::some_value /* check2 */ {
 
 template <typename T, typename U>
 typename std::enable_if<T::some_value &&
@@ -385,31 +385,31 @@ typename std::enable_if<T::some_value &&
   return Obj{};
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}Obj condition_on_two_lines() requires (T::some_value &&{{$}}
-// CHECK-FIXES-NEXT: U::another_value) {{{$}}
+// CHECK-FIXES: Obj condition_on_two_lines() requires (T::some_value &&
+// CHECK-FIXES-NEXT: U::another_value) {
 
 template <typename T>
 typename std::enable_if<T::some_value, int> :: type* pointer_of_enable_if_t_with_spaces() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}int* pointer_of_enable_if_t_with_spaces() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: int* pointer_of_enable_if_t_with_spaces() requires T::some_value {
 
 template <typename T>
 typename std::enable_if<T::some_value, int> :: /*c*/ type* pointer_of_enable_if_t_with_comment() {
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}int* pointer_of_enable_if_t_with_comment() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: int* pointer_of_enable_if_t_with_comment() requires T::some_value {
 
 template <typename T>
 std::enable_if_t<T::some_value // comment
               > trailing_slash_slash_comment() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void trailing_slash_slash_comment() requires T::some_value // comment{{$}}
-// CHECK-FIXES-NEXT: {{^}}               {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void trailing_slash_slash_comment() requires T::some_value // comment
+// CHECK-FIXES-NEXT: {
 
 } // namespace enable_if_in_return_type
 
@@ -424,22 +424,22 @@ template <typename T, typename std::enable_if<T::some_value, int>::type = 0>
 void basic() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void basic() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void basic() requires T::some_value {
 
 template <typename T, std::enable_if_t<T::some_value, int> = 0>
 void basic_t() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void basic_t() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void basic_t() requires T::some_value {
 
 template <typename T, template <typename> class U, class V, std::enable_if_t<T::some_value, int> = 0>
 void basic_many_template_params() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:61: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T, template <typename> class U, class V>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void basic_many_template_params() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T, template <typename> class U, class V>
+// CHECK-FIXES-NEXT: void basic_many_template_params() requires T::some_value {
 
 template <std::enable_if_t<true, int> = 0>
 void no_dependent_type() {
@@ -457,38 +457,37 @@ struct AClass : ABaseClass {
   void no_other_template_params() {
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:13: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  {{$}}
-  // CHECK-FIXES-NEXT: {{^}}  void no_other_template_params() requires T::some_value {{{$}}
+  // CHECK-FIXES: void no_other_template_params() requires T::some_value {
 
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass() {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass() requires U::some_value {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass() requires U::some_value {}
 
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass(int) : data(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int) requires U::some_value : data(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int) requires U::some_value : data(0) {}
 
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass(int, int) : AClass(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int, int) requires U::some_value : AClass(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int, int) requires U::some_value : AClass(0) {}
 
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass(int, int, int) : ABaseClass(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int, int, int) requires U::some_value : ABaseClass(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int, int, int) requires U::some_value : ABaseClass(0) {}
 
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass(int, int, int, int) : data2(), data() {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int, int, int, int) requires U::some_value : data2(), data() {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int, int, int, int) requires U::some_value : data2(), data() {}
 
   int data;
   int data2;
@@ -500,14 +499,14 @@ struct AClass2 : ABaseClass {
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass2() {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass2() requires U::some_value {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass2() requires U::some_value {}
 
   template <typename U, std::enable_if_t<U::some_value, int> = 0>
   AClass2(int) : data2(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass2(int) requires U::some_value : data2(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass2(int) requires U::some_value : data2(0) {}
 
   int data = 10;
   int data2;
@@ -518,16 +517,16 @@ template <typename T, std::enable_if_t<T::some_value, T>* = 0>
 void pointer_type() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void pointer_type() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void pointer_type() requires T::some_value {
 
 template <typename T,
           std::enable_if_t<T::some_value, T>* = nullptr>
 void param_on_newline() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:11: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void param_on_newline() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void param_on_newline() requires T::some_value {
 
 template <typename T,
           typename U,
@@ -537,26 +536,26 @@ template <typename T,
 void param_split_on_two_lines() {
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:11: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T,{{$}}
-// CHECK-FIXES-NEXT: {{^}}          typename U>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void param_split_on_two_lines() requires ConsumeVariadic<T,{{$}}
-// CHECK-FIXES-NEXT: {{^}}                            U>::value {{{$}}
+// CHECK-FIXES: template <typename T,
+// CHECK-FIXES-NEXT: typename U>
+// CHECK-FIXES-NEXT: void param_split_on_two_lines() requires ConsumeVariadic<T,
+// CHECK-FIXES-NEXT: U>::value {
 
 template <typename T, std::enable_if_t<T::some_value // comment
          >* = nullptr>
 void trailing_slash_slash_comment() {
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void trailing_slash_slash_comment() requires T::some_value // comment{{$}}
-// CHECK-FIXES-NEXT: {{^}}          {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void trailing_slash_slash_comment() requires T::some_value // comment
+// CHECK-FIXES-NEXT: {
 
 template <typename T, std::enable_if_t<T::some_value>* = nullptr, std::enable_if_t<T::another_value>* = nullptr>
 void two_enable_ifs() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:67: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T, std::enable_if_t<T::some_value>* = nullptr>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void two_enable_ifs() requires T::another_value {{{$}}
+// CHECK-FIXES: template <typename T, std::enable_if_t<T::some_value>* = nullptr>
+// CHECK-FIXES-NEXT: void two_enable_ifs() requires T::another_value {
 
 ////////////////////////////////
 // Negative tests
@@ -584,16 +583,16 @@ void macro_entire_enable_if() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
 // CHECK-MESSAGES: :[[@LINE-5]]:56: note: expanded from macro 'TEMPLATE_REQUIRES'
-// CHECK-FIXES: {{^}}TEMPLATE_REQUIRES(U, U::some_value)
-// CHECK-FIXES-NEXT: {{^}}void macro_entire_enable_if() {{{$}}
+// CHECK-FIXES: TEMPLATE_REQUIRES(U, U::some_value)
+// CHECK-FIXES-NEXT: void macro_entire_enable_if() {
 
 #define CONDITION U::some_value
 template <typename U, std::enable_if_t<CONDITION, int> = 0>
 void macro_condition() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename U>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void macro_condition() requires CONDITION {{{$}}
+// CHECK-FIXES: template <typename U>
+// CHECK-FIXES-NEXT: void macro_condition() requires CONDITION {
 
 #undef CONDITION
 #define CONDITION !U::some_value
@@ -601,8 +600,8 @@ template <typename U, std::enable_if_t<CONDITION, int> = 0>
 void macro_condition_not_primary() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename U>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void macro_condition_not_primary() requires (CONDITION) {{{$}}
+// CHECK-FIXES: template <typename U>
+// CHECK-FIXES-NEXT: void macro_condition_not_primary() requires (CONDITION) {
 
 } // namespace enable_if_trailing_non_type_parameter
 
@@ -617,22 +616,22 @@ template <typename T, typename = std::enable_if<T::some_value>::type>
 void basic() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void basic() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void basic() requires T::some_value {
 
 template <typename T, typename = std::enable_if_t<T::some_value>>
 void basic_t() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void basic_t() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void basic_t() requires T::some_value {
 
 template <typename T, template <typename> class U, class V, typename = std::enable_if_t<T::some_value>>
 void basic_many_template_params() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:61: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T, template <typename> class U, class V>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void basic_many_template_params() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T, template <typename> class U, class V>
+// CHECK-FIXES-NEXT: void basic_many_template_params() requires T::some_value {
 
 struct ABaseClass {
   ABaseClass();
@@ -645,32 +644,31 @@ struct AClass : ABaseClass {
   void no_other_template_params() {
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:13: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  {{$}}
-  // CHECK-FIXES-NEXT: {{^}}  void no_other_template_params() requires T::some_value {{{$}}
+  // CHECK-FIXES: void no_other_template_params() requires T::some_value {
 
   template <typename U, typename = std::enable_if_t<U::some_value>>
   AClass() {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass() requires U::some_value {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass() requires U::some_value {}
 
   template <typename U, typename = std::enable_if_t<U::some_value>>
   AClass(int) : data(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int) requires U::some_value : data(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int) requires U::some_value : data(0) {}
 
   template <typename U, typename = std::enable_if_t<U::some_value>>
   AClass(int, int) : AClass(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int, int) requires U::some_value : AClass(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int, int) requires U::some_value : AClass(0) {}
 
   template <typename U, typename = std::enable_if_t<U::some_value>>
   AClass(int, int, int) : ABaseClass(0) {}
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-  // CHECK-FIXES: {{^}}  template <typename U>{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  AClass(int, int, int) requires U::some_value : ABaseClass(0) {}{{$}}
+  // CHECK-FIXES: template <typename U>
+  // CHECK-FIXES-NEXT: AClass(int, int, int) requires U::some_value : ABaseClass(0) {}
 
   int data;
 };
@@ -679,23 +677,23 @@ template <typename T, typename = std::enable_if_t<T::some_value>*>
 void pointer_type() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void pointer_type() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void pointer_type() requires T::some_value {
 
 template <typename T, typename = std::enable_if_t<T::some_value>&>
 void reference_type() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void reference_type() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void reference_type() requires T::some_value {
 
 template <typename T,
           typename = std::enable_if_t<T::some_value>*>
 void param_on_newline() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:11: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void param_on_newline() requires T::some_value {{{$}}
+// CHECK-FIXES: template <typename T>
+// CHECK-FIXES-NEXT: void param_on_newline() requires T::some_value {
 
 template <typename T,
           typename U,
@@ -705,10 +703,10 @@ template <typename T,
 void param_split_on_two_lines() {
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:11: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}template <typename T,{{$}}
-// CHECK-FIXES-NEXT: {{^}}          typename U>{{$}}
-// CHECK-FIXES-NEXT: {{^}}void param_split_on_two_lines() requires ConsumeVariadic<T,{{$}}
-// CHECK-FIXES-NEXT: {{^}}                            U>::value {{{$}}
+// CHECK-FIXES: template <typename T,
+// CHECK-FIXES-NEXT: typename U>
+// CHECK-FIXES-NEXT: void param_split_on_two_lines() requires ConsumeVariadic<T,
+// CHECK-FIXES-NEXT: U>::value {
 
 
 ////////////////////////////////
@@ -776,12 +774,12 @@ using enable_if_t = typename enable_if<Condition, T>::type;
 template <typename T>
 typename nonstd::enable_if<some_type_trait<T>::value, void>::type nonstd_enable_if() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void nonstd_enable_if() requires some_type_trait<T>::value {}{{$}}
+// CHECK-FIXES: void nonstd_enable_if() requires some_type_trait<T>::value {}
 
 template <typename T>
 nonstd::enable_if_t<some_type_trait<T>::value, void> nonstd_enable_if_t() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void nonstd_enable_if_t() requires some_type_trait<T>::value {}{{$}}
+// CHECK-FIXES: void nonstd_enable_if_t() requires some_type_trait<T>::value {}
 
 template <>
 nonstd::enable_if_t<some_type_trait<int>::value, void> nonstd_enable_if_t<int>() {}
@@ -790,12 +788,12 @@ nonstd::enable_if_t<some_type_trait<int>::value, void> nonstd_enable_if_t<int>()
 template <typename T>
 typename nonstd::enable_if<some_type_trait<T>::value>::type nonstd_enable_if_one_param() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void nonstd_enable_if_one_param() requires some_type_trait<T>::value {}{{$}}
+// CHECK-FIXES: void nonstd_enable_if_one_param() requires some_type_trait<T>::value {}
 
 template <typename T>
 nonstd::enable_if_t<some_type_trait<T>::value> nonstd_enable_if_t_one_param() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
-// CHECK-FIXES: {{^}}void nonstd_enable_if_t_one_param() requires some_type_trait<T>::value {}{{$}}
+// CHECK-FIXES: void nonstd_enable_if_t_one_param() requires some_type_trait<T>::value {}
 
 // No fix-its are offered for an enable_if with a different signature from the standard one.
 namespace boost {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init-assignment.cpp
@@ -197,32 +197,32 @@ class ArrayValueInit {
   ArrayValueInit() : m_array() {}
   double m_array[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayValueInit()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[1] = {};
+  // CHECK-FIXES:      ArrayValueInit()  {}
+  // CHECK-FIXES-NEXT: double m_array[1] = {};
 };
 
 class ArrayBraceInit {
   ArrayBraceInit() : m_array{} {}
   double m_array[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayBraceInit()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[1] = {};
+  // CHECK-FIXES:      ArrayBraceInit()  {}
+  // CHECK-FIXES-NEXT: double m_array[1] = {};
 };
 
 class ArrayBraceInitWithValue {
   ArrayBraceInitWithValue() : m_array{3.14} {}
   double m_array[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayBraceInitWithValue()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[1] = {3.14};
+  // CHECK-FIXES:      ArrayBraceInitWithValue()  {}
+  // CHECK-FIXES-NEXT: double m_array[1] = {3.14};
 };
 
 class ArrayBraceInitMultipleValues {
   ArrayBraceInitMultipleValues() : m_array{1.0, 2.0, 3.0} {}
   double m_array[3];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayBraceInitMultipleValues()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[3] = {1.0, 2.0, 3.0};
+  // CHECK-FIXES:      ArrayBraceInitMultipleValues()  {}
+  // CHECK-FIXES-NEXT: double m_array[3] = {1.0, 2.0, 3.0};
 };
 
 } // namespace PR63285

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
@@ -479,8 +479,8 @@ struct EmptyBracedIntDefault {
   EmptyBracedIntDefault() : m_i{} {}
   int m_i;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'm_i' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}EmptyBracedIntDefault()  {}
-  // CHECK-FIXES-NEXT: {{^  }}int m_i{};
+  // CHECK-FIXES:      EmptyBracedIntDefault()  {}
+  // CHECK-FIXES-NEXT: int m_i{};
 };
 
 namespace PR63285 {
@@ -489,32 +489,32 @@ class ArrayValueInit {
   ArrayValueInit() : m_array() {}
   double m_array[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayValueInit()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[1]{};
+  // CHECK-FIXES:      ArrayValueInit()  {}
+  // CHECK-FIXES-NEXT: double m_array[1]{};
 };
 
 class ArrayBraceInit {
   ArrayBraceInit() : m_array{} {}
   double m_array[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayBraceInit()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[1]{};
+  // CHECK-FIXES:      ArrayBraceInit()  {}
+  // CHECK-FIXES-NEXT: double m_array[1]{};
 };
 
 class ArrayBraceInitWithValue {
   ArrayBraceInitWithValue() : m_array{3.14} {}
   double m_array[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayBraceInitWithValue()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[1]{3.14};
+  // CHECK-FIXES:      ArrayBraceInitWithValue()  {}
+  // CHECK-FIXES-NEXT: double m_array[1]{3.14};
 };
 
 class ArrayBraceInitMultipleValues {
   ArrayBraceInitMultipleValues() : m_array{1.0, 2.0, 3.0} {}
   double m_array[3];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'm_array' [modernize-use-default-member-init]
-  // CHECK-FIXES:      {{^  }}ArrayBraceInitMultipleValues()  {}
-  // CHECK-FIXES-NEXT: {{^  }}double m_array[3]{1.0, 2.0, 3.0};
+  // CHECK-FIXES:      ArrayBraceInitMultipleValues()  {}
+  // CHECK-FIXES-NEXT: double m_array[3]{1.0, 2.0, 3.0};
 };
 
 } // namespace PR63285

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default-copy.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default-copy.cpp
@@ -147,7 +147,7 @@ struct BF {
   BF(const BF &Other) : Field1(Other.Field1), Field2(Other.Field2), Field3(Other.Field3),
                         Field4(Other.Field4) {};
   // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: use '= default'
-  // CHECK-FIXES: BF(const BF &Other) {{$}}
+  // CHECK-FIXES: BF(const BF &Other)
   // CHECK-FIXES:                     = default;
   BF &operator=(const BF &);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default.cpp
@@ -127,7 +127,7 @@ Priv::Priv() {}
 struct SemiColon {
   SemiColon() {};
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use '= default'
-  // CHECK-FIXES: SemiColon() = default;{{$}}
+  // CHECK-FIXES: SemiColon() = default;
 };
 
 struct SemiColonOutOfLine {
@@ -136,16 +136,16 @@ struct SemiColonOutOfLine {
 
 SemiColonOutOfLine::SemiColonOutOfLine() {};
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use '= default'
-// CHECK-FIXES: SemiColonOutOfLine::SemiColonOutOfLine() = default;{{$}}
+// CHECK-FIXES: SemiColonOutOfLine::SemiColonOutOfLine() = default;
 
 // struct.
 struct ST {
   ST() {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use '= default'
-  // CHECK-FIXES: ST() = default;{{$}}
+  // CHECK-FIXES: ST() = default;
   ~ST() {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use '= default'
-  // CHECK-FIXES: ST() = default;{{$}}
+  // CHECK-FIXES: ST() = default;
 };
 
 // Deleted constructor/destructor.
@@ -238,13 +238,13 @@ struct DC : KW {
   DC() : KW() {}
   ~DC() override {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use '= default'
-  // CHECK-FIXES: ~DC() override = default;{{$}}
+  // CHECK-FIXES: ~DC() override = default;
 };
 
 struct OverrideWithSemiColon : KW {
   ~OverrideWithSemiColon() override {};
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use '= default'
-  // CHECK-FIXES: ~OverrideWithSemiColon() override = default;{{$}}
+  // CHECK-FIXES: ~OverrideWithSemiColon() override = default;
 };
 
 struct Comments {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-allow-override-and-final.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-allow-override-and-final.cpp
@@ -17,24 +17,24 @@ struct Base {
 struct Simple : public Base {
   virtual ~Simple();
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  ~Simple() override;
+  // CHECK-FIXES: ~Simple() override;
   virtual void a() override;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'override' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void a() override;
+  // CHECK-FIXES: void a() override;
   virtual void b() final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'final' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void b() final;
+  // CHECK-FIXES: void b() final;
   virtual void c() final override;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'final' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void c() final override;
+  // CHECK-FIXES: void c() final override;
   virtual void d() override final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'final' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void d() override final;
+  // CHECK-FIXES: void d() override final;
   void e() final override;
   void f() override final;
   void g() final;
   void h() override;
   void i();
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this function with 'override' or (rarely) 'final' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void i() override;
+  // CHECK-FIXES: void i() override;
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-ms.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-ms.cpp
@@ -14,12 +14,12 @@ class EXPORT InheritedBase {
 class Derived : public Base {
   virtual EXPORT void a();
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  EXPORT void a() override;
+  // CHECK-FIXES: EXPORT void a() override;
 };
 
 class EXPORT InheritedDerived : public InheritedBase {
   virtual void a();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void a() override;
+  // CHECK-FIXES: void a() override;
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-no-destructors.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-no-destructors.cpp
@@ -11,5 +11,5 @@ struct Simple : public Base {
   // CHECK-MESSAGES-NOT: warning:
   virtual void f();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void f() override;
+  // CHECK-FIXES: void f() override;
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-templates.cpp
@@ -43,5 +43,5 @@ struct Derived2 : BaseS<T>, BaseU {
   // should warn, comes from non-template BaseU
   virtual void boo3();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^  }}void boo3() override;
+  // CHECK-FIXES: void boo3() override;
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-with-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-with-macro.cpp
@@ -29,41 +29,41 @@ struct SimpleCases : public Base {
 public:
   virtual ~SimpleCases();
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using 'OVERRIDE' or (rarely) 'FINAL' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  ~SimpleCases() OVERRIDE;
+  // CHECK-FIXES: ~SimpleCases() OVERRIDE;
 
   void a();
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this function with 'OVERRIDE' or (rarely) 'FINAL' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void a() OVERRIDE;
+  // CHECK-FIXES: void a() OVERRIDE;
 
   virtual void b();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using 'OVERRIDE' or (rarely) 'FINAL' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void b() OVERRIDE;
+  // CHECK-FIXES: void b() OVERRIDE;
 
   virtual void c();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void c() OVERRIDE;
+  // CHECK-FIXES: void c() OVERRIDE;
 
   virtual void e() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void e() OVERRIDE = 0;
+  // CHECK-FIXES: void e() OVERRIDE = 0;
 
   virtual void f2() const = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void f2() const OVERRIDE = 0;
+  // CHECK-FIXES: void f2() const OVERRIDE = 0;
 
   virtual void g() ABSTRACT;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void g() OVERRIDE ABSTRACT;
+  // CHECK-FIXES: void g() OVERRIDE ABSTRACT;
 
   virtual void j() const;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void j() const OVERRIDE;
+  // CHECK-FIXES: void j() const OVERRIDE;
 
   virtual void k() OVERRIDE;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'OVERRIDE' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void k() OVERRIDE;
+  // CHECK-FIXES: void k() OVERRIDE;
 
   virtual void l() const OVERRIDE;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'OVERRIDE' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void l() const OVERRIDE;
+  // CHECK-FIXES: void l() const OVERRIDE;
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-with-no-macro-inscope.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-with-no-macro-inscope.cpp
@@ -15,13 +15,13 @@ struct SimpleCases : public Base {
 public:
   virtual ~SimpleCases();
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using 'CUSTOM_OVERRIDE' or (rarely) 'CUSTOM_FINAL' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  virtual ~SimpleCases();
+  // CHECK-FIXES: virtual ~SimpleCases();
 
   void a();
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this function with 'CUSTOM_OVERRIDE' or (rarely) 'CUSTOM_FINAL' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  void a();
+  // CHECK-FIXES: void a();
 
   virtual void b();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using 'CUSTOM_OVERRIDE' or (rarely) 'CUSTOM_FINAL' instead of 'virtual' [modernize-use-override]
-  // CHECK-FIXES: {{^}}  virtual void b();
+  // CHECK-FIXES: virtual void b();
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override.cpp
@@ -54,182 +54,182 @@ struct SimpleCases : public Base {
 public:
   virtual ~SimpleCases();
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual'
-  // CHECK-FIXES: {{^}}  ~SimpleCases() override;
+  // CHECK-FIXES: ~SimpleCases() override;
 
   void a();
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this
-  // CHECK-FIXES: {{^}}  void a() override;
+  // CHECK-FIXES: void a() override;
 
   void b() override;
   // CHECK-MESSAGES-NOT: warning:
-  // CHECK-FIXES: {{^}}  void b() override;
+  // CHECK-FIXES: void b() override;
 
   virtual void c();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void c() override;
+  // CHECK-FIXES: void c() override;
 
   virtual void d() override;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'override'
-  // CHECK-FIXES: {{^}}  void d() override;
+  // CHECK-FIXES: void d() override;
 
   virtual void d2() final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'final'
-  // CHECK-FIXES: {{^}}  void d2() final;
+  // CHECK-FIXES: void d2() final;
 
   virtual void e() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void e() override = 0;
+  // CHECK-FIXES: void e() override = 0;
 
   virtual void f()=0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void f() override =0;
+  // CHECK-FIXES: void f() override =0;
 
   virtual void f2() const=0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void f2() const override =0;
+  // CHECK-FIXES: void f2() const override =0;
 
   virtual void g() ABSTRACT;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void g() override ABSTRACT;
+  // CHECK-FIXES: void g() override ABSTRACT;
 
   virtual void j() const;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void j() const override;
+  // CHECK-FIXES: void j() const override;
 
   virtual MustUseResultObject k();  // Has an implicit attribute.
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer using
-  // CHECK-FIXES: {{^}}  MustUseResultObject k() override;
+  // CHECK-FIXES: MustUseResultObject k() override;
 
   virtual bool l() MUST_USE_RESULT UNUSED;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  bool l() override MUST_USE_RESULT UNUSED;
+  // CHECK-FIXES: bool l() override MUST_USE_RESULT UNUSED;
 
   virtual bool n() UNUSED MUST_USE_RESULT;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  bool n() override UNUSED MUST_USE_RESULT;
+  // CHECK-FIXES: bool n() override UNUSED MUST_USE_RESULT;
 
   void m() override final;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'override' is redundant since the function is already declared 'final'
-  // CHECK-FIXES: {{^}}  void m() final;
+  // CHECK-FIXES: void m() final;
 
   virtual void m2() override final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' and 'override' are redundant since the function is already declared 'final'
-  // CHECK-FIXES: {{^}}  void m2() final;
+  // CHECK-FIXES: void m2() final;
 
   virtual void o() __attribute__((unused));
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void o() override __attribute__((unused));
+  // CHECK-FIXES: void o() override __attribute__((unused));
 
   virtual void ne() noexcept(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void ne() noexcept(false) override;
+  // CHECK-FIXES: void ne() noexcept(false) override;
 
   virtual void t() throw();
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void t() throw() override;
+  // CHECK-FIXES: void t() throw() override;
 
   virtual       /*      */ void g2();
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual'
-  // CHECK-FIXES: {{^}}  /*      */ void g2() override;
+  // CHECK-FIXES: /*      */ void g2() override;
 };
 
 // CHECK-MESSAGES-NOT: warning:
 
 void SimpleCases::c() {}
-// CHECK-FIXES: {{^}}void SimpleCases::c() {}
+// CHECK-FIXES: void SimpleCases::c() {}
 
 SimpleCases::~SimpleCases() {}
-// CHECK-FIXES: {{^}}SimpleCases::~SimpleCases() {}
+// CHECK-FIXES: SimpleCases::~SimpleCases() {}
 
 struct DefaultedDestructor : public Base {
   DefaultedDestructor() {}
   virtual ~DefaultedDestructor() = default;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using
-  // CHECK-FIXES: {{^}}  ~DefaultedDestructor() override = default;
+  // CHECK-FIXES: ~DefaultedDestructor() override = default;
 };
 
 struct FinalSpecified : public Base {
 public:
   virtual ~FinalSpecified() final;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'virtual' is redundant since the function is already declared 'final'
-  // CHECK-FIXES: {{^}}  ~FinalSpecified() final;
+  // CHECK-FIXES: ~FinalSpecified() final;
 
   void b() final;
   // CHECK-MESSAGES-NOT: warning:
-  // CHECK-FIXES: {{^}}  void b() final;
+  // CHECK-FIXES: void b() final;
 
   virtual void d() final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant
-  // CHECK-FIXES: {{^}}  void d() final;
+  // CHECK-FIXES: void d() final;
 
   virtual void e() final = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant
-  // CHECK-FIXES: {{^}}  void e() final = 0;
+  // CHECK-FIXES: void e() final = 0;
 
   virtual void j() const final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant
-  // CHECK-FIXES: {{^}}  void j() const final;
+  // CHECK-FIXES: void j() const final;
 
   virtual bool l() final MUST_USE_RESULT UNUSED;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant
-  // CHECK-FIXES: {{^}}  bool l() final MUST_USE_RESULT UNUSED;
+  // CHECK-FIXES: bool l() final MUST_USE_RESULT UNUSED;
 };
 
 struct InlineDefinitions : public Base {
 public:
   virtual ~InlineDefinitions() {}
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using
-  // CHECK-FIXES: {{^}}  ~InlineDefinitions() override {}
+  // CHECK-FIXES: ~InlineDefinitions() override {}
 
   void a() {}
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this
-  // CHECK-FIXES: {{^}}  void a() override {}
+  // CHECK-FIXES: void a() override {}
 
   void b() override {}
   // CHECK-MESSAGES-NOT: warning:
-  // CHECK-FIXES: {{^}}  void b() override {}
+  // CHECK-FIXES: void b() override {}
 
   virtual void c()
   {}
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void c() override
+  // CHECK-FIXES: void c() override
 
   virtual void d() override {}
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant
-  // CHECK-FIXES: {{^}}  void d() override {}
+  // CHECK-FIXES: void d() override {}
 
   virtual void j() const
   {}
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void j() const override
+  // CHECK-FIXES: void j() const override
 
   virtual MustUseResultObject k();  // Has an implicit attribute.
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer using
-  // CHECK-FIXES: {{^}}  MustUseResultObject k() override;
+  // CHECK-FIXES: MustUseResultObject k() override;
 
   virtual bool l() MUST_USE_RESULT UNUSED;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  bool l() override MUST_USE_RESULT UNUSED;
+  // CHECK-FIXES: bool l() override MUST_USE_RESULT UNUSED;
 
   virtual void r() &
   {}
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void r() & override
+  // CHECK-FIXES: void r() & override
 
   virtual void rr() &&
   {}
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void rr() && override
+  // CHECK-FIXES: void rr() && override
 
   virtual void cv() const volatile
   {}
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void cv() const volatile override
+  // CHECK-FIXES: void cv() const volatile override
 
   virtual void cv2() const volatile // some comment
   {}
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void cv2() const volatile override // some comment
+  // CHECK-FIXES: void cv2() const volatile override // some comment
 };
 
 struct DefaultArguments : public Base {
@@ -237,7 +237,7 @@ struct DefaultArguments : public Base {
   // Make sure the override fix is placed after the argument list.
   void il(IntPair p = {1, (2 + (3))}) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this
-  // CHECK-FIXES: {{^}}  void il(IntPair p = {1, (2 + (3))}) override {}
+  // CHECK-FIXES: void il(IntPair p = {1, (2 + (3))}) override {}
 };
 
 struct Macros : public Base {
@@ -245,31 +245,31 @@ struct Macros : public Base {
   // give up for now.
   NOT_VIRTUAL void a() NOT_OVERRIDE;
   // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: annotate this
-  // CHECK-FIXES: {{^}}  NOT_VIRTUAL void a() override NOT_OVERRIDE;
+  // CHECK-FIXES: NOT_VIRTUAL void a() override NOT_OVERRIDE;
 
   VIRTUAL void b() NOT_OVERRIDE;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  VIRTUAL void b() override NOT_OVERRIDE;
+  // CHECK-FIXES: VIRTUAL void b() override NOT_OVERRIDE;
 
   NOT_VIRTUAL void c() OVERRIDE;
   // CHECK-MESSAGES-NOT: warning:
-  // CHECK-FIXES: {{^}}  NOT_VIRTUAL void c() OVERRIDE;
+  // CHECK-FIXES: NOT_VIRTUAL void c() OVERRIDE;
 
   VIRTUAL void d() OVERRIDE;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' is redundant
-  // CHECK-FIXES: {{^}}  VIRTUAL void d() OVERRIDE;
+  // CHECK-FIXES: VIRTUAL void d() OVERRIDE;
 
 #define FUNC(return_type, name) return_type name()
   FUNC(void, e);
-  // CHECK-FIXES: {{^}}  FUNC(void, e);
+  // CHECK-FIXES: FUNC(void, e);
 
 #define F virtual void f();
   F
-  // CHECK-FIXES: {{^}}  F
+  // CHECK-FIXES: F
 
   VIRTUAL void g() OVERRIDE final;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: 'virtual' and 'override' are redundant
-  // CHECK-FIXES: {{^}}  VIRTUAL void g() final;
+  // CHECK-FIXES: VIRTUAL void g() final;
 };
 
 // Tests for templates.
@@ -280,7 +280,7 @@ template <typename T> struct TemplateBase {
 template <typename T> struct DerivedFromTemplate : public TemplateBase<T> {
   virtual void f(T t);
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void f(T t) override;
+  // CHECK-FIXES: void f(T t) override;
 };
 void f() { DerivedFromTemplate<int>().f(2); }
 
@@ -288,7 +288,7 @@ template <class C>
 struct UnusedMemberInstantiation : public C {
   virtual ~UnusedMemberInstantiation() {}
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: prefer using
-  // CHECK-FIXES: {{^}}  ~UnusedMemberInstantiation() override {}
+  // CHECK-FIXES: ~UnusedMemberInstantiation() override {}
 };
 struct IntantiateWithoutUse : public UnusedMemberInstantiation<Base> {};
 
@@ -303,7 +303,7 @@ template <int I>
 struct MembersOfSpecializations : public Base2 {
   void a() override;
   // CHECK-MESSAGES-NOT: warning:
-  // CHECK-FIXES: {{^}}  void a() override;
+  // CHECK-FIXES: void a() override;
 };
 template <> void MembersOfSpecializations<3>::a() {}
 void ff() { MembersOfSpecializations<3>().a(); };
@@ -313,11 +313,11 @@ void ff() { MembersOfSpecializations<3>().a(); };
 struct TryStmtAsBody : public Base {
   void a() try
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate this
-  // CHECK-FIXES: {{^}}  void a() override try
+  // CHECK-FIXES: void a() override try
   { b(); } catch(...) { c(); }
 
   virtual void d() try
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
-  // CHECK-FIXES: {{^}}  void d() override try
+  // CHECK-FIXES: void d() override try
   { e(); } catch(...) { f(); }
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-cxx20.cpp
@@ -17,11 +17,11 @@ concept floating_point = std::is_same<T, float>::value || std::is_same<T, double
 
 std::floating_point auto con1();
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto con1() -> std::floating_point auto;{{$}}
+// CHECK-FIXES: auto con1() -> std::floating_point auto;
 
 std::floating_point auto con1() { return 3.14f; }
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto con1() -> std::floating_point auto { return 3.14f; }{{$}}
+// CHECK-FIXES: auto con1() -> std::floating_point auto { return 3.14f; }
 
 namespace a {
 template <typename T>
@@ -33,25 +33,25 @@ concept BinaryConcept = true;
 
 a::Concept decltype(auto) con2();
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto con2() -> a::Concept decltype(auto);{{$}}
+// CHECK-FIXES: auto con2() -> a::Concept decltype(auto);
 
 a::BinaryConcept<int> decltype(auto) con3();
 // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto con3() -> a::BinaryConcept<int> decltype(auto);{{$}}
+// CHECK-FIXES: auto con3() -> a::BinaryConcept<int> decltype(auto);
 
 const std::floating_point auto* volatile con4();
 // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto con4() -> const std::floating_point auto* volatile;{{$}}
+// CHECK-FIXES: auto con4() -> const std::floating_point auto* volatile;
 
 template <typename T>
 int req1(T t) requires std::floating_point<T>;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto req1(T t) -> int requires std::floating_point<T>;{{$}}
+// CHECK-FIXES: auto req1(T t) -> int requires std::floating_point<T>;
 
 template <typename T>
 T req2(T t) requires requires { t + t; };
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}auto req2(T t) -> T requires requires { t + t; };{{$}}
+  // CHECK-FIXES: auto req2(T t) -> T requires requires { t + t; };
 
 //
 // Operator c++20 defaulted comparison operators
@@ -96,7 +96,7 @@ struct TestDefaultOperatorB {
   friend auto operator==(const TestDefaultOperatorB &, const TestDefaultOperatorB &) noexcept -> bool = default;
   friend bool operator<(const TestDefaultOperatorB &, const TestDefaultOperatorB &) noexcept = default;
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  friend auto operator<(const TestDefaultOperatorB &, const TestDefaultOperatorB &) noexcept -> bool = default;{{$}}
+  // CHECK-FIXES: friend auto operator<(const TestDefaultOperatorB &, const TestDefaultOperatorB &) noexcept -> bool = default;
 };
 
 namespace PR69863 {
@@ -109,7 +109,7 @@ struct CustomCompileTimeString {
 template <CustomCompileTimeString Str>
 constexpr decltype(Str) operator""__csz() noexcept {
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}constexpr auto operator""__csz() noexcept -> decltype(Str) {
+// CHECK-FIXES: constexpr auto operator""__csz() noexcept -> decltype(Str) {
   return Str;
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-transform-lambdas-cxx14.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-transform-lambdas-cxx14.cpp
@@ -10,15 +10,15 @@ namespace std {
 void test_lambda_positive() {
   auto l1 = [](auto x) { return x; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l1 = [](auto x) -> auto { return x; };{{$}}
+  // CHECK-FIXES: auto l1 = [](auto x) -> auto { return x; };
 }
 
 template <template <typename> class C>
 void test_lambda_positive_template() {
   auto l1 = []() { return C<int>{}; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l1 = []() -> auto { return C<int>{}; };{{$}}
+  // CHECK-FIXES: auto l1 = []() -> auto { return C<int>{}; };
   auto l2 = []() { return 0; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l2 = []() -> auto { return 0; };{{$}}
+  // CHECK-FIXES: auto l2 = []() -> auto { return 0; };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-transform-lambdas-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-transform-lambdas-cxx20.cpp
@@ -14,22 +14,22 @@ concept floating_point = std::is_same<T, float>::value || std::is_same<T, double
 void test_lambda_positive() {
   auto l1 = []<typename T, typename U>(T x, U y) { return x + y; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l1 = []<typename T, typename U>(T x, U y) -> auto { return x + y; };{{$}}
+  // CHECK-FIXES: auto l1 = []<typename T, typename U>(T x, U y) -> auto { return x + y; };
   auto l2 = [](auto x) requires requires { x + x; } { return x; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l2 = [](auto x) -> auto requires requires { x + x; } { return x; };{{$}}
+  // CHECK-FIXES: auto l2 = [](auto x) -> auto requires requires { x + x; } { return x; };
   auto l3 = [](auto x) requires std::floating_point<decltype(x)> { return x; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l3 = [](auto x) -> auto requires std::floating_point<decltype(x)> { return x; };{{$}}
+  // CHECK-FIXES: auto l3 = [](auto x) -> auto requires std::floating_point<decltype(x)> { return x; };
   auto l4 = [](int x) consteval { return x; };
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l4 = [](int x) consteval -> int { return x; };{{$}}
+  // CHECK-FIXES: auto l4 = [](int x) consteval -> int { return x; };
   // Complete complex example
   auto l5 = []<typename T, typename U>(T x, U y) constexpr noexcept
     requires std::floating_point<T> && std::floating_point<U>
   { return x * y; };
   // CHECK-MESSAGES: :[[@LINE-3]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES: {{^}}  auto l5 = []<typename T, typename U>(T x, U y) constexpr noexcept{{$}}
-  // CHECK-FIXES: {{^}}    -> auto requires std::floating_point<T> && std::floating_point<U>{{$}}
-  // CHECK-FIXES: {{^}}  { return x * y; };{{$}}
+  // CHECK-FIXES: auto l5 = []<typename T, typename U>(T x, U y) constexpr noexcept
+  // CHECK-FIXES:   -> auto requires std::floating_point<T> && std::floating_point<U>
+  // CHECK-FIXES: { return x * y; };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-transform-lambdas.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-transform-lambdas.cpp
@@ -22,19 +22,19 @@ void test_lambda_positive() {
   auto l01 = [] {};
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:14: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:14: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l01 = [] -> void {};{{$}}
+  // CHECK-FIXES-ALL: auto l01 = [] -> void {};
   auto l1 = []() {};
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l1 = []() -> void {};{{$}}
+  // CHECK-FIXES-ALL: auto l1 = []() -> void {};
   auto l2 = []() { return 42; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l2 = []() -> int { return 42; };{{$}}
+  // CHECK-FIXES-ALL: auto l2 = []() -> int { return 42; };
   auto l3 = [](int x, double y) { return x * y; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l3 = [](int x, double y) -> double { return x * y; };{{$}}
+  // CHECK-FIXES-ALL: auto l3 = [](int x, double y) -> double { return x * y; };
 
   int capture_int = 10;
   double capture_double = 3.14;
@@ -43,31 +43,31 @@ void test_lambda_positive() {
   auto l4 = [capture_int]() { return capture_int; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l4 = [capture_int]() -> int { return capture_int; };{{$}}
+  // CHECK-FIXES-ALL: auto l4 = [capture_int]() -> int { return capture_int; };
   auto l5 = [capture_int, &capture_double](char c) { return capture_int + capture_double + c; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l5 = [capture_int, &capture_double](char c) -> double { return capture_int + capture_double + c; };{{$}}
+  // CHECK-FIXES-ALL: auto l5 = [capture_int, &capture_double](char c) -> double { return capture_int + capture_double + c; };
   auto l6 = [capture_int]() constexpr mutable noexcept { return ++capture_int; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l6 = [capture_int]() constexpr mutable noexcept -> int { return ++capture_int; };{{$}}
+  // CHECK-FIXES-ALL: auto l6 = [capture_int]() constexpr mutable noexcept -> int { return ++capture_int; };
   auto l7 = [&capture_ptr]() { return capture_ptr; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l7 = [&capture_ptr]() -> int * { return capture_ptr; };{{$}}
+  // CHECK-FIXES-ALL: auto l7 = [&capture_ptr]() -> int * { return capture_ptr; };
   auto l8 = [&capture_int]() { return capture_int; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l8 = [&capture_int]() -> int { return capture_int; };{{$}}
+  // CHECK-FIXES-ALL: auto l8 = [&capture_int]() -> int { return capture_int; };
   auto l9 = [] { return std::vector<std::vector<int>>{}; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:13: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l9 = [] -> std::vector<std::vector<int>> { return std::vector<std::vector<int>>{}; };{{$}}
+  // CHECK-FIXES-ALL: auto l9 = [] -> std::vector<std::vector<int>> { return std::vector<std::vector<int>>{}; };
   auto l10 = [] { const char* const * const * const ptr = nullptr; return ptr; };
   // CHECK-MESSAGES-ALL: :[[@LINE-1]]:14: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
   // CHECK-MESSAGES-NOAUTO: :[[@LINE-2]]:14: warning: use a trailing return type for this lambda [modernize-use-trailing-return-type]
-  // CHECK-FIXES-ALL: {{^}}  auto l10 = [] -> const char *const *const * { const char* const * const * const ptr = nullptr; return ptr; };{{$}}
+  // CHECK-FIXES-ALL: auto l10 = [] -> const char *const *const * { const char* const * const * const ptr = nullptr; return ptr; };
 }
 
 // In c++11 mode we can not write 'auto' type, see *-cxx14.cpp for fixes.
@@ -86,4 +86,4 @@ void test_lambda_negative() {
 // this function is solely used to not to get "wrong config error" from the check.
 int f();
 // CHECK-MESSAGES-NONE: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES-NONE: {{^}}auto f() -> int;{{$}}
+// CHECK-FIXES-NONE: auto f() -> int;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type.cpp
@@ -27,25 +27,25 @@ namespace std {
 
 int f();
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto f() -> int;{{$}}
+// CHECK-FIXES: auto f() -> int;
 int ((f))();
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto ((f))() -> int;{{$}}
+// CHECK-FIXES: auto ((f))() -> int;
 int f(int);
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto f(int) -> int;{{$}}
+// CHECK-FIXES: auto f(int) -> int;
 int f(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto f(int arg) -> int;{{$}}
+// CHECK-FIXES: auto f(int arg) -> int;
 int f(int arg1, int arg2, int arg3);
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto f(int arg1, int arg2, int arg3) -> int;{{$}}
+// CHECK-FIXES: auto f(int arg1, int arg2, int arg3) -> int;
 int f(int arg1, int arg2, int arg3, ...);
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto f(int arg1, int arg2, int arg3, ...) -> int;{{$}}
+// CHECK-FIXES: auto f(int arg1, int arg2, int arg3, ...) -> int;
 template <typename T> int f(T t);
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}template <typename T> auto f(T t) -> int;{{$}}
+// CHECK-FIXES: template <typename T> auto f(T t) -> int;
 
 //
 // Functions with formatting
@@ -53,44 +53,44 @@ template <typename T> int f(T t);
 
 int a1() { return 42; }
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a1() -> int { return 42; }{{$}}
+// CHECK-FIXES: auto a1() -> int { return 42; }
 int a2() {
     return 42;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a2() -> int {{{$}}
+// CHECK-FIXES: auto a2() -> int {
 int a3()
 {
     return 42;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a3() -> int{{$}}
+// CHECK-FIXES: auto a3() -> int
 int a4(int   arg   )   ;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a4(int   arg   ) -> int   ;{{$}}
+// CHECK-FIXES: auto a4(int   arg   ) -> int   ;
 int a5
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a5{{$}}
+// CHECK-FIXES: auto a5
 (int arg);
-// CHECK-FIXES: {{^}}(int arg) -> int;{{$}}
+// CHECK-FIXES: (int arg) -> int;
 const
 int
 *
 a7
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
 ()
-// CHECK-FIXES: {{^}}() -> const{{$}}
-// CHECK-FIXES: {{^}}int{{$}}
-// CHECK-FIXES: {{^}}*{{$}}
+// CHECK-FIXES: () -> const
+// CHECK-FIXES: int
+// CHECK-FIXES: *
 ;
 
 int*a7(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a7(int arg) -> int*;{{$}}
+// CHECK-FIXES: auto a7(int arg) -> int*;
 template<template <typename> class C>
 C<int>a8(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto a8(int arg) -> C<int>;{{$}}
+// CHECK-FIXES: auto a8(int arg) -> C<int>;
 
 
 //
@@ -99,63 +99,63 @@ C<int>a8(int arg);
 
 inline int d1(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto d1(int arg) -> int;{{$}}
+// CHECK-FIXES: inline auto d1(int arg) -> int;
 extern "C" int d2(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}extern "C" auto d2(int arg) -> int;{{$}}
+// CHECK-FIXES: extern "C" auto d2(int arg) -> int;
 inline int d3(int arg) noexcept(true);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto d3(int arg) noexcept(true) -> int;{{$}}
+// CHECK-FIXES: inline auto d3(int arg) noexcept(true) -> int;
 inline int d4(int arg) try { return 0; } catch(...) { return 0; }
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto d4(int arg) -> int try { return 0; } catch(...) { return 0; }{{$}}
+// CHECK-FIXES: inline auto d4(int arg) -> int try { return 0; } catch(...) { return 0; }
 int d5(int arg) throw();
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto d5(int arg) throw() -> int;{{$}}
+// CHECK-FIXES: auto d5(int arg) throw() -> int;
 static int d6(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto d6(int arg) -> int;{{$}}
+// CHECK-FIXES: static auto d6(int arg) -> int;
 int static d6(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto static d6(int arg) -> int;{{$}}
+// CHECK-FIXES: auto static d6(int arg) -> int;
 unsigned static int d7(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto d7(int arg) -> unsigned int;{{$}}
+// CHECK-FIXES: static auto d7(int arg) -> unsigned int;
 const long static int volatile constexpr unsigned inline long d8(int arg);
 // CHECK-MESSAGES: :[[@LINE-1]]:63: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static constexpr inline auto d8(int arg) -> const long int volatile unsigned long;{{$}}
+// CHECK-FIXES: static constexpr inline auto d8(int arg) -> const long int volatile unsigned long;
 int constexpr d9();
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto constexpr d9() -> int;{{$}}
+// CHECK-FIXES: auto constexpr d9() -> int;
 inline int constexpr d10();
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto constexpr d10() -> int;{{$}}
+// CHECK-FIXES: inline auto constexpr d10() -> int;
 unsigned constexpr int d11();
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}constexpr auto d11() -> unsigned int;{{$}}
+// CHECK-FIXES: constexpr auto d11() -> unsigned int;
 unsigned extern int d13();
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}extern auto d13() -> unsigned int;{{$}}
+// CHECK-FIXES: extern auto d13() -> unsigned int;
 int static& d14();
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto d14() -> int &;{{$}}
+// CHECK-FIXES: static auto d14() -> int &;
 class DDD {
     int friend unsigned m1();
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    friend auto m1() -> int unsigned;{{$}}
+// CHECK-FIXES: friend auto m1() -> int unsigned;
     int friend unsigned m1() { return 0; }
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    friend auto m1() -> int unsigned { return 0; }{{$}}
+// CHECK-FIXES: friend auto m1() -> int unsigned { return 0; }
     const long int friend volatile constexpr unsigned inline long m2();
 // CHECK-MESSAGES: :[[@LINE-1]]:67: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    friend constexpr inline auto m2() -> const long int volatile unsigned long;{{$}}
+// CHECK-FIXES: friend constexpr inline auto m2() -> const long int volatile unsigned long;
     int virtual unsigned m3();
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto m3() -> int unsigned;{{$}}
+// CHECK-FIXES: virtual auto m3() -> int unsigned;
     template <typename T>
     int friend unsigned m4();
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    friend auto m4() -> int unsigned;{{$}}
+// CHECK-FIXES: friend auto m4() -> int unsigned;
 };
 
 //
@@ -166,27 +166,27 @@ namespace N {
     int e1();
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:9: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto e1() -> int;{{$}}
+// CHECK-FIXES: auto e1() -> int;
 int N::e1() { return 0; }
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto N::e1() -> int { return 0; }{{$}}
+// CHECK-FIXES: auto N::e1() -> int { return 0; }
 
 //
 // Functions with unsupported return types
 //
 int (*e3())(double);
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}int (*e3())(double);{{$}}
+// CHECK-FIXES: int (*e3())(double);
 struct A;
 int A::* e5();
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}int A::* e5();{{$}}
+// CHECK-FIXES: int A::* e5();
 int std::vector<std::string>::* e6();
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}int std::vector<std::string>::* e6();{{$}}
+// CHECK-FIXES: int std::vector<std::string>::* e6();
 int (std::vector<std::string>::*e7())(double);
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}int (std::vector<std::string>::*e7())(double);{{$}}
+// CHECK-FIXES: int (std::vector<std::string>::*e7())(double);
 
 //
 // Functions with complex return types
@@ -194,31 +194,31 @@ int (std::vector<std::string>::*e7())(double);
 
 inline volatile const std::vector<std::string> e2();
 // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto e2() -> volatile const std::vector<std::string>;{{$}}
+// CHECK-FIXES: inline auto e2() -> volatile const std::vector<std::string>;
 inline const std::vector<std::string> volatile e2();
 // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto e2() -> const std::vector<std::string> volatile;{{$}}
+// CHECK-FIXES: inline auto e2() -> const std::vector<std::string> volatile;
 inline std::vector<std::string> const volatile e2();
 // CHECK-MESSAGES: :[[@LINE-1]]:48: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}inline auto e2() -> std::vector<std::string> const volatile;{{$}}
+// CHECK-FIXES: inline auto e2() -> std::vector<std::string> const volatile;
 int* e8();
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto e8() -> int*;{{$}}
+// CHECK-FIXES: auto e8() -> int*;
 static const char* e9(void* user_data);
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto e9(void* user_data) -> const char*;{{$}}
+// CHECK-FIXES: static auto e9(void* user_data) -> const char*;
 static const char* const e10(void* user_data);
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto e10(void* user_data) -> const char* const;{{$}}
+// CHECK-FIXES: static auto e10(void* user_data) -> const char* const;
 static const char** volatile * const & e11(void* user_data);
 // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto e11(void* user_data) -> const char** volatile * const &;{{$}}
+// CHECK-FIXES: static auto e11(void* user_data) -> const char** volatile * const &;
 static const char* const * const * const e12(void* user_data);
 // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}static auto e12(void* user_data) -> const char* const * const * const;{{$}}
+// CHECK-FIXES: static auto e12(void* user_data) -> const char* const * const * const;
 struct A e13();
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto e13() -> struct A;{{$}}
+// CHECK-FIXES: auto e13() -> struct A;
 
 //
 // deduced return types
@@ -226,31 +226,31 @@ struct A e13();
 
 const auto ded1();
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto ded1() -> const auto;{{$}}
+// CHECK-FIXES: auto ded1() -> const auto;
 const auto& ded2();
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto ded2() -> const auto&;{{$}}
+// CHECK-FIXES: auto ded2() -> const auto&;
 
 decltype(auto) ded3();
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto ded3() -> decltype(auto);{{$}}
+// CHECK-FIXES: auto ded3() -> decltype(auto);
 
 
 decltype(1 + 2) dec1() { return 1 + 2; }
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto dec1() -> decltype(1 + 2) { return 1 + 2; }{{$}}
+// CHECK-FIXES: auto dec1() -> decltype(1 + 2) { return 1 + 2; }
 template <typename F, typename T>
 decltype(std::declval<F>(std::declval<T>)) dec2(F f, T t) { return f(t); }
 // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto dec2(F f, T t) -> decltype(std::declval<F>(std::declval<T>)) { return f(t); }{{$}}
+// CHECK-FIXES: auto dec2(F f, T t) -> decltype(std::declval<F>(std::declval<T>)) { return f(t); }
 template <typename T>
 typename decltype(std::declval<T>())::value_type dec3();
 // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto dec3() -> typename decltype(std::declval<T>())::value_type;{{$}}
+// CHECK-FIXES: auto dec3() -> typename decltype(std::declval<T>())::value_type;
 template <typename T>
 decltype(std::declval<T>())* dec4();
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto dec4() -> decltype(std::declval<T>())*;{{$}}
+// CHECK-FIXES: auto dec4() -> decltype(std::declval<T>())*;
 
 //
 // Methods
@@ -259,73 +259,73 @@ decltype(std::declval<T>())* dec4();
 struct B {
     B& operator=(const B&);
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto operator=(const B&) -> B&;{{$}}
+// CHECK-FIXES: auto operator=(const B&) -> B&;
 
     double base1(int, bool b);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto base1(int, bool b) -> double;{{$}}
+// CHECK-FIXES: auto base1(int, bool b) -> double;
 
     virtual double base2(int, bool b) { return 0; }
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto base2(int, bool b) -> double { return 0; }{{$}}
+// CHECK-FIXES: virtual auto base2(int, bool b) -> double { return 0; }
 
     virtual float base3() const = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto base3() const -> float = 0;{{$}}
+// CHECK-FIXES: virtual auto base3() const -> float = 0;
 
     virtual float base4() volatile = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto base4() volatile -> float = 0;{{$}}
+// CHECK-FIXES: virtual auto base4() volatile -> float = 0;
 
     double base5(int, bool b) &&;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto base5(int, bool b) && -> double;{{$}}
+// CHECK-FIXES: auto base5(int, bool b) && -> double;
 
     double base6(int, bool b) const &&;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto base6(int, bool b) const && -> double;{{$}}
+// CHECK-FIXES: auto base6(int, bool b) const && -> double;
 
     double base7(int, bool b) const & = delete;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto base7(int, bool b) const & -> double = delete;{{$}}
+// CHECK-FIXES: auto base7(int, bool b) const & -> double = delete;
 
     double base8(int, bool b) const volatile & = delete;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto base8(int, bool b) const volatile & -> double = delete;{{$}}
+// CHECK-FIXES: auto base8(int, bool b) const volatile & -> double = delete;
 
     virtual const char * base9() const noexcept { return ""; }
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto base9() const noexcept -> const char * { return ""; }{{$}}
+// CHECK-FIXES: virtual auto base9() const noexcept -> const char * { return ""; }
 };
 
 double B::base1(int, bool b) { return 0; }
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto B::base1(int, bool b) -> double { return 0; }{{$}}
+// CHECK-FIXES: auto B::base1(int, bool b) -> double { return 0; }
 
 struct D : B {
     virtual double f1(int, bool b) final;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto f1(int, bool b) -> double final;{{$}}
+// CHECK-FIXES: virtual auto f1(int, bool b) -> double final;
 
     virtual double base2(int, bool b) override;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto base2(int, bool b) -> double override;{{$}}
+// CHECK-FIXES: virtual auto base2(int, bool b) -> double override;
 
     virtual float base3() const override final { return 0; }
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    virtual auto base3() const -> float override final { return 0; }{{$}}
+// CHECK-FIXES: virtual auto base3() const -> float override final { return 0; }
 
     const char * base9() const noexcept override { return ""; }
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto base9() const noexcept -> const char * override { return ""; }{{$}}
+// CHECK-FIXES: auto base9() const noexcept -> const char * override { return ""; }
 
     int f2() __restrict;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto f2() __restrict -> int;{{$}}
+// CHECK-FIXES: auto f2() __restrict -> int;
 
     volatile int* __restrict f3() const __restrict noexcept;
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto f3() const __restrict noexcept -> volatile int* __restrict;{{$}}
+// CHECK-FIXES: auto f3() const __restrict noexcept -> volatile int* __restrict;
 };
 
 //
@@ -334,13 +334,13 @@ struct D : B {
 
 int g1() [[asdf]];
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto g1() -> int {{[[][[]}}asdf{{[]][]]}};{{$}}
+// CHECK-FIXES: auto g1() -> int {{[[][[]}}asdf{{[]][]]}};
 [[noreturn]] int g2();
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}{{[[][[]}}noreturn{{[]][]]}} auto g2() -> int;{{$}}
+// CHECK-FIXES: {{[[][[]}}noreturn{{[]][]]}} auto g2() -> int;
 int g2 [[noreturn]] ();
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto g2 {{[[][[]}}noreturn{{[]][]]}} () -> int;{{$}}
+// CHECK-FIXES: auto g2 {{[[][[]}}noreturn{{[]][]]}} () -> int;
 int unsigned g3() __attribute__((cdecl)); // FunctionTypeLoc is null.
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
 int unsigned __attribute__((cdecl)) g3() ; // FunctionTypeLoc is null.
@@ -354,7 +354,7 @@ __attribute__((cdecl)) int unsigned g3() ; // FunctionTypeLoc is null.
 template <typename Container>
 [[maybe_unused]] typename Container::value_type const volatile&& t1(Container& C) noexcept;
 // CHECK-MESSAGES: :[[@LINE-1]]:66: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}{{[[][[]}}maybe_unused{{[]][]]}} auto t1(Container& C) noexcept -> typename Container::value_type const volatile&&;{{$}}
+// CHECK-FIXES: {{[[][[]}}maybe_unused{{[]][]]}} auto t1(Container& C) noexcept -> typename Container::value_type const volatile&&;
 template <typename T>
 class BB {
     using type = int;
@@ -362,7 +362,7 @@ class BB {
     template <typename U>
     typename BB<U>::type m1();
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto m1() -> typename BB<U>::type;{{$}}
+// CHECK-FIXES: auto m1() -> typename BB<U>::type;
 };
 
 //
@@ -372,38 +372,38 @@ class BB {
 #define DWORD unsigned int
 DWORD h1();
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h1() -> DWORD;{{$}}
+// CHECK-FIXES: auto h1() -> DWORD;
 #define INT int
 #define UNSIGNED unsigned
 UNSIGNED INT h2();
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h2() -> UNSIGNED INT;{{$}}
+// CHECK-FIXES: auto h2() -> UNSIGNED INT;
 #define CONST const
 CONST int h3();
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h3() -> CONST int;{{$}}
+// CHECK-FIXES: auto h3() -> CONST int;
 #define ALWAYS_INLINE inline
 #define DLL_EXPORT __declspec(dllexport)
 ALWAYS_INLINE DLL_EXPORT int h4();
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}ALWAYS_INLINE DLL_EXPORT auto h4() -> int;{{$}}
+// CHECK-FIXES: ALWAYS_INLINE DLL_EXPORT auto h4() -> int;
 #define DEPRECATED __attribute__((deprecated))
 int h5() DEPRECATED;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h5() -> int DEPRECATED;{{$}}
+// CHECK-FIXES: auto h5() -> int DEPRECATED;
 int DEPRECATED h5();
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto DEPRECATED h5() -> int;{{$}}
+// CHECK-FIXES: auto DEPRECATED h5() -> int;
 DEPRECATED int h5();
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}DEPRECATED auto h5() -> int;{{$}}
+// CHECK-FIXES: DEPRECATED auto h5() -> int;
 [[noreturn]] [[nodiscard]] DEPRECATED DLL_EXPORT int h6 [[deprecated]] ();
 // CHECK-MESSAGES: :[[@LINE-1]]:54: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}{{[[][[]}}noreturn{{[]][]]}} {{[[][[]}}nodiscard{{[]][]]}} DEPRECATED DLL_EXPORT auto h6 {{[[][[]}}deprecated{{[]][]]}} () -> int;{{$}}
+// CHECK-FIXES: {{[[][[]}}noreturn{{[]][]]}} {{[[][[]}}nodiscard{{[]][]]}} DEPRECATED DLL_EXPORT auto h6 {{[[][[]}}deprecated{{[]][]]}} () -> int;
 #define FUNCTION_NAME(a, b) a##b
 int FUNCTION_NAME(foo, bar)();
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto FUNCTION_NAME(foo, bar)() -> int;{{$}}
+// CHECK-FIXES: auto FUNCTION_NAME(foo, bar)() -> int;
 #define DEFINE_FUNCTION_1(a, b) int a##b()
 DEFINE_FUNCTION_1(foo, bar);
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
@@ -422,18 +422,18 @@ using Real = T;
 #define PRECISION float
 Real<PRECISION> h8() { return 0.; }
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h8() -> Real<PRECISION> { return 0.; }{{$}}
+// CHECK-FIXES: auto h8() -> Real<PRECISION> { return 0.; }
 
 #define MAYBE_UNUSED_MACRO [[maybe_unused]]
 template <typename Container>
 MAYBE_UNUSED_MACRO typename Container::value_type const volatile** const h9(Container& C) noexcept;
 // CHECK-MESSAGES: :[[@LINE-1]]:74: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}MAYBE_UNUSED_MACRO auto h9(Container& C) noexcept -> typename Container::value_type const volatile** const;{{$}}
+// CHECK-FIXES: MAYBE_UNUSED_MACRO auto h9(Container& C) noexcept -> typename Container::value_type const volatile** const;
 
 #define NOEXCEPT noexcept
 int h9(int arg) NOEXCEPT;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h9(int arg) NOEXCEPT -> int;{{$}}
+// CHECK-FIXES: auto h9(int arg) NOEXCEPT -> int;
 #define STATIC_INT static int
 STATIC_INT h10();
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
@@ -443,20 +443,20 @@ UNSIGNED_STATIC_INT h11();
 #define STATIC static
 unsigned STATIC int h11();
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}STATIC auto h11() -> unsigned int;{{$}}
+// CHECK-FIXES: STATIC auto h11() -> unsigned int;
 #define STATIC_CONSTEXPR static constexpr
 unsigned STATIC_CONSTEXPR int h12();
 // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}STATIC_CONSTEXPR auto h12() -> unsigned int;{{$}}
+// CHECK-FIXES: STATIC_CONSTEXPR auto h12() -> unsigned int;
 #define STATIC_CONSTEXPR_LONG static constexpr long
 unsigned STATIC_CONSTEXPR_LONG int h13();
 // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
 DEPRECATED const int& h14();
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}DEPRECATED auto h14() -> const int&;{{$}}
+// CHECK-FIXES: DEPRECATED auto h14() -> const int&;
 DEPRECATED const long static volatile unsigned& h15();
 // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}DEPRECATED static auto h15() -> const long volatile unsigned&;{{$}}
+// CHECK-FIXES: DEPRECATED static auto h15() -> const long volatile unsigned&;
 #define WRAP(x) x
 WRAP(const) int& h16();
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
@@ -467,25 +467,25 @@ CONCAT(con, st) int& h16();
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
 DEPRECATED const UNSIGNED& h17();
 // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}DEPRECATED auto h17() -> const UNSIGNED&;{{$}}
+// CHECK-FIXES: DEPRECATED auto h17() -> const UNSIGNED&;
 DEPRECATED CONST UNSIGNED STATIC& h18();
 // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}DEPRECATED STATIC auto h18() -> CONST UNSIGNED &;{{$}}
+// CHECK-FIXES: DEPRECATED STATIC auto h18() -> CONST UNSIGNED &;
 #define CONST_CAT con##st
 CONST_CAT int& h19();
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h19() -> CONST_CAT int&;{{$}}
+// CHECK-FIXES: auto h19() -> CONST_CAT int&;
 #define CONST_F_MACRO WRAP(CONST_CAT)
 CONST_F_MACRO int& h19();
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h19() -> CONST_F_MACRO int&;{{$}}
+// CHECK-FIXES: auto h19() -> CONST_F_MACRO int&;
 // Macro COMMAND_LINE_INT is defined on the command line via: -DCOMMAND_LINE_INT=int
 const COMMAND_LINE_INT& h20();
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h20() -> const COMMAND_LINE_INT&;{{$}}
+// CHECK-FIXES: auto h20() -> const COMMAND_LINE_INT&;
 decltype(COMMAND_LINE_INT{}) h21();
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto h21() -> decltype(COMMAND_LINE_INT{});{{$}}
+// CHECK-FIXES: auto h21() -> decltype(COMMAND_LINE_INT{});
 
 //
 // Name collisions
@@ -494,67 +494,67 @@ struct Object { long long value; };
 
 Object j1(unsigned Object) { return {Object * 2}; }
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}Object j1(unsigned Object) { return {Object * 2}; }{{$}}
+// CHECK-FIXES: Object j1(unsigned Object) { return {Object * 2}; }
 ::Object j1(unsigned Object);
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto j1(unsigned Object) -> ::Object;{{$}}
+// CHECK-FIXES: auto j1(unsigned Object) -> ::Object;
 const Object& j2(unsigned a, int b, char Object, long l);
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}const Object& j2(unsigned a, int b, char Object, long l);{{$}}
+// CHECK-FIXES: const Object& j2(unsigned a, int b, char Object, long l);
 const struct Object& j2(unsigned a, int b, char Object, long l);
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto j2(unsigned a, int b, char Object, long l) -> const struct Object&;{{$}}
+// CHECK-FIXES: auto j2(unsigned a, int b, char Object, long l) -> const struct Object&;
 std::vector<Object> j3(unsigned Object);
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}std::vector<Object> j3(unsigned Object);{{$}}
+// CHECK-FIXES: std::vector<Object> j3(unsigned Object);
 std::vector<const Object> j7(unsigned Object);
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}std::vector<const Object> j7(unsigned Object);{{$}}
+// CHECK-FIXES: std::vector<const Object> j7(unsigned Object);
 std::vector<Object> j4(unsigned vector);
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto j4(unsigned vector) -> std::vector<Object>;{{$}}
+// CHECK-FIXES: auto j4(unsigned vector) -> std::vector<Object>;
 std::vector<::Object> j4(unsigned vector);
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto j4(unsigned vector) -> std::vector<::Object>;{{$}}
+// CHECK-FIXES: auto j4(unsigned vector) -> std::vector<::Object>;
 std::vector<struct Object> j4(unsigned vector);
 // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto j4(unsigned vector) -> std::vector<struct Object>;{{$}}
+// CHECK-FIXES: auto j4(unsigned vector) -> std::vector<struct Object>;
 std::vector<Object> j4(unsigned Vector);
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto j4(unsigned Vector) -> std::vector<Object>;{{$}}
+// CHECK-FIXES: auto j4(unsigned Vector) -> std::vector<Object>;
 using std::vector;
 vector<Object> j5(unsigned vector);
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}vector<Object> j5(unsigned vector);{{$}}
+// CHECK-FIXES: vector<Object> j5(unsigned vector);
 constexpr auto Size = 5;
 std::array<int, Size> j6(unsigned Size);
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}std::array<int, Size> j6(unsigned Size);{{$}}
+// CHECK-FIXES: std::array<int, Size> j6(unsigned Size);
 std::array<decltype(Size), (Size * 2) + 1> j8(unsigned Size);
 // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}std::array<decltype(Size), (Size * 2) + 1> j8(unsigned Size);{{$}}
+// CHECK-FIXES: std::array<decltype(Size), (Size * 2) + 1> j8(unsigned Size);
 using std::ostream;
 std::tuple<int, std::string, ostream>& operator<<(ostream& ostream, float i);
 // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}std::tuple<int, std::string, ostream>& operator<<(ostream& ostream, float i);{{$}}
+// CHECK-FIXES: std::tuple<int, std::string, ostream>& operator<<(ostream& ostream, float i);
 
 class CC {
     int Object;
     struct Object m();
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto m() -> struct Object;{{$}}
+// CHECK-FIXES: auto m() -> struct Object;
 };
 Object CC::m() { return {0}; }
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto CC::m() -> Object { return {0}; }{{$}}
+// CHECK-FIXES: auto CC::m() -> Object { return {0}; }
 class DD : public CC {
     ::Object g();
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}    auto g() -> ::Object;{{$}}
+// CHECK-FIXES: auto g() -> ::Object;
 };
 Object DD::g() {
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}auto DD::g() -> Object {{{$}}
+// CHECK-FIXES: auto DD::g() -> Object {
     return {0};
 }
 
@@ -564,7 +564,7 @@ Object DD::g() {
 
 ostream& operator<<(ostream& ostream, int i);
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
-// CHECK-FIXES: {{^}}ostream& operator<<(ostream& ostream, int i);{{$}}
+// CHECK-FIXES: ostream& operator<<(ostream& ostream, int i);
 
 //
 // Samples which do not trigger the check

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/duplicate-include/duplicate-include.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/duplicate-include/duplicate-include.h
@@ -7,9 +7,9 @@ extern int h;
 #include "duplicate-include2.h"
 extern int i;
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
-// CHECK-FIXES:      {{^extern int g;$}}
-// CHECK-FIXES-NEXT: {{^#include "duplicate-include2.h"$}}
-// CHECK-FIXES-NEXT: {{^extern int h;$}}
-// CHECK-FIXES-NEXT: {{^extern int i;$}}
+// CHECK-FIXES:      extern int g;
+// CHECK-FIXES-NEXT: #include "duplicate-include2.h"
+// CHECK-FIXES-NEXT: extern int h;
+// CHECK-FIXES-NEXT: extern int i;
 
 #endif

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -46,20 +46,20 @@ void g(size_t s) {
   std::vector<unsigned char> b(s);
   f(&((b)[(z)]));
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}f(b.data());{{$}}
+  // CHECK-FIXES: f(b.data());
 }
 
 void h() {
   std::string s;
   f(&((s).operator[]((z))));
   // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES-CLASSIC: {{^  }}f(s.data());{{$}}
+  // CHECK-FIXES-CLASSIC: f(s.data());
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
 
   std::wstring w;
   f(&((&(w))->operator[]((z))));
   // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES-CLASSIC: {{^  }}f(w.data());{{$}}
+  // CHECK-FIXES-CLASSIC: f(w.data());
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
 }
 
@@ -69,7 +69,7 @@ void i(U s) {
   std::vector<T> b(s);
   f(&b[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}f(b.data());{{$}}
+  // CHECK-FIXES: f(b.data());
 }
 
 template void i<unsigned char, size_t>(size_t);
@@ -77,13 +77,13 @@ template void i<unsigned char, size_t>(size_t);
 void j(std::vector<unsigned char> * const v) {
   f(&(*v)[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}f(v->data());{{$}}
+  // CHECK-FIXES: f(v->data());
 }
 
 void k(const std::vector<unsigned char> &v) {
   f(&v[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}f(v.data());{{$}}
+  // CHECK-FIXES: f(v.data());
 }
 
 void l() {
@@ -96,7 +96,7 @@ template <typename T>
 void m(const std::vector<T> &v) {
   return &v[0];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}return v.data();{{$}}
+  // CHECK-FIXES: return v.data();
 }
 
 template <typename T>
@@ -115,7 +115,7 @@ const T *n(const container_without_data<T> &c) {
 const int *o(const std::vector<std::vector<std::vector<int>>> &v, const size_t idx1, const size_t idx2) {
   return &v[idx1][idx2][0];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}return v[idx1][idx2].data();{{$}}
+  // CHECK-FIXES: return v[idx1][idx2].data();
 }
 
 std::vector<int> &select(std::vector<int> &u, std::vector<int> &v) {
@@ -125,13 +125,13 @@ std::vector<int> &select(std::vector<int> &u, std::vector<int> &v) {
 int *p(std::vector<int> &v1, std::vector<int> &v2) {
   return &select(*&v1, v2)[0];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}return select(*&v1, v2).data();{{$}}
+  // CHECK-FIXES: return select(*&v1, v2).data();
 }
 
 int *q(std::vector<int> ***v) {
   return &(***v)[0];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}return (**v)->data();{{$}}
+  // CHECK-FIXES: return (**v)->data();
 }
 
 struct VectorHolder {
@@ -142,5 +142,5 @@ int *r() {
   VectorHolder holder;
   return &holder.v[0];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: {{^  }}return holder.v.data();{{$}}
+  // CHECK-FIXES: return holder.v.data();
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty-cxx20.cpp
@@ -34,11 +34,11 @@ void returnsVoid() {
   if (OEO != OpEqOnly<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness
-  // CHECK-FIXES: {{^  }}if (!OEO.empty()){{$}}
+  // CHECK-FIXES: if (!OEO.empty())
   // CHECK-MESSAGES: :19:8: note: method 'OpEqOnly'::empty() defined here
   if (HSM != HasSpaceshipMem<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness
-  // CHECK-FIXES: {{^  }}if (!HSM.empty()){{$}}
+  // CHECK-FIXES: if (!HSM.empty())
   // CHECK-MESSAGES: :27:8: note: method 'HasSpaceshipMem'::empty() defined here
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
@@ -119,110 +119,110 @@ bool returnsBool() {
   if (intSet.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-  // CHECK-FIXES: {{^  }}if (intSet.empty()){{$}}
+  // CHECK-FIXES: if (intSet.empty())
   // CHECK-MESSAGES: :21:8: note: method 'set'::empty() defined here
   if (intSet == std::set<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness
-  // CHECK-FIXES: {{^  }}if (intSet.empty()){{$}}
+  // CHECK-FIXES: if (intSet.empty())
   // CHECK-MESSAGES: :21:8: note: method 'set'::empty() defined here
   if (s_func() == "")
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (s_func().empty()){{$}}
+  // CHECK-FIXES: if (s_func().empty())
   if (str.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size'
-  // CHECK-FIXES: {{^  }}if (str.empty()){{$}}
+  // CHECK-FIXES: if (str.empty())
   if (str.length() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'length'
-  // CHECK-FIXES: {{^  }}if (str.empty()){{$}}
+  // CHECK-FIXES: if (str.empty())
   if ((str + str2).size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size'
-  // CHECK-FIXES: {{^  }}if ((str + str2).empty()){{$}}
+  // CHECK-FIXES: if ((str + str2).empty())
   if ((str + str2).length() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'length'
-  // CHECK-FIXES: {{^  }}if ((str + str2).empty()){{$}}
+  // CHECK-FIXES: if ((str + str2).empty())
   if (str == "")
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (str.empty()){{$}}
+  // CHECK-FIXES: if (str.empty())
   if (str + str2 == "")
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if ((str + str2).empty()){{$}}
+  // CHECK-FIXES: if ((str + str2).empty())
   if (wstr.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size'
-  // CHECK-FIXES: {{^  }}if (wstr.empty()){{$}}
+  // CHECK-FIXES: if (wstr.empty())
   if (wstr.length() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'length'
-  // CHECK-FIXES: {{^  }}if (wstr.empty()){{$}}
+  // CHECK-FIXES: if (wstr.empty())
   if (wstr == L"")
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (wstr.empty()){{$}}
+  // CHECK-FIXES: if (wstr.empty())
   std::vector<int> vect;
   if (vect.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size'
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (vect == std::vector<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (vect.size() != 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (vect != std::vector<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (0 == vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (0 != vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (std::vector<int>() == vect)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (std::vector<int>() != vect)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (vect.size() > 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (0 < vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (vect.size() < 1)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (1 > vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (vect.size() >= 1)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (1 <= vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
   if (vect.size() > 1) // no warning
     ;
   if (1 < vect.size()) // no warning
@@ -234,11 +234,11 @@ bool returnsBool() {
   if (!vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:8: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect.empty()){{$}}
+  // CHECK-FIXES: if (vect.empty())
   if (vect.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect.empty()){{$}}
+  // CHECK-FIXES: if (!vect.empty())
 
   if (vect.empty())
     ;
@@ -247,25 +247,25 @@ bool returnsBool() {
   if (vect2.size() != 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!vect2.empty()){{$}}
+  // CHECK-FIXES: if (!vect2.empty())
 
   std::vector<int> *vect3 = new std::vector<int>();
   if (vect3->size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect3->empty()){{$}}
+  // CHECK-FIXES: if (vect3->empty())
   if ((*vect3).size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if ((*vect3).empty()){{$}}
+  // CHECK-FIXES: if ((*vect3).empty())
   if ((*vect3) == std::vector<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect3->empty()){{$}}
+  // CHECK-FIXES: if (vect3->empty())
   if (*vect3 == std::vector<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect3->empty()){{$}}
+  // CHECK-FIXES: if (vect3->empty())
 
   delete vect3;
 
@@ -273,69 +273,69 @@ bool returnsBool() {
   if (vect4.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect4.empty()){{$}}
+  // CHECK-FIXES: if (vect4.empty())
   if (vect4 == std::vector<int>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (vect4.empty()){{$}}
+  // CHECK-FIXES: if (vect4.empty())
 
   TemplatedContainer<void> templated_container;
   if (templated_container.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (templated_container == TemplatedContainer<void>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (templated_container.size() != 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (templated_container != TemplatedContainer<void>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (0 == templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (TemplatedContainer<void>() == templated_container)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (0 != templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (TemplatedContainer<void>() != templated_container)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (templated_container.size() > 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (0 < templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (templated_container.size() < 1)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (1 > templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (templated_container.size() >= 1)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (1 <= templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (templated_container.size() > 1) // no warning
     ;
   if (1 < templated_container.size()) // no warning
@@ -347,11 +347,11 @@ bool returnsBool() {
   if (!templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:8: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
   if (templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
 
   if (templated_container.empty())
     ;
@@ -411,47 +411,47 @@ bool returnsBool() {
   if (derived.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (derived.empty()){{$}}
+  // CHECK-FIXES: if (derived.empty())
   if (derived == Derived())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (derived.empty()){{$}}
+  // CHECK-FIXES: if (derived.empty())
 
   takesBool(derived.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}takesBool(!derived.empty());
+  // CHECK-FIXES: takesBool(!derived.empty());
 
   takesBool(derived.size() == 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}takesBool(derived.empty());
+  // CHECK-FIXES: takesBool(derived.empty());
 
   takesBool(derived.size() != 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}takesBool(!derived.empty());
+  // CHECK-FIXES: takesBool(!derived.empty());
 
   bool b1 = derived.size();
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}bool b1 = !derived.empty();
+  // CHECK-FIXES: bool b1 = !derived.empty();
 
   bool b2(derived.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}bool b2(!derived.empty());
+  // CHECK-FIXES: bool b2(!derived.empty());
 
   auto b3 = static_cast<bool>(derived.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}auto b3 = static_cast<bool>(!derived.empty());
+  // CHECK-FIXES: auto b3 = static_cast<bool>(!derived.empty());
 
   auto b4 = (bool)derived.size();
   // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}auto b4 = (bool)!derived.empty();
+  // CHECK-FIXES: auto b4 = (bool)!derived.empty();
 
   auto b5 = bool(derived.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}auto b5 = bool(!derived.empty());
+  // CHECK-FIXES: auto b5 = bool(!derived.empty());
 
   return derived.size();
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}return !derived.empty();
+  // CHECK-FIXES: return !derived.empty();
 }
 
 class ConstructWithBoolField {
@@ -460,7 +460,7 @@ public:
   ConstructWithBoolField(const std::vector<int> &C) : B(C.size()) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:57: warning: the 'empty' method should be used
 // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-// CHECK-FIXES: {{^  }}ConstructWithBoolField(const std::vector<int> &C) : B(!C.empty()) {}
+// CHECK-FIXES: ConstructWithBoolField(const std::vector<int> &C) : B(!C.empty()) {}
 };
 
 struct StructWithNSDMI {
@@ -468,21 +468,21 @@ struct StructWithNSDMI {
   bool B = C.size();
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: the 'empty' method should be used
 // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-// CHECK-FIXES: {{^  }}bool B = !C.empty();
+// CHECK-FIXES: bool B = !C.empty();
 };
 
 int func(const std::vector<int> &C) {
   return C.size() ? 0 : 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
 // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-// CHECK-FIXES: {{^  }}return !C.empty() ? 0 : 1;
+// CHECK-FIXES: return !C.empty() ? 0 : 1;
 }
 
 constexpr Lazy L;
 static_assert(!L.size(), "");
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: the 'empty' method should be used
 // CHECK-MESSAGES: :94:18: note: method 'Lazy'::empty() defined here
-// CHECK-FIXES: {{^}}static_assert(L.empty(), "");
+// CHECK-FIXES: static_assert(L.empty(), "");
 
 struct StructWithLazyNoexcept {
   void func() noexcept(L.size());
@@ -497,11 +497,11 @@ template <typename T> void f() {
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!v.empty()){{$}}
+  // CHECK-FIXES: if (!v.empty())
   if (v == std::vector<T>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of comparing to an empty object [readability-container-size-empty]
-  // CHECK-FIXES: {{^  }}if (v.empty()){{$}}
+  // CHECK-FIXES: if (v.empty())
   // CHECK-FIXES-NEXT: ;
   CHECKSIZE(v);
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
@@ -513,12 +513,12 @@ template <typename T> void f() {
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (templated_container != TemplatedContainer<T>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   // CHECK-FIXES-NEXT: ;
   CHECKSIZE(templated_container);
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
@@ -529,12 +529,12 @@ template <typename T> void f() {
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: string:{{[0-9]+}}:8: note: method 'basic_string'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!s.empty()){{$}}
+  // CHECK-FIXES: if (!s.empty())
   if (s.length())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'length' [readability-container-size-empty]
   // CHECK-MESSAGES: string:{{[0-9]+}}:8: note: method 'basic_string'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!s.empty()){{$}}
+  // CHECK-FIXES: if (!s.empty())
 }
 
 void g() {
@@ -550,33 +550,33 @@ bool neverInstantiatedTemplate() {
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!v.empty()){{$}}
+  // CHECK-FIXES: if (!v.empty())
 
   if (v == std::vector<T>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of comparing to an empty object [readability-container-size-empty]
-  // CHECK-FIXES: {{^  }}if (v.empty()){{$}}
+  // CHECK-FIXES: if (v.empty())
   // CHECK-FIXES-NEXT: ;
   if (v.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (v.empty()){{$}}
+  // CHECK-FIXES: if (v.empty())
   if (v.size() != 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!v.empty()){{$}}
+  // CHECK-FIXES: if (!v.empty())
   if (v.size() < 1)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (v.empty()){{$}}
+  // CHECK-FIXES: if (v.empty())
   if (v.size() > 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!v.empty()){{$}}
+  // CHECK-FIXES: if (!v.empty())
   if (v.size() == 1)
     ;
   if (v.size() != 1)
@@ -590,91 +590,91 @@ bool neverInstantiatedTemplate() {
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:25: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (static_cast<bool>(!v.empty())){{$}}
+  // CHECK-FIXES: if (static_cast<bool>(!v.empty()))
   if (v.size() && false)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!v.empty() && false){{$}}
+  // CHECK-FIXES: if (!v.empty() && false)
   if (!v.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:8: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (v.empty()){{$}}
+  // CHECK-FIXES: if (v.empty())
 
   TemplatedContainer<T> templated_container;
   if (templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   if (templated_container != TemplatedContainer<T>())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (!templated_container.empty()){{$}}
+  // CHECK-FIXES: if (!templated_container.empty())
   // CHECK-FIXES-NEXT: ;
   while (templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}while (!templated_container.empty()){{$}}
+  // CHECK-FIXES: while (!templated_container.empty())
 
   do {
   }
   while (templated_container.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}while (!templated_container.empty());
+  // CHECK-FIXES: while (!templated_container.empty());
 
   for (; templated_container.size();)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}for (; !templated_container.empty();){{$}}
+  // CHECK-FIXES: for (; !templated_container.empty();)
 
   if (true && templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:15: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (true && !templated_container.empty()){{$}}
+  // CHECK-FIXES: if (true && !templated_container.empty())
 
   if (true || templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:15: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (true || !templated_container.empty()){{$}}
+  // CHECK-FIXES: if (true || !templated_container.empty())
 
   if (!templated_container.size())
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:8: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}if (templated_container.empty()){{$}}
+  // CHECK-FIXES: if (templated_container.empty())
 
   bool b1 = templated_container.size();
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}bool b1 = !templated_container.empty();
+  // CHECK-FIXES: bool b1 = !templated_container.empty();
 
   bool b2(templated_container.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}bool b2(!templated_container.empty());
+  // CHECK-FIXES: bool b2(!templated_container.empty());
 
   auto b3 = static_cast<bool>(templated_container.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}auto b3 = static_cast<bool>(!templated_container.empty());
+  // CHECK-FIXES: auto b3 = static_cast<bool>(!templated_container.empty());
 
   auto b4 = (bool)templated_container.size();
   // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}auto b4 = (bool)!templated_container.empty();
+  // CHECK-FIXES: auto b4 = (bool)!templated_container.empty();
 
   auto b5 = bool(templated_container.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}auto b5 = bool(!templated_container.empty());
+  // CHECK-FIXES: auto b5 = bool(!templated_container.empty());
 
   takesBool(templated_container.size());
   // We don't detect this one because we don't know the parameter of takesBool
@@ -683,7 +683,7 @@ bool neverInstantiatedTemplate() {
   return templated_container.size();
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :37:8: note: method 'TemplatedContainer'::empty() defined here
-  // CHECK-FIXES: {{^  }}return !templated_container.empty();
+  // CHECK-FIXES: return !templated_container.empty();
 }
 
 template <typename TypeRequiresSize>
@@ -729,14 +729,14 @@ bool call_through_unique_ptr(const std::unique_ptr<std::vector<int>> &ptr) {
   return ptr->size() > 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}return !ptr->empty();
+  // CHECK-FIXES: return !ptr->empty();
 }
 
 bool call_through_unique_ptr_deref(const std::unique_ptr<std::vector<int>> &ptr) {
   return (*ptr).size() > 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
   // CHECK-MESSAGES: :12:8: note: method 'vector'::empty() defined here
-  // CHECK-FIXES: {{^  }}return !(*ptr).empty();
+  // CHECK-FIXES: return !(*ptr).empty();
 }
 
 struct TypedefSize {
@@ -750,7 +750,7 @@ void testTypedefSize() {
   if (ts.size() == 0)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}if (ts.empty()){{$}}
+  // CHECK-FIXES: if (ts.empty())
 }
 
 namespace std {
@@ -783,7 +783,7 @@ typedef std::array<int, 10U> Array;
 bool testArraySize(const Array& value) {
   return value.size() == 0U;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-// CHECK-FIXES: {{^  }}return value.empty();{{$}}
+// CHECK-FIXES: return value.empty();
 // CHECK-MESSAGES: :[[@LINE-25]]:8: note: method 'array'::empty() defined here
 }
 
@@ -794,7 +794,7 @@ bool testArrayCompareToEmpty(const Array& value) {
 bool testDummyType(const DummyType& value) {
   return value == DummyType();
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used to check for emptiness instead of comparing to an empty object [readability-container-size-empty]
-// CHECK-FIXES: {{^  }}return value.empty();{{$}}
+// CHECK-FIXES: return value.empty();
 // CHECK-MESSAGES: :[[@LINE-26]]:8: note: method 'DummyType'::empty() defined here
 }
 
@@ -807,7 +807,7 @@ bool testStringLiterals(const std::string& s)
   using namespace std::string_literals;
   return s == ""s;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
-  // CHECK-FIXES: {{^  }}return s.empty()
+  // CHECK-FIXES: return s.empty()
 }
 
 bool testNotEmptyStringLiterals(const std::string& s)
@@ -835,19 +835,19 @@ namespace PR72619 {
     if (s.size() < 1)
       ;
     // CHECK-MESSAGES: :[[@LINE-2]]:9: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-    // CHECK-FIXES: {{^    }}if (s.empty()){{$}}
+    // CHECK-FIXES: if (s.empty())
     if (1 > s.size())
       ;
     // CHECK-MESSAGES: :[[@LINE-2]]:13: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-    // CHECK-FIXES: {{^    }}if (s.empty()){{$}}
+    // CHECK-FIXES: if (s.empty())
     if (s.size() <= 0)
       ;
     // CHECK-MESSAGES: :[[@LINE-2]]:9: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-    // CHECK-FIXES: {{^    }}if (s.empty()){{$}}
+    // CHECK-FIXES: if (s.empty())
     if (0 >= s.size())
       ;
     // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-    // CHECK-FIXES: {{^    }}if (s.empty()){{$}}
+    // CHECK-FIXES: if (s.empty())
   }
 
   void f(const SS& s) {
@@ -879,14 +879,14 @@ namespace PR88203 {
     if (0 == s.length(1)) {}
     if (0 == s.size()) {}
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
-    // CHECK-FIXES: {{^    }}if (s.empty()) {}{{$}}
+    // CHECK-FIXES: if (s.empty()) {}
   }
 
   void f(const SU& s) {
     if (0 == s.size(1)) {}
     if (0 == s.length()) {}
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: the 'empty' method should be used to check for emptiness instead of 'length' [readability-container-size-empty]
-    // CHECK-FIXES: {{^    }}if (s.empty()) {}{{$}}
+    // CHECK-FIXES: if (s.empty()) {}
   }
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
@@ -14,7 +14,7 @@ class A {
 
   void no_use() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'no_use' can be made static
-    // CHECK-FIXES: {{^}}  static void no_use() {
+    // CHECK-FIXES: static void no_use() {
     int i = 1;
   }
 
@@ -30,25 +30,25 @@ class A {
 
   int call_static_member() {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'call_static_member' can be made static
-    // CHECK-FIXES: {{^}}  static int call_static_member() {
+    // CHECK-FIXES: static int call_static_member() {
     already_static();
     return 0;
   }
 
   int read_static() {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'read_static' can be made static
-    // CHECK-FIXES: {{^}}  static int read_static() {
+    // CHECK-FIXES: static int read_static() {
     return static_field;
   }
   void write_static() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'write_static' can be made static
-    // CHECK-FIXES: {{^}}  static void write_static() {
+    // CHECK-FIXES: static void write_static() {
     static_field = 1;
   }
 
   void static_nested() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'static_nested' can be made static
-    // CHECK-FIXES: {{^}}  static void static_nested() {
+    // CHECK-FIXES: static void static_nested() {
     struct Nested {
       int Foo;
       int getFoo() { return Foo; }
@@ -70,29 +70,29 @@ class A {
 
   int already_const_convert_to_static() const {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'already_const_convert_to_static' can be made static
-    // CHECK-FIXES: {{^}}  static int already_const_convert_to_static() {
+    // CHECK-FIXES: static int already_const_convert_to_static() {
     return static_field;
   }
 
   static int out_of_line_already_static();
 
   void out_of_line_call_static();
-  // CHECK-FIXES: {{^}}  static void out_of_line_call_static();
+  // CHECK-FIXES: static void out_of_line_call_static();
   int out_of_line_const_to_static() const;
-  // CHECK-FIXES: {{^}}  static int out_of_line_const_to_static() ;
+  // CHECK-FIXES: static int out_of_line_const_to_static() ;
 };
 
 int A::out_of_line_already_static() { return 0; }
 
 void A::out_of_line_call_static() {
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: method 'out_of_line_call_static' can be made static
-  // CHECK-FIXES: {{^}}void A::out_of_line_call_static() {
+  // CHECK-FIXES: void A::out_of_line_call_static() {
   already_static();
 }
 
 int A::out_of_line_const_to_static() const {
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'out_of_line_const_to_static' can be made static
-  // CHECK-FIXES: {{^}}int A::out_of_line_const_to_static() {
+  // CHECK-FIXES: int A::out_of_line_const_to_static() {
   return 0;
 }
 
@@ -159,7 +159,7 @@ void instantiate() {
 struct Trailing {
   auto g() const -> int {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'g' can be made static
-    // CHECK-FIXES: {{^}}  static auto g() -> int {
+    // CHECK-FIXES: static auto g() -> int {
     return 0;
   }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include.cpp
@@ -6,10 +6,10 @@ int b;
 #include <string.h>
 int c;
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include [readability-duplicate-include]
-// CHECK-FIXES:      {{^int a;$}}
-// CHECK-FIXES-NEXT: {{^#include <string.h>$}}
-// CHECK-FIXES-NEXT: {{^int b;$}}
-// CHECK-FIXES-NEXT: {{^int c;$}}
+// CHECK-FIXES:      int a;
+// CHECK-FIXES-NEXT: #include <string.h>
+// CHECK-FIXES-NEXT: int b;
+// CHECK-FIXES-NEXT: int c;
 
 int d;
 #include <iostream>
@@ -17,10 +17,10 @@ int e;
 #include <iostream> // extra stuff that will also be removed
 int f;
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
-// CHECK-FIXES:      {{^int d;$}}
-// CHECK-FIXES-NEXT: {{^#include <iostream>$}}
-// CHECK-FIXES-NEXT: {{^int e;$}}
-// CHECK-FIXES-NEXT: {{^int f;$}}
+// CHECK-FIXES:      int d;
+// CHECK-FIXES-NEXT: #include <iostream>
+// CHECK-FIXES-NEXT: int e;
+// CHECK-FIXES-NEXT: int f;
 
 int g;
 #include "duplicate-include.h"
@@ -28,10 +28,10 @@ int h;
 #include "duplicate-include.h"
 int i;
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
-// CHECK-FIXES:      {{^int g;$}}
-// CHECK-FIXES-NEXT: {{^#include "duplicate-include.h"$}}
-// CHECK-FIXES-NEXT: {{^int h;$}}
-// CHECK-FIXES-NEXT: {{^int i;$}}
+// CHECK-FIXES:      int g;
+// CHECK-FIXES-NEXT: #include "duplicate-include.h"
+// CHECK-FIXES-NEXT: int h;
+// CHECK-FIXES-NEXT: int i;
 
 #include <types.h>
 
@@ -41,35 +41,35 @@ int k;
 #include <sys/types.h>
 int l;
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
-// CHECK-FIXES:      {{^int j;$}}
-// CHECK-FIXES-NEXT: {{^#include <sys/types.h>$}}
-// CHECK-FIXES-NEXT: {{^int k;$}}
-// CHECK-FIXES-NEXT: {{^int l;$}}
+// CHECK-FIXES:      int j;
+// CHECK-FIXES-NEXT: #include <sys/types.h>
+// CHECK-FIXES-NEXT: int k;
+// CHECK-FIXES-NEXT: int l;
 
 int m;
         #          include             <string.h>  // lots of space
 int n;
 // CHECK-MESSAGES: :[[@LINE-2]]:9: warning: duplicate include
-// CHECK-FIXES:      {{^int m;$}}
-// CHECK-FIXES-NEXT: {{^int n;$}}
+// CHECK-FIXES:      int m;
+// CHECK-FIXES-NEXT: int n;
 
 // defining a macro in the main file resets the included file cache
 #define ARBITRARY_MACRO
 int o;
 #include <sys/types.h>
 int p;
-// CHECK-FIXES:      {{^int o;$}}
-// CHECK-FIXES-NEXT: {{^#include <sys/types.h>$}}
-// CHECK-FIXES-NEXT: {{^int p;$}}
+// CHECK-FIXES:      int o;
+// CHECK-FIXES-NEXT: #include <sys/types.h>
+// CHECK-FIXES-NEXT: int p;
 
 // undefining a macro resets the cache
 #undef ARBITRARY_MACRO
 int q;
 #include <sys/types.h>
 int r;
-// CHECK-FIXES:      {{^int q;$}}
-// CHECK-FIXES-NEXT: {{^#include <sys/types.h>$}}
-// CHECK-FIXES-NEXT: {{^int r;$}}
+// CHECK-FIXES:      int q;
+// CHECK-FIXES-NEXT: #include <sys/types.h>
+// CHECK-FIXES-NEXT: int r;
 
 namespace Issue_87303 {
 #define RESET_INCLUDE_CACHE

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity.cpp
@@ -79,42 +79,42 @@ void unittest_b1_00() {
   CC100;
 
   if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:9: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:9: note: +1, including nesting penalty of 0, nesting level increased to 1
 
     if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
     } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3
     } else {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2
     }
   } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:16: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:16: note: +2, including nesting penalty of 1, nesting level increased to 2
 
     if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
     } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3
     } else {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2
     }
   } else {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1
 
     if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
     } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3
     } else {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2
     }
   }
 }
@@ -124,8 +124,8 @@ void unittest_b1_01() {
   CC100;
 
   int i = (1 ? 1 : 0) ? 1 : 0;
-// CHECK-NOTES: :[[@LINE-1]]:23: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:23: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2
 }
 
 void unittest_b1_02(int x) {
@@ -133,16 +133,16 @@ void unittest_b1_02(int x) {
   CC100;
 
   switch (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +2, including nesting penalty of 1, nesting level increased to 2
   case -1:
     return;
   case 1 ? 1 : 0:
-// CHECK-NOTES: :[[@LINE-1]]:10: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:10: note: +2, including nesting penalty of 1, nesting level increased to 2
     return;
   case (1 ? 2 : 0) ... (1 ? 3 : 0):
-// CHECK-NOTES: :[[@LINE-1]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:27: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-2]]:27: note: +2, including nesting penalty of 1, nesting level increased to 2
     return;
   default:
     break;
@@ -154,10 +154,10 @@ void unittest_b1_03(int x) {
   CC100;
 
   for (x = 1 ? 1 : 0; x < (1 ? 1 : 0); x += 1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:30: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-4]]:47: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-3]]:30: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-4]]:47: note: +2, including nesting penalty of 1, nesting level increased to 2
     break;
     continue;
   }
@@ -169,8 +169,8 @@ void unittest_b1_04() {
 
   SomeClass C;
   for (int i : (1 ? C : C)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:19: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:19: note: +2, including nesting penalty of 1, nesting level increased to 2
     break;
     continue;
   }
@@ -181,8 +181,8 @@ void unittest_b1_05() {
   CC100;
 
   while (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:12: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:12: note: +2, including nesting penalty of 1, nesting level increased to 2
     break;
     continue;
   }
@@ -193,11 +193,11 @@ void unittest_b1_06() {
   CC100;
 
   do {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     break;
     continue;
   } while (1 ? 1 : 0);
-// CHECK-NOTES: :[[@LINE-1]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2
 }
 
 void unittest_b1_07() {
@@ -206,7 +206,7 @@ void unittest_b1_07() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
   }
 }
 
@@ -215,7 +215,7 @@ void unittest_b1_08_00() {
   CC100;
 
   goto end;
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1
 end:
   return;
 }
@@ -226,7 +226,7 @@ void unittest_b1_08_01() {
 
   void *ptr = &&end;
   goto *ptr;
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1
 end:
   return;
 }
@@ -236,69 +236,69 @@ void unittest_b1_09_00() {
   CC100;
 
   if(1 && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
   }
   if(1 && 1 && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +1
   }
   if((1 && 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
   }
   if(1 && (1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
   }
 
   if(1 && 1 || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:8: note: +1
   }
   if((1 && 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:9: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:9: note: +1
   }
   if(1 && (1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:14: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:14: note: +1
   }
 
   if(1 || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
   }
   if(1 || 1 || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +1
   }
   if((1 || 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
   }
   if(1 || (1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
   }
 
   if(1 || 1 && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:13: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:13: note: +1
   }
   if((1 || 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:9: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:9: note: +1
   }
   if(1 || (1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:14: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:14: note: +1
   }
 }
 
@@ -307,70 +307,70 @@ void unittest_b1_09_01() {
   CC100;
 
   if(1 && some_func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
   if(1 && some_func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
   if(1 || some_func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
   if(1 || some_func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
 
   if(1 && some_func(1 && 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
   if(1 && some_func(1 || 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
   if(1 || some_func(1 || 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
   }
   if(1 || some_func(1 && 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
   }
 
   if(1 && some_func(1 && 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
   }
   if(1 && some_func(1 || 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
   }
   if(1 || some_func(1 || 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
   if(1 || some_func(1 && 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
   }
 }
 
@@ -379,24 +379,24 @@ void unittest_b1_09_02() {
   CC100;
 
   if(1 && SomeClass::func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
   }
   if(1 && SomeClass::func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
   }
   if(1 || SomeClass::func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
   }
   if(1 || SomeClass::func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
   }
 }
 
@@ -414,19 +414,19 @@ void unittest_b2_00() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   } else if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   } else {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -436,9 +436,9 @@ void unittest_b2_01() {
   CC100;
 
   int i = 1 ? (1 ? 1 : 0) : (1 ? 1 : 0);
-// CHECK-NOTES: :[[@LINE-1]]:13: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
-// CHECK-NOTES: :[[@LINE-3]]:32: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:13: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-3]]:32: note: +2, including nesting penalty of 1, nesting level increased to 2
 }
 
 void unittest_b2_02(int x) {
@@ -446,15 +446,15 @@ void unittest_b2_02(int x) {
   CC100;
 
   switch (x) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
   case -1:
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
     return;
   default:
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
     return;
   }
@@ -465,9 +465,9 @@ void unittest_b2_03() {
   CC100;
 
   for (;;) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -478,9 +478,9 @@ void unittest_b2_04() {
 
   SomeClass C;
   for (int i : C) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -490,9 +490,9 @@ void unittest_b2_05() {
   CC100;
 
   while (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -502,9 +502,9 @@ void unittest_b2_06() {
   CC100;
 
   do {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   } while (true);
 }
@@ -515,9 +515,9 @@ void unittest_b2_07() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -528,64 +528,64 @@ void unittest_b2_08_00() {
 
   class X {
     X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     X &operator=(const X &other) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     ~X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     void Y() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     static void Z() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
 // CHECK-NOTES: :[[@LINE-45]]:5: warning: function 'X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-39]]:8: warning: function 'operator=' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-33]]:5: warning: function '~X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-27]]:10: warning: function 'Y' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-21]]:17: warning: function 'Z' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
   };
 }
 
@@ -595,64 +595,64 @@ void unittest_b2_08_01() {
 
   struct X {
     X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     X &operator=(const X &other) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     ~X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     void Y() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
     static void Z() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
       }
     }
 
 // CHECK-NOTES: :[[@LINE-45]]:5: warning: function 'X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-39]]:8: warning: function 'operator=' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-33]]:5: warning: function '~X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-27]]:10: warning: function 'Y' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
 
 // CHECK-NOTES: :[[@LINE-21]]:17: warning: function 'Z' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
   };
 }
 
@@ -661,13 +661,13 @@ void unittest_b2_08_02() {
   CC100;
 
   auto fun = []() {
-// CHECK-NOTES: :[[@LINE-1]]:14: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:14: note: nesting level increased to 1
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   };
 // CHECK-NOTES: :[[@LINE-6]]:14: warning: lambda has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-5]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-5]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
 }
 
 void unittest_b2_09() {
@@ -675,9 +675,9 @@ void unittest_b2_09() {
   CC100;
 
   ({
-// CHECK-NOTES: :[[@LINE-1]]:3: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: nesting level increased to 1
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   });
 }
@@ -687,9 +687,9 @@ void unittest_b2_10() {
   CC100;
 
   void (^foo)(void) = ^(void) {
-// CHECK-NOTES: :[[@LINE-1]]:23: note: nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:23: note: nesting level increased to 1
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   };
 }
@@ -706,9 +706,9 @@ void unittest_b3_00() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -718,9 +718,9 @@ void unittest_b3_01() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     int i = 1 ? 1 : 0;
-// CHECK-NOTES: :[[@LINE-1]]:15: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:15: note: +2, including nesting penalty of 1, nesting level increased to 2
   }
 }
 
@@ -729,9 +729,9 @@ void unittest_b3_02(int x) {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     switch (x) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     case -1:
       return;
     default:
@@ -745,9 +745,9 @@ void unittest_b3_03() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     for (;;) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -757,10 +757,10 @@ void unittest_b3_04() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     SomeClass C;
     for (int i : C) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -770,9 +770,9 @@ void unittest_b3_05() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     while (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -782,9 +782,9 @@ void unittest_b3_06() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     do {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
     } while (true);
   }
 }
@@ -794,10 +794,10 @@ void unittest_b3_07() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
     }
   }
 }
@@ -813,7 +813,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -823,7 +823,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -833,7 +833,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -843,7 +843,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -854,7 +854,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -864,7 +864,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -874,7 +874,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -884,7 +884,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -894,7 +894,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -904,7 +904,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -917,7 +917,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -927,7 +927,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -937,7 +937,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 
@@ -947,7 +947,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
     }
   }
 };
@@ -958,7 +958,7 @@ void CheckClass::PublicFunctionDefinition() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
   }
 }
 
@@ -987,7 +987,7 @@ void templatedFunction() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
   }
 }
 
@@ -998,7 +998,7 @@ void templatedFunction<bool>() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
   }
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity.cpp
@@ -79,42 +79,42 @@ void unittest_b1_00() {
   CC100;
 
   if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:9: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:9: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
     if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3
+// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3{{$}}
     } else {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2{{$}}
     }
   } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:16: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:16: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
 
     if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3
+// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3{{$}}
     } else {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2{{$}}
     }
   } else {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1{{$}}
 
     if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     } else if (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3
+// CHECK-NOTES: :[[@LINE-1]]:12: note: +1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +3, including nesting penalty of 2, nesting level increased to 3{{$}}
     } else {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -124,8 +124,8 @@ void unittest_b1_01() {
   CC100;
 
   int i = (1 ? 1 : 0) ? 1 : 0;
-// CHECK-NOTES: :[[@LINE-1]]:23: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:23: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
 }
 
 void unittest_b1_02(int x) {
@@ -133,16 +133,16 @@ void unittest_b1_02(int x) {
   CC100;
 
   switch (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
   case -1:
     return;
   case 1 ? 1 : 0:
-// CHECK-NOTES: :[[@LINE-1]]:10: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:10: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     return;
   case (1 ? 2 : 0) ... (1 ? 3 : 0):
-// CHECK-NOTES: :[[@LINE-1]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-2]]:27: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:11: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:27: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     return;
   default:
     break;
@@ -154,10 +154,10 @@ void unittest_b1_03(int x) {
   CC100;
 
   for (x = 1 ? 1 : 0; x < (1 ? 1 : 0); x += 1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-3]]:30: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-4]]:47: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:30: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-4]]:47: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     break;
     continue;
   }
@@ -169,8 +169,8 @@ void unittest_b1_04() {
 
   SomeClass C;
   for (int i : (1 ? C : C)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:19: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:19: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     break;
     continue;
   }
@@ -181,8 +181,8 @@ void unittest_b1_05() {
   CC100;
 
   while (1 ? 1 : 0) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:12: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:12: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     break;
     continue;
   }
@@ -193,11 +193,11 @@ void unittest_b1_06() {
   CC100;
 
   do {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     break;
     continue;
   } while (1 ? 1 : 0);
-// CHECK-NOTES: :[[@LINE-1]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:14: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
 }
 
 void unittest_b1_07() {
@@ -206,7 +206,7 @@ void unittest_b1_07() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   }
 }
 
@@ -215,7 +215,7 @@ void unittest_b1_08_00() {
   CC100;
 
   goto end;
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1{{$}}
 end:
   return;
 }
@@ -226,7 +226,7 @@ void unittest_b1_08_01() {
 
   void *ptr = &&end;
   goto *ptr;
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1{{$}}
 end:
   return;
 }
@@ -236,69 +236,69 @@ void unittest_b1_09_00() {
   CC100;
 
   if(1 && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
   }
   if(1 && 1 && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +1{{$}}
   }
   if((1 && 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
   }
   if(1 && (1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
   }
 
   if(1 && 1 || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:8: note: +1{{$}}
   }
   if((1 && 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:9: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:9: note: +1{{$}}
   }
   if(1 && (1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:14: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:14: note: +1{{$}}
   }
 
   if(1 || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
   }
   if(1 || 1 || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:13: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:13: note: +1{{$}}
   }
   if((1 || 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
   }
   if(1 || (1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
   }
 
   if(1 || 1 && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:13: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:13: note: +1{{$}}
   }
   if((1 || 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:15: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:9: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:15: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:9: note: +1{{$}}
   }
   if(1 || (1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:14: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:14: note: +1{{$}}
   }
 }
 
@@ -307,70 +307,70 @@ void unittest_b1_09_01() {
   CC100;
 
   if(1 && some_func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
   if(1 && some_func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
   if(1 || some_func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
   if(1 || some_func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
 
   if(1 && some_func(1 && 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
   if(1 && some_func(1 || 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
   if(1 || some_func(1 || 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
   }
   if(1 || some_func(1 && 1) && 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
   }
 
   if(1 && some_func(1 && 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
   }
   if(1 && some_func(1 || 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-4]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-4]]:23: note: +1{{$}}
   }
   if(1 || some_func(1 || 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
   if(1 || some_func(1 && 1) || 1) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:29: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:23: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:29: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:23: note: +1{{$}}
   }
 }
 
@@ -379,24 +379,24 @@ void unittest_b1_09_02() {
   CC100;
 
   if(1 && SomeClass::func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
   }
   if(1 && SomeClass::func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
   }
   if(1 || SomeClass::func(1 || 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
   }
   if(1 || SomeClass::func(1 && 1)) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:8: note: +1
-// CHECK-NOTES: :[[@LINE-3]]:29: note: +1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:8: note: +1{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:29: note: +1{{$}}
   }
 }
 
@@ -414,19 +414,19 @@ void unittest_b2_00() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   } else if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:10: note: +1, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   } else {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -436,9 +436,9 @@ void unittest_b2_01() {
   CC100;
 
   int i = 1 ? (1 ? 1 : 0) : (1 ? 1 : 0);
-// CHECK-NOTES: :[[@LINE-1]]:13: note: +1, including nesting penalty of 0, nesting level increased to 1
-// CHECK-NOTES: :[[@LINE-2]]:18: note: +2, including nesting penalty of 1, nesting level increased to 2
-// CHECK-NOTES: :[[@LINE-3]]:32: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:13: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
+// CHECK-NOTES: :[[@LINE-2]]:18: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
+// CHECK-NOTES: :[[@LINE-3]]:32: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
 }
 
 void unittest_b2_02(int x) {
@@ -446,15 +446,15 @@ void unittest_b2_02(int x) {
   CC100;
 
   switch (x) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   case -1:
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
     return;
   default:
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
     return;
   }
@@ -465,9 +465,9 @@ void unittest_b2_03() {
   CC100;
 
   for (;;) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -478,9 +478,9 @@ void unittest_b2_04() {
 
   SomeClass C;
   for (int i : C) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -490,9 +490,9 @@ void unittest_b2_05() {
   CC100;
 
   while (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -502,9 +502,9 @@ void unittest_b2_06() {
   CC100;
 
   do {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   } while (true);
 }
@@ -515,9 +515,9 @@ void unittest_b2_07() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if(true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -528,64 +528,64 @@ void unittest_b2_08_00() {
 
   class X {
     X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     X &operator=(const X &other) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     ~X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     void Y() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     static void Z() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
 // CHECK-NOTES: :[[@LINE-45]]:5: warning: function 'X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-39]]:8: warning: function 'operator=' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-33]]:5: warning: function '~X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-27]]:10: warning: function 'Y' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-21]]:17: warning: function 'Z' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   };
 }
 
@@ -595,64 +595,64 @@ void unittest_b2_08_01() {
 
   struct X {
     X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     X &operator=(const X &other) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     ~X() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     void Y() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
     static void Z() {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: nesting level increased to 1{{$}}
       CC100;
 
       if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
       }
     }
 
 // CHECK-NOTES: :[[@LINE-45]]:5: warning: function 'X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-42]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-39]]:8: warning: function 'operator=' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-36]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-33]]:5: warning: function '~X' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-30]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-27]]:10: warning: function 'Y' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-24]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 
 // CHECK-NOTES: :[[@LINE-21]]:17: warning: function 'Z' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-18]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   };
 }
 
@@ -661,13 +661,13 @@ void unittest_b2_08_02() {
   CC100;
 
   auto fun = []() {
-// CHECK-NOTES: :[[@LINE-1]]:14: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:14: note: nesting level increased to 1{{$}}
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   };
 // CHECK-NOTES: :[[@LINE-6]]:14: warning: lambda has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
-// CHECK-NOTES: :[[@LINE-5]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-5]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
 }
 
 void unittest_b2_09() {
@@ -675,9 +675,9 @@ void unittest_b2_09() {
   CC100;
 
   ({
-// CHECK-NOTES: :[[@LINE-1]]:3: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: nesting level increased to 1{{$}}
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   });
 }
@@ -687,9 +687,9 @@ void unittest_b2_10() {
   CC100;
 
   void (^foo)(void) = ^(void) {
-// CHECK-NOTES: :[[@LINE-1]]:23: note: nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:23: note: nesting level increased to 1{{$}}
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   };
 }
@@ -706,9 +706,9 @@ void unittest_b3_00() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -718,9 +718,9 @@ void unittest_b3_01() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     int i = 1 ? 1 : 0;
-// CHECK-NOTES: :[[@LINE-1]]:15: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:15: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
   }
 }
 
@@ -729,9 +729,9 @@ void unittest_b3_02(int x) {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     switch (x) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     case -1:
       return;
     default:
@@ -745,9 +745,9 @@ void unittest_b3_03() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     for (;;) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -757,10 +757,10 @@ void unittest_b3_04() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     SomeClass C;
     for (int i : C) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -770,9 +770,9 @@ void unittest_b3_05() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     while (true) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -782,9 +782,9 @@ void unittest_b3_06() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     do {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     } while (true);
   }
 }
@@ -794,10 +794,10 @@ void unittest_b3_07() {
   CC100;
 
   if (true) {
-// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:3: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +2, including nesting penalty of 1, nesting level increased to 2{{$}}
     }
   }
 }
@@ -813,7 +813,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -823,7 +823,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -833,7 +833,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -843,7 +843,7 @@ class CheckClass {
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -854,7 +854,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -864,7 +864,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -874,7 +874,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -884,7 +884,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -894,7 +894,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -904,7 +904,7 @@ public:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -917,7 +917,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -927,7 +927,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -937,7 +937,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 
@@ -947,7 +947,7 @@ protected:
 
     try {
     } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:7: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
     }
   }
 };
@@ -958,7 +958,7 @@ void CheckClass::PublicFunctionDefinition() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   }
 }
 
@@ -987,7 +987,7 @@ void templatedFunction() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   }
 }
 
@@ -998,7 +998,7 @@ void templatedFunction<bool>() {
 
   try {
   } catch (...) {
-// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1
+// CHECK-NOTES: :[[@LINE-1]]:5: note: +1, including nesting penalty of 0, nesting level increased to 1{{$}}
   }
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-anon-record-fields.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-anon-record-fields.cpp
@@ -36,19 +36,19 @@
 static union {
   int global;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'global'
-// CHECK-FIXES: {{^}}  int g_global;{{$}}
+// CHECK-FIXES: int g_global;
 
   const int global_const;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global constant 'global_const'
-// CHECK-FIXES: {{^}}  const int GLOBAL_CONST;{{$}}
+// CHECK-FIXES: const int GLOBAL_CONST;
 
   int *global_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'global_ptr'
-// CHECK-FIXES: {{^}}  int *GlobalPtr_Ptr;{{$}}
+// CHECK-FIXES: int *GlobalPtr_Ptr;
 
   int *const global_const_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global constant pointer 'global_const_ptr'
-// CHECK-FIXES: {{^}}  int *const GLOBAL_CONST_PTR_Ptr;{{$}}
+// CHECK-FIXES: int *const GLOBAL_CONST_PTR_Ptr;
 };
 
 namespace ns {
@@ -56,19 +56,19 @@ namespace ns {
 static union {
   int ns_global;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ns_global'
-// CHECK-FIXES: {{^}}  int g_ns_global;{{$}}
+// CHECK-FIXES: int g_ns_global;
 
   const int ns_global_const;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global constant 'ns_global_const'
-// CHECK-FIXES: {{^}}  const int NS_GLOBAL_CONST;{{$}}
+// CHECK-FIXES: const int NS_GLOBAL_CONST;
 
   int *ns_global_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'ns_global_ptr'
-// CHECK-FIXES: {{^}}  int *NsGlobalPtr_Ptr;{{$}}
+// CHECK-FIXES: int *NsGlobalPtr_Ptr;
 
   int *const ns_global_const_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global constant pointer 'ns_global_const_ptr'
-// CHECK-FIXES: {{^}}  int *const NS_GLOBAL_CONST_PTR_Ptr;{{$}}
+// CHECK-FIXES: int *const NS_GLOBAL_CONST_PTR_Ptr;
 };
 
 namespace {
@@ -76,19 +76,19 @@ namespace {
 union {
   int anon_ns_global;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'anon_ns_global'
-// CHECK-FIXES: {{^}}  int g_anon_ns_global;{{$}}
+// CHECK-FIXES: int g_anon_ns_global;
 
   const int anon_ns_global_const;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global constant 'anon_ns_global_const'
-// CHECK-FIXES: {{^}}  const int ANON_NS_GLOBAL_CONST;{{$}}
+// CHECK-FIXES: const int ANON_NS_GLOBAL_CONST;
 
   int *anon_ns_global_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'anon_ns_global_ptr'
-// CHECK-FIXES: {{^}}  int *AnonNsGlobalPtr_Ptr;{{$}}
+// CHECK-FIXES: int *AnonNsGlobalPtr_Ptr;
 
   int *const anon_ns_global_const_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global constant pointer 'anon_ns_global_const_ptr'
-// CHECK-FIXES: {{^}}  int *const ANON_NS_GLOBAL_CONST_PTR_Ptr;{{$}}
+// CHECK-FIXES: int *const ANON_NS_GLOBAL_CONST_PTR_Ptr;
 };
 
 }
@@ -101,32 +101,32 @@ public:
   union {
     int PubMember;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for public member 'PubMember'
-// CHECK-FIXES: {{^}}    int pub_member;{{$}}
+// CHECK-FIXES: int pub_member;
 
     const int PubConstMember;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for constant member 'PubConstMember'
-// CHECK-FIXES: {{^}}    const int pub_const_member;{{$}}
+// CHECK-FIXES: const int pub_const_member;
 
     int *PubPtrMember;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for public member 'PubPtrMember'
-// CHECK-FIXES: {{^}}    int *pub_ptr_member;{{$}}
+// CHECK-FIXES: int *pub_ptr_member;
 
     int *const PubConstPtrMember;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for constant member 'PubConstPtrMember'
-// CHECK-FIXES: {{^}}    int *const pub_const_ptr_member;{{$}}
+// CHECK-FIXES: int *const pub_const_ptr_member;
   };
 
 protected:
   union {
     int prot_member;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for protected member 'prot_member'
-// CHECK-FIXES: {{^}}    int _prot_member;{{$}}
+// CHECK-FIXES: int _prot_member;
 
     const int prot_const_member;
 
     int *prot_ptr_member;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for protected member 'prot_ptr_member'
-// CHECK-FIXES: {{^}}    int *_prot_ptr_member;{{$}}
+// CHECK-FIXES: int *_prot_ptr_member;
 
     int *const prot_const_ptr_member;
   };
@@ -136,13 +136,13 @@ private:
   union {
     int pri_member;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for private member 'pri_member'
-// CHECK-FIXES: {{^}}    int __pri_member;{{$}}
+// CHECK-FIXES: int __pri_member;
 
     const int pri_const_member;
 
     int *pri_ptr_member;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for private member 'pri_ptr_member'
-// CHECK-FIXES: {{^}}    int *__pri_ptr_member;{{$}}
+// CHECK-FIXES: int *__pri_ptr_member;
 
     int *const pri_const_ptr_member;
   };
@@ -154,32 +154,32 @@ void test() {
 
     const int local_const;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for local constant 'local_const'
-// CHECK-FIXES: {{^}}    const int kLocalConst;{{$}}
+// CHECK-FIXES: const int kLocalConst;
 
     int *local_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for local pointer 'local_ptr'
-// CHECK-FIXES: {{^}}    int *l_LocalPtr;{{$}}
+// CHECK-FIXES: int *l_LocalPtr;
 
     int *const local_const_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for local constant pointer 'local_const_ptr'
-// CHECK-FIXES: {{^}}    int *const lc_LocalConstPtr;{{$}}
+// CHECK-FIXES: int *const lc_LocalConstPtr;
   };
 
   static union {
     int local_static;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for static variable 'local_static'
-// CHECK-FIXES: {{^}}    int s_localStatic;{{$}}
+// CHECK-FIXES: int s_localStatic;
 
     const int local_static_const;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for static constant 'local_static_const'
-// CHECK-FIXES: {{^}}    const int LOCAL_STATIC_CONST;{{$}}
+// CHECK-FIXES: const int LOCAL_STATIC_CONST;
 
     int *local_static_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for static variable 'local_static_ptr'
-// CHECK-FIXES: {{^}}    int *s_localStaticPtr;{{$}}
+// CHECK-FIXES: int *s_localStaticPtr;
 
     int *const local_static_const_ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for static constant 'local_static_const_ptr'
-// CHECK-FIXES: {{^}}    int *const LOCAL_STATIC_CONST_PTR;{{$}}
+// CHECK-FIXES: int *const LOCAL_STATIC_CONST_PTR;
   };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-bugfix-name-conflicts.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-bugfix-name-conflicts.cpp
@@ -5,9 +5,9 @@
 
 int func(int Break) {
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for parameter 'Break'; cannot be fixed because 'break' would conflict with a keyword
-  // CHECK-FIXES: {{^}}int func(int Break) {{{$}}
+  // CHECK-FIXES: int func(int Break) {
   if (Break == 1) {
-    // CHECK-FIXES: {{^}}  if (Break == 1) {{{$}}
+    // CHECK-FIXES: if (Break == 1) {
     return 2;
   }
 
@@ -17,9 +17,9 @@ int func(int Break) {
 #define foo 3
 int func2(int Foo) {
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for parameter 'Foo'; cannot be fixed because 'foo' would conflict with a macro definition
-  // CHECK-FIXES: {{^}}int func2(int Foo) {{{$}}
+  // CHECK-FIXES: int func2(int Foo) {
   if (Foo == 1) {
-    // CHECK-FIXES: {{^}}  if (Foo == 1) {{{$}}
+    // CHECK-FIXES: if (Foo == 1) {
     return 2;
   }
 
@@ -28,9 +28,9 @@ int func2(int Foo) {
 
 int func3(int _0Bad) {
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for parameter '_0Bad'; cannot be fixed automatically [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}int func3(int _0Bad) {{{$}}
+  // CHECK-FIXES: int func3(int _0Bad) {
   if (_0Bad == 1) {
-    // CHECK-FIXES: {{^}}  if (_0Bad == 1) {{{$}}
+    // CHECK-FIXES: if (_0Bad == 1) {
     return 2;
   }
   return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-case-match.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-case-match.cpp
@@ -16,27 +16,27 @@ class XML_Parser_2 {};
 
 class XmlParser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'XmlParser'
-// CHECK-FIXES: {{^}}class Xml_Parser {};{{$}}
+// CHECK-FIXES: class Xml_Parser {};
 
 class Xml_parser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'Xml_parser'
-// CHECK-FIXES: {{^}}class Xml_Parser {};{{$}}
+// CHECK-FIXES: class Xml_Parser {};
 
 class xml_parser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'xml_parser'
-// CHECK-FIXES: {{^}}class Xml_Parser {};{{$}}
+// CHECK-FIXES: class Xml_Parser {};
 
 class xml_Parser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'xml_Parser'
-// CHECK-FIXES: {{^}}class Xml_Parser {};{{$}}
+// CHECK-FIXES: class Xml_Parser {};
 
 class xml_Parser_2 {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'xml_Parser_2'
-// CHECK-FIXES: {{^}}class Xml_Parser_2 {};{{$}}
+// CHECK-FIXES: class Xml_Parser_2 {};
 
 class t {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 't'
-// CHECK-FIXES: {{^}}class T {};{{$}}
+// CHECK-FIXES: class T {};
 
 //===----------------------------------------------------------------------===//
 // camel_Snake_Back tests
@@ -48,13 +48,13 @@ struct u {};
 
 struct JsonParser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'JsonParser'
-// CHECK-FIXES: {{^}}struct json_Parser {};{{$}}
+// CHECK-FIXES: struct json_Parser {};
 
 struct Json_parser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'Json_parser'
-// CHECK-FIXES: {{^}}struct json_Parser {};{{$}}
+// CHECK-FIXES: struct json_Parser {};
 
 struct json_parser {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'json_parser'
-// CHECK-FIXES: {{^}}struct json_Parser {};{{$}}
+// CHECK-FIXES: struct json_Parser {};
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation-c-language.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation-c-language.c
@@ -9,95 +9,95 @@
 //===----------------------------------------------------------------------===//
 const int GlobalConstantCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global constant 'GlobalConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int iGlobalConstantCase = 0;
+// CHECK-FIXES: const int iGlobalConstantCase = 0;
 
 const int* GlobalConstantPointerCase = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global pointer 'GlobalConstantPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int* piGlobalConstantPointerCase = NULL;
+// CHECK-FIXES: const int* piGlobalConstantPointerCase = NULL;
 
 int* GlobalPointerCase = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'GlobalPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int* piGlobalPointerCase = NULL;
+// CHECK-FIXES: int* piGlobalPointerCase = NULL;
 
 int GlobalVariableCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iGlobalVariableCase = 0;
+// CHECK-FIXES: int iGlobalVariableCase = 0;
 
 void Func1(){
   int const LocalConstantCase = 3;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for local constant 'LocalConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int const iLocalConstantCase = 3;
+  // CHECK-FIXES: int const iLocalConstantCase = 3;
 
   unsigned const ConstantCase = 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for local constant 'ConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  unsigned const uConstantCase = 1;
+  // CHECK-FIXES: unsigned const uConstantCase = 1;
 
   int* const LocalConstantPointerCase = NULL;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for local constant pointer 'LocalConstantPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int* const piLocalConstantPointerCase = NULL;
+  // CHECK-FIXES: int* const piLocalConstantPointerCase = NULL;
 
   int *LocalPointerCase = NULL;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for local pointer 'LocalPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int *piLocalPointerCase = NULL;
+  // CHECK-FIXES: int *piLocalPointerCase = NULL;
 
   int LocalVariableCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for local variable 'LocalVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int iLocalVariableCase = 0;
+  // CHECK-FIXES: int iLocalVariableCase = 0;
 }
 
 struct CMyClass2 {
   char MemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for public member 'MemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char cMemberCase;
+  // CHECK-FIXES: char cMemberCase;
 };
 
 static const int StaticConstantCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global constant 'StaticConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static const int iStaticConstantCase = 3;
+// CHECK-FIXES: static const int iStaticConstantCase = 3;
 
 static int StaticVariableCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'StaticVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static int iStaticVariableCase = 3;
+// CHECK-FIXES: static int iStaticVariableCase = 3;
 
 struct MyStruct { int StructCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: invalid case style for public member 'StructCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct MyStruct { int iStructCase; };
+// CHECK-FIXES: struct MyStruct { int iStructCase; };
 
 struct shouldBeCamelCaseStruct { int iField; };
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'shouldBeCamelCaseStruct' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct ShouldBeCamelCaseStruct { int iField; };
+// CHECK-FIXES: struct ShouldBeCamelCaseStruct { int iField; };
 
 union MyUnion { int UnionCase; long lUnionCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for union 'MyUnion' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:21: warning: invalid case style for public member 'UnionCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}union myUnion { int iUnionCase; long lUnionCase; };
+// CHECK-FIXES: union myUnion { int iUnionCase; long lUnionCase; };
 
 //===----------------------------------------------------------------------===//
 // C string
 //===----------------------------------------------------------------------===//
 const char *NamePtr = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global pointer 'NamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *szNamePtr = "Name";
+// CHECK-FIXES: const char *szNamePtr = "Name";
 
 const char NameArray[] = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global constant 'NameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char szNameArray[] = "Name";
+// CHECK-FIXES: const char szNameArray[] = "Name";
 
 const char *NamePtrArray[] = {"AA", "BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'NamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *pszNamePtrArray[] = {"AA", "BB"};
+// CHECK-FIXES: const char *pszNamePtrArray[] = {"AA", "BB"};
 
 const wchar_t *WideNamePtr = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'WideNamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *wszWideNamePtr = L"Name";
+// CHECK-FIXES: const wchar_t *wszWideNamePtr = L"Name";
 
 const wchar_t WideNameArray[] = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global constant 'WideNameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t wszWideNameArray[] = L"Name";
+// CHECK-FIXES: const wchar_t wszWideNameArray[] = L"Name";
 
 const wchar_t *WideNamePtrArray[] = {L"AA", L"BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'WideNamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *pwszWideNamePtrArray[] = {L"AA", L"BB"};
+// CHECK-FIXES: const wchar_t *pwszWideNamePtrArray[] = {L"AA", L"BB"};
 
 
 //===----------------------------------------------------------------------===//
@@ -105,123 +105,123 @@ const wchar_t *WideNamePtrArray[] = {L"AA", L"BB"};
 //===----------------------------------------------------------------------===//
 DWORD MsDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD dwMsDword = 0;
+// CHECK-FIXES: DWORD dwMsDword = 0;
 
 BYTE MsByte = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BYTE byMsByte = 0;
+// CHECK-FIXES: BYTE byMsByte = 0;
 
 WORD MsWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD wMsWord = 0;
+// CHECK-FIXES: WORD wMsWord = 0;
 
 BOOL MsBool = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOL bMsBool = 0;
+// CHECK-FIXES: BOOL bMsBool = 0;
 
 BOOLEAN MsBoolean = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsBoolean' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOLEAN bMsBoolean = 0;
+// CHECK-FIXES: BOOLEAN bMsBoolean = 0;
 
 CHAR MsValueChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}CHAR cMsValueChar = 0;
+// CHECK-FIXES: CHAR cMsValueChar = 0;
 
 UCHAR MsValueUchar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UCHAR ucMsValueUchar = 0;
+// CHECK-FIXES: UCHAR ucMsValueUchar = 0;
 
 SHORT MsValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}SHORT sMsValueShort = 0;
+// CHECK-FIXES: SHORT sMsValueShort = 0;
 
 USHORT MsValueUshort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUshort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}USHORT usMsValueUshort = 0;
+// CHECK-FIXES: USHORT usMsValueUshort = 0;
 
 WORD MsValueWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD wMsValueWord = 0;
+// CHECK-FIXES: WORD wMsValueWord = 0;
 
 DWORD MsValueDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD dwMsValueDword = 0;
+// CHECK-FIXES: DWORD dwMsValueDword = 0;
 
 DWORD32 MsValueDword32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD32 dw32MsValueDword32 = 0;
+// CHECK-FIXES: DWORD32 dw32MsValueDword32 = 0;
 
 DWORD64 MsValueDword64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD64 dw64MsValueDword64 = 0;
+// CHECK-FIXES: DWORD64 dw64MsValueDword64 = 0;
 
 LONG MsValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}LONG lMsValueLong = 0;
+// CHECK-FIXES: LONG lMsValueLong = 0;
 
 ULONG MsValueUlong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUlong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG ulMsValueUlong = 0;
+// CHECK-FIXES: ULONG ulMsValueUlong = 0;
 
 ULONG32 MsValueUlong32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG32 ul32MsValueUlong32 = 0;
+// CHECK-FIXES: ULONG32 ul32MsValueUlong32 = 0;
 
 ULONG64 MsValueUlong64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG64 ul64MsValueUlong64 = 0;
+// CHECK-FIXES: ULONG64 ul64MsValueUlong64 = 0;
 
 ULONGLONG MsValueUlongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'MsValueUlongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONGLONG ullMsValueUlongLong = 0;
+// CHECK-FIXES: ULONGLONG ullMsValueUlongLong = 0;
 
 HANDLE MsValueHandle = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'MsValueHandle' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}HANDLE hMsValueHandle = 0;
+// CHECK-FIXES: HANDLE hMsValueHandle = 0;
 
 INT MsValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'MsValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT iMsValueInt = 0;
+// CHECK-FIXES: INT iMsValueInt = 0;
 
 INT8 MsValueInt8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueInt8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT8 i8MsValueInt8 = 0;
+// CHECK-FIXES: INT8 i8MsValueInt8 = 0;
 
 INT16 MsValueInt16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT16 i16MsValueInt16 = 0;
+// CHECK-FIXES: INT16 i16MsValueInt16 = 0;
 
 INT32 MsValueInt32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT32 i32MsValueInt32 = 0;
+// CHECK-FIXES: INT32 i32MsValueInt32 = 0;
 
 INT64 MsValueINt64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueINt64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT64 i64MsValueINt64 = 0;
+// CHECK-FIXES: INT64 i64MsValueINt64 = 0;
 
 UINT MsValueUint = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueUint' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT uiMsValueUint = 0;
+// CHECK-FIXES: UINT uiMsValueUint = 0;
 
 UINT8 MsValueUint8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUint8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT8 u8MsValueUint8 = 0;
+// CHECK-FIXES: UINT8 u8MsValueUint8 = 0;
 
 UINT16 MsValueUint16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT16 u16MsValueUint16 = 0;
+// CHECK-FIXES: UINT16 u16MsValueUint16 = 0;
 
 UINT32 MsValueUint32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT32 u32MsValueUint32 = 0;
+// CHECK-FIXES: UINT32 u32MsValueUint32 = 0;
 
 UINT64 MsValueUint64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT64 u64MsValueUint64 = 0;
+// CHECK-FIXES: UINT64 u64MsValueUint64 = 0;
 
 PVOID MsValuePvoid = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'MsValuePvoid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}PVOID pMsValuePvoid = NULL;
+// CHECK-FIXES: PVOID pMsValuePvoid = NULL;
 
 
 //===----------------------------------------------------------------------===//
@@ -229,19 +229,19 @@ PVOID MsValuePvoid = NULL;
 //===----------------------------------------------------------------------===//
 unsigned GlobalUnsignedArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'GlobalUnsignedArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned aGlobalUnsignedArray[] = {1, 2, 3};
+// CHECK-FIXES: unsigned aGlobalUnsignedArray[] = {1, 2, 3};
 
 int GlobalIntArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalIntArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int aGlobalIntArray[] = {1, 2, 3};
+// CHECK-FIXES: int aGlobalIntArray[] = {1, 2, 3};
 
 int DataInt[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int aDataInt[1] = {0};
+// CHECK-FIXES: int aDataInt[1] = {0};
 
 int DataArray[2] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int aDataArray[2] = {0};
+// CHECK-FIXES: int aDataArray[2] = {0};
 
 
 //===----------------------------------------------------------------------===//
@@ -249,56 +249,56 @@ int DataArray[2] = {0};
 //===----------------------------------------------------------------------===//
 int *DataIntPtr[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'DataIntPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *paDataIntPtr[1] = {0};
+// CHECK-FIXES: int *paDataIntPtr[1] = {0};
 
 void *BufferPtr1;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'BufferPtr1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *pBufferPtr1;
+// CHECK-FIXES: void *pBufferPtr1;
 
 void **BufferPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'BufferPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **ppBufferPtr2;
+// CHECK-FIXES: void **ppBufferPtr2;
 
 void **pBufferPtr3;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'pBufferPtr3' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **ppBufferPtr3;
+// CHECK-FIXES: void **ppBufferPtr3;
 
 int *pBufferPtr4;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'pBufferPtr4' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *piBufferPtr4;
+// CHECK-FIXES: int *piBufferPtr4;
 
 typedef void (*FUNC_PTR_HELLO)();
 FUNC_PTR_HELLO Hello = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'Hello' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}FUNC_PTR_HELLO fnHello = NULL;
+// CHECK-FIXES: FUNC_PTR_HELLO fnHello = NULL;
 
 void *ValueVoidPtr = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'ValueVoidPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *pValueVoidPtr = NULL;
+// CHECK-FIXES: void *pValueVoidPtr = NULL;
 
 ptrdiff_t PtrDiff = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'PtrDiff' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ptrdiff_t pPtrDiff = NULL;
+// CHECK-FIXES: ptrdiff_t pPtrDiff = NULL;
 
 int8_t *ValueI8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global pointer 'ValueI8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t *pi8ValueI8Ptr;
+// CHECK-FIXES: int8_t *pi8ValueI8Ptr;
 
 uint8_t *ValueU8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global pointer 'ValueU8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t *pu8ValueU8Ptr;
+// CHECK-FIXES: uint8_t *pu8ValueU8Ptr;
 
 unsigned char *ValueUcPtr;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'ValueUcPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char *pucValueUcPtr;
+// CHECK-FIXES: unsigned char *pucValueUcPtr;
 
 unsigned char **ValueUcPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global pointer 'ValueUcPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char **ppucValueUcPtr2;
+// CHECK-FIXES: unsigned char **ppucValueUcPtr2;
 
 void MyFunc2(void* Val){}
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for pointer parameter 'Val' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void MyFunc2(void* pVal){}
+// CHECK-FIXES: void MyFunc2(void* pVal){}
 
 
 //===----------------------------------------------------------------------===//
@@ -306,151 +306,151 @@ void MyFunc2(void* Val){}
 //===----------------------------------------------------------------------===//
 int8_t ValueI8;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueI8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t i8ValueI8;
+// CHECK-FIXES: int8_t i8ValueI8;
 
 int16_t ValueI16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int16_t i16ValueI16 = 0;
+// CHECK-FIXES: int16_t i16ValueI16 = 0;
 
 int32_t ValueI32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int32_t i32ValueI32 = 0;
+// CHECK-FIXES: int32_t i32ValueI32 = 0;
 
 int64_t ValueI64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int64_t i64ValueI64 = 0;
+// CHECK-FIXES: int64_t i64ValueI64 = 0;
 
 uint8_t ValueU8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueU8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t u8ValueU8 = 0;
+// CHECK-FIXES: uint8_t u8ValueU8 = 0;
 
 uint16_t ValueU16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint16_t u16ValueU16 = 0;
+// CHECK-FIXES: uint16_t u16ValueU16 = 0;
 
 uint32_t ValueU32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint32_t u32ValueU32 = 0;
+// CHECK-FIXES: uint32_t u32ValueU32 = 0;
 
 uint64_t ValueU64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint64_t u64ValueU64 = 0;
+// CHECK-FIXES: uint64_t u64ValueU64 = 0;
 
 float ValueFloat = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueFloat' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}float fValueFloat = 0;
+// CHECK-FIXES: float fValueFloat = 0;
 
 double ValueDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}double dValueDouble = 0;
+// CHECK-FIXES: double dValueDouble = 0;
 
 char ValueChar = 'c';
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}char cValueChar = 'c';
+// CHECK-FIXES: char cValueChar = 'c';
 
 bool ValueBool = true;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}bool bValueBool = true;
+// CHECK-FIXES: bool bValueBool = true;
 
 int ValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'ValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iValueInt = 0;
+// CHECK-FIXES: int iValueInt = 0;
 
 size_t ValueSize = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSize' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}size_t nValueSize = 0;
+// CHECK-FIXES: size_t nValueSize = 0;
 
 wchar_t ValueWchar = 'w';
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueWchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}wchar_t wcValueWchar = 'w';
+// CHECK-FIXES: wchar_t wcValueWchar = 'w';
 
 short ValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}short sValueShort = 0;
+// CHECK-FIXES: short sValueShort = 0;
 
 unsigned ValueUnsigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueUnsigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned uValueUnsigned = 0;
+// CHECK-FIXES: unsigned uValueUnsigned = 0;
 
 signed ValueSigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed sValueSigned = 0;
+// CHECK-FIXES: signed sValueSigned = 0;
 
 long ValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long lValueLong = 0;
+// CHECK-FIXES: long lValueLong = 0;
 
 long long ValueLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'ValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long llValueLongLong = 0;
+// CHECK-FIXES: long long llValueLongLong = 0;
 
 long long int ValueLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long int lliValueLongLongInt = 0;
+// CHECK-FIXES: long long int lliValueLongLongInt = 0;
 
 long double ValueLongDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueLongDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long double ldValueLongDouble = 0;
+// CHECK-FIXES: long double ldValueLongDouble = 0;
 
 signed int ValueSignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ValueSignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed int siValueSignedInt = 0;
+// CHECK-FIXES: signed int siValueSignedInt = 0;
 
 signed short ValueSignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueSignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short ssValueSignedShort = 0;
+// CHECK-FIXES: signed short ssValueSignedShort = 0;
 
 signed short int ValueSignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short int ssiValueSignedShortInt = 0;
+// CHECK-FIXES: signed short int ssiValueSignedShortInt = 0;
 
 signed long long ValueSignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long long sllValueSignedLongLong = 0;
+// CHECK-FIXES: signed long long sllValueSignedLongLong = 0;
 
 signed long int ValueSignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global variable 'ValueSignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long int sliValueSignedLongInt = 0;
+// CHECK-FIXES: signed long int sliValueSignedLongInt = 0;
 
 signed long ValueSignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueSignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long slValueSignedLong = 0;
+// CHECK-FIXES: signed long slValueSignedLong = 0;
 
 unsigned long long int ValueUnsignedLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for global variable 'ValueUnsignedLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long int ulliValueUnsignedLongLongInt = 0;
+// CHECK-FIXES: unsigned long long int ulliValueUnsignedLongLongInt = 0;
 
 unsigned long long ValueUnsignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long ullValueUnsignedLongLong = 0;
+// CHECK-FIXES: unsigned long long ullValueUnsignedLongLong = 0;
 
 unsigned long int ValueUnsignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for global variable 'ValueUnsignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long int uliValueUnsignedLongInt = 0;
+// CHECK-FIXES: unsigned long int uliValueUnsignedLongInt = 0;
 
 unsigned long ValueUnsignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long ulValueUnsignedLong = 0;
+// CHECK-FIXES: unsigned long ulValueUnsignedLong = 0;
 
 unsigned short int ValueUnsignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short int usiValueUnsignedShortInt = 0;
+// CHECK-FIXES: unsigned short int usiValueUnsignedShortInt = 0;
 
 unsigned short ValueUnsignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'ValueUnsignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short usValueUnsignedShort = 0;
+// CHECK-FIXES: unsigned short usValueUnsignedShort = 0;
 
 unsigned int ValueUnsignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueUnsignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned int uiValueUnsignedInt = 0;
+// CHECK-FIXES: unsigned int uiValueUnsignedInt = 0;
 
 unsigned char ValueUnsignedChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char ucValueUnsignedChar = 0;
+// CHECK-FIXES: unsigned char ucValueUnsignedChar = 0;
 
 long int ValueLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long int liValueLongInt = 0;
+// CHECK-FIXES: long int liValueLongInt = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -458,11 +458,11 @@ long int ValueLongInt = 0;
 //===----------------------------------------------------------------------===//
 volatile int VolatileInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'VolatileInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}volatile int iVolatileInt = 0;
+// CHECK-FIXES: volatile int iVolatileInt = 0;
 
 extern int ExternValueInt;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ExternValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}extern int iExternValueInt;
+// CHECK-FIXES: extern int iExternValueInt;
 
 //===----------------------------------------------------------------------===//
 // Redefined types
@@ -470,7 +470,7 @@ extern int ExternValueInt;
 typedef int INDEX;
 INDEX iIndex = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'iIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INDEX Index = 0;
+// CHECK-FIXES: INDEX Index = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -478,72 +478,72 @@ INDEX iIndex = 0;
 //===----------------------------------------------------------------------===//
 int lower_case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iLowerCase = 0;
+// CHECK-FIXES: int iLowerCase = 0;
 
 int lower_case1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iLowerCase1 = 0;
+// CHECK-FIXES: int iLowerCase1 = 0;
 
 int lower_case_2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case_2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iLowerCase2 = 0;
+// CHECK-FIXES: int iLowerCase2 = 0;
 
 int UPPER_CASE = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iUpperCase = 0;
+// CHECK-FIXES: int iUpperCase = 0;
 
 int UPPER_CASE_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iUpperCase1 = 0;
+// CHECK-FIXES: int iUpperCase1 = 0;
 
 int camelBack = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelBack = 0;
+// CHECK-FIXES: int iCamelBack = 0;
 
 int camelBack_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelBack1 = 0;
+// CHECK-FIXES: int iCamelBack1 = 0;
 
 int camelBack2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelBack2 = 0;
+// CHECK-FIXES: int iCamelBack2 = 0;
 
 int CamelCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelCase = 0;
+// CHECK-FIXES: int iCamelCase = 0;
 
 int CamelCase_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelCase1 = 0;
+// CHECK-FIXES: int iCamelCase1 = 0;
 
 int CamelCase2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelCase2 = 0;
+// CHECK-FIXES: int iCamelCase2 = 0;
 
 int camel_Snake_Back = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeBack = 0;
+// CHECK-FIXES: int iCamelSnakeBack = 0;
 
 int camel_Snake_Back_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeBack1 = 0;
+// CHECK-FIXES: int iCamelSnakeBack1 = 0;
 
 int Camel_Snake_Case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeCase = 0;
+// CHECK-FIXES: int iCamelSnakeCase = 0;
 
 int Camel_Snake_Case_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeCase1 = 0;
+// CHECK-FIXES: int iCamelSnakeCase1 = 0;
 
 //===----------------------------------------------------------------------===//
 // Enum
 //===----------------------------------------------------------------------===//
 enum REV_TYPE { RevValid };
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for enum constant 'RevValid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum REV_TYPE { rtRevValid };
+// CHECK-FIXES: enum REV_TYPE { rtRevValid };
 
 enum EnumConstantCase { OneByte, TwoByte };
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for enum constant 'OneByte' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: invalid case style for enum constant 'TwoByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum EnumConstantCase { eccOneByte, eccTwoByte };
+// CHECK-FIXES: enum EnumConstantCase { eccOneByte, eccTwoByte };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation-cfgfile.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation-cfgfile.cpp
@@ -11,159 +11,159 @@ class CMyClass1 {
 public:
   static int ClassMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for class member 'ClassMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  static int myiClassMemberCase;
+  // CHECK-FIXES: static int myiClassMemberCase;
 
   char const ConstantMemberCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for constant member 'ConstantMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char const mycConstantMemberCase = 0;
+  // CHECK-FIXES: char const mycConstantMemberCase = 0;
 
   void MyFunc1(const int ConstantParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: invalid case style for constant parameter 'ConstantParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void MyFunc1(const int myiConstantParameterCase);
+  // CHECK-FIXES: void MyFunc1(const int myiConstantParameterCase);
 
   void MyFunc2(const int* ConstantPointerParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: invalid case style for pointer parameter 'ConstantPointerParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void MyFunc2(const int* mypmyiConstantPointerParameterCase);
+  // CHECK-FIXES: void MyFunc2(const int* mypmyiConstantPointerParameterCase);
 
   static constexpr int ConstexprVariableCase = 123;
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for constexpr variable 'ConstexprVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  static constexpr int myiConstexprVariableCase = 123;
+  // CHECK-FIXES: static constexpr int myiConstexprVariableCase = 123;
 };
 
 const int GlobalConstantCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global constant 'GlobalConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int myiGlobalConstantCase = 0;
+// CHECK-FIXES: const int myiGlobalConstantCase = 0;
 
 const int* GlobalConstantPointerCase = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global pointer 'GlobalConstantPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int* mypmyiGlobalConstantPointerCase = nullptr;
+// CHECK-FIXES: const int* mypmyiGlobalConstantPointerCase = nullptr;
 
 int* GlobalPointerCase = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'GlobalPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int* mypmyiGlobalPointerCase = nullptr;
+// CHECK-FIXES: int* mypmyiGlobalPointerCase = nullptr;
 
 int GlobalVariableCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiGlobalVariableCase = 0;
+// CHECK-FIXES: int myiGlobalVariableCase = 0;
 
 void Func1(){
   int const LocalConstantCase = 3;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for local constant 'LocalConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int const myiLocalConstantCase = 3;
+  // CHECK-FIXES: int const myiLocalConstantCase = 3;
 
   unsigned const ConstantCase = 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for local constant 'ConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  unsigned const myuConstantCase = 1;
+  // CHECK-FIXES: unsigned const myuConstantCase = 1;
 
   int* const LocalConstantPointerCase = nullptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for local constant pointer 'LocalConstantPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int* const mypmyiLocalConstantPointerCase = nullptr;
+  // CHECK-FIXES: int* const mypmyiLocalConstantPointerCase = nullptr;
 
   int *LocalPointerCase = nullptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for local pointer 'LocalPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int *mypmyiLocalPointerCase = nullptr;
+  // CHECK-FIXES: int *mypmyiLocalPointerCase = nullptr;
 
   int LocalVariableCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for local variable 'LocalVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int myiLocalVariableCase = 0;
+  // CHECK-FIXES: int myiLocalVariableCase = 0;
 }
 
 class CMyClass2 {
   char MemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for private member 'MemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char mycMemberCase;
+  // CHECK-FIXES: char mycMemberCase;
 
   void Func1(int ParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for parameter 'ParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func1(int myiParameterCase);
+  // CHECK-FIXES: void Func1(int myiParameterCase);
 
   void Func2(const int ParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for constant parameter 'ParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func2(const int myiParameterCase);
+  // CHECK-FIXES: void Func2(const int myiParameterCase);
 
   void Func3(const int *PointerParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for pointer parameter 'PointerParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func3(const int *mypmyiPointerParameterCase);
+  // CHECK-FIXES: void Func3(const int *mypmyiPointerParameterCase);
 };
 
 class CMyClass3 {
 private:
   char PrivateMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for private member 'PrivateMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char mycPrivateMemberCase;
+  // CHECK-FIXES: char mycPrivateMemberCase;
 
 protected:
   char ProtectedMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for protected member 'ProtectedMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char mycProtectedMemberCase;
+  // CHECK-FIXES: char mycProtectedMemberCase;
 
 public:
   char PublicMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for public member 'PublicMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char mycPublicMemberCase;
+  // CHECK-FIXES: char mycPublicMemberCase;
 };
 
 static const int StaticConstantCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global constant 'StaticConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static const int myiStaticConstantCase = 3;
+// CHECK-FIXES: static const int myiStaticConstantCase = 3;
 
 static int StaticVariableCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'StaticVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static int myiStaticVariableCase = 3;
+// CHECK-FIXES: static int myiStaticVariableCase = 3;
 
 struct CMyStruct { int StructCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for public member 'StructCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct CMyStruct { int myiStructCase; };
+// CHECK-FIXES: struct CMyStruct { int myiStructCase; };
 
 union MyUnion { int UnionCase; long mylUnionCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: invalid case style for public member 'UnionCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}union MyUnion { int myiUnionCase; long mylUnionCase; };
+// CHECK-FIXES: union MyUnion { int myiUnionCase; long mylUnionCase; };
 
 //===----------------------------------------------------------------------===//
 // C string
 //===----------------------------------------------------------------------===//
 const char *NamePtr = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global pointer 'NamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *myszNamePtr = "Name";
+// CHECK-FIXES: const char *myszNamePtr = "Name";
 
 const char NameArray[] = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global constant 'NameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char myszNameArray[] = "Name";
+// CHECK-FIXES: const char myszNameArray[] = "Name";
 
 const char *NamePtrArray[] = {"AA", "BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'NamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *mypmyszNamePtrArray[] = {"AA", "BB"};
+// CHECK-FIXES: const char *mypmyszNamePtrArray[] = {"AA", "BB"};
 
 const wchar_t *WideNamePtr = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'WideNamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *mywszWideNamePtr = L"Name";
+// CHECK-FIXES: const wchar_t *mywszWideNamePtr = L"Name";
 
 const wchar_t WideNameArray[] = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global constant 'WideNameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t mywszWideNameArray[] = L"Name";
+// CHECK-FIXES: const wchar_t mywszWideNameArray[] = L"Name";
 
 const wchar_t *WideNamePtrArray[] = {L"AA", L"BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'WideNamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *mypmywszWideNamePtrArray[] = {L"AA", L"BB"};
+// CHECK-FIXES: const wchar_t *mypmywszWideNamePtrArray[] = {L"AA", L"BB"};
 
 class CMyClass4 {
 private:
   char *Name = "Text";
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for private member 'Name' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char *myszName = "Text";
+  // CHECK-FIXES: char *myszName = "Text";
 
   const char *ConstName = "Text";
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for private member 'ConstName' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  const char *myszConstName = "Text";
+  // CHECK-FIXES: const char *myszConstName = "Text";
 
 public:
   const char* DuplicateString(const char* Input, size_t mynRequiredSize);
   // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: invalid case style for pointer parameter 'Input' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  const char* DuplicateString(const char* myszInput, size_t mynRequiredSize);
+  // CHECK-FIXES: const char* DuplicateString(const char* myszInput, size_t mynRequiredSize);
 
   size_t UpdateText(const char* Buffer, size_t mynBufferSize);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: invalid case style for pointer parameter 'Buffer' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  size_t UpdateText(const char* myszBuffer, size_t mynBufferSize);
+  // CHECK-FIXES: size_t UpdateText(const char* myszBuffer, size_t mynBufferSize);
 };
 
 
@@ -172,123 +172,123 @@ public:
 //===----------------------------------------------------------------------===//
 DWORD MsDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD mydwMsDword = 0;
+// CHECK-FIXES: DWORD mydwMsDword = 0;
 
 BYTE MsByte = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BYTE mybyMsByte = 0;
+// CHECK-FIXES: BYTE mybyMsByte = 0;
 
 WORD MsWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD mywMsWord = 0;
+// CHECK-FIXES: WORD mywMsWord = 0;
 
 BOOL MsBool = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOL mybMsBool = 0;
+// CHECK-FIXES: BOOL mybMsBool = 0;
 
 BOOLEAN MsBoolean = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsBoolean' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOLEAN mybMsBoolean = 0;
+// CHECK-FIXES: BOOLEAN mybMsBoolean = 0;
 
 CHAR MsValueChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}CHAR mycMsValueChar = 0;
+// CHECK-FIXES: CHAR mycMsValueChar = 0;
 
 UCHAR MsValueUchar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UCHAR myucMsValueUchar = 0;
+// CHECK-FIXES: UCHAR myucMsValueUchar = 0;
 
 SHORT MsValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}SHORT mysMsValueShort = 0;
+// CHECK-FIXES: SHORT mysMsValueShort = 0;
 
 USHORT MsValueUshort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUshort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}USHORT myusMsValueUshort = 0;
+// CHECK-FIXES: USHORT myusMsValueUshort = 0;
 
 WORD MsValueWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD mywMsValueWord = 0;
+// CHECK-FIXES: WORD mywMsValueWord = 0;
 
 DWORD MsValueDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD mydwMsValueDword = 0;
+// CHECK-FIXES: DWORD mydwMsValueDword = 0;
 
 DWORD32 MsValueDword32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD32 mydw32MsValueDword32 = 0;
+// CHECK-FIXES: DWORD32 mydw32MsValueDword32 = 0;
 
 DWORD64 MsValueDword64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD64 mydw64MsValueDword64 = 0;
+// CHECK-FIXES: DWORD64 mydw64MsValueDword64 = 0;
 
 LONG MsValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}LONG mylMsValueLong = 0;
+// CHECK-FIXES: LONG mylMsValueLong = 0;
 
 ULONG MsValueUlong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUlong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG myulMsValueUlong = 0;
+// CHECK-FIXES: ULONG myulMsValueUlong = 0;
 
 ULONG32 MsValueUlong32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG32 myul32MsValueUlong32 = 0;
+// CHECK-FIXES: ULONG32 myul32MsValueUlong32 = 0;
 
 ULONG64 MsValueUlong64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG64 myul64MsValueUlong64 = 0;
+// CHECK-FIXES: ULONG64 myul64MsValueUlong64 = 0;
 
 ULONGLONG MsValueUlongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'MsValueUlongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONGLONG myullMsValueUlongLong = 0;
+// CHECK-FIXES: ULONGLONG myullMsValueUlongLong = 0;
 
 HANDLE MsValueHandle = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'MsValueHandle' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}HANDLE myhMsValueHandle = 0;
+// CHECK-FIXES: HANDLE myhMsValueHandle = 0;
 
 INT MsValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'MsValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT myiMsValueInt = 0;
+// CHECK-FIXES: INT myiMsValueInt = 0;
 
 INT8 MsValueInt8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueInt8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT8 myi8MsValueInt8 = 0;
+// CHECK-FIXES: INT8 myi8MsValueInt8 = 0;
 
 INT16 MsValueInt16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT16 myi16MsValueInt16 = 0;
+// CHECK-FIXES: INT16 myi16MsValueInt16 = 0;
 
 INT32 MsValueInt32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT32 myi32MsValueInt32 = 0;
+// CHECK-FIXES: INT32 myi32MsValueInt32 = 0;
 
 INT64 MsValueINt64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueINt64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT64 myi64MsValueINt64 = 0;
+// CHECK-FIXES: INT64 myi64MsValueINt64 = 0;
 
 UINT MsValueUint = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueUint' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT myuiMsValueUint = 0;
+// CHECK-FIXES: UINT myuiMsValueUint = 0;
 
 UINT8 MsValueUint8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUint8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT8 myu8MsValueUint8 = 0;
+// CHECK-FIXES: UINT8 myu8MsValueUint8 = 0;
 
 UINT16 MsValueUint16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT16 myu16MsValueUint16 = 0;
+// CHECK-FIXES: UINT16 myu16MsValueUint16 = 0;
 
 UINT32 MsValueUint32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT32 myu32MsValueUint32 = 0;
+// CHECK-FIXES: UINT32 myu32MsValueUint32 = 0;
 
 UINT64 MsValueUint64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT64 myu64MsValueUint64 = 0;
+// CHECK-FIXES: UINT64 myu64MsValueUint64 = 0;
 
 PVOID MsValuePvoid = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'MsValuePvoid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}PVOID mypMsValuePvoid = NULL;
+// CHECK-FIXES: PVOID mypMsValuePvoid = NULL;
 
 
 //===----------------------------------------------------------------------===//
@@ -296,19 +296,19 @@ PVOID MsValuePvoid = NULL;
 //===----------------------------------------------------------------------===//
 unsigned GlobalUnsignedArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'GlobalUnsignedArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned myaGlobalUnsignedArray[] = {1, 2, 3};
+// CHECK-FIXES: unsigned myaGlobalUnsignedArray[] = {1, 2, 3};
 
 int GlobalIntArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalIntArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myaGlobalIntArray[] = {1, 2, 3};
+// CHECK-FIXES: int myaGlobalIntArray[] = {1, 2, 3};
 
 int DataInt[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myaDataInt[1] = {0};
+// CHECK-FIXES: int myaDataInt[1] = {0};
 
 int DataArray[2] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myaDataArray[2] = {0};
+// CHECK-FIXES: int myaDataArray[2] = {0};
 
 
 //===----------------------------------------------------------------------===//
@@ -316,56 +316,56 @@ int DataArray[2] = {0};
 //===----------------------------------------------------------------------===//
 int *DataIntPtr[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'DataIntPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *mypmyaDataIntPtr[1] = {0};
+// CHECK-FIXES: int *mypmyaDataIntPtr[1] = {0};
 
 void *BufferPtr1;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'BufferPtr1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *mypmyvBufferPtr1;
+// CHECK-FIXES: void *mypmyvBufferPtr1;
 
 void **BufferPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'BufferPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **mypmypmyvBufferPtr2;
+// CHECK-FIXES: void **mypmypmyvBufferPtr2;
 
 void **mypBufferPtr3;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'mypBufferPtr3' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **mypmypmyvBufferPtr3;
+// CHECK-FIXES: void **mypmypmyvBufferPtr3;
 
 int *mypBufferPtr4;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'mypBufferPtr4' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *mypmyiBufferPtr4;
+// CHECK-FIXES: int *mypmyiBufferPtr4;
 
 typedef void (*FUNC_PTR_HELLO)();
 FUNC_PTR_HELLO Hello = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'Hello' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}FUNC_PTR_HELLO myfnHello = NULL;
+// CHECK-FIXES: FUNC_PTR_HELLO myfnHello = NULL;
 
 void *ValueVoidPtr = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'ValueVoidPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *mypmyvValueVoidPtr = NULL;
+// CHECK-FIXES: void *mypmyvValueVoidPtr = NULL;
 
 ptrdiff_t PtrDiff = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'PtrDiff' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ptrdiff_t mypPtrDiff = NULL;
+// CHECK-FIXES: ptrdiff_t mypPtrDiff = NULL;
 
 int8_t *ValueI8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global pointer 'ValueI8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t *mypmyi8ValueI8Ptr;
+// CHECK-FIXES: int8_t *mypmyi8ValueI8Ptr;
 
 uint8_t *ValueU8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global pointer 'ValueU8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t *mypmyu8ValueU8Ptr;
+// CHECK-FIXES: uint8_t *mypmyu8ValueU8Ptr;
 
 unsigned char *ValueUcPtr;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'ValueUcPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char *mypmyucValueUcPtr;
+// CHECK-FIXES: unsigned char *mypmyucValueUcPtr;
 
 unsigned char **ValueUcPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global pointer 'ValueUcPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char **mypmypmyucValueUcPtr2;
+// CHECK-FIXES: unsigned char **mypmypmyucValueUcPtr2;
 
 void MyFunc2(void* Val){}
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for pointer parameter 'Val' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void MyFunc2(void* mypmyvVal){}
+// CHECK-FIXES: void MyFunc2(void* mypmyvVal){}
 
 
 //===----------------------------------------------------------------------===//
@@ -374,16 +374,16 @@ void MyFunc2(void* Val){}
 int myiValueIndex = 1;
 int &RefValueIndex = myiValueIndex;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'RefValueIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int &myiRefValueIndex = myiValueIndex;
+// CHECK-FIXES: int &myiRefValueIndex = myiValueIndex;
 
 const int &ConstRefValue = myiValueIndex;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ConstRefValue' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int &myiConstRefValue = myiValueIndex;
+// CHECK-FIXES: const int &myiConstRefValue = myiValueIndex;
 
 long long myllValueLongLong = 2;
 long long &RefValueLongLong = myllValueLongLong;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'RefValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long &myllRefValueLongLong = myllValueLongLong;
+// CHECK-FIXES: long long &myllRefValueLongLong = myllValueLongLong;
 
 
 //===----------------------------------------------------------------------===//
@@ -391,151 +391,151 @@ long long &RefValueLongLong = myllValueLongLong;
 //===----------------------------------------------------------------------===//
 int8_t ValueI8;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueI8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t myi8ValueI8;
+// CHECK-FIXES: int8_t myi8ValueI8;
 
 int16_t ValueI16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int16_t myi16ValueI16 = 0;
+// CHECK-FIXES: int16_t myi16ValueI16 = 0;
 
 int32_t ValueI32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int32_t myi32ValueI32 = 0;
+// CHECK-FIXES: int32_t myi32ValueI32 = 0;
 
 int64_t ValueI64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int64_t myi64ValueI64 = 0;
+// CHECK-FIXES: int64_t myi64ValueI64 = 0;
 
 uint8_t ValueU8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueU8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t myu8ValueU8 = 0;
+// CHECK-FIXES: uint8_t myu8ValueU8 = 0;
 
 uint16_t ValueU16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint16_t myu16ValueU16 = 0;
+// CHECK-FIXES: uint16_t myu16ValueU16 = 0;
 
 uint32_t ValueU32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint32_t myu32ValueU32 = 0;
+// CHECK-FIXES: uint32_t myu32ValueU32 = 0;
 
 uint64_t ValueU64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint64_t myu64ValueU64 = 0;
+// CHECK-FIXES: uint64_t myu64ValueU64 = 0;
 
 float ValueFloat = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueFloat' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}float myfValueFloat = 0;
+// CHECK-FIXES: float myfValueFloat = 0;
 
 double ValueDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}double mydValueDouble = 0;
+// CHECK-FIXES: double mydValueDouble = 0;
 
 char ValueChar = 'c';
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}char mycValueChar = 'c';
+// CHECK-FIXES: char mycValueChar = 'c';
 
 bool ValueBool = true;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}bool mybValueBool = true;
+// CHECK-FIXES: bool mybValueBool = true;
 
 int ValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'ValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiValueInt = 0;
+// CHECK-FIXES: int myiValueInt = 0;
 
 size_t ValueSize = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSize' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}size_t mynValueSize = 0;
+// CHECK-FIXES: size_t mynValueSize = 0;
 
 wchar_t ValueWchar = 'w';
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueWchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}wchar_t mywcValueWchar = 'w';
+// CHECK-FIXES: wchar_t mywcValueWchar = 'w';
 
 short ValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}short mysValueShort = 0;
+// CHECK-FIXES: short mysValueShort = 0;
 
 unsigned ValueUnsigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueUnsigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned myuValueUnsigned = 0;
+// CHECK-FIXES: unsigned myuValueUnsigned = 0;
 
 signed ValueSigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed mysValueSigned = 0;
+// CHECK-FIXES: signed mysValueSigned = 0;
 
 long ValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long mylValueLong = 0;
+// CHECK-FIXES: long mylValueLong = 0;
 
 long long ValueLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'ValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long myllValueLongLong = 0;
+// CHECK-FIXES: long long myllValueLongLong = 0;
 
 long long int ValueLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long int mylliValueLongLongInt = 0;
+// CHECK-FIXES: long long int mylliValueLongLongInt = 0;
 
 long double ValueLongDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueLongDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long double myldValueLongDouble = 0;
+// CHECK-FIXES: long double myldValueLongDouble = 0;
 
 signed int ValueSignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ValueSignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed int mysiValueSignedInt = 0;
+// CHECK-FIXES: signed int mysiValueSignedInt = 0;
 
 signed short ValueSignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueSignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short myssValueSignedShort = 0;
+// CHECK-FIXES: signed short myssValueSignedShort = 0;
 
 signed short int ValueSignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short int myssiValueSignedShortInt = 0;
+// CHECK-FIXES: signed short int myssiValueSignedShortInt = 0;
 
 signed long long ValueSignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long long mysllValueSignedLongLong = 0;
+// CHECK-FIXES: signed long long mysllValueSignedLongLong = 0;
 
 signed long int ValueSignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global variable 'ValueSignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long int mysliValueSignedLongInt = 0;
+// CHECK-FIXES: signed long int mysliValueSignedLongInt = 0;
 
 signed long ValueSignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueSignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long myslValueSignedLong = 0;
+// CHECK-FIXES: signed long myslValueSignedLong = 0;
 
 unsigned long long int ValueUnsignedLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for global variable 'ValueUnsignedLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long int myulliValueUnsignedLongLongInt = 0;
+// CHECK-FIXES: unsigned long long int myulliValueUnsignedLongLongInt = 0;
 
 unsigned long long ValueUnsignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long myullValueUnsignedLongLong = 0;
+// CHECK-FIXES: unsigned long long myullValueUnsignedLongLong = 0;
 
 unsigned long int ValueUnsignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for global variable 'ValueUnsignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long int myuliValueUnsignedLongInt = 0;
+// CHECK-FIXES: unsigned long int myuliValueUnsignedLongInt = 0;
 
 unsigned long ValueUnsignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long myulValueUnsignedLong = 0;
+// CHECK-FIXES: unsigned long myulValueUnsignedLong = 0;
 
 unsigned short int ValueUnsignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short int myusiValueUnsignedShortInt = 0;
+// CHECK-FIXES: unsigned short int myusiValueUnsignedShortInt = 0;
 
 unsigned short ValueUnsignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'ValueUnsignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short myusValueUnsignedShort = 0;
+// CHECK-FIXES: unsigned short myusValueUnsignedShort = 0;
 
 unsigned int ValueUnsignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueUnsignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned int myuiValueUnsignedInt = 0;
+// CHECK-FIXES: unsigned int myuiValueUnsignedInt = 0;
 
 unsigned char ValueUnsignedChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char myucValueUnsignedChar = 0;
+// CHECK-FIXES: unsigned char myucValueUnsignedChar = 0;
 
 long int ValueLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long int myliValueLongInt = 0;
+// CHECK-FIXES: long int myliValueLongInt = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -543,25 +543,25 @@ long int ValueLongInt = 0;
 //===----------------------------------------------------------------------===//
 volatile int VolatileInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'VolatileInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}volatile int myiVolatileInt = 0;
+// CHECK-FIXES: volatile int myiVolatileInt = 0;
 
 thread_local int ThreadLocalValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ThreadLocalValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}thread_local int myiThreadLocalValueInt = 0;
+// CHECK-FIXES: thread_local int myiThreadLocalValueInt = 0;
 
 extern int ExternValueInt;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ExternValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}extern int myiExternValueInt;
+// CHECK-FIXES: extern int myiExternValueInt;
 
 struct CDataBuffer {
     mutable size_t Size;
 };
 // CHECK-MESSAGES: :[[@LINE-2]]:20: warning: invalid case style for public member 'Size' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}    mutable size_t mynSize;
+// CHECK-FIXES: mutable size_t mynSize;
 
 static constexpr int const &ConstExprInt = 42;
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: invalid case style for constexpr variable 'ConstExprInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static constexpr int const &myiConstExprInt = 42;
+// CHECK-FIXES: static constexpr int const &myiConstExprInt = 42;
 
 
 //===----------------------------------------------------------------------===//
@@ -570,7 +570,7 @@ static constexpr int const &ConstExprInt = 42;
 typedef int INDEX;
 INDEX myiIndex = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'myiIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INDEX Index = 0;
+// CHECK-FIXES: INDEX Index = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -578,100 +578,100 @@ INDEX myiIndex = 0;
 //===----------------------------------------------------------------------===//
 class ClassCase { int Func(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class CClassCase { int Func(); };
+// CHECK-FIXES: class CClassCase { int Func(); };
 
 class AbstractClassCase { virtual int Func() = 0; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'AbstractClassCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class IAbstractClassCase { virtual int Func() = 0; };
+// CHECK-FIXES: class IAbstractClassCase { virtual int Func() = 0; };
 
 class AbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'AbstractClassCase1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class IAbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
+// CHECK-FIXES: class IAbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
 
 class ClassConstantCase { public: static const int myiConstantCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class CClassConstantCase { public: static const int myiConstantCase; };
+// CHECK-FIXES: class CClassConstantCase { public: static const int myiConstantCase; };
 
 struct StructCase { int Func(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for class 'StructCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct CStructCase { int Func(); };
+// CHECK-FIXES: struct CStructCase { int Func(); };
 
 //===----------------------------------------------------------------------===//
 // Other Cases
 //===----------------------------------------------------------------------===//
 int lower_case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiLowerCase = 0;
+// CHECK-FIXES: int myiLowerCase = 0;
 
 int lower_case1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiLowerCase1 = 0;
+// CHECK-FIXES: int myiLowerCase1 = 0;
 
 int lower_case_2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case_2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiLowerCase2 = 0;
+// CHECK-FIXES: int myiLowerCase2 = 0;
 
 int UPPER_CASE = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiUpperCase = 0;
+// CHECK-FIXES: int myiUpperCase = 0;
 
 int UPPER_CASE_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiUpperCase1 = 0;
+// CHECK-FIXES: int myiUpperCase1 = 0;
 
 int camelBack = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelBack = 0;
+// CHECK-FIXES: int myiCamelBack = 0;
 
 int camelBack_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelBack1 = 0;
+// CHECK-FIXES: int myiCamelBack1 = 0;
 
 int camelBack2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelBack2 = 0;
+// CHECK-FIXES: int myiCamelBack2 = 0;
 
 int CamelCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelCase = 0;
+// CHECK-FIXES: int myiCamelCase = 0;
 
 int CamelCase_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelCase1 = 0;
+// CHECK-FIXES: int myiCamelCase1 = 0;
 
 int CamelCase2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelCase2 = 0;
+// CHECK-FIXES: int myiCamelCase2 = 0;
 
 int camel_Snake_Back = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelSnakeBack = 0;
+// CHECK-FIXES: int myiCamelSnakeBack = 0;
 
 int camel_Snake_Back_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelSnakeBack1 = 0;
+// CHECK-FIXES: int myiCamelSnakeBack1 = 0;
 
 int Camel_Snake_Case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelSnakeCase = 0;
+// CHECK-FIXES: int myiCamelSnakeCase = 0;
 
 int Camel_Snake_Case_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int myiCamelSnakeCase1 = 0;
+// CHECK-FIXES: int myiCamelSnakeCase1 = 0;
 
 //===----------------------------------------------------------------------===//
 // Enum
 //===----------------------------------------------------------------------===//
 enum REV_TYPE { RevValid };
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for enum constant 'RevValid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum REV_TYPE { rtRevValid };
+// CHECK-FIXES: enum REV_TYPE { rtRevValid };
 
 enum EnumConstantCase { OneByte, TwoByte };
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for enum constant 'OneByte' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: invalid case style for enum constant 'TwoByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum EnumConstantCase { eccOneByte, eccTwoByte };
+// CHECK-FIXES: enum EnumConstantCase { eccOneByte, eccTwoByte };
 
 enum class ScopedEnumConstantCase { Case1 };
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: invalid case style for scoped enum constant 'Case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum class ScopedEnumConstantCase { seccCase1 };
+// CHECK-FIXES: enum class ScopedEnumConstantCase { seccCase1 };
 // clang-format on

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation.cpp
@@ -11,164 +11,164 @@ class CMyClass1 {
 public:
   static int ClassMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for class member 'ClassMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  static int iClassMemberCase;
+  // CHECK-FIXES: static int iClassMemberCase;
 
   char const ConstantMemberCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for constant member 'ConstantMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char const cConstantMemberCase = 0;
+  // CHECK-FIXES: char const cConstantMemberCase = 0;
 
   void MyFunc1(const int ConstantParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: invalid case style for constant parameter 'ConstantParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void MyFunc1(const int iConstantParameterCase);
+  // CHECK-FIXES: void MyFunc1(const int iConstantParameterCase);
 
   void MyFunc2(const int* ConstantPointerParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: invalid case style for pointer parameter 'ConstantPointerParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void MyFunc2(const int* piConstantPointerParameterCase);
+  // CHECK-FIXES: void MyFunc2(const int* piConstantPointerParameterCase);
 
   static constexpr int ConstexprVariableCase = 123;
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for constexpr variable 'ConstexprVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  static constexpr int iConstexprVariableCase = 123;
+  // CHECK-FIXES: static constexpr int iConstexprVariableCase = 123;
 };
 
 const int GlobalConstantCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global constant 'GlobalConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int iGlobalConstantCase = 0;
+// CHECK-FIXES: const int iGlobalConstantCase = 0;
 
 const int* GlobalConstantPointerCase = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global pointer 'GlobalConstantPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int* piGlobalConstantPointerCase = nullptr;
+// CHECK-FIXES: const int* piGlobalConstantPointerCase = nullptr;
 
 int* GlobalPointerCase = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'GlobalPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int* piGlobalPointerCase = nullptr;
+// CHECK-FIXES: int* piGlobalPointerCase = nullptr;
 
 int GlobalVariableCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iGlobalVariableCase = 0;
+// CHECK-FIXES: int iGlobalVariableCase = 0;
 
 void Func1(){
   int const LocalConstantCase = 3;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for local constant 'LocalConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int const iLocalConstantCase = 3;
+  // CHECK-FIXES: int const iLocalConstantCase = 3;
 
   unsigned const ConstantCase = 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for local constant 'ConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  unsigned const uConstantCase = 1;
+  // CHECK-FIXES: unsigned const uConstantCase = 1;
 
   int* const LocalConstantPointerCase = nullptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for local constant pointer 'LocalConstantPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int* const piLocalConstantPointerCase = nullptr;
+  // CHECK-FIXES: int* const piLocalConstantPointerCase = nullptr;
 
   int *LocalPointerCase = nullptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for local pointer 'LocalPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int *piLocalPointerCase = nullptr;
+  // CHECK-FIXES: int *piLocalPointerCase = nullptr;
 
   int LocalVariableCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for local variable 'LocalVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int iLocalVariableCase = 0;
+  // CHECK-FIXES: int iLocalVariableCase = 0;
 }
 
 class CMyClass2 {
   char MemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for private member 'MemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char cMemberCase;
+  // CHECK-FIXES: char cMemberCase;
 
   void Func1(int ParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for parameter 'ParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func1(int iParameterCase);
+  // CHECK-FIXES: void Func1(int iParameterCase);
 
   void Func2(const int ParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for constant parameter 'ParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func2(const int iParameterCase);
+  // CHECK-FIXES: void Func2(const int iParameterCase);
 
   void Func3(const int *PointerParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for pointer parameter 'PointerParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func3(const int *piPointerParameterCase);
+  // CHECK-FIXES: void Func3(const int *piPointerParameterCase);
 };
 
 class CMyClass3 {
 private:
   char PrivateMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for private member 'PrivateMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char cPrivateMemberCase;
+  // CHECK-FIXES: char cPrivateMemberCase;
 
 protected:
   char ProtectedMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for protected member 'ProtectedMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char cProtectedMemberCase;
+  // CHECK-FIXES: char cProtectedMemberCase;
 
 public:
   char PublicMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for public member 'PublicMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char cPublicMemberCase;
+  // CHECK-FIXES: char cPublicMemberCase;
 };
 
 static const int StaticConstantCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global constant 'StaticConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static const int iStaticConstantCase = 3;
+// CHECK-FIXES: static const int iStaticConstantCase = 3;
 
 static int StaticVariableCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'StaticVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static int iStaticVariableCase = 3;
+// CHECK-FIXES: static int iStaticVariableCase = 3;
 
 struct MyStruct { int StructCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: invalid case style for public member 'StructCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct MyStruct { int iStructCase; };
+// CHECK-FIXES: struct MyStruct { int iStructCase; };
 
 struct shouldBeCamelCaseStruct { int iField; };
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'shouldBeCamelCaseStruct' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct ShouldBeCamelCaseStruct { int iField; };
+// CHECK-FIXES: struct ShouldBeCamelCaseStruct { int iField; };
 
 union MyUnion { int UnionCase; long lUnionCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for union 'MyUnion' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:21: warning: invalid case style for public member 'UnionCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}union myUnion { int iUnionCase; long lUnionCase; };
+// CHECK-FIXES: union myUnion { int iUnionCase; long lUnionCase; };
 
 //===----------------------------------------------------------------------===//
 // C string
 //===----------------------------------------------------------------------===//
 const char *NamePtr = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global pointer 'NamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *szNamePtr = "Name";
+// CHECK-FIXES: const char *szNamePtr = "Name";
 
 const char NameArray[] = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global constant 'NameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char szNameArray[] = "Name";
+// CHECK-FIXES: const char szNameArray[] = "Name";
 
 const char *NamePtrArray[] = {"AA", "BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'NamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *pszNamePtrArray[] = {"AA", "BB"};
+// CHECK-FIXES: const char *pszNamePtrArray[] = {"AA", "BB"};
 
 const wchar_t *WideNamePtr = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'WideNamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *wszWideNamePtr = L"Name";
+// CHECK-FIXES: const wchar_t *wszWideNamePtr = L"Name";
 
 const wchar_t WideNameArray[] = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global constant 'WideNameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t wszWideNameArray[] = L"Name";
+// CHECK-FIXES: const wchar_t wszWideNameArray[] = L"Name";
 
 const wchar_t *WideNamePtrArray[] = {L"AA", L"BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'WideNamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *pwszWideNamePtrArray[] = {L"AA", L"BB"};
+// CHECK-FIXES: const wchar_t *pwszWideNamePtrArray[] = {L"AA", L"BB"};
 
 class CMyClass4 {
 private:
   char *Name = "Text";
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for private member 'Name' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char *szName = "Text";
+  // CHECK-FIXES: char *szName = "Text";
 
   const char *ConstName = "Text";
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for private member 'ConstName' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  const char *szConstName = "Text";
+  // CHECK-FIXES: const char *szConstName = "Text";
 
 public:
   const char* DuplicateString(const char* Input, size_t nRequiredSize);
   // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: invalid case style for pointer parameter 'Input' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  const char* DuplicateString(const char* szInput, size_t nRequiredSize);
+  // CHECK-FIXES: const char* DuplicateString(const char* szInput, size_t nRequiredSize);
 
   size_t UpdateText(const char* Buffer, size_t nBufferSize);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: invalid case style for pointer parameter 'Buffer' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  size_t UpdateText(const char* szBuffer, size_t nBufferSize);
+  // CHECK-FIXES: size_t UpdateText(const char* szBuffer, size_t nBufferSize);
 };
 
 
@@ -177,123 +177,123 @@ public:
 //===----------------------------------------------------------------------===//
 DWORD MsDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD dwMsDword = 0;
+// CHECK-FIXES: DWORD dwMsDword = 0;
 
 BYTE MsByte = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BYTE byMsByte = 0;
+// CHECK-FIXES: BYTE byMsByte = 0;
 
 WORD MsWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD wMsWord = 0;
+// CHECK-FIXES: WORD wMsWord = 0;
 
 BOOL MsBool = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOL bMsBool = 0;
+// CHECK-FIXES: BOOL bMsBool = 0;
 
 BOOLEAN MsBoolean = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsBoolean' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOLEAN bMsBoolean = 0;
+// CHECK-FIXES: BOOLEAN bMsBoolean = 0;
 
 CHAR MsValueChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}CHAR cMsValueChar = 0;
+// CHECK-FIXES: CHAR cMsValueChar = 0;
 
 UCHAR MsValueUchar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UCHAR ucMsValueUchar = 0;
+// CHECK-FIXES: UCHAR ucMsValueUchar = 0;
 
 SHORT MsValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}SHORT sMsValueShort = 0;
+// CHECK-FIXES: SHORT sMsValueShort = 0;
 
 USHORT MsValueUshort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUshort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}USHORT usMsValueUshort = 0;
+// CHECK-FIXES: USHORT usMsValueUshort = 0;
 
 WORD MsValueWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD wMsValueWord = 0;
+// CHECK-FIXES: WORD wMsValueWord = 0;
 
 DWORD MsValueDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD dwMsValueDword = 0;
+// CHECK-FIXES: DWORD dwMsValueDword = 0;
 
 DWORD32 MsValueDword32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD32 dw32MsValueDword32 = 0;
+// CHECK-FIXES: DWORD32 dw32MsValueDword32 = 0;
 
 DWORD64 MsValueDword64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD64 dw64MsValueDword64 = 0;
+// CHECK-FIXES: DWORD64 dw64MsValueDword64 = 0;
 
 LONG MsValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}LONG lMsValueLong = 0;
+// CHECK-FIXES: LONG lMsValueLong = 0;
 
 ULONG MsValueUlong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUlong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG ulMsValueUlong = 0;
+// CHECK-FIXES: ULONG ulMsValueUlong = 0;
 
 ULONG32 MsValueUlong32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG32 ul32MsValueUlong32 = 0;
+// CHECK-FIXES: ULONG32 ul32MsValueUlong32 = 0;
 
 ULONG64 MsValueUlong64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG64 ul64MsValueUlong64 = 0;
+// CHECK-FIXES: ULONG64 ul64MsValueUlong64 = 0;
 
 ULONGLONG MsValueUlongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'MsValueUlongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONGLONG ullMsValueUlongLong = 0;
+// CHECK-FIXES: ULONGLONG ullMsValueUlongLong = 0;
 
 HANDLE MsValueHandle = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'MsValueHandle' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}HANDLE hMsValueHandle = 0;
+// CHECK-FIXES: HANDLE hMsValueHandle = 0;
 
 INT MsValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'MsValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT iMsValueInt = 0;
+// CHECK-FIXES: INT iMsValueInt = 0;
 
 INT8 MsValueInt8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueInt8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT8 i8MsValueInt8 = 0;
+// CHECK-FIXES: INT8 i8MsValueInt8 = 0;
 
 INT16 MsValueInt16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT16 i16MsValueInt16 = 0;
+// CHECK-FIXES: INT16 i16MsValueInt16 = 0;
 
 INT32 MsValueInt32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT32 i32MsValueInt32 = 0;
+// CHECK-FIXES: INT32 i32MsValueInt32 = 0;
 
 INT64 MsValueINt64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueINt64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT64 i64MsValueINt64 = 0;
+// CHECK-FIXES: INT64 i64MsValueINt64 = 0;
 
 UINT MsValueUint = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueUint' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT uiMsValueUint = 0;
+// CHECK-FIXES: UINT uiMsValueUint = 0;
 
 UINT8 MsValueUint8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUint8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT8 u8MsValueUint8 = 0;
+// CHECK-FIXES: UINT8 u8MsValueUint8 = 0;
 
 UINT16 MsValueUint16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT16 u16MsValueUint16 = 0;
+// CHECK-FIXES: UINT16 u16MsValueUint16 = 0;
 
 UINT32 MsValueUint32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT32 u32MsValueUint32 = 0;
+// CHECK-FIXES: UINT32 u32MsValueUint32 = 0;
 
 UINT64 MsValueUint64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT64 u64MsValueUint64 = 0;
+// CHECK-FIXES: UINT64 u64MsValueUint64 = 0;
 
 PVOID MsValuePvoid = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'MsValuePvoid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}PVOID pMsValuePvoid = NULL;
+// CHECK-FIXES: PVOID pMsValuePvoid = NULL;
 
 
 //===----------------------------------------------------------------------===//
@@ -301,19 +301,19 @@ PVOID MsValuePvoid = NULL;
 //===----------------------------------------------------------------------===//
 unsigned GlobalUnsignedArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'GlobalUnsignedArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned aGlobalUnsignedArray[] = {1, 2, 3};
+// CHECK-FIXES: unsigned aGlobalUnsignedArray[] = {1, 2, 3};
 
 int GlobalIntArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalIntArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int aGlobalIntArray[] = {1, 2, 3};
+// CHECK-FIXES: int aGlobalIntArray[] = {1, 2, 3};
 
 int DataInt[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int aDataInt[1] = {0};
+// CHECK-FIXES: int aDataInt[1] = {0};
 
 int DataArray[2] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int aDataArray[2] = {0};
+// CHECK-FIXES: int aDataArray[2] = {0};
 
 
 //===----------------------------------------------------------------------===//
@@ -321,56 +321,56 @@ int DataArray[2] = {0};
 //===----------------------------------------------------------------------===//
 int *DataIntPtr[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'DataIntPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *paDataIntPtr[1] = {0};
+// CHECK-FIXES: int *paDataIntPtr[1] = {0};
 
 void *BufferPtr1;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'BufferPtr1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *pBufferPtr1;
+// CHECK-FIXES: void *pBufferPtr1;
 
 void **BufferPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'BufferPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **ppBufferPtr2;
+// CHECK-FIXES: void **ppBufferPtr2;
 
 void **pBufferPtr3;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'pBufferPtr3' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **ppBufferPtr3;
+// CHECK-FIXES: void **ppBufferPtr3;
 
 int *pBufferPtr4;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'pBufferPtr4' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *piBufferPtr4;
+// CHECK-FIXES: int *piBufferPtr4;
 
 typedef void (*FUNC_PTR_HELLO)();
 FUNC_PTR_HELLO Hello = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'Hello' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}FUNC_PTR_HELLO fnHello = NULL;
+// CHECK-FIXES: FUNC_PTR_HELLO fnHello = NULL;
 
 void *ValueVoidPtr = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'ValueVoidPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *pValueVoidPtr = NULL;
+// CHECK-FIXES: void *pValueVoidPtr = NULL;
 
 ptrdiff_t PtrDiff = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'PtrDiff' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ptrdiff_t pPtrDiff = NULL;
+// CHECK-FIXES: ptrdiff_t pPtrDiff = NULL;
 
 int8_t *ValueI8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global pointer 'ValueI8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t *pi8ValueI8Ptr;
+// CHECK-FIXES: int8_t *pi8ValueI8Ptr;
 
 uint8_t *ValueU8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global pointer 'ValueU8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t *pu8ValueU8Ptr;
+// CHECK-FIXES: uint8_t *pu8ValueU8Ptr;
 
 unsigned char *ValueUcPtr;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'ValueUcPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char *pucValueUcPtr;
+// CHECK-FIXES: unsigned char *pucValueUcPtr;
 
 unsigned char **ValueUcPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global pointer 'ValueUcPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char **ppucValueUcPtr2;
+// CHECK-FIXES: unsigned char **ppucValueUcPtr2;
 
 void MyFunc2(void* Val){}
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for pointer parameter 'Val' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void MyFunc2(void* pVal){}
+// CHECK-FIXES: void MyFunc2(void* pVal){}
 
 
 //===----------------------------------------------------------------------===//
@@ -379,16 +379,16 @@ void MyFunc2(void* Val){}
 int iValueIndex = 1;
 int &RefValueIndex = iValueIndex;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'RefValueIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int &iRefValueIndex = iValueIndex;
+// CHECK-FIXES: int &iRefValueIndex = iValueIndex;
 
 const int &ConstRefValue = iValueIndex;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ConstRefValue' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int &iConstRefValue = iValueIndex;
+// CHECK-FIXES: const int &iConstRefValue = iValueIndex;
 
 long long llValueLongLong = 2;
 long long &RefValueLongLong = llValueLongLong;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'RefValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long &llRefValueLongLong = llValueLongLong;
+// CHECK-FIXES: long long &llRefValueLongLong = llValueLongLong;
 
 
 //===----------------------------------------------------------------------===//
@@ -396,151 +396,151 @@ long long &RefValueLongLong = llValueLongLong;
 //===----------------------------------------------------------------------===//
 int8_t ValueI8;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueI8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t i8ValueI8;
+// CHECK-FIXES: int8_t i8ValueI8;
 
 int16_t ValueI16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int16_t i16ValueI16 = 0;
+// CHECK-FIXES: int16_t i16ValueI16 = 0;
 
 int32_t ValueI32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int32_t i32ValueI32 = 0;
+// CHECK-FIXES: int32_t i32ValueI32 = 0;
 
 int64_t ValueI64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int64_t i64ValueI64 = 0;
+// CHECK-FIXES: int64_t i64ValueI64 = 0;
 
 uint8_t ValueU8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueU8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t u8ValueU8 = 0;
+// CHECK-FIXES: uint8_t u8ValueU8 = 0;
 
 uint16_t ValueU16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint16_t u16ValueU16 = 0;
+// CHECK-FIXES: uint16_t u16ValueU16 = 0;
 
 uint32_t ValueU32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint32_t u32ValueU32 = 0;
+// CHECK-FIXES: uint32_t u32ValueU32 = 0;
 
 uint64_t ValueU64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint64_t u64ValueU64 = 0;
+// CHECK-FIXES: uint64_t u64ValueU64 = 0;
 
 float ValueFloat = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueFloat' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}float fValueFloat = 0;
+// CHECK-FIXES: float fValueFloat = 0;
 
 double ValueDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}double dValueDouble = 0;
+// CHECK-FIXES: double dValueDouble = 0;
 
 char ValueChar = 'c';
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}char cValueChar = 'c';
+// CHECK-FIXES: char cValueChar = 'c';
 
 bool ValueBool = true;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}bool bValueBool = true;
+// CHECK-FIXES: bool bValueBool = true;
 
 int ValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'ValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iValueInt = 0;
+// CHECK-FIXES: int iValueInt = 0;
 
 size_t ValueSize = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSize' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}size_t nValueSize = 0;
+// CHECK-FIXES: size_t nValueSize = 0;
 
 wchar_t ValueWchar = 'w';
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueWchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}wchar_t wcValueWchar = 'w';
+// CHECK-FIXES: wchar_t wcValueWchar = 'w';
 
 short ValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}short sValueShort = 0;
+// CHECK-FIXES: short sValueShort = 0;
 
 unsigned ValueUnsigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueUnsigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned uValueUnsigned = 0;
+// CHECK-FIXES: unsigned uValueUnsigned = 0;
 
 signed ValueSigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed sValueSigned = 0;
+// CHECK-FIXES: signed sValueSigned = 0;
 
 long ValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long lValueLong = 0;
+// CHECK-FIXES: long lValueLong = 0;
 
 long long ValueLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'ValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long llValueLongLong = 0;
+// CHECK-FIXES: long long llValueLongLong = 0;
 
 long long int ValueLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long int lliValueLongLongInt = 0;
+// CHECK-FIXES: long long int lliValueLongLongInt = 0;
 
 long double ValueLongDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueLongDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long double ldValueLongDouble = 0;
+// CHECK-FIXES: long double ldValueLongDouble = 0;
 
 signed int ValueSignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ValueSignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed int siValueSignedInt = 0;
+// CHECK-FIXES: signed int siValueSignedInt = 0;
 
 signed short ValueSignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueSignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short ssValueSignedShort = 0;
+// CHECK-FIXES: signed short ssValueSignedShort = 0;
 
 signed short int ValueSignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short int ssiValueSignedShortInt = 0;
+// CHECK-FIXES: signed short int ssiValueSignedShortInt = 0;
 
 signed long long ValueSignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long long sllValueSignedLongLong = 0;
+// CHECK-FIXES: signed long long sllValueSignedLongLong = 0;
 
 signed long int ValueSignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global variable 'ValueSignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long int sliValueSignedLongInt = 0;
+// CHECK-FIXES: signed long int sliValueSignedLongInt = 0;
 
 signed long ValueSignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueSignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long slValueSignedLong = 0;
+// CHECK-FIXES: signed long slValueSignedLong = 0;
 
 unsigned long long int ValueUnsignedLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for global variable 'ValueUnsignedLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long int ulliValueUnsignedLongLongInt = 0;
+// CHECK-FIXES: unsigned long long int ulliValueUnsignedLongLongInt = 0;
 
 unsigned long long ValueUnsignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long ullValueUnsignedLongLong = 0;
+// CHECK-FIXES: unsigned long long ullValueUnsignedLongLong = 0;
 
 unsigned long int ValueUnsignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for global variable 'ValueUnsignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long int uliValueUnsignedLongInt = 0;
+// CHECK-FIXES: unsigned long int uliValueUnsignedLongInt = 0;
 
 unsigned long ValueUnsignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long ulValueUnsignedLong = 0;
+// CHECK-FIXES: unsigned long ulValueUnsignedLong = 0;
 
 unsigned short int ValueUnsignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short int usiValueUnsignedShortInt = 0;
+// CHECK-FIXES: unsigned short int usiValueUnsignedShortInt = 0;
 
 unsigned short ValueUnsignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'ValueUnsignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short usValueUnsignedShort = 0;
+// CHECK-FIXES: unsigned short usValueUnsignedShort = 0;
 
 unsigned int ValueUnsignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueUnsignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned int uiValueUnsignedInt = 0;
+// CHECK-FIXES: unsigned int uiValueUnsignedInt = 0;
 
 unsigned char ValueUnsignedChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char ucValueUnsignedChar = 0;
+// CHECK-FIXES: unsigned char ucValueUnsignedChar = 0;
 
 long int ValueLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long int liValueLongInt = 0;
+// CHECK-FIXES: long int liValueLongInt = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -548,25 +548,25 @@ long int ValueLongInt = 0;
 //===----------------------------------------------------------------------===//
 volatile int VolatileInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'VolatileInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}volatile int iVolatileInt = 0;
+// CHECK-FIXES: volatile int iVolatileInt = 0;
 
 thread_local int ThreadLocalValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ThreadLocalValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}thread_local int iThreadLocalValueInt = 0;
+// CHECK-FIXES: thread_local int iThreadLocalValueInt = 0;
 
 extern int ExternValueInt;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ExternValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}extern int iExternValueInt;
+// CHECK-FIXES: extern int iExternValueInt;
 
 struct DataBuffer {
     mutable size_t Size;
 };
 // CHECK-MESSAGES: :[[@LINE-2]]:20: warning: invalid case style for public member 'Size' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}    mutable size_t nSize;
+// CHECK-FIXES: mutable size_t nSize;
 
 static constexpr int const &ConstExprInt = 42;
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: invalid case style for constexpr variable 'ConstExprInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static constexpr int const &iConstExprInt = 42;
+// CHECK-FIXES: static constexpr int const &iConstExprInt = 42;
 
 
 //===----------------------------------------------------------------------===//
@@ -575,7 +575,7 @@ static constexpr int const &ConstExprInt = 42;
 typedef int INDEX;
 INDEX iIndex = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'iIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INDEX Index = 0;
+// CHECK-FIXES: INDEX Index = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -583,96 +583,96 @@ INDEX iIndex = 0;
 //===----------------------------------------------------------------------===//
 class ClassCase { int Func(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class CClassCase { int Func(); };
+// CHECK-FIXES: class CClassCase { int Func(); };
 
 class AbstractClassCase { virtual int Func() = 0; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'AbstractClassCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class IAbstractClassCase { virtual int Func() = 0; };
+// CHECK-FIXES: class IAbstractClassCase { virtual int Func() = 0; };
 
 class AbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'AbstractClassCase1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class IAbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
+// CHECK-FIXES: class IAbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
 
 class ClassConstantCase { public: static const int iConstantCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class CClassConstantCase { public: static const int iConstantCase; };
+// CHECK-FIXES: class CClassConstantCase { public: static const int iConstantCase; };
 
 //===----------------------------------------------------------------------===//
 // Other Cases
 //===----------------------------------------------------------------------===//
 int lower_case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iLowerCase = 0;
+// CHECK-FIXES: int iLowerCase = 0;
 
 int lower_case1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iLowerCase1 = 0;
+// CHECK-FIXES: int iLowerCase1 = 0;
 
 int lower_case_2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case_2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iLowerCase2 = 0;
+// CHECK-FIXES: int iLowerCase2 = 0;
 
 int UPPER_CASE = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iUpperCase = 0;
+// CHECK-FIXES: int iUpperCase = 0;
 
 int UPPER_CASE_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iUpperCase1 = 0;
+// CHECK-FIXES: int iUpperCase1 = 0;
 
 int camelBack = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelBack = 0;
+// CHECK-FIXES: int iCamelBack = 0;
 
 int camelBack_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelBack1 = 0;
+// CHECK-FIXES: int iCamelBack1 = 0;
 
 int camelBack2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelBack2 = 0;
+// CHECK-FIXES: int iCamelBack2 = 0;
 
 int CamelCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelCase = 0;
+// CHECK-FIXES: int iCamelCase = 0;
 
 int CamelCase_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelCase1 = 0;
+// CHECK-FIXES: int iCamelCase1 = 0;
 
 int CamelCase2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelCase2 = 0;
+// CHECK-FIXES: int iCamelCase2 = 0;
 
 int camel_Snake_Back = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeBack = 0;
+// CHECK-FIXES: int iCamelSnakeBack = 0;
 
 int camel_Snake_Back_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeBack1 = 0;
+// CHECK-FIXES: int iCamelSnakeBack1 = 0;
 
 int Camel_Snake_Case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeCase = 0;
+// CHECK-FIXES: int iCamelSnakeCase = 0;
 
 int Camel_Snake_Case_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int iCamelSnakeCase1 = 0;
+// CHECK-FIXES: int iCamelSnakeCase1 = 0;
 
 //===----------------------------------------------------------------------===//
 // Enum
 //===----------------------------------------------------------------------===//
 enum REV_TYPE { RevValid };
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for enum constant 'RevValid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum REV_TYPE { rtRevValid };
+// CHECK-FIXES: enum REV_TYPE { rtRevValid };
 
 enum EnumConstantCase { OneByte, TwoByte };
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for enum constant 'OneByte' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: invalid case style for enum constant 'TwoByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum EnumConstantCase { eccOneByte, eccTwoByte };
+// CHECK-FIXES: enum EnumConstantCase { eccOneByte, eccTwoByte };
 
 enum class ScopedEnumConstantCase { Case1 };
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: invalid case style for scoped enum constant 'Case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum class ScopedEnumConstantCase { seccCase1 };
+// CHECK-FIXES: enum class ScopedEnumConstantCase { seccCase1 };
 // clang-format on

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-ignored-regexp.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-ignored-regexp.cpp
@@ -13,11 +13,11 @@ int testFunc(int ab, char **ba);
 int testFunc(int abc, char **cba);
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for parameter 'abc'
 // CHECK-MESSAGES: :[[@LINE-2]]:30: warning: invalid case style for parameter 'cba'
-// CHECK-FIXES: {{^}}int testFunc(int Abc, char **Cba);{{$}}
+// CHECK-FIXES: int testFunc(int Abc, char **Cba);
 int testFunc(int dE, char **eD);
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for parameter 'dE'
 // CHECK-MESSAGES: :[[@LINE-2]]:29: warning: invalid case style for parameter 'eD'
-// CHECK-FIXES: {{^}}int testFunc(int DE, char **ED);{{$}}
+// CHECK-FIXES: int testFunc(int DE, char **ED);
 int testFunc(int Abc, char **Cba);
 
 class fo {
@@ -25,12 +25,12 @@ class fo {
 
 class fofo {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'fofo'
-  // CHECK-FIXES: {{^}}class Fofo {{{$}}
+  // CHECK-FIXES: class Fofo {
 };
 
 class foo {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'foo'
-  // CHECK-FIXES: {{^}}class Foo {{{$}}
+  // CHECK-FIXES: class Foo {
 };
 
 class fooo {
@@ -38,10 +38,10 @@ class fooo {
 
 class afooo {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'afooo'
-  // CHECK-FIXES: {{^}}class Afooo {{{$}}
+  // CHECK-FIXES: class Afooo {
 };
 
 struct soo {
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'soo'
-  // CHECK-FIXES: {{^}}struct Soo {{{$}}
+  // CHECK-FIXES: struct Soo {
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-member-decl-usage.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-member-decl-usage.cpp
@@ -13,41 +13,41 @@ class Foo {
 public:
   const int bar_baz; // comment-0
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for member 'bar_baz'
-  // CHECK-FIXES: {{^}}  const int BarBaz; // comment-0
+  // CHECK-FIXES: const int BarBaz; // comment-0
 
   Foo(int Val) : bar_baz(Val) { // comment-1
-    // CHECK-FIXES: {{^}}  Foo(int Val) : BarBaz(Val) { // comment-1
+    // CHECK-FIXES: Foo(int Val) : BarBaz(Val) { // comment-1
     set_up(bar_baz); // comment-2
-    // CHECK-FIXES: {{^}}    set_up(BarBaz); // comment-2
+    // CHECK-FIXES: set_up(BarBaz); // comment-2
   }
 
   Foo() : Foo(0) {}
 
   ~Foo() {
     clear(bar_baz); // comment-3
-    // CHECK-FIXES: {{^}}    clear(BarBaz); // comment-3
+    // CHECK-FIXES: clear(BarBaz); // comment-3
   }
 
   int getBar() const { return bar_baz; } // comment-4
-  // CHECK-FIXES: {{^}}  int getBar() const { return BarBaz; } // comment-4
+  // CHECK-FIXES: int getBar() const { return BarBaz; } // comment-4
 };
 
 class FooBar : public Foo {
 public:
   int getFancyBar() const {
     return this->bar_baz; // comment-5
-    // CHECK-FIXES: {{^}}    return this->BarBaz; // comment-5
+    // CHECK-FIXES: return this->BarBaz; // comment-5
   }
 };
 
 int getBar(const Foo &Foo) {
   return Foo.bar_baz; // comment-6
-  // CHECK-FIXES: {{^}}  return Foo.BarBaz; // comment-6
+  // CHECK-FIXES: return Foo.BarBaz; // comment-6
 }
 
 int getBar(const FooBar &Foobar) {
   return Foobar.bar_baz; // comment-7
-  // CHECK-FIXES: {{^}}  return Foobar.BarBaz; // comment-7
+  // CHECK-FIXES: return Foobar.BarBaz; // comment-7
 }
 
 int getFancyBar(const FooBar &Foobar) {
@@ -60,9 +60,9 @@ public:
   TempTest() = default;
   TempTest(int Val) : Foo(Val) {}
   int getBar() const { return Foo::bar_baz; } // comment-8
-  // CHECK-FIXES: {{^}}  int getBar() const { return Foo::BarBaz; } // comment-8
+  // CHECK-FIXES: int getBar() const { return Foo::BarBaz; } // comment-8
   int getBar2() const { return this->bar_baz; } // comment-9
-  // CHECK-FIXES: {{^}}  int getBar2() const { return this->BarBaz; } // comment-9
+  // CHECK-FIXES: int getBar2() const { return this->BarBaz; } // comment-9
 };
 
 namespace Bug41122 {
@@ -82,15 +82,15 @@ class Foo {
 public:
   Foo(std::vector<bool> &stack)
       // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: invalid case style for parameter 'stack' [readability-identifier-naming]
-      // CHECK-FIXES: {{^}}  Foo(std::vector<bool> &Stack)
+      // CHECK-FIXES: Foo(std::vector<bool> &Stack)
       : stack(stack) {
-    // CHECK-FIXES: {{^}}      : Stack(Stack) {
+    // CHECK-FIXES: : Stack(Stack) {
     stack.push_back(true);
-    // CHECK-FIXES: {{^}}    Stack.push_back(true);
+    // CHECK-FIXES: Stack.push_back(true);
   }
   ~Foo() {
     stack.pop_back();
-    // CHECK-FIXES: {{^}}    Stack.pop_back();
+    // CHECK-FIXES: Stack.pop_back();
   }
 };
 }; // namespace Bug41122
@@ -100,13 +100,13 @@ class Foo {
 public:
   int a_member_of_foo = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for member 'a_member_of_foo'
-  // CHECK-FIXES: {{^}}  int AMemberOfFoo = 0;
+  // CHECK-FIXES: int AMemberOfFoo = 0;
 };
 
 int main() {
   Foo foo;
   return foo.a_member_of_foo;
-  // CHECK-FIXES: {{^}}  return foo.AMemberOfFoo;
+  // CHECK-FIXES: return foo.AMemberOfFoo;
 }
 }; // namespace Bug29005
 
@@ -115,13 +115,13 @@ template <typename T, unsigned N>
 class Container {
   T storage[N];
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for member 'storage'
-  // CHECK-FIXES: {{^}}  T Storage[N];
+  // CHECK-FIXES: T Storage[N];
   T *pointer = &storage[0];
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for member 'pointer'
-  // CHECK-FIXES: {{^}}  T *Pointer = &Storage[0];
+  // CHECK-FIXES: T *Pointer = &Storage[0];
 public:
   Container() : pointer(&storage[0]) {}
-  // CHECK-FIXES: {{^}}  Container() : Pointer(&Storage[0]) {}
+  // CHECK-FIXES: Container() : Pointer(&Storage[0]) {}
 };
 
 void foo() {
@@ -137,8 +137,8 @@ struct A0 {
   A0 &operator=(const A0 &Other) {
     value = Other.value;       // A0
     this->value = Other.value; // A0
-    // CHECK-FIXES:      {{^}}    Value = Other.Value;       // A0
-    // CHECK-FIXES-NEXT: {{^}}    this->Value = Other.Value; // A0
+    // CHECK-FIXES:      Value = Other.Value;       // A0
+    // CHECK-FIXES-NEXT: this->Value = Other.Value; // A0
     return *this;
   }
   void outOfLineReset();
@@ -147,14 +147,14 @@ struct A0 {
 template <typename T>
 void A0<T>::outOfLineReset() {
   this->value -= value; // A0
-  // CHECK-FIXES: {{^}}  this->Value -= Value; // A0
+  // CHECK-FIXES: this->Value -= Value; // A0
 }
 
 template <typename T>
 struct A1 {
   int value; // A1
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for member 'value'
-  // CHECK-FIXES: {{^}}  int Value; // A1
+  // CHECK-FIXES: int Value; // A1
   int GetValue() const { return value; } // A1
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for method 'GetValue'
   // CHECK-FIXES {{^}}  int getValue() const { return Value; } // A1
@@ -164,8 +164,8 @@ struct A1 {
   A1 &operator=(const A1 &Other) {
     this->SetValue(Other.GetValue()); // A1
     this->value = Other.value;        // A1
-    // CHECK-FIXES:      {{^}}    this->setValue(Other.getValue()); // A1
-    // CHECK-FIXES-NEXT: {{^}}    this->Value = Other.Value;        // A1
+    // CHECK-FIXES:      this->setValue(Other.getValue()); // A1
+    // CHECK-FIXES-NEXT: this->Value = Other.Value;        // A1
     return *this;
   }
   void outOfLineReset();
@@ -174,19 +174,19 @@ struct A1 {
 template <typename T>
 void A1<T>::outOfLineReset() {
   this->value -= value; // A1
-  // CHECK-FIXES: {{^}}  this->Value -= Value; // A1
+  // CHECK-FIXES: this->Value -= Value; // A1
 }
 
 template <unsigned T>
 struct A2 {
   int value; // A2
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for member 'value'
-  // CHECK-FIXES: {{^}}  int Value; // A2
+  // CHECK-FIXES: int Value; // A2
   A2 &operator=(const A2 &Other) {
     value = Other.value;       // A2
     this->value = Other.value; // A2
-    // CHECK-FIXES:      {{^}}    Value = Other.Value;       // A2
-    // CHECK-FIXES-NEXT: {{^}}    this->Value = Other.Value; // A2
+    // CHECK-FIXES:      Value = Other.Value;       // A2
+    // CHECK-FIXES-NEXT: this->Value = Other.Value; // A2
     return *this;
   }
 };
@@ -203,14 +203,14 @@ template <typename T>
 struct DependentBase {
   int depValue;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for member 'depValue'
-  // CHECK-FIXES:  {{^}}  int DepValue;
+  // CHECK-FIXES:  int DepValue;
 };
 
 template <typename T>
 struct Derived : DependentBase<T> {
   Derived &operator=(const Derived &Other) {
     this->depValue = Other.depValue;
-    // CHECK-FIXES: {{^}}    this->DepValue = Other.DepValue;
+    // CHECK-FIXES: this->DepValue = Other.DepValue;
     return *this;
   }
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-member-decl-usage.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-member-decl-usage.cpp
@@ -203,7 +203,7 @@ template <typename T>
 struct DependentBase {
   int depValue;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for member 'depValue'
-  // CHECK-FIXES:  int DepValue;
+  // CHECK-FIXES: int DepValue;
 };
 
 template <typename T>

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -96,14 +96,14 @@
 
 namespace FOO_NS {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for namespace 'FOO_NS' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}namespace foo_ns {{{$}}
+// CHECK-FIXES: namespace foo_ns {
 inline namespace InlineNamespace {
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for inline namespace 'InlineNamespace'
-// CHECK-FIXES: {{^}}inline namespace inline_namespace {{{$}}
+// CHECK-FIXES: inline namespace inline_namespace {
 
 namespace FOO_ALIAS = FOO_NS;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for namespace 'FOO_ALIAS' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}namespace foo_alias = FOO_NS;{{$}}
+// CHECK-FIXES: namespace foo_alias = FOO_NS;
 
 SYSTEM_NS::structure g_s1;
 // NO warnings or fixes expected as SYSTEM_NS and structure are declared in a header file
@@ -113,11 +113,11 @@ USER_NS::object g_s2;
 
 SYSTEM_MACRO(var1);
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'var1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}SYSTEM_MACRO(g_var1);
+// CHECK-FIXES: SYSTEM_MACRO(g_var1);
 
 USER_MACRO(var2);
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'var2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}USER_MACRO(g_var2);
+// CHECK-FIXES: USER_MACRO(g_var2);
 
 #define BLA int FOO_bar
 BLA;
@@ -144,116 +144,116 @@ USE_RECONSTRUCTED(glo, bal2);
 
 int global;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'global'
-// CHECK-FIXES: {{^}}int g_global;{{$}}
+// CHECK-FIXES: int g_global;
 #define USE_IN_MACRO(m) auto use_##m = m
 USE_IN_MACRO(global);
 
 int global3;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'global3'
-// CHECK-FIXES: {{^}}int g_global3;{{$}}
+// CHECK-FIXES: int g_global3;
 #define ADD_TO_SELF(m) (m) + (m)
 int g_twice_global3 = ADD_TO_SELF(global3);
-// CHECK-FIXES: {{^}}int g_twice_global3 = ADD_TO_SELF(g_global3);{{$}}
+// CHECK-FIXES: int g_twice_global3 = ADD_TO_SELF(g_global3);
 
 int g_Global4;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'g_Global4'
-// CHECK-FIXES: {{^}}int g_global4;{{$}}
+// CHECK-FIXES: int g_global4;
 
 enum my_enumeration {
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for enum 'my_enumeration'
-// CHECK-FIXES: {{^}}enum EMyEnumeration {{{$}}
+// CHECK-FIXES: enum EMyEnumeration {
     MyConstant = 1,
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for enum constant 'MyConstant'
-// CHECK-FIXES: {{^}}    MY_CONSTANT = 1,{{$}}
+// CHECK-FIXES: MY_CONSTANT = 1,
     your_CONST = 1,
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for enum constant 'your_CONST'
-// CHECK-FIXES: {{^}}    YOUR_CONST = 1,{{$}}
+// CHECK-FIXES: YOUR_CONST = 1,
     THIS_ConstValue = 1,
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for enum constant 'THIS_ConstValue'
-// CHECK-FIXES: {{^}}    THIS_CONST_VALUE = 1,{{$}}
+// CHECK-FIXES: THIS_CONST_VALUE = 1,
 };
 
 enum class EMyEnumeration {
     myConstant = 1,
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for scoped enum constant 'myConstant'
-// CHECK-FIXES: {{^}}    MyConstant = 1,{{$}}
+// CHECK-FIXES: MyConstant = 1,
     your_CONST = 1,
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for scoped enum constant 'your_CONST'
-// CHECK-FIXES: {{^}}    YourConst = 1,{{$}}
+// CHECK-FIXES: YourConst = 1,
     THIS_ConstValue = 1,
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for scoped enum constant 'THIS_ConstValue'
-// CHECK-FIXES: {{^}}    ThisConstValue = 1,{{$}}
+// CHECK-FIXES: ThisConstValue = 1,
 };
 
 constexpr int ConstExpr_variable = MyConstant;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for constexpr variable 'ConstExpr_variable'
-// CHECK-FIXES: {{^}}constexpr int const_expr_variable = MY_CONSTANT;{{$}}
+// CHECK-FIXES: constexpr int const_expr_variable = MY_CONSTANT;
 
 class my_class {
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'my_class'
-// CHECK-FIXES: {{^}}class CMyClass {{{$}}
+// CHECK-FIXES: class CMyClass {
 public:
     my_class();
-// CHECK-FIXES: {{^}}    CMyClass();{{$}}
+// CHECK-FIXES: CMyClass();
 
     my_class(void*) : my_class() {}
-// CHECK-FIXES: {{^}}    CMyClass(void*) : CMyClass() {}{{$}}
+// CHECK-FIXES: CMyClass(void*) : CMyClass() {}
 
     ~
       my_class();
 // (space in destructor token test, we could check trigraph but they will be deprecated)
-// CHECK-FIXES: {{^}}    ~{{$}}
-// CHECK-FIXES: {{^}}      CMyClass();{{$}}
+// CHECK-FIXES: ~
+// CHECK-FIXES:   CMyClass();
 
 private:
   const int MEMBER_one_1 = ConstExpr_variable;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for constant member 'MEMBER_one_1'
-// CHECK-FIXES: {{^}}  const int member_one_1 = const_expr_variable;{{$}}
+// CHECK-FIXES: const int member_one_1 = const_expr_variable;
   int member2 = 2;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for private member 'member2'
-// CHECK-FIXES: {{^}}  int __member2 = 2;{{$}}
+// CHECK-FIXES: int __member2 = 2;
   int _memberWithExtraUnderscores_ = 42;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for private member '_memberWithExtraUnderscores_'
-// CHECK-FIXES: {{^}}  int __memberWithExtraUnderscores = 42;{{$}}
+// CHECK-FIXES: int __memberWithExtraUnderscores = 42;
 
 private:
     int private_member = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for private member 'private_member'
-// CHECK-FIXES: {{^}}    int __private_member = 3;{{$}}
+// CHECK-FIXES: int __private_member = 3;
 
 protected:
     int ProtMember;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for protected member 'ProtMember'
-// CHECK-FIXES: {{^}}    int _ProtMember;{{$}}
+// CHECK-FIXES: int _ProtMember;
 
 public:
     int PubMem;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for public member 'PubMem'
-// CHECK-FIXES: {{^}}    int pub_mem;{{$}}
+// CHECK-FIXES: int pub_mem;
 
     static const int classConstant;
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: invalid case style for class constant 'classConstant'
-// CHECK-FIXES: {{^}}    static const int kClassConstant;{{$}}
+// CHECK-FIXES: static const int kClassConstant;
     static int ClassMember_2;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for class member 'ClassMember_2'
-// CHECK-FIXES: {{^}}    static int ClassMember2;{{$}}
+// CHECK-FIXES: static int ClassMember2;
 };
 class my_class;
 // No warning needed here as this is tied to the previous declaration.
 // Just make sure the fix is applied.
-// CHECK-FIXES: {{^}}class CMyClass;{{$}}
+// CHECK-FIXES: class CMyClass;
 
 class my_forward_declared_class; // No warning should be triggered.
 
 const int my_class::classConstant = 4;
-// CHECK-FIXES: {{^}}const int CMyClass::kClassConstant = 4;{{$}}
+// CHECK-FIXES: const int CMyClass::kClassConstant = 4;
 
 int my_class::ClassMember_2 = 5;
-// CHECK-FIXES: {{^}}int CMyClass::ClassMember2 = 5;{{$}}
+// CHECK-FIXES: int CMyClass::ClassMember2 = 5;
 
 class my_derived_class : public virtual my_class {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'my_derived_class'
-// CHECK-FIXES: {{^}}class CMyDerivedClass : public virtual CMyClass {};{{$}}
+// CHECK-FIXES: class CMyDerivedClass : public virtual CMyClass {};
 
 class CMyWellNamedClass {};
 // No warning expected as this class is well named.
@@ -265,26 +265,26 @@ concept MyConcept = requires (t_t a_t) { {a_t++}; };
 template<typename t_t>
 concept my_concept_2 = requires (t_t a_t) { {a_t++}; };
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for concept 'my_concept_2'
-// CHECK-FIXES: {{^}}concept MyConcept2 = requires (t_t a_t) { {a_t++}; };{{$}}
+// CHECK-FIXES: concept MyConcept2 = requires (t_t a_t) { {a_t++}; };
 
 template <typename t_t>
 class CMyWellNamedClass2 : public my_class {
-  // CHECK-FIXES: {{^}}class CMyWellNamedClass2 : public CMyClass {{{$}}
+  // CHECK-FIXES: class CMyWellNamedClass2 : public CMyClass {
   t_t my_Bad_Member;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for private member 'my_Bad_Member'
-  // CHECK-FIXES: {{^}}  t_t __my_Bad_Member;{{$}}
+  // CHECK-FIXES: t_t __my_Bad_Member;
   int my_Other_Bad_Member = 42;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for private member 'my_Other_Bad_Member'
-  // CHECK-FIXES: {{^}}  int __my_Other_Bad_Member = 42;{{$}}
+  // CHECK-FIXES: int __my_Other_Bad_Member = 42;
 public:
   CMyWellNamedClass2() = default;
   CMyWellNamedClass2(CMyWellNamedClass2 const&) = default;
   CMyWellNamedClass2(CMyWellNamedClass2 &&) = default;
   CMyWellNamedClass2(t_t a_v, void *p_p) : my_class(p_p), my_Bad_Member(a_v) {}
-  // CHECK-FIXES: {{^}}  CMyWellNamedClass2(t_t a_v, void *p_p) : CMyClass(p_p), __my_Bad_Member(a_v) {}{{$}}
+  // CHECK-FIXES: CMyWellNamedClass2(t_t a_v, void *p_p) : CMyClass(p_p), __my_Bad_Member(a_v) {}
 
   CMyWellNamedClass2(t_t a_v) : my_class(), my_Bad_Member(a_v), my_Other_Bad_Member(11) {}
-  // CHECK-FIXES: {{^}}  CMyWellNamedClass2(t_t a_v) : CMyClass(), __my_Bad_Member(a_v), __my_Other_Bad_Member(11) {}{{$}}
+  // CHECK-FIXES: CMyWellNamedClass2(t_t a_v) : CMyClass(), __my_Bad_Member(a_v), __my_Other_Bad_Member(11) {}
 };
 void InstantiateClassMethods() {
   // Ensure we trigger the instantiation of each constructor
@@ -300,40 +300,40 @@ public:
   virtual ~AOverridden() = default;
   virtual void BadBaseMethod() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for virtual method 'BadBaseMethod'
-  // CHECK-FIXES: {{^}}  virtual void v_Bad_Base_Method() = 0;
+  // CHECK-FIXES: virtual void v_Bad_Base_Method() = 0;
 
   virtual void BadBaseMethodNoAttr() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for virtual method 'BadBaseMethodNoAttr'
-  // CHECK-FIXES: {{^}}  virtual void v_Bad_Base_Method_No_Attr() = 0;
+  // CHECK-FIXES: virtual void v_Bad_Base_Method_No_Attr() = 0;
 };
 
 class COverriding : public AOverridden {
 public:
   // Overriding a badly-named base isn't a new violation.
   void BadBaseMethod() override {}
-  // CHECK-FIXES: {{^}}  void v_Bad_Base_Method() override {}
+  // CHECK-FIXES: void v_Bad_Base_Method() override {}
 
   void BadBaseMethodNoAttr() /* override */ {}
-  // CHECK-FIXES: {{^}}  void v_Bad_Base_Method_No_Attr() /* override */ {}
+  // CHECK-FIXES: void v_Bad_Base_Method_No_Attr() /* override */ {}
 
   void foo() {
     BadBaseMethod();
-    // CHECK-FIXES: {{^}}    v_Bad_Base_Method();
+    // CHECK-FIXES: v_Bad_Base_Method();
     this->BadBaseMethod();
-    // CHECK-FIXES: {{^}}    this->v_Bad_Base_Method();
+    // CHECK-FIXES: this->v_Bad_Base_Method();
     AOverridden::BadBaseMethod();
-    // CHECK-FIXES: {{^}}    AOverridden::v_Bad_Base_Method();
+    // CHECK-FIXES: AOverridden::v_Bad_Base_Method();
     COverriding::BadBaseMethod();
-    // CHECK-FIXES: {{^}}    COverriding::v_Bad_Base_Method();
+    // CHECK-FIXES: COverriding::v_Bad_Base_Method();
 
     BadBaseMethodNoAttr();
-    // CHECK-FIXES: {{^}}    v_Bad_Base_Method_No_Attr();
+    // CHECK-FIXES: v_Bad_Base_Method_No_Attr();
     this->BadBaseMethodNoAttr();
-    // CHECK-FIXES: {{^}}    this->v_Bad_Base_Method_No_Attr();
+    // CHECK-FIXES: this->v_Bad_Base_Method_No_Attr();
     AOverridden::BadBaseMethodNoAttr();
-    // CHECK-FIXES: {{^}}    AOverridden::v_Bad_Base_Method_No_Attr();
+    // CHECK-FIXES: AOverridden::v_Bad_Base_Method_No_Attr();
     COverriding::BadBaseMethodNoAttr();
-    // CHECK-FIXES: {{^}}    COverriding::v_Bad_Base_Method_No_Attr();
+    // CHECK-FIXES: COverriding::v_Bad_Base_Method_No_Attr();
   }
 };
 
@@ -343,11 +343,11 @@ class ATOverridden {
 public:
   virtual void BadBaseMethod() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for virtual method 'BadBaseMethod'
-  // CHECK-FIXES: {{^}}  virtual void v_Bad_Base_Method() = 0;
+  // CHECK-FIXES: virtual void v_Bad_Base_Method() = 0;
 
   virtual void BadBaseMethodNoAttr() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for virtual method 'BadBaseMethodNoAttr'
-  // CHECK-FIXES: {{^}}  virtual void v_Bad_Base_Method_No_Attr() = 0;
+  // CHECK-FIXES: virtual void v_Bad_Base_Method_No_Attr() = 0;
 };
 
 template<typename some_t>
@@ -361,13 +361,13 @@ class CTOverriding : public ATOverridden<some_t> {
   // known whether this method overrides anything, so we get the warning here.
   virtual void BadBaseMethodNoAttr() {};
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for virtual method 'BadBaseMethodNoAttr'
-  // CHECK-FIXES: {{^}}  virtual void v_Bad_Base_Method_No_Attr() {};
+  // CHECK-FIXES: virtual void v_Bad_Base_Method_No_Attr() {};
 };
 
 template<typename some_t>
 void VirtualCall(AOverridden &a_vItem, ATOverridden<some_t> &a_vTitem) {
   a_vItem.BadBaseMethod();
-  // CHECK-FIXES: {{^}}  a_vItem.v_Bad_Base_Method();
+  // CHECK-FIXES: a_vItem.v_Bad_Base_Method();
 
   // FIXME: The fixes from ATOverridden should be propagated to the following call
   a_vTitem.BadBaseMethod();
@@ -379,7 +379,7 @@ class ATIOverridden {
 public:
   virtual void BadBaseMethod() = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for virtual method 'BadBaseMethod'
-  // CHECK-FIXES: {{^}}  virtual void v_Bad_Base_Method() = 0;
+  // CHECK-FIXES: virtual void v_Bad_Base_Method() = 0;
 };
 
 template<typename some_t>
@@ -387,17 +387,17 @@ class CTIOverriding : public ATIOverridden<some_t> {
 public:
   // Overriding a badly-named base isn't a new violation.
   void BadBaseMethod() override {}
-  // CHECK-FIXES: {{^}}  void v_Bad_Base_Method() override {}
+  // CHECK-FIXES: void v_Bad_Base_Method() override {}
 };
 
 template class CTIOverriding<int>;
 
 void VirtualCallI(ATIOverridden<int>& a_vItem, CTIOverriding<int>& a_vCitem) {
   a_vItem.BadBaseMethod();
-  // CHECK-FIXES: {{^}}  a_vItem.v_Bad_Base_Method();
+  // CHECK-FIXES: a_vItem.v_Bad_Base_Method();
 
   a_vCitem.BadBaseMethod();
-  // CHECK-FIXES: {{^}}  a_vCitem.v_Bad_Base_Method();
+  // CHECK-FIXES: a_vCitem.v_Bad_Base_Method();
 }
 
 template <typename derived_t>
@@ -415,51 +415,51 @@ public:
 
 template<typename T>
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for type template parameter 'T'
-// CHECK-FIXES: {{^}}template<typename t_t>{{$}}
+// CHECK-FIXES: template<typename t_t>
 class my_templated_class : CMyWellNamedClass {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'my_templated_class'
-// CHECK-FIXES: {{^}}class CMyTemplatedClass : CMyWellNamedClass {};{{$}}
+// CHECK-FIXES: class CMyTemplatedClass : CMyWellNamedClass {};
 
 template<typename T>
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for type template parameter 'T'
-// CHECK-FIXES: {{^}}template<typename t_t>{{$}}
+// CHECK-FIXES: template<typename t_t>
 class my_other_templated_class : my_templated_class<  my_class>, private my_derived_class {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'my_other_templated_class'
-// CHECK-FIXES: {{^}}class CMyOtherTemplatedClass : CMyTemplatedClass<  CMyClass>, private CMyDerivedClass {};{{$}}
+// CHECK-FIXES: class CMyOtherTemplatedClass : CMyTemplatedClass<  CMyClass>, private CMyDerivedClass {};
 
 template<typename t_t>
 using mysuper_tpl_t = my_other_templated_class  <:: FOO_NS  ::my_class>;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for type alias 'mysuper_tpl_t'
-// CHECK-FIXES: {{^}}using mysuper_Tpl_t = CMyOtherTemplatedClass  <:: foo_ns  ::CMyClass>;{{$}}
+// CHECK-FIXES: using mysuper_Tpl_t = CMyOtherTemplatedClass  <:: foo_ns  ::CMyClass>;
 
 const int global_Constant = 6;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global constant 'global_Constant'
-// CHECK-FIXES: {{^}}const int GLOBAL_CONSTANT = 6;{{$}}
+// CHECK-FIXES: const int GLOBAL_CONSTANT = 6;
 int Global_variable = 7;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Global_variable'
-// CHECK-FIXES: {{^}}int g_global_variable = 7;{{$}}
+// CHECK-FIXES: int g_global_variable = 7;
 
 void global_function(int PARAMETER_1, int const CONST_parameter) {
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global function 'global_function'
 // CHECK-MESSAGES: :[[@LINE-2]]:26: warning: invalid case style for parameter 'PARAMETER_1'
 // CHECK-MESSAGES: :[[@LINE-3]]:49: warning: invalid case style for constant parameter 'CONST_parameter'
-// CHECK-FIXES: {{^}}void GlobalFunction(int a_parameter1, int const i_constParameter) {{{$}}
+// CHECK-FIXES: void GlobalFunction(int a_parameter1, int const i_constParameter) {
     static const int THIS_static_ConsTant = 4;
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: invalid case style for static constant 'THIS_static_ConsTant'
-// CHECK-FIXES: {{^}}    static const int THIS_STATIC_CONS_TANT = 4;{{$}}
+// CHECK-FIXES: static const int THIS_STATIC_CONS_TANT = 4;
     static int THIS_static_variable;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for static variable 'THIS_static_variable'
-// CHECK-FIXES: {{^}}    static int s_thisStaticVariable;{{$}}
+// CHECK-FIXES: static int s_thisStaticVariable;
     int const local_Constant = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for local constant 'local_Constant'
-// CHECK-FIXES: {{^}}    int const kLocalConstant = 3;{{$}}
+// CHECK-FIXES: int const kLocalConstant = 3;
     int LOCAL_VARIABLE;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for local variable 'LOCAL_VARIABLE'
-// CHECK-FIXES: {{^}}    int local_variable;{{$}}
+// CHECK-FIXES: int local_variable;
 
     int LOCAL_Array__[] = {0, 1, 2};
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for local variable 'LOCAL_Array__'
-// CHECK-FIXES: {{^}}    int local_array[] = {0, 1, 2};{{$}}
+// CHECK-FIXES: int local_array[] = {0, 1, 2};
 
     for (auto _ : LOCAL_Array__) {
     }
@@ -467,15 +467,15 @@ void global_function(int PARAMETER_1, int const CONST_parameter) {
 
 template<typename ... TYPE_parameters>
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: invalid case style for type template parameter 'TYPE_parameters'
-// CHECK-FIXES: {{^}}template<typename ... typeParameters_t>{{$}}
+// CHECK-FIXES: template<typename ... typeParameters_t>
 void Global_Fun(TYPE_parameters... PARAMETER_PACK) {
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global function 'Global_Fun'
 // CHECK-MESSAGES: :[[@LINE-2]]:36: warning: invalid case style for parameter pack 'PARAMETER_PACK'
-// CHECK-FIXES: {{^}}void GlobalFun(typeParameters_t... parameterPack) {{{$}}
+// CHECK-FIXES: void GlobalFun(typeParameters_t... parameterPack) {
     global_function(1, 2);
-// CHECK-FIXES: {{^}}    GlobalFunction(1, 2);{{$}}
+// CHECK-FIXES: GlobalFunction(1, 2);
     FOO_bar = Global_variable;
-// CHECK-FIXES: {{^}}    FOO_bar = g_global_variable;{{$}}
+// CHECK-FIXES: FOO_bar = g_global_variable;
 // NO fix expected for FOO_bar declared in macro expansion
 }
 
@@ -483,134 +483,134 @@ template<template<typename> class TPL_parameter, int COUNT_params, typename ... 
 // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: invalid case style for template template parameter 'TPL_parameter'
 // CHECK-MESSAGES: :[[@LINE-2]]:54: warning: invalid case style for value template parameter 'COUNT_params'
 // CHECK-MESSAGES: :[[@LINE-3]]:81: warning: invalid case style for type template parameter 'TYPE_parameters'
-// CHECK-FIXES: {{^}}template<template<typename> class TplParameter, int countParams, typename ... typeParameters_t>{{$}}
+// CHECK-FIXES: template<template<typename> class TplParameter, int countParams, typename ... typeParameters_t>
 class test_CLASS {
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'test_CLASS'
-// CHECK-FIXES: {{^}}class CTestClass {{{$}}
+// CHECK-FIXES: class CTestClass {
 };
 
 class abstract_class {
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'abstract_class'
-// CHECK-FIXES: {{^}}class AAbstractClass {{{$}}
+// CHECK-FIXES: class AAbstractClass {
     virtual ~abstract_class() = 0;
-// CHECK-FIXES: {{^}}    virtual ~AAbstractClass() = 0;{{$}}
+// CHECK-FIXES: virtual ~AAbstractClass() = 0;
     virtual void VIRTUAL_METHOD();
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for virtual method 'VIRTUAL_METHOD'
-// CHECK-FIXES: {{^}}    virtual void v_Virtual_Method();{{$}}
+// CHECK-FIXES: virtual void v_Virtual_Method();
     void non_Virtual_METHOD() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for private method 'non_Virtual_METHOD'
-// CHECK-FIXES: {{^}}    void __non_Virtual_METHOD() {}{{$}}
+// CHECK-FIXES: void __non_Virtual_METHOD() {}
 
 public:
     static void CLASS_METHOD() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for class method 'CLASS_METHOD'
-// CHECK-FIXES: {{^}}    static void classMethod() {}{{$}}
+// CHECK-FIXES: static void classMethod() {}
 
     constexpr int CST_expr_Method() { return 2; }
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for constexpr method 'CST_expr_Method'
-// CHECK-FIXES: {{^}}    constexpr int cst_expr_method() { return 2; }{{$}}
+// CHECK-FIXES: constexpr int cst_expr_method() { return 2; }
 
 private:
     void PRIVate_Method();
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for private method 'PRIVate_Method'
-// CHECK-FIXES: {{^}}    void __PRIVate_Method();{{$}}
+// CHECK-FIXES: void __PRIVate_Method();
 protected:
     void protected_Method();
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for protected method 'protected_Method'
-// CHECK-FIXES: {{^}}    void _protected_Method();{{$}}
+// CHECK-FIXES: void _protected_Method();
 public:
     void public_Method();
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for method 'public_Method'
-// CHECK-FIXES: {{^}}    void publicMethod();{{$}}
+// CHECK-FIXES: void publicMethod();
 };
 
 constexpr int CE_function() { return 3; }
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for constexpr function 'CE_function'
-// CHECK-FIXES: {{^}}constexpr int ce_function() { return 3; }{{$}}
+// CHECK-FIXES: constexpr int ce_function() { return 3; }
 
 struct THIS___Structure {
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'THIS___Structure'
-// CHECK-FIXES: {{^}}struct This_structure {{{$}}
+// CHECK-FIXES: struct This_structure {
     THIS___Structure();
-// CHECK-FIXES: {{^}}    This_structure();{{$}}
+// CHECK-FIXES: This_structure();
 
   union __MyUnion_is_wonderful__ {};
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for union '__MyUnion_is_wonderful__'
-// CHECK-FIXES: {{^}}  union UMyUnionIsWonderful {};{{$}}
+// CHECK-FIXES: union UMyUnionIsWonderful {};
 };
 
 typedef THIS___Structure struct_type;
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: invalid case style for typedef 'struct_type'
-// CHECK-FIXES: {{^}}typedef This_structure struct_type_t;{{$}}
+// CHECK-FIXES: typedef This_structure struct_type_t;
 
 struct_type GlobalTypedefTestFunction(struct_type a_argument1) {
-// CHECK-FIXES: {{^}}struct_type_t GlobalTypedefTestFunction(struct_type_t a_argument1) {
+// CHECK-FIXES: struct_type_t GlobalTypedefTestFunction(struct_type_t a_argument1) {
     struct_type typedef_test_1;
-// CHECK-FIXES: {{^}}    struct_type_t typedef_test_1;
+// CHECK-FIXES: struct_type_t typedef_test_1;
   return {};
 }
 
 using my_struct_type = THIS___Structure;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for type alias 'my_struct_type'
-// CHECK-FIXES: {{^}}using my_Struct_Type_t = This_structure;{{$}}
+// CHECK-FIXES: using my_Struct_Type_t = This_structure;
 
 template<typename t_t>
 using SomeOtherTemplate = my_other_templated_class  <:: FOO_NS  ::my_class>;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for type alias 'SomeOtherTemplate'
-// CHECK-FIXES: {{^}}using some_Other_Template_t = CMyOtherTemplatedClass  <:: foo_ns  ::CMyClass>;{{$}}
+// CHECK-FIXES: using some_Other_Template_t = CMyOtherTemplatedClass  <:: foo_ns  ::CMyClass>;
 
 static void static_Function() {
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for function 'static_Function'
-// CHECK-FIXES: {{^}}static void staticFunction() {{{$}}
+// CHECK-FIXES: static void staticFunction() {
 
   ::FOO_NS::InlineNamespace::abstract_class::CLASS_METHOD();
-// CHECK-FIXES: {{^}}  ::foo_ns::inline_namespace::AAbstractClass::classMethod();{{$}}
+// CHECK-FIXES: ::foo_ns::inline_namespace::AAbstractClass::classMethod();
   ::FOO_NS::InlineNamespace::static_Function();
-// CHECK-FIXES: {{^}}  ::foo_ns::inline_namespace::staticFunction();{{$}}
+// CHECK-FIXES: ::foo_ns::inline_namespace::staticFunction();
 
   using ::FOO_NS::InlineNamespace::CE_function;
-// CHECK-FIXES: {{^}}  using ::foo_ns::inline_namespace::ce_function;{{$}}
+// CHECK-FIXES: using ::foo_ns::inline_namespace::ce_function;
 
   unsigned MY_LOCAL_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for local variable 'MY_LOCAL_array'
-// CHECK-FIXES: {{^}}  unsigned my_local_array[] = {1,2,3};{{$}}
+// CHECK-FIXES: unsigned my_local_array[] = {1,2,3};
 
   unsigned const MyConstLocal_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for local constant 'MyConstLocal_array'
-// CHECK-FIXES: {{^}}  unsigned const kMyConstLocalArray[] = {1,2,3};{{$}}
+// CHECK-FIXES: unsigned const kMyConstLocalArray[] = {1,2,3};
 
   static unsigned MY_STATIC_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for static variable 'MY_STATIC_array'
-// CHECK-FIXES: {{^}}  static unsigned s_myStaticArray[] = {1,2,3};{{$}}
+// CHECK-FIXES: static unsigned s_myStaticArray[] = {1,2,3};
 
   static unsigned const MyConstStatic_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for static constant 'MyConstStatic_array'
-// CHECK-FIXES: {{^}}  static unsigned const MY_CONST_STATIC_ARRAY[] = {1,2,3};{{$}}
+// CHECK-FIXES: static unsigned const MY_CONST_STATIC_ARRAY[] = {1,2,3};
 
   char MY_LOCAL_string[] = "123";
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for local variable 'MY_LOCAL_string'
-// CHECK-FIXES: {{^}}  char my_local_string[] = "123";{{$}}
+// CHECK-FIXES: char my_local_string[] = "123";
 
   char const MyConstLocal_string[] = "123";
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for local constant 'MyConstLocal_string'
-// CHECK-FIXES: {{^}}  char const kMyConstLocalString[] = "123";{{$}}
+// CHECK-FIXES: char const kMyConstLocalString[] = "123";
 
   static char MY_STATIC_string[] = "123";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for static variable 'MY_STATIC_string'
-// CHECK-FIXES: {{^}}  static char s_myStaticString[] = "123";{{$}}
+// CHECK-FIXES: static char s_myStaticString[] = "123";
 
   static char const MyConstStatic_string[] = "123";
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: invalid case style for static constant 'MyConstStatic_string'
-// CHECK-FIXES: {{^}}  static char const MY_CONST_STATIC_STRING[] = "123";{{$}}
+// CHECK-FIXES: static char const MY_CONST_STATIC_STRING[] = "123";
 }
 
 #define MY_TEST_Macro(X) X()
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for macro definition 'MY_TEST_Macro'
-// CHECK-FIXES: {{^}}#define MY_TEST_MACRO(X) X()
+// CHECK-FIXES: #define MY_TEST_MACRO(X) X()
 
 void MY_TEST_Macro(function) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global function 'function' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void MY_TEST_MACRO(Function) {}
+// CHECK-FIXES: void MY_TEST_MACRO(Function) {}
 
 #define MY_CAT_IMPL(l, r) l ## r
 #define MY_CAT(l, r) MY_CAT_IMPL(l, r)
@@ -626,21 +626,21 @@ MY_MACRO3(myglob);
 
 template <typename t_t> struct a {
 // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: invalid case style for struct 'a'
-// CHECK-FIXES: {{^}}template <typename t_t> struct A {{{$}}
+// CHECK-FIXES: template <typename t_t> struct A {
   typename t_t::template b<> c;
 
   char const MY_ConstMember_string[4] = "123";
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for constant member 'MY_ConstMember_string'
-// CHECK-FIXES: {{^}}  char const my_const_member_string[4] = "123";{{$}}
+// CHECK-FIXES: char const my_const_member_string[4] = "123";
 
   static char const MyConstClass_string[];
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: invalid case style for class constant 'MyConstClass_string'
-// CHECK-FIXES: {{^}}  static char const kMyConstClassString[];{{$}}
+// CHECK-FIXES: static char const kMyConstClassString[];
 };
 
 template<typename t_t>
 char const a<t_t>::MyConstClass_string[] = "123";
-// CHECK-FIXES: {{^}}char const A<t_t>::kMyConstClassString[] = "123";{{$}}
+// CHECK-FIXES: char const A<t_t>::kMyConstClassString[] = "123";
 
 template <template <typename> class A> struct b { A<int> c; };
 // CHECK-MESSAGES: :[[@LINE-1]]:47: warning: invalid case style for struct 'b'
@@ -648,47 +648,47 @@ template <template <typename> class A> struct b { A<int> c; };
 
 unsigned MY_GLOBAL_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'MY_GLOBAL_array'
-// CHECK-FIXES: {{^}}unsigned g_my_global_array[] = {1,2,3};{{$}}
+// CHECK-FIXES: unsigned g_my_global_array[] = {1,2,3};
 
 unsigned const MyConstGlobal_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global constant 'MyConstGlobal_array'
-// CHECK-FIXES: {{^}}unsigned const MY_CONST_GLOBAL_ARRAY[] = {1,2,3};{{$}}
+// CHECK-FIXES: unsigned const MY_CONST_GLOBAL_ARRAY[] = {1,2,3};
 
 int * MyGlobal_Ptr;// -> ok
 int * my_second_global_Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'my_second_global_Ptr'
-// CHECK-FIXES: {{^}}int * MySecondGlobal_Ptr;{{$}}
+// CHECK-FIXES: int * MySecondGlobal_Ptr;
 int * const MyConstantGlobalPointer = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global constant pointer 'MyConstantGlobalPointer'
-// CHECK-FIXES: {{^}}int * const MY_CONSTANT_GLOBAL_POINTER_Ptr = nullptr;{{$}}
+// CHECK-FIXES: int * const MY_CONSTANT_GLOBAL_POINTER_Ptr = nullptr;
 
 void MyPoiterFunction(int * p_normal_pointer, int * const constant_ptr){
 // CHECK-MESSAGES: :[[@LINE-1]]:59: warning: invalid case style for constant pointer parameter 'constant_ptr'
-// CHECK-FIXES: {{^}}void MyPoiterFunction(int * p_normal_pointer, int * const cp_ConstantPtr){{{$}}
+// CHECK-FIXES: void MyPoiterFunction(int * p_normal_pointer, int * const cp_ConstantPtr){
     int * l_PointerA;
     int * const pointer_b = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for local constant pointer 'pointer_b'
-// CHECK-FIXES: {{^}}    int * const lc_PointerB = nullptr;{{$}}
+// CHECK-FIXES: int * const lc_PointerB = nullptr;
 }
 
 using namespace FOO_NS;
-// CHECK-FIXES: {{^}}using namespace foo_ns;
+// CHECK-FIXES: using namespace foo_ns;
 
 using namespace FOO_NS::InlineNamespace;
-// CHECK-FIXES: {{^}}using namespace foo_ns::inline_namespace;
+// CHECK-FIXES: using namespace foo_ns::inline_namespace;
 
 void QualifiedTypeLocTest(THIS___Structure);
-// CHECK-FIXES: {{^}}void QualifiedTypeLocTest(This_structure);{{$}}
+// CHECK-FIXES: void QualifiedTypeLocTest(This_structure);
 void QualifiedTypeLocTest(THIS___Structure &);
-// CHECK-FIXES: {{^}}void QualifiedTypeLocTest(This_structure &);{{$}}
+// CHECK-FIXES: void QualifiedTypeLocTest(This_structure &);
 void QualifiedTypeLocTest(THIS___Structure &&);
-// CHECK-FIXES: {{^}}void QualifiedTypeLocTest(This_structure &&);{{$}}
+// CHECK-FIXES: void QualifiedTypeLocTest(This_structure &&);
 void QualifiedTypeLocTest(const THIS___Structure);
-// CHECK-FIXES: {{^}}void QualifiedTypeLocTest(const This_structure);{{$}}
+// CHECK-FIXES: void QualifiedTypeLocTest(const This_structure);
 void QualifiedTypeLocTest(const THIS___Structure &);
-// CHECK-FIXES: {{^}}void QualifiedTypeLocTest(const This_structure &);{{$}}
+// CHECK-FIXES: void QualifiedTypeLocTest(const This_structure &);
 void QualifiedTypeLocTest(volatile THIS___Structure &);
-// CHECK-FIXES: {{^}}void QualifiedTypeLocTest(volatile This_structure &);{{$}}
+// CHECK-FIXES: void QualifiedTypeLocTest(volatile This_structure &);
 
 namespace redecls {
 // We only want the warning to show up once here for the first decl.
@@ -696,15 +696,15 @@ namespace redecls {
 void badNamedFunction();
 void badNamedFunction();
 void badNamedFunction(){}
-//      CHECK-FIXES: {{^}}void BadNamedFunction();
-// CHECK-FIXES-NEXT: {{^}}void BadNamedFunction();
-// CHECK-FIXES-NEXT: {{^}}void BadNamedFunction(){}
+//      CHECK-FIXES: void BadNamedFunction();
+// CHECK-FIXES-NEXT: void BadNamedFunction();
+// CHECK-FIXES-NEXT: void BadNamedFunction(){}
 void ReferenceBadNamedFunction() {
   auto l_Ptr = badNamedFunction;
-  // CHECK-FIXES: {{^}}  auto l_Ptr = BadNamedFunction;
+  // CHECK-FIXES: auto l_Ptr = BadNamedFunction;
   l_Ptr();
   badNamedFunction();
-  // CHECK-FIXES: {{^}}  BadNamedFunction();
+  // CHECK-FIXES: BadNamedFunction();
 }
 
 } // namespace redecls
@@ -734,7 +734,7 @@ auto GetRes(type_t& Param) -> decltype(Param.res());
 
 struct async_obj {
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'async_obj'
-// CHECK-FIXES: {{^}}struct Async_obj {{{$}}
+// CHECK-FIXES: struct Async_obj {
 public:
   never_suspend operator co_await() const noexcept;
 };
@@ -746,15 +746,15 @@ task ImplicitDeclTest(async_obj &a_object) {
 // Test scenario when canonical declaration will be a forward declaration
 struct ForwardDeclStruct;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'ForwardDeclStruct' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct Forward_decl_struct;
-// CHECK-FIXES: {{^}}struct Forward_decl_struct {
+// CHECK-FIXES: struct Forward_decl_struct;
+// CHECK-FIXES: struct Forward_decl_struct {
 struct ForwardDeclStruct {
 };
 
 struct forward_declared_as_struct;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for class 'forward_declared_as_struct' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct CForwardDeclaredAsStruct;
-// CHECK-FIXES: {{^}}class CForwardDeclaredAsStruct {
+// CHECK-FIXES: struct CForwardDeclaredAsStruct;
+// CHECK-FIXES: class CForwardDeclaredAsStruct {
 class forward_declared_as_struct {
 };
 
@@ -767,30 +767,30 @@ typedef enum {
   VALUE1,
 } ValueType;
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: invalid case style for typedef 'ValueType' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}} value_type_t;
+// CHECK-FIXES: } value_type_t;
 
 typedef ValueType (*MyFunPtr)(const ValueType&, Wrap<ValueType>*);
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: invalid case style for typedef 'MyFunPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}typedef value_type_t (*my_fun_ptr_t)(const value_type_t&, Wrap<value_type_t>*);
+// CHECK-FIXES: typedef value_type_t (*my_fun_ptr_t)(const value_type_t&, Wrap<value_type_t>*);
 
 #define STATIC_MACRO static
 STATIC_MACRO void someFunc(ValueType a_v1, const ValueType& a_v2) {}
-// CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(value_type_t a_v1, const value_type_t& a_v2) {}
+// CHECK-FIXES: STATIC_MACRO void someFunc(value_type_t a_v1, const value_type_t& a_v2) {}
 STATIC_MACRO void someFunc(const ValueType** p_a_v1, ValueType (*p_a_v2)()) {}
-// CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(const value_type_t** p_a_v1, value_type_t (*p_a_v2)()) {}
+// CHECK-FIXES: STATIC_MACRO void someFunc(const value_type_t** p_a_v1, value_type_t (*p_a_v2)()) {}
 STATIC_MACRO ValueType someFunc() { return {}; }
-// CHECK-FIXES: {{^}}STATIC_MACRO value_type_t someFunc() { return {}; }
+// CHECK-FIXES: STATIC_MACRO value_type_t someFunc() { return {}; }
 STATIC_MACRO void someFunc(MyFunPtr, const MyFunPtr****) {}
-// CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(my_fun_ptr_t, const my_fun_ptr_t****) {}
+// CHECK-FIXES: STATIC_MACRO void someFunc(my_fun_ptr_t, const my_fun_ptr_t****) {}
 #undef STATIC_MACRO
 }
 
 struct Some_struct {
   int SomeMember;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for public member 'SomeMember' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}  int some_member;
+// CHECK-FIXES: int some_member;
 };
 Some_struct g_s1{ .SomeMember = 1 };
-// CHECK-FIXES: {{^}}Some_struct g_s1{ .some_member = 1 };
+// CHECK-FIXES: Some_struct g_s1{ .some_member = 1 };
 Some_struct g_s2{.SomeMember=1};
-// CHECK-FIXES: {{^}}Some_struct g_s2{.some_member=1};
+// CHECK-FIXES: Some_struct g_s2{.some_member=1};

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -644,7 +644,7 @@ char const a<t_t>::MyConstClass_string[] = "123";
 
 template <template <typename> class A> struct b { A<int> c; };
 // CHECK-MESSAGES: :[[@LINE-1]]:47: warning: invalid case style for struct 'b'
-// CHECK-FIXES:template <template <typename> class A> struct B { A<int> c; };{{$}}
+// CHECK-FIXES: template <template <typename> class A> struct B { A<int> c; };
 
 unsigned MY_GLOBAL_array[] = {1,2,3};
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'MY_GLOBAL_array'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name-macros.cpp
@@ -22,7 +22,7 @@ struct S2 {
   // CHECK-NOTES: :[[@LINE+9]]:12: note: expanded from macro 'DEFINITION'
   // This one is unfortunate, but the location this points to is in a scratch
   // space, so it's not helpful to the user.
-  // CHECK-NOTES: note: expanded from here
+  // CHECK-NOTES: {{^}}note: expanded from here{{$}}
   // CHECK-NOTES: :[[@LINE-7]]:8: note: differing parameters are named here: ('g'), in definition: ('w')
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name-macros.cpp
@@ -22,7 +22,7 @@ struct S2 {
   // CHECK-NOTES: :[[@LINE+9]]:12: note: expanded from macro 'DEFINITION'
   // This one is unfortunate, but the location this points to is in a scratch
   // space, so it's not helpful to the user.
-  // CHECK-NOTES: {{^}}note: expanded from here{{$}}
+  // CHECK-NOTES: note: expanded from here
   // CHECK-NOTES: :[[@LINE-7]]:8: note: differing parameters are named here: ('g'), in definition: ('w')
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration-fixing.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration-fixing.cpp
@@ -13,43 +13,43 @@ void member_pointers() {
   int S::*p = &S::a, S::*const q = &S::a;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int S::*p = &S::a;
-  // CHECK-FIXES: {{^  }}int S::*const q = &S::a;
+  // CHECK-FIXES: int S::*const q = &S::a;
 
   int /* :: */ S::*pp2 = &S::a, var1 = 0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int /* :: */ S::*pp2 = &S::a;
-  // CHECK-FIXES: {{^  }}int var1 = 0;
+  // CHECK-FIXES: int var1 = 0;
 
   const int S::*r = &S::b, S::*t;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: const int S::*r = &S::b;
-  // CHECK-FIXES: {{^  }}const int S::*t;
+  // CHECK-FIXES: const int S::*t;
 
   {
     int S::*mdpa1[2] = {&S::a, &S::a}, var1 = 0;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: int S::*mdpa1[2] = {&S::a, &S::a};
-    // CHECK-FIXES: {{^    }}int var1 = 0;
+    // CHECK-FIXES: int var1 = 0;
 
     int S ::**mdpa2[2] = {&p, &pp2}, var2 = 0;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: int S ::**mdpa2[2] = {&p, &pp2};
-    // CHECK-FIXES: {{^    }}int var2 = 0;
+    // CHECK-FIXES: int var2 = 0;
 
     void (S::*mdfp1)() = &S::f, (S::*mdfp2)() = &S::f;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: void (S::*mdfp1)() = &S::f;
-    // CHECK-FIXES: {{^    }}void (S::*mdfp2)() = &S::f;
+    // CHECK-FIXES: void (S::*mdfp2)() = &S::f;
 
     void (S::*mdfpa1[2])() = {&S::f, &S::f}, (S::*mdfpa2)() = &S::f;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: void (S::*mdfpa1[2])() = {&S::f, &S::f};
-    // CHECK-FIXES: {{^    }}void (S::*mdfpa2)() = &S::f;
+    // CHECK-FIXES: void (S::*mdfpa2)() = &S::f;
 
     void (S::* * mdfpa3[2])() = {&mdfpa1[0], &mdfpa1[1]}, (S::*mdfpa4)() = &S::f;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: void (S::* * mdfpa3[2])() = {&mdfpa1[0], &mdfpa1[1]};
-    // CHECK-FIXES: {{^    }}void (S::*mdfpa4)() = &S::f;
+    // CHECK-FIXES: void (S::*mdfpa4)() = &S::f;
   }
 
   class CS {
@@ -60,5 +60,5 @@ void member_pointers() {
   int const CS ::*pp = &CS::a, CS::*const qq = &CS::a;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int const CS ::*pp = &CS::a;
-  // CHECK-FIXES: {{^  }}int const CS::*const qq = &CS::a;
+  // CHECK-FIXES: int const CS::*const qq = &CS::a;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
@@ -8,14 +8,14 @@ void f2() {
   int i, j, *k, lala = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int i;
-  // CHECK-FIXES: {{^  }}int j;
-  // CHECK-FIXES: {{^  }}int *k;
-  // CHECK-FIXES: {{^  }}int lala = 42;
+  // CHECK-FIXES: int j;
+  // CHECK-FIXES: int *k;
+  // CHECK-FIXES: int lala = 42;
 
   int normal, weird = /* comment */ 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int normal;
-  // CHECK-FIXES: {{^  }}int weird = /* comment */ 42;
+  // CHECK-FIXES: int weird = /* comment */ 42;
 
   int /* here is a comment */ v1,
       // another comment
@@ -23,79 +23,79 @@ void f2() {
       ;
   // CHECK-MESSAGES: [[@LINE-4]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int /* here is a comment */ v1;
-  // CHECK-FIXES: {{^  }}int /* here is a comment */ // another comment
-  // CHECK-FIXES: {{^      }}v2 = 42 // Ok, more comments
-  // CHECK-FIXES: {{^      }};
+  // CHECK-FIXES: int /* here is a comment */ // another comment
+  // CHECK-FIXES: v2 = 42 // Ok, more comments
+  // CHECK-FIXES: ;
 
   auto int1 = 42, int2 = 0, int3 = 43;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: auto int1 = 42;
-  // CHECK-FIXES: {{^  }}auto int2 = 0;
-  // CHECK-FIXES: {{^  }}auto int3 = 43;
+  // CHECK-FIXES: auto int2 = 0;
+  // CHECK-FIXES: auto int3 = 43;
 
   decltype(auto) ptr1 = &int1, ptr2 = &int1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: decltype(auto) ptr1 = &int1;
-  // CHECK-FIXES: {{^  }}decltype(auto) ptr2 = &int1;
+  // CHECK-FIXES: decltype(auto) ptr2 = &int1;
 
   decltype(k) ptr3 = &int1, ptr4 = &int1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: decltype(k) ptr3 = &int1;
-  // CHECK-FIXES: {{^  }}decltype(k) ptr4 = &int1;
+  // CHECK-FIXES: decltype(k) ptr4 = &int1;
 }
 
 void f3() {
   int i, *pointer1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int i;
-  // CHECK-FIXES: {{^  }}int *pointer1;
+  // CHECK-FIXES: int *pointer1;
   //
   int *pointer2 = nullptr, *pointer3 = &i;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int *pointer2 = nullptr;
-  // CHECK-FIXES: {{^  }}int *pointer3 = &i;
+  // CHECK-FIXES: int *pointer3 = &i;
 
   int *(i_ptr) = nullptr, *((i_ptr2));
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int *(i_ptr) = nullptr;
-  // CHECK-FIXES: {{^  }}int *((i_ptr2));
+  // CHECK-FIXES: int *((i_ptr2));
 
   float(*f_ptr)[42], (((f_value))) = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: float (*f_ptr)[42];
-  // CHECK-FIXES: {{^  }}float (((f_value))) = 42;
+  // CHECK-FIXES: float (((f_value))) = 42;
 
   float(((*f_ptr2)))[42], ((*f_ptr3)), f_value2 = 42.f;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: float (((*f_ptr2)))[42];
-  // CHECK-FIXES: {{^  }}float ((*f_ptr3));
-  // CHECK-FIXES: {{^  }}float f_value2 = 42.f;
+  // CHECK-FIXES: float ((*f_ptr3));
+  // CHECK-FIXES: float f_value2 = 42.f;
 
   float(((*f_ptr4)))[42], *f_ptr5, ((f_value3));
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: float (((*f_ptr4)))[42];
-  // CHECK-FIXES: {{^  }}float *f_ptr5;
-  // CHECK-FIXES: {{^  }}float ((f_value3));
+  // CHECK-FIXES: float *f_ptr5;
+  // CHECK-FIXES: float ((f_value3));
 
   void(((*f2))(int)), (*g2)(int, float);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: void (((*f2))(int));
-  // CHECK-FIXES: {{^  }}void (*g2)(int, float);
+  // CHECK-FIXES: void (*g2)(int, float);
 
   float(*(*(*f_ptr6)))[42], (*f_ptr7);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: float (*(*(*f_ptr6)))[42];
-  // CHECK-FIXES: {{^  }}float (*f_ptr7);
+  // CHECK-FIXES: float (*f_ptr7);
 }
 
 void f4() {
   double d = 42. /* foo */, z = 43., /* hi */ y, c /* */ /*  */, l = 2.;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: double d = 42. /* foo */;
-  // CHECK-FIXES: {{^  }}double z = 43.;
-  // CHECK-FIXES: {{^  }}double /* hi */ y;
-  // CHECK-FIXES: {{^  }}double c /* */ /*  */;
-  // CHECK-FIXES: {{^  }}double l = 2.;
+  // CHECK-FIXES: double z = 43.;
+  // CHECK-FIXES: double /* hi */ y;
+  // CHECK-FIXES: double c /* */ /*  */;
+  // CHECK-FIXES: double l = 2.;
 }
 
 struct SomeClass {
@@ -123,35 +123,35 @@ void f5() {
   SomeClass v1, v2(42), v3{42}, v4(42.5);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: SomeClass v1;
-  // CHECK-FIXES: {{^  }}SomeClass v2(42);
-  // CHECK-FIXES: {{^  }}SomeClass v3{42};
-  // CHECK-FIXES: {{^  }}SomeClass v4(42.5);
+  // CHECK-FIXES: SomeClass v2(42);
+  // CHECK-FIXES: SomeClass v3{42};
+  // CHECK-FIXES: SomeClass v4(42.5);
 
   SomeClass v5 = 42, *p1 = nullptr;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: SomeClass v5 = 42;
-  // CHECK-FIXES: {{^  }}SomeClass *p1 = nullptr;
+  // CHECK-FIXES: SomeClass *p1 = nullptr;
 
   Point P1(0., 2.), P2{2., 0.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: Point P1(0., 2.);
-  // CHECK-FIXES: {{^  }}Point P2{2., 0.};
+  // CHECK-FIXES: Point P2{2., 0.};
 
   Rectangle R1({0., 0.}, {1., -2.}), R2{{0., 1.}, {1., 0.}}, R3(P1, P2), R4{P1, P2};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: Rectangle R1({0., 0.}, {1., -2.});
-  // CHECK-FIXES: {{^  }}Rectangle R2{{[{][{]}}0., 1.}, {1., 0.{{[}][}]}};
-  // CHECK-FIXES: {{^  }}Rectangle R3(P1, P2);
-  // CHECK-FIXES: {{^  }}Rectangle R4{P1, P2};
+  // CHECK-FIXES: Rectangle R2{{[{][{]}}0., 1.}, {1., 0.{{[}][}]}};
+  // CHECK-FIXES: Rectangle R3(P1, P2);
+  // CHECK-FIXES: Rectangle R4{P1, P2};
 }
 
 void f6() {
   int array1[] = {1, 2, 3, 4}, array2[] = {1, 2, 3}, value1, value2 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int array1[] = {1, 2, 3, 4};
-  // CHECK-FIXES: {{^  }}int array2[] = {1, 2, 3};
-  // CHECK-FIXES: {{^  }}int value1;
-  // CHECK-FIXES: {{^  }}int value2 = 42;
+  // CHECK-FIXES: int array2[] = {1, 2, 3};
+  // CHECK-FIXES: int value1;
+  // CHECK-FIXES: int value2 = 42;
 }
 
 template <typename T>
@@ -164,25 +164,25 @@ void f7() {
   TemplatedType<int> TT1(42), TT2{42}, TT3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: TemplatedType<int> TT1(42);
-  // CHECK-FIXES: {{^  }}TemplatedType<int> TT2{42};
-  // CHECK-FIXES: {{^  }}TemplatedType<int> TT3;
+  // CHECK-FIXES: TemplatedType<int> TT2{42};
+  // CHECK-FIXES: TemplatedType<int> TT3;
   //
   TemplatedType<int *> *TT4(nullptr), TT5, **TT6 = nullptr, *const *const TT7{nullptr};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: TemplatedType<int *> *TT4(nullptr);
-  // CHECK-FIXES: {{^  }}TemplatedType<int *> TT5;
-  // CHECK-FIXES: {{^  }}TemplatedType<int *> **TT6 = nullptr;
-  // CHECK-FIXES: {{^  }}TemplatedType<int *> *const *const TT7{nullptr};
+  // CHECK-FIXES: TemplatedType<int *> TT5;
+  // CHECK-FIXES: TemplatedType<int *> **TT6 = nullptr;
+  // CHECK-FIXES: TemplatedType<int *> *const *const TT7{nullptr};
 
   TemplatedType<int &> **TT8(nullptr), *TT9;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: TemplatedType<int &> **TT8(nullptr);
-  // CHECK-FIXES: {{^  }}TemplatedType<int &> *TT9;
+  // CHECK-FIXES: TemplatedType<int &> *TT9;
 
   TemplatedType<int *> TT10{nullptr}, *TT11(nullptr);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: TemplatedType<int *> TT10{nullptr};
-  // CHECK-FIXES: {{^  }}TemplatedType<int *> *TT11(nullptr);
+  // CHECK-FIXES: TemplatedType<int *> *TT11(nullptr);
 }
 
 void forbidden_transformations() {
@@ -199,7 +199,7 @@ void macros() {
   int *p1 = NULL, *p2 = NULL;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int *p1 = NULL;
-  // CHECK-FIXES: {{^  }}int *p2 = NULL;
+  // CHECK-FIXES: int *p2 = NULL;
 
   // Macros are involved, so there will be no transformation
   MY_NICE_TYPE p3, v1, v2;
@@ -253,25 +253,25 @@ void complex_typedefs() {
   IntPtr intptr1, intptr2 = nullptr, intptr3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: IntPtr intptr1;
-  // CHECK-FIXES: {{^  }}IntPtr intptr2 = nullptr;
-  // CHECK-FIXES: {{^  }}IntPtr intptr3;
+  // CHECK-FIXES: IntPtr intptr2 = nullptr;
+  // CHECK-FIXES: IntPtr intptr3;
 
   IntPtr *DoublePtr1 = nullptr, **TriplePtr, SinglePtr = nullptr;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: IntPtr *DoublePtr1 = nullptr;
-  // CHECK-FIXES: {{^  }}IntPtr **TriplePtr;
-  // CHECK-FIXES: {{^  }}IntPtr SinglePtr = nullptr;
+  // CHECK-FIXES: IntPtr **TriplePtr;
+  // CHECK-FIXES: IntPtr SinglePtr = nullptr;
 
   IntPtr intptr_array1[2], intptr_array2[4] = {nullptr, nullptr, nullptr, nullptr};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: IntPtr intptr_array1[2];
-  // CHECK-FIXES: {{^  }}IntPtr intptr_array2[4] = {nullptr, nullptr, nullptr, nullptr};
+  // CHECK-FIXES: IntPtr intptr_array2[4] = {nullptr, nullptr, nullptr, nullptr};
 
   ArrayType arraytype1, arraytype2 = {1}, arraytype3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: ArrayType arraytype1;
-  // CHECK-FIXES: {{^  }}ArrayType arraytype2 = {1};
-  // CHECK-FIXES: {{^  }}ArrayType arraytype3;
+  // CHECK-FIXES: ArrayType arraytype2 = {1};
+  // CHECK-FIXES: ArrayType arraytype3;
 
   // Don't touch function declarations.
   FunType funtype1, funtype2, functype3;
@@ -280,29 +280,29 @@ void complex_typedefs() {
     int localFor1 = 1, localFor2 = 2;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: int localFor1 = 1;
-    // CHECK-FIXES: {{^    }}int localFor2 = 2;
+    // CHECK-FIXES: int localFor2 = 2;
   }
 
   StructOne s1, s2(23), s3, s4(3), *sptr = new StructOne(2);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: StructOne s1;
-  // CHECK-FIXES: {{^  }}StructOne s2(23);
-  // CHECK-FIXES: {{^  }}StructOne s3;
-  // CHECK-FIXES: {{^  }}StructOne s4(3);
-  // CHECK-FIXES: {{^  }}StructOne *sptr = new StructOne(2);
+  // CHECK-FIXES: StructOne s2(23);
+  // CHECK-FIXES: StructOne s3;
+  // CHECK-FIXES: StructOne s4(3);
+  // CHECK-FIXES: StructOne *sptr = new StructOne(2);
 
   struct StructOne cs1, cs2(42);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: struct StructOne cs1;
-  // CHECK-FIXES: {{^  }}struct StructOne cs2(42);
+  // CHECK-FIXES: struct StructOne cs2(42);
 
   int *ptrArray[3], dummy, **ptrArray2[5], twoDim[2][3], *twoDimPtr[2][3];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int *ptrArray[3];
-  // CHECK-FIXES: {{^  }}int dummy;
-  // CHECK-FIXES: {{^  }}int **ptrArray2[5];
-  // CHECK-FIXES: {{^  }}int twoDim[2][3];
-  // CHECK-FIXES: {{^  }}int *twoDimPtr[2][3];
+  // CHECK-FIXES: int dummy;
+  // CHECK-FIXES: int **ptrArray2[5];
+  // CHECK-FIXES: int twoDim[2][3];
+  // CHECK-FIXES: int *twoDimPtr[2][3];
 
   {
     void f1(int), g1(int, float);
@@ -314,12 +314,12 @@ void complex_typedefs() {
     void (*f2)(int), (*g2)(int, float) = gg;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: void (*f2)(int);
-    // CHECK-FIXES: {{^    }}void (*g2)(int, float) = gg;
+    // CHECK-FIXES: void (*g2)(int, float) = gg;
 
     void /*(*/ (/*(*/ *f3)(int), (*g3)(int, float);
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: void /*(*/ (/*(*/ *f3)(int);
-    // CHECK-FIXES: {{^    }}void /*(*/ (*g3)(int, float);
+    // CHECK-FIXES: void /*(*/ (*g3)(int, float);
   }
 
   // clang-format off
@@ -333,26 +333,26 @@ void complex_typedefs() {
           }, bb = 4;
   // CHECK-MESSAGES: [[@LINE-7]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int intfunction = returner();
-  // CHECK-FIXES: {{^  }}int intarray[] =
-  // CHECK-FIXES: {{^          }}{
-  // CHECK-FIXES: {{^                  }}1,
-  // CHECK-FIXES: {{^                  }}2,
-  // CHECK-FIXES: {{^                  }}3,
-  // CHECK-FIXES: {{^                  }}4
-  // CHECK-FIXES: {{^          }}};
-  // CHECK-FIXES: {{^  }}int bb = 4;
+  // CHECK-FIXES: int intarray[] =
+  // CHECK-FIXES: {
+  // CHECK-FIXES: 1,
+  // CHECK-FIXES: 2,
+  // CHECK-FIXES: 3,
+  // CHECK-FIXES: 4
+  // CHECK-FIXES: };
+  // CHECK-FIXES: int bb = 4;
   // clang-format on
 
   TemT *T1 = &TT1, *T2 = &TT2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: TemT *T1 = &TT1;
-  // CHECK-FIXES: {{^  }}TemT *T2 = &TT2;
+  // CHECK-FIXES: TemT *T2 = &TT2;
 
   const PointerType *PT1 = T1->getAs<PointerType>(),
                     *PT2 = T2->getAs<PointerType>();
   // CHECK-MESSAGES: [[@LINE-2]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: const PointerType *PT1 = T1->getAs<PointerType>();
-  // CHECK-FIXES: {{^  }}const PointerType *PT2 = T2->getAs<PointerType>();
+  // CHECK-FIXES: const PointerType *PT2 = T2->getAs<PointerType>();
 
   const int *p1 = nullptr;
   const int *p2 = nullptr;
@@ -360,7 +360,7 @@ void complex_typedefs() {
   const int *&pref1 = p1, *&pref2 = p2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: const int *&pref1 = p1;
-  // CHECK-FIXES: {{^  }}const int *&pref2 = p2;
+  // CHECK-FIXES: const int *&pref2 = p2;
 
   // clang-format off
   const char *literal1 = "clang"   "test"\
@@ -368,9 +368,9 @@ void complex_typedefs() {
              *literal2 = "empty", literal3[] = "three";
   // CHECK-MESSAGES: [[@LINE-3]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: const char *literal1 = "clang"   "test"\
-  // CHECK-FIXES: {{^                         }}"one";
-  // CHECK-FIXES: {{^  }}const char *literal2 = "empty";
-  // CHECK-FIXES: {{^  }}const char literal3[] = "three";
+  // CHECK-FIXES: "one";
+  // CHECK-FIXES: const char *literal2 = "empty";
+  // CHECK-FIXES: const char literal3[] = "three";
   // clang-format on
 }
 
@@ -378,7 +378,7 @@ void g() try {
   int i, j;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int i;
-  // CHECK-FIXES: {{^  }}int j;
+  // CHECK-FIXES: int j;
 } catch (...) {
 }
 
@@ -393,7 +393,7 @@ void memberPointers() {
   MemPtr aaa = &S::a, bbb = &S::b;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: MemPtr aaa = &S::a;
-  // CHECK-FIXES: {{^  }}MemPtr bbb = &S::b;
+  // CHECK-FIXES: MemPtr bbb = &S::b;
 }
 
 typedef int *tptr, tbt;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
@@ -24,8 +24,8 @@ void f2() {
   // CHECK-MESSAGES: [[@LINE-4]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int /* here is a comment */ v1;
   // CHECK-FIXES: int /* here is a comment */ // another comment
-  // CHECK-FIXES: v2 = 42 // Ok, more comments
-  // CHECK-FIXES: ;
+  // CHECK-FIXES:     v2 = 42 // Ok, more comments
+  // CHECK-FIXES:     ;
 
   auto int1 = 42, int2 = 0, int3 = 43;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
@@ -334,12 +334,12 @@ void complex_typedefs() {
   // CHECK-MESSAGES: [[@LINE-7]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int intfunction = returner();
   // CHECK-FIXES: int intarray[] =
-  // CHECK-FIXES: {
-  // CHECK-FIXES: 1,
-  // CHECK-FIXES: 2,
-  // CHECK-FIXES: 3,
-  // CHECK-FIXES: 4
-  // CHECK-FIXES: };
+  // CHECK-FIXES:         {
+  // CHECK-FIXES:                 1,
+  // CHECK-FIXES:                 2,
+  // CHECK-FIXES:                 3,
+  // CHECK-FIXES:                 4
+  // CHECK-FIXES:         };
   // CHECK-FIXES: int bb = 4;
   // clang-format on
 
@@ -368,7 +368,7 @@ void complex_typedefs() {
              *literal2 = "empty", literal3[] = "three";
   // CHECK-MESSAGES: [[@LINE-3]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: const char *literal1 = "clang"   "test"\
-  // CHECK-FIXES: "one";
+  // CHECK-FIXES:                        "one";
   // CHECK-FIXES: const char *literal2 = "empty";
   // CHECK-FIXES: const char literal3[] = "three";
   // clang-format on

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/make-member-function-const.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/make-member-function-const.cpp
@@ -24,107 +24,107 @@ struct A {
 
   int read_field() {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'read_field' can be made const
-    // CHECK-FIXES: {{^}}  int read_field() const {
+    // CHECK-FIXES: int read_field() const {
     return M;
   }
 
   int read_struct_field() {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'read_struct_field' can be made const
-    // CHECK-FIXES: {{^}}  int read_struct_field() const {
+    // CHECK-FIXES: int read_struct_field() const {
     return Struct.M;
   }
 
   int read_const_field() {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'read_const_field' can be made const
-    // CHECK-FIXES: {{^}}  int read_const_field() const {
+    // CHECK-FIXES: int read_const_field() const {
     return ConstM;
   }
 
   int read_fields_in_parentheses() {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'read_fields_in_parentheses' can be made const
-    // CHECK-FIXES: {{^}}  int read_fields_in_parentheses() const {
+    // CHECK-FIXES: int read_fields_in_parentheses() const {
     return (this)->M + (((((Struct.M))))) + ((this->ConstM));
   }
 
   void call_const_member() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'call_const_member' can be made const
-    // CHECK-FIXES: {{^}}  void call_const_member() const {
+    // CHECK-FIXES: void call_const_member() const {
     already_const();
   }
 
   void call_const_member_on_public_field() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'call_const_member_on_public_field' can be made const
-    // CHECK-FIXES: {{^}}  void call_const_member_on_public_field() const {
+    // CHECK-FIXES: void call_const_member_on_public_field() const {
     S.const_method();
   }
 
   void call_const_member_on_public_field_ref() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'call_const_member_on_public_field_ref' can be made const
-    // CHECK-FIXES: {{^}}  void call_const_member_on_public_field_ref() const {
+    // CHECK-FIXES: void call_const_member_on_public_field_ref() const {
     Sref.const_method();
   }
 
   const Str &return_public_field_ref() {
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: method 'return_public_field_ref' can be made const
-    // CHECK-FIXES: {{^}}  const Str &return_public_field_ref() const {
+    // CHECK-FIXES: const Str &return_public_field_ref() const {
     return S;
   }
 
   const A *return_this_const() {
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: method 'return_this_const' can be made const
-    // CHECK-FIXES: {{^}}  const A *return_this_const() const {
+    // CHECK-FIXES: const A *return_this_const() const {
     return this;
   }
 
   const A &return_this_const_ref() {
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: method 'return_this_const_ref' can be made const
-    // CHECK-FIXES: {{^}}  const A &return_this_const_ref() const {
+    // CHECK-FIXES: const A &return_this_const_ref() const {
     return *this;
   }
 
   void const_use() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'const_use' can be made const
-    // CHECK-FIXES: {{^}}  void const_use() const {
+    // CHECK-FIXES: void const_use() const {
     free_const_use(this);
   }
 
   void const_use_ref() {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'const_use_ref' can be made const
-    // CHECK-FIXES: {{^}}  void const_use_ref() const {
+    // CHECK-FIXES: void const_use_ref() const {
     free_const_use(*this);
   }
 
   auto trailingReturn() -> int {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'trailingReturn' can be made const
-    // CHECK-FIXES: {{^}}  auto trailingReturn() const -> int {
+    // CHECK-FIXES: auto trailingReturn() const -> int {
     return M;
   }
 
   int volatileFunction() volatile {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'volatileFunction' can be made const
-    // CHECK-FIXES: {{^}}  int volatileFunction() const volatile {
+    // CHECK-FIXES: int volatileFunction() const volatile {
     return M;
   }
 
   int restrictFunction() __restrict {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'restrictFunction' can be made const
-    // CHECK-FIXES: {{^}}  int restrictFunction() const __restrict {
+    // CHECK-FIXES: int restrictFunction() const __restrict {
     return M;
   }
 
   int refFunction() & {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'refFunction' can be made const
-    // CHECK-FIXES: {{^}}  int refFunction() const & {
+    // CHECK-FIXES: int refFunction() const & {
     return M;
   }
 
   void out_of_line_call_const();
-  // CHECK-FIXES: {{^}}  void out_of_line_call_const() const;
+  // CHECK-FIXES: void out_of_line_call_const() const;
 };
 
 void A::out_of_line_call_const() {
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: method 'out_of_line_call_const' can be made const
-  // CHECK-FIXES: {{^}}void A::out_of_line_call_const() const {
+  // CHECK-FIXES: void A::out_of_line_call_const() const {
   already_const();
 }
 } // namespace Diagnose

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.c
@@ -5,7 +5,7 @@ static int f();
 int f(p)
   int *p;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: pointer parameter 'p' can be pointer to const [readability-non-const-parameter]
-// CHECK-FIXES: {{^}}  const int *p;{{$}}
+// CHECK-FIXES: const int *p;
 {
     return *p;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -14,7 +14,7 @@ unsigned my_strlen(const char *buf);
 
 // CHECK-MESSAGES: :[[@LINE+1]]:29: warning: pointer parameter 'last' can be pointer to const [readability-non-const-parameter]
 void warn1(int *first, int *last) {
-  // CHECK-FIXES: {{^}}void warn1(int *first, const int *last) {{{$}}
+  // CHECK-FIXES: void warn1(int *first, const int *last) {
   *first = 0;
   if (first < last) {
   } // <- last can be const
@@ -28,14 +28,14 @@ void warn2(char *p) {
 
 // CHECK-MESSAGES: :[[@LINE+1]]:19: warning: pointer parameter 'p' can be
 void assign1(int *p) {
-  // CHECK-FIXES: {{^}}void assign1(const int *p) {{{$}}
+  // CHECK-FIXES: void assign1(const int *p) {
   const int *q;
   q = p;
 }
 
 // CHECK-MESSAGES: :[[@LINE+1]]:19: warning: pointer parameter 'p' can be
 void assign2(int *p) {
-  // CHECK-FIXES: {{^}}void assign2(const int *p) {{{$}}
+  // CHECK-FIXES: void assign2(const int *p) {
   const int *q;
   q = p + 1;
 }
@@ -82,13 +82,13 @@ void assign10(int *buf) {
 
 // CHECK-MESSAGES: :[[@LINE+1]]:17: warning: pointer parameter 'p' can be
 void init1(int *p) {
-  // CHECK-FIXES: {{^}}void init1(const int *p) {{{$}}
+  // CHECK-FIXES: void init1(const int *p) {
   const int *q = p;
 }
 
 // CHECK-MESSAGES: :[[@LINE+1]]:17: warning: pointer parameter 'p' can be
 void init2(int *p) {
-  // CHECK-FIXES: {{^}}void init2(const int *p) {{{$}}
+  // CHECK-FIXES: void init2(const int *p) {
   const int *q = p + 1;
 }
 
@@ -115,25 +115,25 @@ void init7(int *p, int x) {
 
 // CHECK-MESSAGES: :[[@LINE+1]]:18: warning: pointer parameter 'p' can be
 int return1(int *p) {
-  // CHECK-FIXES: {{^}}int return1(const int *p) {{{$}}
+  // CHECK-FIXES: int return1(const int *p) {
   return *p;
 }
 
 // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: pointer parameter 'p' can be
 const int *return2(int *p) {
-  // CHECK-FIXES: {{^}}const int *return2(const int *p) {{{$}}
+  // CHECK-FIXES: const int *return2(const int *p) {
   return p;
 }
 
 // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: pointer parameter 'p' can be
 const int *return3(int *p) {
-  // CHECK-FIXES: {{^}}const int *return3(const int *p) {{{$}}
+  // CHECK-FIXES: const int *return3(const int *p) {
   return p + 1;
 }
 
 // CHECK-MESSAGES: :[[@LINE+1]]:27: warning: pointer parameter 'p' can be
 const char *return4(char *p) {
-  // CHECK-FIXES: {{^}}const char *return4(const char *p) {{{$}}
+  // CHECK-FIXES: const char *return4(const char *p) {
   return p ? p : "";
 }
 
@@ -231,13 +231,13 @@ struct XYConst {
 };
 // CHECK-MESSAGES: :[[@LINE+1]]:30: warning: pointer parameter 'x' can be pointer to const
 void recordInitListDiag(int *x) {
-  // CHECK-FIXES: {{^}}void recordInitListDiag(const int *x) {{{$}}
+  // CHECK-FIXES: void recordInitListDiag(const int *x) {
   XYConst xy = {x};
 }
 typedef XYConst XYConstAlias;
 // CHECK-MESSAGES: :[[@LINE+1]]:35: warning: pointer parameter 'x' can be pointer to const
 void recordInitListAliasDiag(int *x) {
-  // CHECK-FIXES: {{^}}void recordInitListAliasDiag(const int *x) {{{$}}
+  // CHECK-FIXES: void recordInitListAliasDiag(const int *x) {
   XYConstAlias xy = {x};
 }
 
@@ -253,7 +253,7 @@ class C2 {
 public:
   // CHECK-MESSAGES: :[[@LINE+1]]:11: warning: pointer parameter 'p' can be
   C2(int *p) : p(p) {}
-  // CHECK-FIXES: {{^}}  C2(const int *p) : p(p) {}{{$}}
+  // CHECK-FIXES: C2(const int *p) : p(p) {}
 
 private:
   const int *p;
@@ -272,7 +272,7 @@ class Warn {
 public:
   // CHECK-MESSAGES: :[[@LINE+1]]:21: warning: pointer parameter 'p' can be
   void doStuff(int *p) {
-    // CHECK-FIXES: {{^}}  void doStuff(const int *p) {{{$}}
+    // CHECK-FIXES: void doStuff(const int *p) {
     x = *p;
   }
 
@@ -297,14 +297,14 @@ public:
 };
 
 extern char foo(char *s); // 1
-// CHECK-FIXES: {{^}}extern char foo(const char *s); // 1{{$}}
+// CHECK-FIXES: extern char foo(const char *s); // 1
 // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: pointer parameter 's' can be
 char foo(char *s) {
-  // CHECK-FIXES: {{^}}char foo(const char *s) {{{$}}
+  // CHECK-FIXES: char foo(const char *s) {
   return *s;
 }
 char foo(char *s); // 2
-// CHECK-FIXES: {{^}}char foo(const char *s); // 2{{$}}
+// CHECK-FIXES: char foo(const char *s); // 2
 
 void lvalueReference(int *p) {
   // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be
@@ -313,7 +313,7 @@ void lvalueReference(int *p) {
 
 // CHECK-MESSAGES: :[[@LINE+1]]:32: warning: pointer parameter 'p' can be
 void constLValueReference(int *p) {
-  // CHECK-FIXES: {{^}}void constLValueReference(const int *p) {{{$}}
+  // CHECK-FIXES: void constLValueReference(const int *p) {
   const int &x = *p;
 }
 
@@ -326,7 +326,7 @@ void lambdaLVRef(int *p) {
 
 // CHECK-MESSAGES: :[[@LINE+1]]:28: warning: pointer parameter 'p' can be
 void lambdaConstLVRef(int *p) {
-  // CHECK-FIXES: {{^}}void lambdaConstLVRef(const int *p) {{{$}}
+  // CHECK-FIXES: void lambdaConstLVRef(const int *p) {
   auto foo = [&]() {
     const int &x = *p;
   };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/operators-representation-to-alternative.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/operators-representation-to-alternative.cpp
@@ -7,47 +7,47 @@ void testAllTokensToAlternative(int a, int b) {
 
   value = a||b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '||' is a traditional token spelling, consider using an alternative token 'or' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a or b;{{$}}
+  // CHECK-FIXES: value = a or b;
 
   value = a&&b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '&&' is a traditional token spelling, consider using an alternative token 'and' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a and b;{{$}}
+  // CHECK-FIXES: value = a and b;
 
   value = a | b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '|' is a traditional token spelling, consider using an alternative token 'bitor' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a bitor b;{{$}}
+  // CHECK-FIXES: value = a bitor b;
 
   value = a & b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '&' is a traditional token spelling, consider using an alternative token 'bitand' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a bitand b;{{$}}
+  // CHECK-FIXES: value = a bitand b;
 
   value = !a;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: '!' is a traditional token spelling, consider using an alternative token 'not' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = not a;{{$}}
+  // CHECK-FIXES: value = not a;
 
   value = a^b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '^' is a traditional token spelling, consider using an alternative token 'xor' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a xor b;{{$}}
+  // CHECK-FIXES: value = a xor b;
 
   value = ~b;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: '~' is a traditional token spelling, consider using an alternative token 'compl' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = compl b;{{$}}
+  // CHECK-FIXES: value = compl b;
 
   value &= b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '&=' is a traditional token spelling, consider using an alternative token 'and_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value and_eq b;{{$}}
+  // CHECK-FIXES: value and_eq b;
 
   value |= b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '|=' is a traditional token spelling, consider using an alternative token 'or_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value or_eq b;{{$}}
+  // CHECK-FIXES: value or_eq b;
 
   value = a != b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '!=' is a traditional token spelling, consider using an alternative token 'not_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a not_eq b;{{$}}
+  // CHECK-FIXES: value = a not_eq b;
 
   value ^= a;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '^=' is a traditional token spelling, consider using an alternative token 'xor_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value xor_eq a;{{$}}
+  // CHECK-FIXES: value xor_eq a;
 }
 
 struct Class {
@@ -70,47 +70,47 @@ void testAllTokensToAlternative(Class a, Class b) {
 
   value = a||b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '||' is a traditional token spelling, consider using an alternative token 'or' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a or b;{{$}}
+  // CHECK-FIXES: value = a or b;
 
   value = a&&b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '&&' is a traditional token spelling, consider using an alternative token 'and' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a and b;{{$}}
+  // CHECK-FIXES: value = a and b;
 
   clval = a | b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '|' is a traditional token spelling, consider using an alternative token 'bitor' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a bitor b;{{$}}
+  // CHECK-FIXES: clval = a bitor b;
 
   clval = a & b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '&' is a traditional token spelling, consider using an alternative token 'bitand' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a bitand b;{{$}}
+  // CHECK-FIXES: clval = a bitand b;
 
   value = !a;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: '!' is a traditional token spelling, consider using an alternative token 'not' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = not a;{{$}}
+  // CHECK-FIXES: value = not a;
 
   clval = a^b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '^' is a traditional token spelling, consider using an alternative token 'xor' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a xor b;{{$}}
+  // CHECK-FIXES: clval = a xor b;
 
   clval = ~b;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: '~' is a traditional token spelling, consider using an alternative token 'compl' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = compl b;{{$}}
+  // CHECK-FIXES: clval = compl b;
 
   clval &= b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '&=' is a traditional token spelling, consider using an alternative token 'and_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval and_eq b;{{$}}
+  // CHECK-FIXES: clval and_eq b;
 
   clval |= b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '|=' is a traditional token spelling, consider using an alternative token 'or_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval or_eq b;{{$}}
+  // CHECK-FIXES: clval or_eq b;
 
   value = a != b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '!=' is a traditional token spelling, consider using an alternative token 'not_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a not_eq b;{{$}}
+  // CHECK-FIXES: value = a not_eq b;
 
   clval ^= a;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '^=' is a traditional token spelling, consider using an alternative token 'xor_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval xor_eq a;{{$}}
+  // CHECK-FIXES: clval xor_eq a;
 }
 
 struct ClassO {};
@@ -133,45 +133,45 @@ void testAllTokensToAlternative(ClassO a, ClassO b) {
 
   value = a||b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '||' is a traditional token spelling, consider using an alternative token 'or' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a or b;{{$}}
+  // CHECK-FIXES: value = a or b;
 
   value = a&&b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '&&' is a traditional token spelling, consider using an alternative token 'and' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a and b;{{$}}
+  // CHECK-FIXES: value = a and b;
 
   clval = a | b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '|' is a traditional token spelling, consider using an alternative token 'bitor' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a bitor b;{{$}}
+  // CHECK-FIXES: clval = a bitor b;
 
   clval = a & b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '&' is a traditional token spelling, consider using an alternative token 'bitand' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a bitand b;{{$}}
+  // CHECK-FIXES: clval = a bitand b;
 
   value = !a;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: '!' is a traditional token spelling, consider using an alternative token 'not' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = not a;{{$}}
+  // CHECK-FIXES: value = not a;
 
   clval = a^b;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: '^' is a traditional token spelling, consider using an alternative token 'xor' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a xor b;{{$}}
+  // CHECK-FIXES: clval = a xor b;
 
   clval = ~b;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: '~' is a traditional token spelling, consider using an alternative token 'compl' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = compl b;{{$}}
+  // CHECK-FIXES: clval = compl b;
 
   clval &= b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '&=' is a traditional token spelling, consider using an alternative token 'and_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval and_eq b;{{$}}
+  // CHECK-FIXES: clval and_eq b;
 
   clval |= b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '|=' is a traditional token spelling, consider using an alternative token 'or_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval or_eq b;{{$}}
+  // CHECK-FIXES: clval or_eq b;
 
   value = a != b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: '!=' is a traditional token spelling, consider using an alternative token 'not_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a not_eq b;{{$}}
+  // CHECK-FIXES: value = a not_eq b;
 
   clval ^= a;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: '^=' is a traditional token spelling, consider using an alternative token 'xor_eq' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval xor_eq a;{{$}}
+  // CHECK-FIXES: clval xor_eq a;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/operators-representation-to-traditional.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/operators-representation-to-traditional.cpp
@@ -7,47 +7,47 @@ void testAllTokensToAlternative(int a, int b) {
 
   value = a or b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'or' is an alternative token spelling, consider using a traditional token '||' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a || b;{{$}}
+  // CHECK-FIXES: value = a || b;
 
   value = a and b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'and' is an alternative token spelling, consider using a traditional token '&&' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a && b;{{$}}
+  // CHECK-FIXES: value = a && b;
 
   value = a bitor b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'bitor' is an alternative token spelling, consider using a traditional token '|' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a | b;{{$}}
+  // CHECK-FIXES: value = a | b;
 
   value = a bitand b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'bitand' is an alternative token spelling, consider using a traditional token '&' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a & b;{{$}}
+  // CHECK-FIXES: value = a & b;
 
   value = not a;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'not' is an alternative token spelling, consider using a traditional token '!' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = ! a;{{$}}
+  // CHECK-FIXES: value = ! a;
 
   value = a xor b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'xor' is an alternative token spelling, consider using a traditional token '^' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a ^ b;{{$}}
+  // CHECK-FIXES: value = a ^ b;
 
   value = compl b;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'compl' is an alternative token spelling, consider using a traditional token '~' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = ~ b;{{$}}
+  // CHECK-FIXES: value = ~ b;
 
   value and_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'and_eq' is an alternative token spelling, consider using a traditional token '&=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value &= b;{{$}}
+  // CHECK-FIXES: value &= b;
 
   value or_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'or_eq' is an alternative token spelling, consider using a traditional token '|=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value |= b;{{$}}
+  // CHECK-FIXES: value |= b;
 
   value = a not_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'not_eq' is an alternative token spelling, consider using a traditional token '!=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a != b;{{$}}
+  // CHECK-FIXES: value = a != b;
 
   value xor_eq a;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'xor_eq' is an alternative token spelling, consider using a traditional token '^=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value ^= a;{{$}}
+  // CHECK-FIXES: value ^= a;
 }
 
 struct Class {
@@ -70,47 +70,47 @@ void testAllTokensToAlternative(Class a, Class b) {
 
   value = a or b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'or' is an alternative token spelling, consider using a traditional token '||' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a || b;{{$}}
+  // CHECK-FIXES: value = a || b;
 
   value = a and b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'and' is an alternative token spelling, consider using a traditional token '&&' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a && b;{{$}}
+  // CHECK-FIXES: value = a && b;
 
   clval = a bitor b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'bitor' is an alternative token spelling, consider using a traditional token '|' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a | b;{{$}}
+  // CHECK-FIXES: clval = a | b;
 
   clval = a bitand b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'bitand' is an alternative token spelling, consider using a traditional token '&' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a & b;{{$}}
+  // CHECK-FIXES: clval = a & b;
 
   value = not a;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'not' is an alternative token spelling, consider using a traditional token '!' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = ! a;{{$}}
+  // CHECK-FIXES: value = ! a;
 
   clval = a xor b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'xor' is an alternative token spelling, consider using a traditional token '^' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a ^ b;{{$}}
+  // CHECK-FIXES: clval = a ^ b;
 
   clval = compl b;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'compl' is an alternative token spelling, consider using a traditional token '~' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = ~ b;{{$}}
+  // CHECK-FIXES: clval = ~ b;
 
   clval and_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'and_eq' is an alternative token spelling, consider using a traditional token '&=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval &= b;{{$}}
+  // CHECK-FIXES: clval &= b;
 
   clval or_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'or_eq' is an alternative token spelling, consider using a traditional token '|=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval |= b;{{$}}
+  // CHECK-FIXES: clval |= b;
 
   value = a not_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'not_eq' is an alternative token spelling, consider using a traditional token '!=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a != b;{{$}}
+  // CHECK-FIXES: value = a != b;
 
   clval xor_eq a;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'xor_eq' is an alternative token spelling, consider using a traditional token '^=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval ^= a;{{$}}
+  // CHECK-FIXES: clval ^= a;
 }
 
 struct ClassO {};
@@ -133,45 +133,45 @@ void testAllTokensToAlternative(ClassO a, ClassO b) {
 
   value = a or b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'or' is an alternative token spelling, consider using a traditional token '||' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a || b;{{$}}
+  // CHECK-FIXES: value = a || b;
 
   value = a and b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'and' is an alternative token spelling, consider using a traditional token '&&' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a && b;{{$}}
+  // CHECK-FIXES: value = a && b;
 
   clval = a bitor b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'bitor' is an alternative token spelling, consider using a traditional token '|' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a | b;{{$}}
+  // CHECK-FIXES: clval = a | b;
 
   clval = a bitand b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'bitand' is an alternative token spelling, consider using a traditional token '&' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a & b;{{$}}
+  // CHECK-FIXES: clval = a & b;
 
   value = not a;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'not' is an alternative token spelling, consider using a traditional token '!' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = ! a;{{$}}
+  // CHECK-FIXES: value = ! a;
 
   clval = a xor b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'xor' is an alternative token spelling, consider using a traditional token '^' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = a ^ b;{{$}}
+  // CHECK-FIXES: clval = a ^ b;
 
   clval = compl b;
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'compl' is an alternative token spelling, consider using a traditional token '~' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval = ~ b;{{$}}
+  // CHECK-FIXES: clval = ~ b;
 
   clval and_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'and_eq' is an alternative token spelling, consider using a traditional token '&=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval &= b;{{$}}
+  // CHECK-FIXES: clval &= b;
 
   clval or_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'or_eq' is an alternative token spelling, consider using a traditional token '|=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval |= b;{{$}}
+  // CHECK-FIXES: clval |= b;
 
   value = a not_eq b;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'not_eq' is an alternative token spelling, consider using a traditional token '!=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}value = a != b;{{$}}
+  // CHECK-FIXES: value = a != b;
 
   clval xor_eq a;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: 'xor_eq' is an alternative token spelling, consider using a traditional token '^=' for consistency [readability-operators-representation]
-  // CHECK-FIXES: {{^  }}clval ^= a;{{$}}
+  // CHECK-FIXES: clval ^= a;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/qualified-auto-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/qualified-auto-cxx20.cpp
@@ -18,32 +18,32 @@ const std::vector<int> *getCVec();
 void foo() {
   if (auto X = getVec(); X->size() > 0) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'auto X' can be declared as 'auto *X'
-    // CHECK-FIXES: {{^}}  if (auto *X = getVec(); X->size() > 0) {
+    // CHECK-FIXES: if (auto *X = getVec(); X->size() > 0) {
   }
   switch (auto X = getVec(); X->size()) {
     // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'auto X' can be declared as 'auto *X'
-    // CHECK-FIXES: {{^}}  switch (auto *X = getVec(); X->size()) {
+    // CHECK-FIXES: switch (auto *X = getVec(); X->size()) {
   default:
     break;
   }
   for (auto X = getVec(); auto Xi : *X) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto X' can be declared as 'auto *X'
-    // CHECK-FIXES: {{^}}  for (auto *X = getVec(); auto Xi : *X) {
+    // CHECK-FIXES: for (auto *X = getVec(); auto Xi : *X) {
   }
 }
 void bar() {
   if (auto X = getCVec(); X->size() > 0) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'auto X' can be declared as 'const auto *X'
-    // CHECK-FIXES: {{^}}  if (const auto *X = getCVec(); X->size() > 0) {
+    // CHECK-FIXES: if (const auto *X = getCVec(); X->size() > 0) {
   }
   switch (auto X = getCVec(); X->size()) {
     // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'auto X' can be declared as 'const auto *X'
-    // CHECK-FIXES: {{^}}  switch (const auto *X = getCVec(); X->size()) {
+    // CHECK-FIXES: switch (const auto *X = getCVec(); X->size()) {
   default:
     break;
   }
   for (auto X = getCVec(); auto Xi : *X) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto X' can be declared as 'const auto *X'
-    // CHECK-FIXES: {{^}}  for (const auto *X = getCVec(); auto Xi : *X) {
+    // CHECK-FIXES: for (const auto *X = getCVec(); auto Xi : *X) {
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/qualified-auto.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/qualified-auto.cpp
@@ -24,27 +24,27 @@ CMyRef getCRef();
 void foo() {
   auto TdNakedPtr = getPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto TdNakedPtr' can be declared as 'auto *TdNakedPtr'
-  // CHECK-FIXES: {{^}}  auto *TdNakedPtr = getPtr();
+  // CHECK-FIXES: auto *TdNakedPtr = getPtr();
   auto TdNakedPtrPtr = getPtrPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto TdNakedPtrPtr' can be declared as 'auto *TdNakedPtrPtr'
-  // CHECK-FIXES: {{^}}  auto *TdNakedPtrPtr = getPtrPtr();
+  // CHECK-FIXES: auto *TdNakedPtrPtr = getPtrPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto TdNakedPtrPtr' can be declared as 'auto *TdNakedPtrPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  auto *TdNakedPtrPtr = getPtrPtr();
+  // CHECK-FIXES-ALIAS: auto *TdNakedPtrPtr = getPtrPtr();
   auto &TdNakedRef = getRef();
   auto TdNakedRefDeref = getRef();
   auto TdNakedCPtr = getCPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto TdNakedCPtr' can be declared as 'const auto *TdNakedCPtr'
-  // CHECK-FIXES: {{^}}  const auto *TdNakedCPtr = getCPtr();
+  // CHECK-FIXES: const auto *TdNakedCPtr = getCPtr();
   auto TdNakedCPtrPtr = getCPtrPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto TdNakedCPtrPtr' can be declared as 'auto *TdNakedCPtrPtr'
-  // CHECK-FIXES: {{^}}  auto *TdNakedCPtrPtr = getCPtrPtr();
+  // CHECK-FIXES: auto *TdNakedCPtrPtr = getCPtrPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto TdNakedCPtrPtr' can be declared as 'auto *TdNakedCPtrPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  auto *TdNakedCPtrPtr = getCPtrPtr();
+  // CHECK-FIXES-ALIAS: auto *TdNakedCPtrPtr = getCPtrPtr();
   auto &TdNakedCRef = getCRef();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto &TdNakedCRef' can be declared as 'const auto &TdNakedCRef'
-  // CHECK-FIXES: {{^}}  const auto &TdNakedCRef = getCRef();
+  // CHECK-FIXES: const auto &TdNakedCRef = getCRef();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto &TdNakedCRef' can be declared as 'const auto &TdNakedCRef'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto &TdNakedCRef = getCRef();
+  // CHECK-FIXES-ALIAS: const auto &TdNakedCRef = getCRef();
   auto TdNakedCRefDeref = getCRef();
 }
 
@@ -65,22 +65,22 @@ CMyRef getCRef();
 void foo() {
   auto UNakedPtr = getPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto UNakedPtr' can be declared as 'auto *UNakedPtr'
-  // CHECK-FIXES: {{^}}  auto *UNakedPtr = getPtr();
+  // CHECK-FIXES: auto *UNakedPtr = getPtr();
   auto UNakedPtrPtr = getPtrPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto UNakedPtrPtr' can be declared as 'auto *UNakedPtrPtr'
-  // CHECK-FIXES: {{^}}  auto *UNakedPtrPtr = getPtrPtr();
+  // CHECK-FIXES: auto *UNakedPtrPtr = getPtrPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto UNakedPtrPtr' can be declared as 'auto *UNakedPtrPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  auto *UNakedPtrPtr = getPtrPtr();
+  // CHECK-FIXES-ALIAS: auto *UNakedPtrPtr = getPtrPtr();
   auto &UNakedRef = getRef();
   auto UNakedRefDeref = getRef();
   auto UNakedCPtr = getCPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto UNakedCPtr' can be declared as 'const auto *UNakedCPtr'
-  // CHECK-FIXES: {{^}}  const auto *UNakedCPtr = getCPtr();
+  // CHECK-FIXES: const auto *UNakedCPtr = getCPtr();
   auto &UNakedCRef = getCRef();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto &UNakedCRef' can be declared as 'const auto &UNakedCRef'
-  // CHECK-FIXES: {{^}}  const auto &UNakedCRef = getCRef();
+  // CHECK-FIXES: const auto &UNakedCRef = getCRef();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto &UNakedCRef' can be declared as 'const auto &UNakedCRef'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto &UNakedCRef = getCRef();
+  // CHECK-FIXES-ALIAS: const auto &UNakedCRef = getCRef();
   auto UNakedCRefDeref = getCRef();
 }
 
@@ -103,68 +103,68 @@ void foo() {
 
   auto NakedPtr = getIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto NakedPtr' can be declared as 'auto *NakedPtr'
-  // CHECK-FIXES: {{^}}  auto *NakedPtr = getIntPtr();
+  // CHECK-FIXES: auto *NakedPtr = getIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto NakedPtr' can be declared as 'auto *NakedPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  auto *NakedPtr = getIntPtr();
+  // CHECK-FIXES-ALIAS: auto *NakedPtr = getIntPtr();
   auto NakedCPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto NakedCPtr' can be declared as 'const auto *NakedCPtr'
-  // CHECK-FIXES: {{^}}  const auto *NakedCPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *NakedCPtr = getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto NakedCPtr' can be declared as 'const auto *NakedCPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto *NakedCPtr = getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto *NakedCPtr = getCIntPtr();
 
   const auto ConstPtr = getIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'const auto ConstPtr' can be declared as 'auto *const ConstPtr'
-  // CHECK-FIXES: {{^}}  auto *const ConstPtr = getIntPtr();
+  // CHECK-FIXES: auto *const ConstPtr = getIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'const auto ConstPtr' can be declared as 'auto *const ConstPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  auto *const ConstPtr = getIntPtr();
+  // CHECK-FIXES-ALIAS: auto *const ConstPtr = getIntPtr();
   const auto ConstCPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'const auto ConstCPtr' can be declared as 'const auto *const ConstCPtr'
-  // CHECK-FIXES: {{^}}  const auto *const ConstCPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *const ConstCPtr = getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'const auto ConstCPtr' can be declared as 'const auto *const ConstCPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto *const ConstCPtr = getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto *const ConstCPtr = getCIntPtr();
 
   volatile auto VolatilePtr = getIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'volatile auto VolatilePtr' can be declared as 'auto *volatile VolatilePtr'
-  // CHECK-FIXES: {{^}}  auto *volatile VolatilePtr = getIntPtr();
+  // CHECK-FIXES: auto *volatile VolatilePtr = getIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'volatile auto VolatilePtr' can be declared as 'auto *volatile VolatilePtr'
-  // CHECK-FIXES-ALIAS: {{^}}  auto *volatile VolatilePtr = getIntPtr();
+  // CHECK-FIXES-ALIAS: auto *volatile VolatilePtr = getIntPtr();
   volatile auto VolatileCPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'volatile auto VolatileCPtr' can be declared as 'const auto *volatile VolatileCPtr'
-  // CHECK-FIXES: {{^}}  const auto *volatile VolatileCPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *volatile VolatileCPtr = getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'volatile auto VolatileCPtr' can be declared as 'const auto *volatile VolatileCPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto *volatile VolatileCPtr = getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto *volatile VolatileCPtr = getCIntPtr();
 
   auto *QualPtr = getIntPtr();
   auto *QualCPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto *QualCPtr' can be declared as 'const auto *QualCPtr'
-  // CHECK-FIXES: {{^}}  const auto *QualCPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *QualCPtr = getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto *QualCPtr' can be declared as 'const auto *QualCPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto *QualCPtr = getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto *QualCPtr = getCIntPtr();
   auto *const ConstantQualCPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto *const ConstantQualCPtr' can be declared as 'const auto *const ConstantQualCPtr'
-  // CHECK-FIXES: {{^}}  const auto *const ConstantQualCPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *const ConstantQualCPtr = getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto *const ConstantQualCPtr' can be declared as 'const auto *const ConstantQualCPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto *const ConstantQualCPtr = getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto *const ConstantQualCPtr = getCIntPtr();
   auto *volatile VolatileQualCPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto *volatile VolatileQualCPtr' can be declared as 'const auto *volatile VolatileQualCPtr'
-  // CHECK-FIXES: {{^}}  const auto *volatile VolatileQualCPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *volatile VolatileQualCPtr = getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto *volatile VolatileQualCPtr' can be declared as 'const auto *volatile VolatileQualCPtr'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto *volatile VolatileQualCPtr = getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto *volatile VolatileQualCPtr = getCIntPtr();
   const auto *ConstQualCPtr = getCIntPtr();
 
   auto &Ref = *getIntPtr();
   auto &CRef = *getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto &CRef' can be declared as 'const auto &CRef'
-  // CHECK-FIXES: {{^}}  const auto &CRef = *getCIntPtr();
+  // CHECK-FIXES: const auto &CRef = *getCIntPtr();
   // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:3: warning: 'auto &CRef' can be declared as 'const auto &CRef'
-  // CHECK-FIXES-ALIAS: {{^}}  const auto &CRef = *getCIntPtr();
+  // CHECK-FIXES-ALIAS: const auto &CRef = *getCIntPtr();
   const auto &ConstCRef = *getCIntPtr();
 
   if (auto X = getCIntPtr()) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'auto X' can be declared as 'const auto *X'
-    // CHECK-FIXES: {{^}}  if (const auto *X = getCIntPtr()) {
+    // CHECK-FIXES: if (const auto *X = getCIntPtr()) {
     // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:7: warning: 'auto X' can be declared as 'const auto *X'
-    // CHECK-FIXES-ALIAS: {{^}}  if (const auto *X = getCIntPtr()) {
+    // CHECK-FIXES-ALIAS: if (const auto *X = getCIntPtr()) {
   }
 }
 
@@ -201,9 +201,9 @@ void loopRef(std::vector<int> &Mutate, const std::vector<int> &Constant) {
   }
   for (auto &Data : Constant) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto &Data' can be declared as 'const auto &Data'
-    // CHECK-FIXES: {{^}}  for (const auto &Data : Constant) {
+    // CHECK-FIXES: for (const auto &Data : Constant) {
     // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:8: warning: 'auto &Data' can be declared as 'const auto &Data'
-    // CHECK-FIXES-ALIAS: {{^}}  for (const auto &Data : Constant) {
+    // CHECK-FIXES-ALIAS: for (const auto &Data : Constant) {
     observe(Data);
   }
 }
@@ -211,16 +211,16 @@ void loopRef(std::vector<int> &Mutate, const std::vector<int> &Constant) {
 void loopPtr(const std::vector<int *> &Mutate, const std::vector<const int *> &Constant) {
   for (auto Data : Mutate) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto Data' can be declared as 'auto *Data'
-    // CHECK-FIXES: {{^}}  for (auto *Data : Mutate) {
+    // CHECK-FIXES: for (auto *Data : Mutate) {
     // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:8: warning: 'auto Data' can be declared as 'auto *Data'
-    // CHECK-FIXES-ALIAS: {{^}}  for (auto *Data : Mutate) {
+    // CHECK-FIXES-ALIAS: for (auto *Data : Mutate) {
     change(*Data);
   }
   for (auto Data : Constant) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto Data' can be declared as 'const auto *Data'
-    // CHECK-FIXES: {{^}}  for (const auto *Data : Constant) {
+    // CHECK-FIXES: for (const auto *Data : Constant) {
     // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:8: warning: 'auto Data' can be declared as 'const auto *Data'
-    // CHECK-FIXES-ALIAS: {{^}}  for (const auto *Data : Constant) {
+    // CHECK-FIXES-ALIAS: for (const auto *Data : Constant) {
     observe(*Data);
   }
 }
@@ -229,17 +229,17 @@ template <typename T>
 void tempLoopPtr(std::vector<T *> &MutateTemplate, std::vector<const T *> &ConstantTemplate) {
   for (auto Data : MutateTemplate) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto Data' can be declared as 'auto *Data'
-    // CHECK-FIXES: {{^}}  for (auto *Data : MutateTemplate) {
+    // CHECK-FIXES: for (auto *Data : MutateTemplate) {
     // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:8: warning: 'auto Data' can be declared as 'auto *Data'
-    // CHECK-FIXES-ALIAS: {{^}}  for (auto *Data : MutateTemplate) {
+    // CHECK-FIXES-ALIAS: for (auto *Data : MutateTemplate) {
     change(*Data);
   }
   //FixMe
   for (auto Data : ConstantTemplate) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'auto Data' can be declared as 'const auto *Data'
-    // CHECK-FIXES: {{^}}  for (const auto *Data : ConstantTemplate) {
+    // CHECK-FIXES: for (const auto *Data : ConstantTemplate) {
     // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:8: warning: 'auto Data' can be declared as 'const auto *Data'
-    // CHECK-FIXES-ALIAS: {{^}}  for (const auto *Data : ConstantTemplate) {
+    // CHECK-FIXES-ALIAS: for (const auto *Data : ConstantTemplate) {
     observe(*Data);
   }
 }
@@ -250,17 +250,17 @@ public:
   void operator()(const std::vector<T *> &MClassTemplate, const std::vector<const T *> &CClassTemplate) {
     for (auto Data : MClassTemplate) {
       // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'auto Data' can be declared as 'auto *Data'
-      // CHECK-FIXES: {{^}}    for (auto *Data : MClassTemplate) {
+      // CHECK-FIXES: for (auto *Data : MClassTemplate) {
       // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:10: warning: 'auto Data' can be declared as 'auto *Data'
-      // CHECK-FIXES-ALIAS: {{^}}    for (auto *Data : MClassTemplate) {
+      // CHECK-FIXES-ALIAS: for (auto *Data : MClassTemplate) {
       change(*Data);
     }
     //FixMe
     for (auto Data : CClassTemplate) {
       // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'auto Data' can be declared as 'const auto *Data'
-      // CHECK-FIXES: {{^}}    for (const auto *Data : CClassTemplate) {
+      // CHECK-FIXES: for (const auto *Data : CClassTemplate) {
       // CHECK-MESSAGES-ALIAS: :[[@LINE-3]]:10: warning: 'auto Data' can be declared as 'const auto *Data'
-      // CHECK-FIXES-ALIAS: {{^}}    for (const auto *Data : CClassTemplate) {
+      // CHECK-FIXES-ALIAS: for (const auto *Data : CClassTemplate) {
       observe(*Data);
     }
   }
@@ -285,32 +285,32 @@ functionRetVal getValFunction();
 void baz() {
   auto MyFunctionPtr = getPtrFunction();
   // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: 'auto MyFunctionPtr' can be declared as 'auto *MyFunctionPtr'
-  // CHECK-FIXES-NOT: {{^}}  auto *MyFunctionPtr = getPtrFunction();
+  // CHECK-FIXES-NOT: auto *MyFunctionPtr = getPtrFunction();
   // CHECK-MESSAGES-NOT-ALIAS: :[[@LINE-1]]:3: warning: 'auto MyFunctionPtr' can be declared as 'auto *MyFunctionPtr'
-  // CHECK-FIXES-NOT-ALIAS: {{^}}  auto *MyFunctionPtr = getPtrFunction();
+  // CHECK-FIXES-NOT-ALIAS: auto *MyFunctionPtr = getPtrFunction();
   auto MyFunctionVal = getValFunction();
   // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: 'auto MyFunctionVal' can be declared as 'auto *MyFunctionVal'
-  // CHECK-FIXES-NOT: {{^}}  auto *MyFunctionVal = getValFunction();
+  // CHECK-FIXES-NOT: auto *MyFunctionVal = getValFunction();
   // CHECK-MESSAGES-NOT-ALIAS: :[[@LINE-3]]:3: warning: 'auto MyFunctionVal' can be declared as 'auto *MyFunctionVal'
-  // CHECK-FIXES-NOT-ALIAS: {{^}}  auto *MyFunctionVal = getValFunction();
+  // CHECK-FIXES-NOT-ALIAS: auto *MyFunctionVal = getValFunction();
 
   auto LambdaTest = [] { return 0; };
   // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: 'auto LambdaTest' can be declared as 'auto *LambdaTest'
-  // CHECK-FIXES-NOT: {{^}}  auto *LambdaTest = [] { return 0; };
+  // CHECK-FIXES-NOT: auto *LambdaTest = [] { return 0; };
   // CHECK-MESSAGES-NOT-ALIAS: :[[@LINE-3]]:3: warning: 'auto LambdaTest' can be declared as 'auto *LambdaTest'
-  // CHECK-FIXES-NOT-ALIAS: {{^}}  auto *LambdaTest = [] { return 0; };
+  // CHECK-FIXES-NOT-ALIAS: auto *LambdaTest = [] { return 0; };
 
   auto LambdaTest2 = +[] { return 0; };
   // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: 'auto LambdaTest2' can be declared as 'auto *LambdaTest2'
-  // CHECK-FIXES-NOT: {{^}}  auto *LambdaTest2 = +[] { return 0; };
+  // CHECK-FIXES-NOT: auto *LambdaTest2 = +[] { return 0; };
   // CHECK-MESSAGES-NOT-ALIAS: :[[@LINE-3]]:3: warning: 'auto LambdaTest2' can be declared as 'auto *LambdaTest2'
-  // CHECK-FIXES-NOT-ALIAS: {{^}}  auto *LambdaTest2 = +[] { return 0; };
+  // CHECK-FIXES-NOT-ALIAS: auto *LambdaTest2 = +[] { return 0; };
 
   auto MyFunctionRef = *getPtrFunction();
   // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: 'auto MyFunctionRef' can be declared as 'auto *MyFunctionRef'
-  // CHECK-FIXES-NOT: {{^}}  auto *MyFunctionRef = *getPtrFunction();
+  // CHECK-FIXES-NOT: auto *MyFunctionRef = *getPtrFunction();
   // CHECK-MESSAGES-NOT-ALIAS: :[[@LINE-3]]:3: warning: 'auto MyFunctionRef' can be declared as 'auto *MyFunctionRef'
-  // CHECK-FIXES-NOT-ALIAS: {{^}}  auto *MyFunctionRef = *getPtrFunction();
+  // CHECK-FIXES-NOT-ALIAS: auto *MyFunctionRef = *getPtrFunction();
 
   auto &MyFunctionRef2 = *getPtrFunction();
 }
@@ -456,13 +456,13 @@ void ignored_types_template(std::array<T, 4> arr, const std::array<T, 4>& carr) 
 
   for (auto Data : arr) {
     // CHECK-MESSAGES-NOT: warning: 'auto Data' can be declared as 'auto *Data'
-    // CHECK-FIXES-NOT: {{^}}    for (auto *Data : MClassTemplate) {
+    // CHECK-FIXES-NOT: for (auto *Data : MClassTemplate) {
     change(*Data);
   }
 
   for (auto Data : carr) {
     // CHECK-MESSAGES-NOT: warning: 'auto Data' can be declared as 'const auto *Data'
-    // CHECK-FIXES-NOT: {{^}}    for (const auto *Data : MClassTemplate) {
+    // CHECK-FIXES-NOT: for (const auto *Data : MClassTemplate) {
     change(*Data);
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-access-specifiers-check-first-declaration.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-access-specifiers-check-first-declaration.cpp
@@ -4,21 +4,21 @@
 class FooPublic {
 private: // comment-0
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the implicit access specifier [readability-redundant-access-specifiers]
-  // CHECK-FIXES: {{^}}// comment-0{{$}}
+  // CHECK-FIXES: // comment-0
   int a;
 };
 
 struct StructPublic {
 public: // comment-1
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the implicit access specifier [readability-redundant-access-specifiers]
-  // CHECK-FIXES: {{^}}// comment-1{{$}}
+  // CHECK-FIXES: // comment-1
   int a;
 };
 
 union UnionPublic {
 public: // comment-2
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the implicit access specifier [readability-redundant-access-specifiers]
-  // CHECK-FIXES: {{^}}// comment-2{{$}}
+  // CHECK-FIXES: // comment-2
   int a;
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-access-specifiers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-access-specifiers.cpp
@@ -6,7 +6,7 @@ public:
 public: // comment-0
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
   // CHECK-MESSAGES: :[[@LINE-4]]:1: note: previously declared here
-  // CHECK-FIXES: {{^}}// comment-0{{$}}
+  // CHECK-FIXES: // comment-0
   int b;
 private:
   int c;
@@ -18,7 +18,7 @@ public:
 public: // comment-1
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
   // CHECK-MESSAGES: :[[@LINE-4]]:1: note: previously declared here
-  // CHECK-FIXES: {{^}}// comment-1{{$}}
+  // CHECK-FIXES: // comment-1
   int b;
 private:
   int c;
@@ -30,7 +30,7 @@ public:
 public: // comment-2
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
   // CHECK-MESSAGES: :[[@LINE-4]]:1: note: previously declared here
-  // CHECK-FIXES: {{^}}// comment-2{{$}}
+  // CHECK-FIXES: // comment-2
   int b;
 private:
   int c;
@@ -42,7 +42,7 @@ protected:
 protected: // comment-3
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
   // CHECK-MESSAGES: :[[@LINE-4]]:1: note: previously declared here
-  // CHECK-FIXES: {{^}}// comment-3{{$}}
+  // CHECK-FIXES: // comment-3
   int b;
 private:
   int c;
@@ -54,7 +54,7 @@ private:
 private: // comment-4
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
   // CHECK-MESSAGES: :[[@LINE-4]]:1: note: previously declared here
-  // CHECK-FIXES: {{^}}// comment-4{{$}}
+  // CHECK-FIXES: // comment-4
   int b;
 public:
   int c;
@@ -70,7 +70,7 @@ private:
 private: // comment-5
   // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
   // CHECK-MESSAGES: :[[@LINE-8]]:1: note: previously declared here
-  // CHECK-FIXES: {{^}}// comment-5{{$}}
+  // CHECK-FIXES: // comment-5
   int c;
 protected:
   int d;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -22,35 +22,35 @@ void testRedundantStaticCasting(A& value) {
   A& a1 = static_cast<A&>(value);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:36: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  A& a1 = value;
+  // CHECK-FIXES: A& a1 = value;
 }
 
 void testRedundantConstCasting1(A& value) {
   A& a2 = const_cast<A&>(value);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:36: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  A& a2 = value;
+  // CHECK-FIXES: A& a2 = value;
 }
 
 void testRedundantConstCasting2(const A& value) {
   const A& a3 = const_cast<const A&>(value);
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: redundant explicit casting to the same type 'const A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:42: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  const A& a3 = value;
+  // CHECK-FIXES: const A& a3 = value;
 }
 
 void testRedundantReinterpretCasting(A& value) {
   A& a4 = reinterpret_cast<A&>(value);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:41: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  A& a4 = value;
+  // CHECK-FIXES: A& a4 = value;
 }
 
 void testRedundantCCasting(A& value) {
   A& a5 = (A&)(value);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:31: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  A& a5 = value;
+  // CHECK-FIXES: A& a5 = value;
 }
 
 void testDoubleCasting(A& value) {
@@ -58,7 +58,7 @@ void testDoubleCasting(A& value) {
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-4]]:27: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  A& a6 = value;
+  // CHECK-FIXES: A& a6 = value;
 }
 
 void testDiffrentTypesCast(B& value) {
@@ -76,7 +76,7 @@ void testCastingWithAuto() {
   A& a8 = static_cast<A&>(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:8: note: source type originates from referencing this variable
-  // CHECK-FIXES: {{^}}  A& a8 = a;
+  // CHECK-FIXES: A& a8 = a;
 }
 
 void testCastingWithConstAuto() {
@@ -84,7 +84,7 @@ void testCastingWithConstAuto() {
   const A& a9 = static_cast<const A&>(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: redundant explicit casting to the same type 'const A' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:14: note: source type originates from referencing this variable
-  // CHECK-FIXES: {{^}}  const A& a9 = a;
+  // CHECK-FIXES: const A& a9 = a;
 }
 
 void testCastingWithAutoPtr(A& ptr) {
@@ -92,7 +92,7 @@ void testCastingWithAutoPtr(A& ptr) {
   A* a10 = static_cast<A*>(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant explicit casting to the same type 'A *' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-3]]:9: note: source type originates from referencing this variable
-  // CHECK-FIXES: {{^}}  A* a10 = a;
+  // CHECK-FIXES: A* a10 = a;
 }
 
 template<typename T>
@@ -101,7 +101,7 @@ void testRedundantTemplateCasting(T& value) {
   T& t = static_cast<T&>(value);
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: redundant explicit casting to the same type 'T' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-4]]:38: note: source type originates from referencing this parameter
-  // CHECK-FIXES: {{^}}  T& t = value;
+  // CHECK-FIXES: T& t = value;
 }
 
 void testTemplate() {
@@ -130,7 +130,7 @@ void testMacroCasting(int value) {
 void testMacroCasting(A* PTR_NAME) {
   A* a13 = static_cast<A*>(PTR_NAME);
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant explicit casting to the same type 'A *' as the sub-expression, remove this casting [readability-redundant-casting]
-  // CHECK-FIXES: {{^}}  A* a13 = PTR_NAME;
+  // CHECK-FIXES: A* a13 = PTR_NAME;
 }
 
 struct CastBool {
@@ -148,19 +148,19 @@ using TypeA = A;
 void testTypedefCast(A& value) {
   TypeA& a = static_cast<TypeA&>(value);
   // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:14: warning: redundant explicit casting to the same type 'TypeA' (aka 'A') as the sub-expression, remove this casting [readability-redundant-casting]
-  // CHECK-FIXES-ALIASES: {{^}}  TypeA& a = value;
+  // CHECK-FIXES-ALIASES: TypeA& a = value;
 }
 
 void testTypedefCast2(TypeA& value) {
   A& a = static_cast<A&>(value);
   // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:10: warning: redundant explicit casting to the same type 'A' as the sub-expression, remove this casting [readability-redundant-casting]
-  // CHECK-FIXES-ALIASES: {{^}}  A& a = value;
+  // CHECK-FIXES-ALIASES: A& a = value;
 }
 
 void testFunctionalCastWithPrimitive(int a) {
   int b = int(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
-  // CHECK-FIXES: {{^}}  int b = a;
+  // CHECK-FIXES: int b = a;
 }
 
 void testFunctionalCastWithInitExpr(unsigned a) {
@@ -190,7 +190,7 @@ struct Class {
     return static_cast<Iterator>(first());
 // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:12: warning: redundant explicit casting to the same type 'Iterator' (aka 'const char *') as the sub-expression, remove this casting [readability-redundant-casting]
 // CHECK-MESSAGES-ALIASES: :[[@LINE+4]]:15: note: source type originates from the invocation of this method
-// CHECK-FIXES-ALIASES: {{^}}    return first();
+// CHECK-FIXES-ALIASES: return first();
   }
 
   const char* first();
@@ -199,20 +199,20 @@ struct Class {
 void testAddOperation(int aa, int bb) {
   int c = static_cast<int>(aa + bb) * aa;
  // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
- // CHECK-FIXES: {{^}}  int c = (aa + bb) * aa;
+ // CHECK-FIXES: int c = (aa + bb) * aa;
 }
 
 void testAddOperationWithParen(int a, int b) {
   int c = static_cast<int>((a+b))*a;
  // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
- // CHECK-FIXES: {{^}}  int c = (a+b)*a;
+ // CHECK-FIXES: int c = (a+b)*a;
 }
 
 void testRValueCast(int&& a) {
   int&& b = static_cast<int&&>(a);
   int&& c = static_cast<int&&>(10);
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
-  // CHECK-FIXES: {{^}}  int&& c = 10;
+  // CHECK-FIXES: int&& c = 10;
 }
 
 template <int V>
@@ -220,7 +220,7 @@ void testRedundantNTTPCasting() {
   int a = static_cast<int>(V);
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-4]]:15: note: source type originates from referencing this non-type template parameter
-  // CHECK-FIXES: {{^}}  int a = V;
+  // CHECK-FIXES: int a = V;
 }
 
 template <typename T, T V>
@@ -233,5 +233,5 @@ void testRedundantDependentNTTPCasting() {
   T a = static_cast<T>(V);
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant explicit casting to the same type 'T' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES: :[[@LINE-4]]:25: note: source type originates from referencing this non-type template parameter
-  // CHECK-FIXES: {{^}}  T a = V;
+  // CHECK-FIXES: T a = V;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-control-flow.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-control-flow.cpp
@@ -7,7 +7,7 @@ void f() {
   return;
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: redundant return statement at the end of a function with a void return type [readability-redundant-control-flow]
-// CHECK-FIXES: {{^}}void f() {{{$}}
+// CHECK-FIXES: void f() {
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 void g() {
@@ -15,7 +15,7 @@ void g() {
   return;
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: redundant return statement
-// CHECK-FIXES: {{^  }}f();{{$}}
+// CHECK-FIXES: f();
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 void g(int i) {
@@ -40,7 +40,7 @@ void k() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement at the end of loop statement
-// CHECK-FIXES: {{^}}  for (int i = 0; i < 10; ++i) {{{$}}
+// CHECK-FIXES: for (int i = 0; i < 10; ++i) {
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 void k2() {
@@ -50,7 +50,7 @@ void k2() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement
-// CHECK-FIXES: {{^}}  for (auto i : v) {{{$}}
+// CHECK-FIXES: for (auto i : v) {
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 void m() {
@@ -62,8 +62,8 @@ void m() {
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement
 // CHECK-FIXES: {{^  do {$}}
-// CHECK-FIXES-NEXT: {{^}}    ++i;{{$}}
-// CHECK-FIXES-NEXT: {{^ *}}} while (i < 10);{{$}}
+// CHECK-FIXES-NEXT: ++i;
+// CHECK-FIXES-NEXT: } while (i < 10);
 
 void p() {
   int i = 0;
@@ -73,8 +73,8 @@ void p() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement
-// CHECK-FIXES: {{^}}  while (i < 10) {{{$}}
-// CHECK-FIXES-NEXT: {{^}}    ++i;{{$}}
+// CHECK-FIXES: while (i < 10) {
+// CHECK-FIXES-NEXT: ++i;
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 void im_not_dead(int i) {
@@ -176,7 +176,7 @@ void template_return(T check) {
   return;
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: redundant return statement
-// CHECK-FIXES: {{^}}  if (check < T(0)) {{{$}}
+// CHECK-FIXES: if (check < T(0)) {
 // CHECK-FIXES-NEXT: {{^    return;$}}
 // CHECK-FIXES-NEXT: {{^ *}$}}
 // CHECK-FIXES-NEXT: {{^ *}$}}
@@ -189,7 +189,7 @@ void template_return(int check) {
   return;
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: redundant return statement
-// CHECK-FIXES: {{^}}  if (check < 0) {{{$}}
+// CHECK-FIXES: if (check < 0) {
 // CHECK-FIXES-NEXT: {{^    return;$}}
 // CHECK-FIXES-NEXT: {{^ *}$}}
 // CHECK-FIXES-NEXT: {{^ *}$}}
@@ -201,7 +201,7 @@ void template_loop(T end) {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement
-// CHECK-FIXES: {{^}}  for (T i = 0; i < end; ++i) {{{$}}
+// CHECK-FIXES: for (T i = 0; i < end; ++i) {
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 template <>
@@ -211,7 +211,7 @@ void template_loop(int end) {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement
-// CHECK-FIXES: {{^}}  for (int i = 0; i < end; ++i) {{{$}}
+// CHECK-FIXES: for (int i = 0; i < end; ++i) {
 // CHECK-FIXES-NEXT: {{^ *}$}}
 
 void call_templates() {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-declaration.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-declaration.c
@@ -3,23 +3,23 @@
 extern int Xyz;
 extern int Xyz; // Xyz
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'Xyz' declaration [readability-redundant-declaration]
-// CHECK-FIXES: {{^}}// Xyz{{$}}
+// CHECK-FIXES: // Xyz
 int Xyz = 123;
 
 extern int A;
 extern int A, B;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'A' declaration
-// CHECK-FIXES: {{^}}extern int A, B;{{$}}
+// CHECK-FIXES: extern int A, B;
 
 extern int Buf[10];
 extern int Buf[10]; // Buf[10]
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'Buf' declaration
-// CHECK-FIXES: {{^}}// Buf[10]{{$}}
+// CHECK-FIXES: // Buf[10]
 
 static int f(void);
 static int f(void); // f
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'f' declaration
-// CHECK-FIXES: {{^}}// f{{$}}
+// CHECK-FIXES: // f
 static int f(void) { return 0; }
 
 inline void g(void) {}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-declaration.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-declaration.cpp
@@ -21,23 +21,23 @@
 extern int Xyz;
 extern int Xyz; // Xyz
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'Xyz' declaration [readability-redundant-declaration]
-// CHECK-FIXES: {{^}}// Xyz{{$}}
+// CHECK-FIXES: // Xyz
 int Xyz = 123;
 
 extern int A;
 extern int A, B;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'A' declaration
-// CHECK-FIXES: {{^}}extern int A, B;{{$}}
+// CHECK-FIXES: extern int A, B;
 
 extern int Buf[10];
 extern int Buf[10]; // Buf[10]
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'Buf' declaration
-// CHECK-FIXES: {{^}}// Buf[10]{{$}}
+// CHECK-FIXES: // Buf[10]
 
 static int f();
 static int f(); // f
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'f' declaration
-// CHECK-FIXES: {{^}}// f{{$}}
+// CHECK-FIXES: // f
 static int f() { return 0; }
 
 // Original check crashed for the code below.
@@ -102,10 +102,10 @@ namespace macros {
 DECLARE(test);
 DEFINE(test);
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: redundant 'test' declaration
-// CHECK-FIXES: {{^}}#define DECLARE(x) extern int x{{$}}
-// CHECK-FIXES: {{^}}#define DEFINE(x) extern int x; int x = 42{{$}}
-// CHECK-FIXES: {{^}}DECLARE(test);{{$}}
-// CHECK-FIXES: {{^}}DEFINE(test);{{$}}
+// CHECK-FIXES: #define DECLARE(x) extern int x
+// CHECK-FIXES: #define DEFINE(x) extern int x; int x = 42
+// CHECK-FIXES: DECLARE(test);
+// CHECK-FIXES: DEFINE(test);
 
 } // namespace macros
 
@@ -113,16 +113,16 @@ inline void g() {}
 
 inline void g(); // g
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: redundant 'g' declaration
-// CHECK-FIXES: {{^}}// g{{$}}
+// CHECK-FIXES: // g
 
 #if defined(EXTERNINLINE)
 extern inline void g(); // extern g
 // CHECK-MESSAGES-NOMSCOMPAT: :[[@LINE-1]]:20: warning: redundant 'g' declaration
-// CHECK-FIXES-NOMSCOMPAT: {{^}}// extern g{{$}}
+// CHECK-FIXES-NOMSCOMPAT: // extern g
 #endif
 
 // PR42068
 extern "C" int externX;
 int dummyBeforeBegin;extern "C" int externX;int dummyAfterEnd;
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant 'externX' declaration [readability-redundant-declaration]
-// CHECK-FIXES: {{^}}int dummyBeforeBegin;int dummyAfterEnd;{{$}}
+// CHECK-FIXES: int dummyBeforeBegin;int dummyAfterEnd;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
@@ -146,7 +146,7 @@ WithCopyConstructor2::WithCopyConstructor2(const WithCopyConstructor2& other)
 {}
 // No warning in copy constructor about T since IgnoreBaseInCopyConstructors=1
 // CHECK-MESSAGES: :[[@LINE-3]]:10: warning: initializer for member 'a' is redundant
-// CHECK-FIXES: {{^}}  : T() {{$}}
+// CHECK-FIXES: : T()
 // CHECK-NEXT: {}
 
 // Initializer not written

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr-format.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr-format.cpp
@@ -57,35 +57,35 @@ std::wstring return_wtemporary();
 void std_format(const std::string &s1, const std::string &s2, const std::string &s3) {
   auto r1 = std::format("One:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-1]]:37: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDFORMAT: {{^  }}auto r1 = std::format("One:{}\n", s1);
+  // CHECK-FIXES-STDFORMAT: auto r1 = std::format("One:{}\n", s1);
 
   auto r2 = std::format("One:{} Two:{} Three:{} Four:{}\n", s1.c_str(), s2, s3.c_str(), return_temporary().c_str());
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-1]]:61: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-2]]:77: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-3]]:89: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDFORMAT: {{^  }}auto r2 = std::format("One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_temporary());
+  // CHECK-FIXES-STDFORMAT: auto r2 = std::format("One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_temporary());
 
   using namespace std;
   auto r3 = format("Four:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-1]]:33: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDFORMAT: {{^  }}auto r3 = format("Four:{}\n", s1);
+  // CHECK-FIXES-STDFORMAT: auto r3 = format("Four:{}\n", s1);
 }
 
 void std_format_wide(const std::wstring &s1, const std::wstring &s2, const std::wstring &s3) {
   auto r1 = std::format(L"One:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-1]]:38: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDFORMAT: {{^  }}auto r1 = std::format(L"One:{}\n", s1);
+  // CHECK-FIXES-STDFORMAT: auto r1 = std::format(L"One:{}\n", s1);
 
   auto r2 = std::format(L"One:{} Two:{} Three:{} Four:{}\n", s1.c_str(), s2, s3.c_str(), return_wtemporary().c_str());
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-1]]:62: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-2]]:78: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-3]]:90: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDFORMAT: {{^  }}auto r2 = std::format(L"One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_wtemporary());
+  // CHECK-FIXES-STDFORMAT: auto r2 = std::format(L"One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_wtemporary());
 
   using namespace std;
   auto r3 = format(L"Four:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDFORMAT: :[[@LINE-1]]:34: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDFORMAT: {{^  }}auto r3 = format(L"Four:{}\n", s1);
+  // CHECK-FIXES-STDFORMAT: auto r3 = format(L"Four:{}\n", s1);
 }
 
 // There's are c_str() calls here, so it shouldn't be touched.
@@ -119,35 +119,35 @@ std::string not_std_format_wide(const std::string &s1) {
 void std_print(const std::string &s1, const std::string &s2, const std::string &s3) {
   std::print("One:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-1]]:26: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDPRINT: {{^  }}std::print("One:{}\n", s1);
+  // CHECK-FIXES-STDPRINT: std::print("One:{}\n", s1);
 
   std::print("One:{} Two:{} Three:{} Four:{}\n", s1.c_str(), s2, s3.c_str(), return_temporary().c_str());
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-1]]:50: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-2]]:66: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-3]]:78: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDPRINT: {{^  }}std::print("One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_temporary());
+  // CHECK-FIXES-STDPRINT: std::print("One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_temporary());
 
   using namespace std;
   print("Four:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-1]]:22: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDPRINT: {{^  }}print("Four:{}\n", s1);
+  // CHECK-FIXES-STDPRINT: print("Four:{}\n", s1);
 }
 
 void std_print_wide(const std::wstring &s1, const std::wstring &s2, const std::wstring &s3) {
   std::print(L"One:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-1]]:27: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDPRINT: {{^  }}std::print(L"One:{}\n", s1);
+  // CHECK-FIXES-STDPRINT: std::print(L"One:{}\n", s1);
 
   std::print(L"One:{} Two:{} Three:{} Four:{}\n", s1.c_str(), s2, s3.c_str(), return_wtemporary().c_str());
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-1]]:51: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-2]]:67: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-3]]:79: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDPRINT: {{^  }}std::print(L"One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_wtemporary());
+  // CHECK-FIXES-STDPRINT: std::print(L"One:{} Two:{} Three:{} Four:{}\n", s1, s2, s3, return_wtemporary());
 
   using namespace std;
   print(L"Four:{}\n", s1.c_str());
   // CHECK-MESSAGES-STDPRINT: :[[@LINE-1]]:23: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES-STDPRINT: {{^  }}print(L"Four:{}\n", s1);
+  // CHECK-FIXES-STDPRINT: print(L"Four:{}\n", s1);
 }
 
 // There's no c_str() call here, so it shouldn't be touched.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr-function.cpp
@@ -27,12 +27,12 @@ namespace notfmt {
 void fmt_print(const std::string &s1, const std::string &s2, const std::string &s3) {
   fmt::print("One:{}\n", s1.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}fmt::print("One:{}\n", s1);
+  // CHECK-FIXES: fmt::print("One:{}\n", s1);
 
   fmt::print("One:{} Two:{} Three:{}\n", s1.c_str(), s2, s3.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:58: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}fmt::print("One:{} Two:{} Three:{}\n", s1, s2, s3);
+  // CHECK-FIXES: fmt::print("One:{} Two:{} Three:{}\n", s1, s2, s3);
 }
 
 // There's no c_str() call here, so it shouldn't be touched
@@ -48,12 +48,12 @@ void not_fmt_print(const std::string &s1) {
 void fmt_format(const std::string &s1, const std::string &s2, const std::string &s3) {
   auto r1 = fmt::format("One:{}\n", s1.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}auto r1 = fmt::format("One:{}\n", s1);
+  // CHECK-FIXES: auto r1 = fmt::format("One:{}\n", s1);
 
   auto r2 = fmt::format("One:{} Two:{} Three:{}\n", s1.c_str(), s2, s3.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:53: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:69: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}auto r2 = fmt::format("One:{} Two:{} Three:{}\n", s1, s2, s3);
+  // CHECK-FIXES: auto r2 = fmt::format("One:{} Two:{} Three:{}\n", s1, s2, s3);
 }
 
 // There's are c_str() calls here, so it shouldn't be touched
@@ -87,25 +87,25 @@ void logger1(const std::string &s1, const std::string &s2, const std::string &s3
   LOGGER("%s\n", s1.c_str(), s2, s3.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}LOGGER("%s\n", s1, s2, s3);
+  // CHECK-FIXES: LOGGER("%s\n", s1, s2, s3);
 
   DerivedLogger LOGGER2;
   LOGGER2("%d %s\n", 42, s1.c_str(), s2.c_str(), s3);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:38: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}LOGGER2("%d %s\n", 42, s1, s2, s3);
+  // CHECK-FIXES: LOGGER2("%d %s\n", 42, s1, s2, s3);
 
   DoubleDerivedLogger LOGGERD;
   LOGGERD("%d %s\n", 42, s1.c_str(), s2, s3.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:42: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}LOGGERD("%d %s\n", 42, s1, s2, s3);
+  // CHECK-FIXES: LOGGERD("%d %s\n", 42, s1, s2, s3);
 
   TypedefDerivedLogger LOGGERT;
   LOGGERT("%d %s\n", 42, s1.c_str(), s2, s3.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:42: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}LOGGERT("%d %s\n", 42, s1, s2, s3);
+  // CHECK-FIXES: LOGGERT("%d %s\n", 42, s1, s2, s3);
 }
 
 void logger2(const std::string &s1, const std::string &s2) {
@@ -114,13 +114,13 @@ void logger2(const std::string &s1, const std::string &s2) {
   LOGGER3.Log("%s\n", s1.c_str(), s2.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:35: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}LOGGER3.Log("%s\n", s1, s2);
+  // CHECK-FIXES: LOGGER3.Log("%s\n", s1, s2);
 
   DerivedLogger LOGGER4;
   LOGGER4.Log("%d %s\n", 42, s1.c_str(), s2.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
   // CHECK-MESSAGES: :[[@LINE-2]]:42: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}LOGGER4.Log("%d %s\n", 42, s1, s2);
+  // CHECK-FIXES: LOGGER4.Log("%d %s\n", 42, s1, s2);
 }
 
 class NotLogger {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr-msvc.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr-msvc.cpp
@@ -26,22 +26,22 @@ struct StringRef {
 void f1(const std::string &s) {
   f1(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f1(s);{{$}}
+  // CHECK-FIXES: f1(s);
   f1(s.data());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'data' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f1(s);{{$}}
+  // CHECK-FIXES: f1(s);
 }
 void f2(const llvm::StringRef r) {
   std::string s;
   f2(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}std::string s;{{$}}
-  // CHECK-FIXES-NEXT: {{^  }}f2(s);{{$}}
+  // CHECK-FIXES: std::string s;
+  // CHECK-FIXES-NEXT: f2(s);
 }
 void f3(const llvm::StringRef &r) {
   std::string s;
   f3(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}std::string s;{{$}}
-  // CHECK-FIXES-NEXT: {{^  }}f3(s);{{$}}
+  // CHECK-FIXES: std::string s;
+  // CHECK-FIXES-NEXT: f3(s);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-string-cstr.cpp
@@ -19,83 +19,83 @@ struct StringRef {
 void f1(const std::string &s) {
   f1(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f1(s);{{$}}
+  // CHECK-FIXES: f1(s);
   f1(s.data());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'data' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f1(s);{{$}}
+  // CHECK-FIXES: f1(s);
 }
 void f2(const llvm::StringRef r) {
   std::string s;
   f2(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}std::string s;{{$}}
-  // CHECK-FIXES-NEXT: {{^  }}f2(s);{{$}}
+  // CHECK-FIXES: std::string s;
+  // CHECK-FIXES-NEXT: f2(s);
 }
 void f3(const llvm::StringRef &r) {
   std::string s;
   f3(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}std::string s;{{$}}
-  // CHECK-FIXES-NEXT: {{^  }}f3(s);{{$}}
+  // CHECK-FIXES: std::string s;
+  // CHECK-FIXES-NEXT: f3(s);
 }
 void f4(const std::string &s) {
   const std::string* ptr = &s;
   f1(ptr->c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f1(*ptr);{{$}}
+  // CHECK-FIXES: f1(*ptr);
 }
 void f5(const std::string &s) {
   std::string tmp;
   tmp.append(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp.append(s);{{$}}
+  // CHECK-FIXES: tmp.append(s);
   tmp.assign(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp.assign(s);{{$}}
+  // CHECK-FIXES: tmp.assign(s);
 
   if (tmp.compare(s.c_str()) == 0) return;
   // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}if (tmp.compare(s) == 0) return;{{$}}
+  // CHECK-FIXES: if (tmp.compare(s) == 0) return;
 
   if (tmp.compare(1, 2, s.c_str()) == 0) return;
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}if (tmp.compare(1, 2, s) == 0) return;{{$}}
+  // CHECK-FIXES: if (tmp.compare(1, 2, s) == 0) return;
 
   if (tmp.find(s.c_str()) == 0) return;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}if (tmp.find(s) == 0) return;{{$}}
+  // CHECK-FIXES: if (tmp.find(s) == 0) return;
 
   if (tmp.find(s.c_str(), 2) == 0) return;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}if (tmp.find(s, 2) == 0) return;{{$}}
+  // CHECK-FIXES: if (tmp.find(s, 2) == 0) return;
 
   if (tmp.find(s.c_str(), 2) == 0) return;
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}if (tmp.find(s, 2) == 0) return;{{$}}
+  // CHECK-FIXES: if (tmp.find(s, 2) == 0) return;
 
   tmp.insert(1, s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp.insert(1, s);{{$}}
+  // CHECK-FIXES: tmp.insert(1, s);
 
   tmp = s.c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp = s;{{$}}
+  // CHECK-FIXES: tmp = s;
 
   tmp += s.c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp += s;{{$}}
+  // CHECK-FIXES: tmp += s;
 
   if (tmp == s.c_str()) return;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}if (tmp == s) return;{{$}}
+  // CHECK-FIXES: if (tmp == s) return;
 
   tmp = s + s.c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp = s + s;{{$}}
+  // CHECK-FIXES: tmp = s + s;
 
   tmp = s.c_str() + s;
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant call {{.*}}
-  // CHECK-FIXES: {{^  }}tmp = s + s;{{$}}
+  // CHECK-FIXES: tmp = s + s;
 }
 void f6(const std::string &s) {
   std::string tmp;
@@ -122,10 +122,10 @@ void f7(std::string_view sv) {
   std::string s;
   f7(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f7(s);{{$}}
+  // CHECK-FIXES: f7(s);
   f7(s.data());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'data' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}f7(s);{{$}}
+  // CHECK-FIXES: f7(s);
 }
 
 // Tests for std::wstring.
@@ -133,16 +133,16 @@ void f7(std::string_view sv) {
 void g1(const std::wstring &s) {
   g1(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}g1(s);{{$}}
+  // CHECK-FIXES: g1(s);
 }
 void g2(std::wstring_view sv) {
   std::wstring s;
   g2(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}g2(s);{{$}}
+  // CHECK-FIXES: g2(s);
   g2(s.data());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'data' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}g2(s);{{$}}
+  // CHECK-FIXES: g2(s);
 }
 
 // Tests for std::u16string.
@@ -150,16 +150,16 @@ void g2(std::wstring_view sv) {
 void h1(const std::u16string &s) {
   h1(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}h1(s);{{$}}
+  // CHECK-FIXES: h1(s);
 }
 void h2(std::u16string_view sv) {
   std::u16string s;
   h2(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}h2(s);{{$}}
+  // CHECK-FIXES: h2(s);
   h2(s.data());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'data' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}h2(s);{{$}}
+  // CHECK-FIXES: h2(s);
 }
 
 // Tests for std::u32string.
@@ -167,16 +167,16 @@ void h2(std::u16string_view sv) {
 void k1(const std::u32string &s) {
   k1(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}k1(s);{{$}}
+  // CHECK-FIXES: k1(s);
 }
 void k2(std::u32string_view sv) {
   std::u32string s;
   k2(s.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}k2(s);{{$}}
+  // CHECK-FIXES: k2(s);
   k2(s.data());
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: redundant call to 'data' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}k2(s);{{$}}
+  // CHECK-FIXES: k2(s);
 }
 
 // Tests on similar classes that aren't good candidates for this checker.
@@ -214,23 +214,23 @@ void it(iterator<std::string> i)
   std::string tmp;
   tmp = i->c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}tmp = *i;{{$}}
+  // CHECK-FIXES: tmp = *i;
 
   // An unlikely situation and the outcome is not ideal, but at least the fix doesn't generate broken code.
   tmp = i.operator->()->c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}tmp = *i.operator->();{{$}}
+  // CHECK-FIXES: tmp = *i.operator->();
 
   // The fix contains an unnecessary set of parentheses, but these have no effect.
   iterator<std::string> *pi = &i;
   tmp = (*pi)->c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}tmp = *(*pi);{{$}}
+  // CHECK-FIXES: tmp = *(*pi);
 
   // An unlikely situation, but at least the fix doesn't generate broken code.
   tmp = pi->operator->()->c_str();
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}tmp = *pi->operator->();{{$}}
+  // CHECK-FIXES: tmp = *pi->operator->();
 }
 
 namespace PR45286 {
@@ -244,7 +244,7 @@ void bar() {
   Foo Foo;
   Foo.func(Str.c_str());
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}Foo.func(Str);{{$}}
+  // CHECK-FIXES: Foo.func(Str);
 
   // Ensure it doesn't transform Binding to r values
   Foo.func2(Str.c_str());
@@ -252,7 +252,7 @@ void bar() {
   // Ensure its not confused by parens
   Foo.func((Str.c_str()));
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: redundant call to 'c_str' [readability-redundant-string-cstr]
-  // CHECK-FIXES: {{^  }}Foo.func((Str));{{$}}
+  // CHECK-FIXES: Foo.func((Str));
   Foo.func2((Str.c_str()));
 }
 } // namespace PR45286

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-chained-conditional-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-chained-conditional-assignment.cpp
@@ -12,9 +12,9 @@ void chained_conditional_compound_assignment(int i) {
     b = false;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:9: warning: redundant boolean literal in conditional assignment [readability-simplify-boolean-expr]
-  // CHECK-FIXES:      {{^}}  } else if (i < 10) {{{$}}
-  // CHECK-FIXES-NEXT: {{^}}    b = false;{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  } else b = i > 20;{{$}}
+  // CHECK-FIXES:      } else if (i < 10) {
+  // CHECK-FIXES-NEXT:   b = false;
+  // CHECK-FIXES-NEXT: } else b = i > 20;
 }
 
 void chained_conditional_assignment(int i) {
@@ -28,7 +28,7 @@ void chained_conditional_assignment(int i) {
   else
     b = false;
   // CHECK-MESSAGES: :[[@LINE-3]]:9: warning: {{.*}} in conditional assignment
-  // CHECK-FIXES:      {{^}}  else if (i < 10)
-  // CHECK-FIXES-NEXT: {{^}}    b = false;
-  // CHECK-FIXES-NEXT: {{^}}  else b = i > 20;
+  // CHECK-FIXES:      else if (i < 10)
+  // CHECK-FIXES-NEXT: b = false;
+  // CHECK-FIXES-NEXT: else b = i > 20;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-chained-conditional-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-chained-conditional-assignment.cpp
@@ -29,6 +29,6 @@ void chained_conditional_assignment(int i) {
     b = false;
   // CHECK-MESSAGES: :[[@LINE-3]]:9: warning: {{.*}} in conditional assignment
   // CHECK-FIXES:      else if (i < 10)
-  // CHECK-FIXES-NEXT: b = false;
+  // CHECK-FIXES-NEXT:   b = false;
   // CHECK-FIXES-NEXT: else b = i > 20;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-chained-conditional-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-chained-conditional-return.cpp
@@ -11,9 +11,9 @@ bool chained_conditional_compound_return(int i) {
     return false;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: redundant boolean literal in conditional return statement [readability-simplify-boolean-expr]
-  // CHECK-FIXES:      {{^}}  } else if (i < 10) {{{$}}
-  // CHECK-FIXES-NEXT: {{^}}    return false;{{$}}
-  // CHECK-FIXES-NEXT: {{^}}  } else return i > 20;{{$}}
+  // CHECK-FIXES:      } else if (i < 10) {
+  // CHECK-FIXES-NEXT:   return false;
+  // CHECK-FIXES-NEXT: } else return i > 20;
 }
 
 bool chained_conditional_return(int i) {
@@ -26,9 +26,9 @@ bool chained_conditional_return(int i) {
   else
     return false;
   // CHECK-MESSAGES: :[[@LINE-3]]:12: warning: {{.*}} in conditional return statement
-  // CHECK-FIXES:      {{^}}  else if (i < 10)
-  // CHECK-FIXES-NEXT: {{^}}    return false;
-  // CHECK-FIXES-NEXT: {{^}}  else return i > 20;
+  // CHECK-FIXES:      else if (i < 10)
+  // CHECK-FIXES-NEXT:   return false;
+  // CHECK-FIXES-NEXT: else return i > 20;
 }
 
 bool chained_simple_if_return(int i) {
@@ -39,11 +39,11 @@ bool chained_simple_if_return(int i) {
   return false;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: {{^}}bool chained_simple_if_return(int i) {{{$}}
-// CHECK-FIXES: {{^}}  if (i < 5){{$}}
-// CHECK-FIXES: {{^    return true;$}}
-// CHECK-FIXES: {{^  return i > 10;$}}
-// CHECK-FIXES: {{^}$}}
+// CHECK-FIXES: bool chained_simple_if_return(int i) {
+// CHECK-FIXES:   if (i < 5)
+// CHECK-FIXES:     return true;
+// CHECK-FIXES:   return i > 10;
+// CHECK-FIXES: }
 
 bool chained_simple_if_return_negated(int i) {
   if (i < 5)
@@ -53,11 +53,11 @@ bool chained_simple_if_return_negated(int i) {
   return true;
 }
 // CHECK-MESSAGES: :[[@LINE-3]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: {{^}}bool chained_simple_if_return_negated(int i) {{{$}}
-// CHECK-FIXES: {{^}}  if (i < 5){{$}}
-// CHECK-FIXES: {{^    return false;$}}
-// CHECK-FIXES: {{^  return i <= 10;$}}
-// CHECK-FIXES: {{^}$}}
+// CHECK-FIXES: bool chained_simple_if_return_negated(int i) {
+// CHECK-FIXES:   if (i < 5)
+// CHECK-FIXES:     return false;
+// CHECK-FIXES:   return i <= 10;
+// CHECK-FIXES: }
 
 bool complex_chained_if_return_return(int i) {
   if (i < 5) {
@@ -69,12 +69,12 @@ bool complex_chained_if_return_return(int i) {
   return false;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: {{^}}bool complex_chained_if_return_return(int i) {{{$}}
-// CHECK-FIXES: {{^}}  if (i < 5) {{{$}}
-// CHECK-FIXES: {{^}}    return true;{{$}}
-// CHECK-FIXES: {{^}}  }{{$}}
-// CHECK-FIXES: {{^  return i > 10;$}}
-// CHECK-FIXES: {{^}$}}
+// CHECK-FIXES: bool complex_chained_if_return_return(int i) {
+// CHECK-FIXES:   if (i < 5) {
+// CHECK-FIXES:     return true;
+// CHECK-FIXES:   }
+// CHECK-FIXES:   return i > 10;
+// CHECK-FIXES: }
 
 bool complex_chained_if_return_return_negated(int i) {
   if (i < 5) {
@@ -86,12 +86,12 @@ bool complex_chained_if_return_return_negated(int i) {
   return true;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: {{^}}bool complex_chained_if_return_return_negated(int i) {{{$}}
-// CHECK-FIXES: {{^}}  if (i < 5) {{{$}}
-// CHECK-FIXES: {{^}}    return false;{{$}}
-// CHECK-FIXES: {{^}}  }{{$}}
-// CHECK-FIXES: {{^  return i <= 10;$}}
-// CHECK-FIXES: {{^}$}}
+// CHECK-FIXES: bool complex_chained_if_return_return_negated(int i) {
+// CHECK-FIXES:   if (i < 5) {
+// CHECK-FIXES:     return false;
+// CHECK-FIXES:   }
+// CHECK-FIXES:   return i <= 10;
+// CHECK-FIXES: }
 
 
 bool PR57819(int x) {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
@@ -42,7 +42,7 @@ void S::operator_equals() {
   m_b1 = (i > 2);
   if (m_b1 == true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b1\) {$}}
+    // CHECK-FIXES: if (m_b1)
     i = 5;
   } else {
     i = 6;
@@ -50,7 +50,7 @@ void S::operator_equals() {
   m_b2 = (i > 4);
   if (m_b2 == false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(!m_b2\) {$}}
+    // CHECK-FIXES: if (!m_b2)
     i = 7;
   } else {
     i = 9;
@@ -58,7 +58,7 @@ void S::operator_equals() {
   m_b3 = (i > 6);
   if (true == m_b3) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b3\) {$}}
+    // CHECK-FIXES: if (m_b3)
     i = 10;
   } else {
     i = 11;
@@ -66,7 +66,7 @@ void S::operator_equals() {
   m_b4 = (i > 8);
   if (false == m_b4) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(!m_b4\) {$}}
+    // CHECK-FIXES: if (!m_b4)
     i = 12;
   } else {
     i = 13;
@@ -78,7 +78,7 @@ void S::operator_or() {
   m_b1 = (i > 10);
   if (m_b1 || false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b1\) {$}}
+    // CHECK-FIXES: if (m_b1)
     i = 14;
   } else {
     i = 15;
@@ -86,7 +86,7 @@ void S::operator_or() {
   m_b2 = (i > 10);
   if (m_b2 || true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(true\) {$}}
+    // CHECK-FIXES: if (true)
     i = 16;
   } else {
     i = 17;
@@ -94,7 +94,7 @@ void S::operator_or() {
   m_b3 = (i > 10);
   if (false || m_b3) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b3\) {$}}
+    // CHECK-FIXES: if (m_b3)
     i = 18;
   } else {
     i = 19;
@@ -102,7 +102,7 @@ void S::operator_or() {
   m_b4 = (i > 10);
   if (true || m_b4) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(true\) {$}}
+    // CHECK-FIXES: if (true)
     i = 20;
   } else {
     i = 21;
@@ -114,7 +114,7 @@ void S::operator_and() {
   m_b1 = (i > 20);
   if (m_b1 && false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(false\) {$}}
+    // CHECK-FIXES: if (false)
     i = 22;
   } else {
     i = 23;
@@ -122,7 +122,7 @@ void S::operator_and() {
   m_b2 = (i > 20);
   if (m_b2 && true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b2\) {$}}
+    // CHECK-FIXES: if (m_b2)
     i = 24;
   } else {
     i = 25;
@@ -130,7 +130,7 @@ void S::operator_and() {
   m_b3 = (i > 20);
   if (false && m_b3) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(false\) {$}}
+    // CHECK-FIXES: if (false)
     i = 26;
   } else {
     i = 27;
@@ -138,7 +138,7 @@ void S::operator_and() {
   m_b4 = (i > 20);
   if (true && m_b4) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b4\) {$}}
+    // CHECK-FIXES: if (m_b4)
     i = 28;
   } else {
     i = 29;
@@ -149,15 +149,15 @@ void S::ternary_operator() {
   int i = 0;
   m_b1 = (i > 20) ? true : false;
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: {{.*}} in ternary expression result
-  // CHECK-FIXES: {{^  m_b1 = i > 20;$}}
+  // CHECK-FIXES: m_b1 = i > 20;
 
   m_b2 = (i > 20) ? false : true;
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: {{.*}} in ternary expression result
-  // CHECK-FIXES: {{^  m_b2 = i <= 20;$}}
+  // CHECK-FIXES: m_b2 = i <= 20;
 
   m_b3 = ((i > 20)) ? false : true;
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: {{.*}} in ternary expression result
-  // CHECK-FIXES: {{^  m_b3 = i <= 20;$}}
+  // CHECK-FIXES: m_b3 = i <= 20;
 }
 
 void S::operator_not_equal() {
@@ -165,7 +165,7 @@ void S::operator_not_equal() {
   m_b1 = (i > 20);
   if (false != m_b1) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b1\) {$}}
+    // CHECK-FIXES: if (m_b1)
     i = 30;
   } else {
     i = 31;
@@ -173,7 +173,7 @@ void S::operator_not_equal() {
   m_b2 = (i > 20);
   if (true != m_b2) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(!m_b2\) {$}}
+    // CHECK-FIXES: if (!m_b2)
     i = 32;
   } else {
     i = 33;
@@ -181,7 +181,7 @@ void S::operator_not_equal() {
   m_b3 = (i > 20);
   if (m_b3 != false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(m_b3\) {$}}
+    // CHECK-FIXES: if (m_b3)
     i = 34;
   } else {
     i = 35;
@@ -189,7 +189,7 @@ void S::operator_not_equal() {
   m_b4 = (i > 20);
   if (m_b4 != true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: {{^  if \(!m_b4\) {$}}
+    // CHECK-FIXES: if (!m_b4)
     i = 36;
   } else {
     i = 37;
@@ -203,7 +203,7 @@ void S::simple_conditional_assignment_statements() {
     m_b1 = false;
   bool bb = false;
   // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional assignment
-  // CHECK-FIXES: {{^  }}m_b1 = m_i > 10;{{$}}
+  // CHECK-FIXES: m_b1 = m_i > 10;
   // CHECK-FIXES: bool bb = false;
 
   if (m_i > 20)
@@ -212,7 +212,7 @@ void S::simple_conditional_assignment_statements() {
     m_b2 = true;
   bool c2 = false;
   // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional assignment
-  // CHECK-FIXES: {{^  }}m_b2 = m_i <= 20;{{$}}
+  // CHECK-FIXES: m_b2 = m_i <= 20;
   // CHECK-FIXES: bool c2 = false;
 
   // Unchanged: different variables.
@@ -249,7 +249,7 @@ void S::complex_conditional_assignment_statements() {
   }
   m_b1 = false;
   // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional assignment
-  // CHECK-FIXES: {{^  }}m_b1 = m_i > 30;{{$}}
+  // CHECK-FIXES: m_b1 = m_i > 30;
   // CHECK-FIXES: m_b1 = false;
 
   if (m_i > 40) {
@@ -259,7 +259,7 @@ void S::complex_conditional_assignment_statements() {
   }
   m_b2 = false;
   // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional assignment
-  // CHECK-FIXES: {{^  }}m_b2 = m_i <= 40;{{$}}
+  // CHECK-FIXES: m_b2 = m_i <= 40;
   // CHECK-FIXES: m_b2 = false;
 }
 
@@ -283,7 +283,7 @@ bool S::non_null_pointer_condition() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: return m_p != nullptr;{{$}}
+// CHECK-FIXES: return m_p != nullptr;
 
 bool S::null_pointer_condition() {
   if (!m_p) {
@@ -293,7 +293,7 @@ bool S::null_pointer_condition() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: return m_p == nullptr;{{$}}
+// CHECK-FIXES: return m_p == nullptr;
 
 bool S::negated_non_null_pointer_condition() {
   if (m_p) {
@@ -303,7 +303,7 @@ bool S::negated_non_null_pointer_condition() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: return m_p == nullptr;{{$}}
+// CHECK-FIXES: return m_p == nullptr;
 
 bool S::negated_null_pointer_condition() {
   if (!m_p) {
@@ -313,7 +313,7 @@ bool S::negated_null_pointer_condition() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: return m_p != nullptr;{{$}}
+// CHECK-FIXES: return m_p != nullptr;
 
 bool S::integer_not_zero() {
   if (m_i) {
@@ -323,7 +323,7 @@ bool S::integer_not_zero() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: {{^}}  return m_i == 0;{{$}}
+// CHECK-FIXES: return m_i == 0;
 
 bool S::member_pointer_nullptr() {
   if (m_m) {
@@ -333,7 +333,7 @@ bool S::member_pointer_nullptr() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: return m_m != nullptr;{{$}}
+// CHECK-FIXES: return m_m != nullptr;
 
 bool S::integer_member_implicit_cast() {
   if (m_a->m) {
@@ -343,7 +343,7 @@ bool S::integer_member_implicit_cast() {
   }
 }
 // CHECK-MESSAGES: :[[@LINE-5]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: return m_a->m != 0;{{$}}
+// CHECK-FIXES: return m_a->m != 0;
 
 bool operator!=(const A &, const A &) { return false; }
 bool S::expr_with_cleanups() {
@@ -353,4 +353,4 @@ bool S::expr_with_cleanups() {
   return true;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: m_ar == (A)m_ar;{{$}}
+// CHECK-FIXES: m_ar == (A)m_ar;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
@@ -42,7 +42,7 @@ void S::operator_equals() {
   m_b1 = (i > 2);
   if (m_b1 == true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b1)
+    // CHECK-FIXES: if (m_b1) {
     i = 5;
   } else {
     i = 6;
@@ -50,7 +50,7 @@ void S::operator_equals() {
   m_b2 = (i > 4);
   if (m_b2 == false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (!m_b2)
+    // CHECK-FIXES: if (!m_b2) {
     i = 7;
   } else {
     i = 9;
@@ -58,7 +58,7 @@ void S::operator_equals() {
   m_b3 = (i > 6);
   if (true == m_b3) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b3)
+    // CHECK-FIXES: if (m_b3) {
     i = 10;
   } else {
     i = 11;
@@ -66,7 +66,7 @@ void S::operator_equals() {
   m_b4 = (i > 8);
   if (false == m_b4) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (!m_b4)
+    // CHECK-FIXES: if (!m_b4) {
     i = 12;
   } else {
     i = 13;
@@ -78,7 +78,7 @@ void S::operator_or() {
   m_b1 = (i > 10);
   if (m_b1 || false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b1)
+    // CHECK-FIXES: if (m_b1) {
     i = 14;
   } else {
     i = 15;
@@ -86,7 +86,7 @@ void S::operator_or() {
   m_b2 = (i > 10);
   if (m_b2 || true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (true)
+    // CHECK-FIXES: if (true) {
     i = 16;
   } else {
     i = 17;
@@ -94,7 +94,7 @@ void S::operator_or() {
   m_b3 = (i > 10);
   if (false || m_b3) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b3)
+    // CHECK-FIXES: if (m_b3) {
     i = 18;
   } else {
     i = 19;
@@ -102,7 +102,7 @@ void S::operator_or() {
   m_b4 = (i > 10);
   if (true || m_b4) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (true)
+    // CHECK-FIXES: if (true) {
     i = 20;
   } else {
     i = 21;
@@ -114,7 +114,7 @@ void S::operator_and() {
   m_b1 = (i > 20);
   if (m_b1 && false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (false)
+    // CHECK-FIXES: if (false) {
     i = 22;
   } else {
     i = 23;
@@ -122,7 +122,7 @@ void S::operator_and() {
   m_b2 = (i > 20);
   if (m_b2 && true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b2)
+    // CHECK-FIXES: if (m_b2) {
     i = 24;
   } else {
     i = 25;
@@ -130,7 +130,7 @@ void S::operator_and() {
   m_b3 = (i > 20);
   if (false && m_b3) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (false)
+    // CHECK-FIXES: if (false) {
     i = 26;
   } else {
     i = 27;
@@ -138,7 +138,7 @@ void S::operator_and() {
   m_b4 = (i > 20);
   if (true && m_b4) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b4)
+    // CHECK-FIXES: if (m_b4) {
     i = 28;
   } else {
     i = 29;
@@ -165,7 +165,7 @@ void S::operator_not_equal() {
   m_b1 = (i > 20);
   if (false != m_b1) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b1)
+    // CHECK-FIXES: if (m_b1) {
     i = 30;
   } else {
     i = 31;
@@ -173,7 +173,7 @@ void S::operator_not_equal() {
   m_b2 = (i > 20);
   if (true != m_b2) {
     // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (!m_b2)
+    // CHECK-FIXES: if (!m_b2) {
     i = 32;
   } else {
     i = 33;
@@ -181,7 +181,7 @@ void S::operator_not_equal() {
   m_b3 = (i > 20);
   if (m_b3 != false) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (m_b3)
+    // CHECK-FIXES: if (m_b3) {
     i = 34;
   } else {
     i = 35;
@@ -189,7 +189,7 @@ void S::operator_not_equal() {
   m_b4 = (i > 20);
   if (m_b4 != true) {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: {{.*}} to boolean operator
-    // CHECK-FIXES: if (!m_b4)
+    // CHECK-FIXES: if (!m_b4) {
     i = 36;
   } else {
     i = 37;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/static-accessed-through-instance-nesting-threshold.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/static-accessed-through-instance-nesting-threshold.cpp
@@ -19,15 +19,15 @@ void f(M::N::V::T::U u) {
   M::N::V v;
   v.v = 12;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  M::N::V::v = 12;{{$}}
+  // CHECK-FIXES: M::N::V::v = 12;
 
   M::N::V::T w;
   w.t = 12;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  M::N::V::T::t = 12;{{$}}
+  // CHECK-FIXES: M::N::V::T::t = 12;
 
   // u.u is not changed, because the nesting level is over 4
   u.u = 12;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  u.u = 12;{{$}}
+  // CHECK-FIXES: u.u = 12;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/static-accessed-through-instance.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/static-accessed-through-instance.cpp
@@ -48,7 +48,7 @@ void g() {
   f(1, 2, 3, 4).x;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member accessed through instance  [readability-static-accessed-through-instance]
   // CHECK-MESSAGES: :[[@LINE-2]]:3: note: member base expression may carry some side effects
-  // CHECK-FIXES: {{^}}  C::x;{{$}}
+  // CHECK-FIXES: C::x;
 }
 
 int i(int &);
@@ -61,13 +61,13 @@ void f(C c) {
   j(i(h().x));
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: static member
   // CHECK-MESSAGES: :[[@LINE-2]]:7: note: member base expression may carry some side effects
-  // CHECK-FIXES: {{^}}  j(i(C::x));{{$}}
+  // CHECK-FIXES: j(i(C::x));
 
   // The execution of h() depends on the return value of a().
   j(k(a() && h().x));
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: static member
   // CHECK-MESSAGES: :[[@LINE-2]]:14: note: member base expression may carry some side effects
-  // CHECK-FIXES: {{^}}  j(k(a() && C::x));{{$}}
+  // CHECK-FIXES: j(k(a() && C::x));
 
   if ([c]() {
         c.ns();
@@ -76,7 +76,7 @@ void f(C c) {
     ;
   // CHECK-MESSAGES: :[[@LINE-5]]:7: warning: static member
   // CHECK-MESSAGES: :[[@LINE-6]]:7: note: member base expression may carry some side effects
-  // CHECK-FIXES: {{^}}  if (C::x == 15){{$}}
+  // CHECK-FIXES: if (C::x == 15)
 }
 
 // Nested specifiers
@@ -96,23 +96,23 @@ void f(N::V::T::U u) {
   N::V v;
   v.v = 12;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  N::V::v = 12;{{$}}
+  // CHECK-FIXES: N::V::v = 12;
 
   N::V::T w;
   w.t = 12;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  N::V::T::t = 12;{{$}}
+  // CHECK-FIXES: N::V::T::t = 12;
 
   // u.u is not changed to N::V::T::U::u; because the nesting level is over 3.
   u.u = 12;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  u.u = 12;{{$}}
+  // CHECK-FIXES: u.u = 12;
 
   using B = N::V::T::U;
   B b;
   b.u;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  B::u;{{$}}
+  // CHECK-FIXES: B::u;
 }
 
 // Templates
@@ -134,7 +134,7 @@ template <typename T> void f(T t, C c) {
   t.x; // OK, t is a template parameter.
   c.x;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::x;{{$}}
+  // CHECK-FIXES: C::x;
 }
 
 template <int N> struct S { static int x; };
@@ -148,33 +148,33 @@ template <int N> void h() {
   S<2> s2;
   s2.x;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  S<2>::x;{{$}}
+  // CHECK-FIXES: S<2>::x;
 }
 
 void static_through_instance() {
   C *c1 = new C();
   c1->foo(); // 1
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::foo(); // 1{{$}}
+  // CHECK-FIXES: C::foo(); // 1
   c1->x; // 2
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::x; // 2{{$}}
+  // CHECK-FIXES: C::x; // 2
   c1->Anonymous; // 3
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::Anonymous; // 3{{$}}
+  // CHECK-FIXES: C::Anonymous; // 3
   c1->E1; // 4
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::E1; // 4{{$}}
+  // CHECK-FIXES: C::E1; // 4
   c1->E0; // 5
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::E0; // 5{{$}}
+  // CHECK-FIXES: C::E0; // 5
 
   c1->nsx; // OK, nsx is a non-static member.
 
   const C *c2 = new C();
   c2->foo(); // 2
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  C::foo(); // 2{{$}}
+  // CHECK-FIXES: C::foo(); // 2
 
   C::foo(); // OK, foo() is accessed using a qualified-id.
   C::x;     // OK, x is accessed using a qualified-id.
@@ -182,18 +182,18 @@ void static_through_instance() {
   D d;
   d.foo();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  D::foo();{{$}}
+  // CHECK-FIXES: D::foo();
   d.x;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  D::x;{{$}}
+  // CHECK-FIXES: D::x;
 
   E e;
   e.foo();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  E::foo();{{$}}
+  // CHECK-FIXES: E::foo();
   e.x;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  E::x;{{$}}
+  // CHECK-FIXES: E::x;
 
   CC *cc = new CC;
 
@@ -210,10 +210,10 @@ void static_through_instance() {
   CT<int> ct;
   ct.foo();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  CT<int>::foo();{{$}}
+  // CHECK-FIXES: CT<int>::foo();
   ct.x;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  CT<int>::x;{{$}}
+  // CHECK-FIXES: CT<int>::x;
   ct.nsx; // OK, nsx is a non-static member
 
   CCT<int> cct;
@@ -230,7 +230,7 @@ struct SP {
 void usep() {
   P.I;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  SP::I;{{$}}
+  // CHECK-FIXES: SP::I;
 }
 
 namespace NSP {
@@ -242,7 +242,7 @@ struct SP {
 void usensp() {
   NSP::P.I;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  NSP::SP::I;{{$}}
+  // CHECK-FIXES: NSP::SP::I;
 }
 
 // Overloaded member access operator
@@ -269,7 +269,7 @@ void func(Qptr qp) {
   qp->K = 10;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member accessed through instance [readability-static-accessed-through-instance]
   // CHECK-MESSAGES: :[[@LINE-2]]:3: note: member base expression may carry some side effects
-  // CHECK-FIXES: {{^}}  Q::K = 10;
+  // CHECK-FIXES: Q::K = 10;
 }
 
 namespace {
@@ -282,7 +282,7 @@ void use_anonymous() {
   Anonymous Anon;
   Anon.I;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  Anonymous::I;{{$}}
+  // CHECK-FIXES: Anonymous::I;
 }
 
 namespace Outer {
@@ -297,7 +297,7 @@ void use_inline() {
   Outer::S V;
   V.I;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member
-  // CHECK-FIXES: {{^}}  Outer::S::I;{{$}}
+  // CHECK-FIXES: Outer::S::I;
 }
 
 // https://bugs.llvm.org/show_bug.cgi?id=48758
@@ -356,17 +356,17 @@ void testEmbeddedAnonymousStructAndClass() {
   Embedded E;
   E.EmbeddedStruct.f();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member accessed through instance [readability-static-accessed-through-instance]
-  // CHECK-FIXES: {{^}}  llvm_issue_61736::Embedded::EmbeddedStruct.f();{{$}}
+  // CHECK-FIXES: llvm_issue_61736::Embedded::EmbeddedStruct.f();
   E.EmbeddedStructPointer->f();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member accessed through instance [readability-static-accessed-through-instance]
-  // CHECK-FIXES: {{^}}  llvm_issue_61736::Embedded::EmbeddedStructPointer->f();{{$}}
+  // CHECK-FIXES: llvm_issue_61736::Embedded::EmbeddedStructPointer->f();
 
   E.EmbeddedClass.f();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member accessed through instance [readability-static-accessed-through-instance]
-  // CHECK-FIXES: {{^}}  llvm_issue_61736::Embedded::EmbeddedClass.f();{{$}}
+  // CHECK-FIXES: llvm_issue_61736::Embedded::EmbeddedClass.f();
   E.EmbeddedClassPointer->f();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: static member accessed through instance [readability-static-accessed-through-instance]
-  // CHECK-FIXES: {{^}}  llvm_issue_61736::Embedded::EmbeddedClassPointer->f();{{$}}
+  // CHECK-FIXES: llvm_issue_61736::Embedded::EmbeddedClassPointer->f();
 }
 
 } // namespace llvm_issue_61736
@@ -384,7 +384,7 @@ namespace PR51861 {
     auto& params = Foo::getInstance();
     params.getBar();
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: static member accessed through instance [readability-static-accessed-through-instance]
-    // CHECK-FIXES: {{^}}    PR51861::Foo::getBar();{{$}}
+    // CHECK-FIXES: PR51861::Foo::getBar();
   }
 }
 
@@ -401,6 +401,6 @@ namespace PR75163 {
     ptr->call();
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: static member accessed through instance [readability-static-accessed-through-instance]
     // CHECK-MESSAGES: :[[@LINE-2]]:5: note: member base expression may carry some side effects
-    // CHECK-FIXES: {{^}}    PR75163::Static::call();{{$}}
+    // CHECK-FIXES: PR75163::Static::call();
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/static-definition-in-anonymous-namespace.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/static-definition-in-anonymous-namespace.cpp
@@ -6,13 +6,13 @@ int a = 1;
 const int b = 1;
 static int c = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: 'c' is a static definition in anonymous namespace; static is redundant here [readability-static-definition-in-anonymous-namespace]
-// CHECK-FIXES: {{^}}int c = 1;
+// CHECK-FIXES: int c = 1;
 static const int d = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: 'd' is a static definition in anonymous namespace
-// CHECK-FIXES: {{^}}const int d = 1;
+// CHECK-FIXES: const int d = 1;
 const static int e = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: 'e' is a static definition in anonymous namespace
-// CHECK-FIXES: {{^}}const int e = 1;
+// CHECK-FIXES: const int e = 1;
 
 void f() {
   int a = 1;
@@ -21,40 +21,40 @@ void f() {
 
 static int g() {
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: 'g' is a static definition in anonymous namespace
-// CHECK-FIXES: {{^}}int g() {
+// CHECK-FIXES: int g() {
   return 1;
 }
 
 #define DEFINE_STATIC static
-// CHECK-FIXES: {{^}}#define DEFINE_STATIC static
+// CHECK-FIXES: #define DEFINE_STATIC static
 DEFINE_STATIC int h = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: 'h' is a static definition in anonymous namespace
-// CHECK-FIXES: {{^}}DEFINE_STATIC int h = 1;
+// CHECK-FIXES: DEFINE_STATIC int h = 1;
 
 #define DEFINE_STATIC_VAR(x) static int x = 2
-// CHECK-FIXES: {{^}}#define DEFINE_STATIC_VAR(x) static int x = 2
+// CHECK-FIXES: #define DEFINE_STATIC_VAR(x) static int x = 2
 DEFINE_STATIC_VAR(i);
-// CHECK-FIXES: {{^}}DEFINE_STATIC_VAR(i);
+// CHECK-FIXES: DEFINE_STATIC_VAR(i);
 
 namespace inner {
 int a = 1;
 const int b = 1;
 static int c = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: 'c' is a static definition in anonymous namespace; static is redundant here [readability-static-definition-in-anonymous-namespace]
-// CHECK-FIXES: {{^}}int c = 1;
+// CHECK-FIXES: int c = 1;
 namespace deep_inner {
 int a = 1;
 const int b = 1;
 static int c = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: 'c' is a static definition in anonymous namespace; static is redundant here [readability-static-definition-in-anonymous-namespace]
-// CHECK-FIXES: {{^}}int c = 1;
+// CHECK-FIXES: int c = 1;
 } // namespace deep_inner
 } // namespace inner
 
 template<typename T>
 static void printTemplate(T&&) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: 'printTemplate' is a static definition in anonymous namespace; static is redundant here [readability-static-definition-in-anonymous-namespace]
-// CHECK-FIXES: {{^}}void printTemplate(T&&) {}
+// CHECK-FIXES: void printTemplate(T&&) {}
 
 void testTemplate() {
   printTemplate(5);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/uniqueptr-delete-release.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/uniqueptr-delete-release.cpp
@@ -27,60 +27,60 @@ void Positives() {
   delete P.release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr' to reset 'unique_ptr<>' objects
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()' to reset 'unique_ptr<>' objects
-  // CHECK-FIXES-NULLPTR: {{^}}  P = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  P.reset();
+  // CHECK-FIXES-NULLPTR: P = nullptr;
+  // CHECK-FIXES-RESET: P.reset();
 
   auto P2 = P;
   delete P2.release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr' to reset 'unique_ptr<>' objects
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()' to reset 'unique_ptr<>' objects
-  // CHECK-FIXES-NULLPTR: {{^}}  P2 = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  P2.reset();
+  // CHECK-FIXES-NULLPTR: P2 = nullptr;
+  // CHECK-FIXES-RESET: P2.reset();
 
   delete (P2.release());
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  (P2 = nullptr);
-  // CHECK-FIXES-RESET: {{^}}  (P2.reset());
+  // CHECK-FIXES-NULLPTR: (P2 = nullptr);
+  // CHECK-FIXES-RESET: (P2.reset());
 
   std::unique_ptr<int> Array[20];
   delete Array[4].release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  Array[4] = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  Array[4].reset();
+  // CHECK-FIXES-NULLPTR: Array[4] = nullptr;
+  // CHECK-FIXES-RESET: Array[4].reset();
 
   delete ReturnsAUnique().release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  ReturnsAUnique() = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  ReturnsAUnique().reset();
+  // CHECK-FIXES-NULLPTR: ReturnsAUnique() = nullptr;
+  // CHECK-FIXES-RESET: ReturnsAUnique().reset();
 
   std::unique_ptr<int> *P3(&P);
   delete P3->release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  *P3 = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  P3->reset();
+  // CHECK-FIXES-NULLPTR: *P3 = nullptr;
+  // CHECK-FIXES-RESET: P3->reset();
 
   std::unique_ptr<std::unique_ptr<int>> P4;
   delete (*P4).release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  (*P4) = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  (*P4).reset();
+  // CHECK-FIXES-NULLPTR: (*P4) = nullptr;
+  // CHECK-FIXES-RESET: (*P4).reset();
 
   delete P4->release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  *P4 = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  P4->reset();
+  // CHECK-FIXES-NULLPTR: *P4 = nullptr;
+  // CHECK-FIXES-RESET: P4->reset();
 
   delete (P4)->release();
   // CHECK-MESSAGES-NULLPTR: :[[@LINE-1]]:3: warning: prefer '= nullptr'
   // CHECK-MESSAGES-RESET: :[[@LINE-2]]:3: warning: prefer 'reset()'
-  // CHECK-FIXES-NULLPTR: {{^}}  *(P4) = nullptr;
-  // CHECK-FIXES-RESET: {{^}}  (P4)->reset();
+  // CHECK-FIXES-NULLPTR: *(P4) = nullptr;
+  // CHECK-FIXES-RESET: (P4)->reset();
 }
 
 struct NotDefaultDeleter {};


### PR DESCRIPTION
This is part of the migration started by #133756. The next step would be moving many tests away from `--match-partial-fixes`.

Since the changes are all mechanical, I'm trying this as one PR, but I'll understand if people think this is too big and ask for it to be split up (in which case: how many chunks would you like?).