### PR TITLE
[llvm][utils] Improve the StringRef summary provider

### DIFF
--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -197,6 +197,13 @@ def StringRefSummaryProvider(valobj, internal_dict):
         return '""'
 
     data = data_pointer.deref
+    # StringRef may be uninitialized with length exceeding available memory,
+    # potentially causing bad_alloc exceptions. Limit the length to max string summary setting.
+    limit_obj = (
+        valobj.GetTarget().GetDebugger().GetSetting("target.max-string-summary-length")
+    )
+    if limit_obj:
+        length = min(length, limit_obj.GetUnsignedIntegerValue())
     # Get a char[N] type, from the underlying char type.
     array_type = data.type.GetArrayType(length)
     # Cast the char* string data to a char[N] array.

--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -200,7 +200,7 @@ def StringRefSummaryProvider(valobj, internal_dict):
     # StringRef may be uninitialized with length exceeding available memory,
     # potentially causing bad_alloc exceptions. Limit the length to max string summary setting.
     limit_obj = (
-        valobj.GetTarget().GetDebugger().GetSetting("target.max-string-summary-length")
+        valobj.target.debugger.GetSetting("target.max-string-summary-length")
     )
     if limit_obj:
         length = min(length, limit_obj.GetUnsignedIntegerValue())

--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -199,9 +199,7 @@ def StringRefSummaryProvider(valobj, internal_dict):
     data = data_pointer.deref
     # StringRef may be uninitialized with length exceeding available memory,
     # potentially causing bad_alloc exceptions. Limit the length to max string summary setting.
-    limit_obj = (
-        valobj.target.debugger.GetSetting("target.max-string-summary-length")
-    )
+    limit_obj = valobj.target.debugger.GetSetting("target.max-string-summary-length")
     if limit_obj:
         length = min(length, limit_obj.GetUnsignedIntegerValue())
     # Get a char[N] type, from the underlying char type.


### PR DESCRIPTION
- check the length of data before casting as `char[N]` because the will cause lldb to allocate `N` bytes of memory.