### PR TITLE
[BOLT][AArch64] Fix perf2bolt-spe test

### DIFF
--- a/bolt/test/perf2bolt/AArch64/perf2bolt-spe.test
+++ b/bolt/test/perf2bolt/AArch64/perf2bolt-spe.test
@@ -6,7 +6,6 @@ RUN: %clang %cflags %p/../../Inputs/asm_foo.s %p/../../Inputs/asm_main.c -o %t.e
 
 RUN: perf record -e cycles -q -o %t.perf.data -- %t.exe 2> /dev/null
 
-RUN: (perf2bolt -p %t.perf.data -o %t.perf.boltdata --spe %t.exe 2> /dev/null; exit 0) | FileCheck %s --check-prefix=CHECK-SPE-LBR
+RUN: perf2bolt -p %t.perf.data -o %t.perf.boltdata --spe %t.exe | FileCheck %s --check-prefix=CHECK-SPE-LBR
 
 CHECK-SPE-LBR: PERF2BOLT: parse SPE branch events in LBR-format
-


### PR DESCRIPTION
Lit recently started failing on some machines when using a subshell. The test used a subshell to handle kernels where SPE's brstack option is unavailable (<6.14), but it appears to work without it now.

Tested with perf 6.8 and 6.17.