### PR TITLE
[lldb] Fix off-by-one error in ToDwarfSourceLanguage

### DIFF
--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -549,7 +549,7 @@ Language::~Language() = default;
 
 static std::optional<llvm::dwarf::SourceLanguage>
 ToDwarfSourceLanguage(lldb::LanguageType language_type) {
-  if (language_type < lldb::eLanguageTypeLastStandardLanguage)
+  if (language_type <= lldb::eLanguageTypeLastStandardLanguage)
     return static_cast<llvm::dwarf::SourceLanguage>(language_type);
 
   switch (language_type) {

--- a/lldb/unittests/Target/LanguageTest.cpp
+++ b/lldb/unittests/Target/LanguageTest.cpp
@@ -24,9 +24,6 @@ TEST_F(LanguageTest, SourceLanguage_GetDescription) {
       continue;
 
     auto lang_type = static_cast<lldb::LanguageType>(i);
-    if (lang_type == lldb::eLanguageTypeLastStandardLanguage)
-      continue;
-
     SourceLanguage lang(lang_type);
 
     // eLanguageTypeHIP is not implemented as a DW_LNAME because of a conflict.

--- a/lldb/unittests/Target/LanguageTest.cpp
+++ b/lldb/unittests/Target/LanguageTest.cpp
@@ -67,3 +67,16 @@ TEST_F(LanguageTest, SourceLanguage_AsLanguageType) {
   EXPECT_EQ(SourceLanguage(eLanguageTypeUnknown).AsLanguageType(),
             eLanguageTypeUnknown);
 }
+
+TEST_F(LanguageTest, SourceLanguage_LastStandardLanguage) {
+  // eLanguageTypeLastStandardLanguage should be treated as a standard DWARF
+  // language.
+  SourceLanguage lang(eLanguageTypeLastStandardLanguage);
+  EXPECT_TRUE(lang);
+
+  // It should have a valid description (not "Unknown").
+  EXPECT_NE(lang.GetDescription(), "Unknown");
+
+  // It should convert to the correct language type.
+  EXPECT_EQ(lang.AsLanguageType(), eLanguageTypeLastStandardLanguage);
+}


### PR DESCRIPTION
The ToDwarfSourceLanguage function incorrectly excluded languages that equal eLanguageTypeLastStandardLanguage. The comparison used `<` instead of `<=`, causing the last standard language to fall through to the default case and return std::nullopt.

This broke language plugins that use eLanguageTypeLastStandardLanguage (currently Mojo at 0x0033) as their language code, preventing proper DWARF language conversion and breaking REPL functionality.

The fix changes the comparison from `<` to `<=` to include the last standard language in the automatic conversion to DWARF source language.

This is a regression from commit 7f51a2a47d2e706d04855b0e41690ebafa2b3238 which introduced the ToDwarfSourceLanguage function.