### PR TITLE
[Offload] Let binary utility take empty arguments

### DIFF
--- a/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
+++ b/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
@@ -8,3 +8,7 @@
 ; CHECK-NEXT: arch            abc
 ; CHECK-NEXT: triple          x-y-z
 ; CHECK-NEXT: producer        none
+
+; RUN: llvm-offload-binary -o %t3 --image=file=%s
+; RUN: llvm-offload-binary %t3 --image=file=%t4
+; RUN: diff %s %t4

--- a/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
+++ b/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
@@ -92,10 +92,9 @@ static Error bundleImages() {
     StringSaver Saver(Alloc);
     DenseMap<StringRef, StringRef> Args = getImageArguments(Image, Saver);
 
-    if (!Args.count("triple") || !Args.count("file"))
-      return createStringError(
-          inconvertibleErrorCode(),
-          "'file' and 'triple' are required image arguments");
+    if (!Args.count("file"))
+      return createStringError(inconvertibleErrorCode(),
+                               "'file' is a required image arguments");
 
     // Permit using multiple instances of `file` in a single string.
     for (auto &File : llvm::split(Args["file"], ",")) {


### PR DESCRIPTION
Summary:
There's no real reason to restrict people if they don't want to use
`triple`. It's important for the normal pipeline but I can see people
using these for other purposes.
