### PR TITLE
[libcxx] Use %{temp} instead of %T

### DIFF
--- a/libcxx/docs/TestingLibcxx.rst
+++ b/libcxx/docs/TestingLibcxx.rst
@@ -415,14 +415,17 @@ writing tests easier. See `libc++-specific Lit Directives`_ for more information
    * - Directive
      - Parameters
      - Usage
+   * - ``%{temp}``
+     - N/A
+     - This directive points to a temporary directory unique to the test.
    * - ``FILE_DEPENDENCIES``
      - ``// FILE_DEPENDENCIES: file, directory, /path/to/file, ...``
      - The paths given to the ``FILE_DEPENDENCIES`` directive can specify directories or specific files upon which a given test depend. For example, a test that requires some test
        input stored in a data file would use this libc++-specific Lit directive. When a test file contains the ``FILE_DEPENDENCIES`` directive, Lit will collect the named files and copy
-       them to the directory represented by the ``%T`` substitution before the test executes. The copy is performed from the directory represented by the ``%S`` substitution
+       them to the directory represented by the ``%{temp}`` substitution before the test executes. The copy is performed from the directory represented by the ``%S`` substitution
        (i.e. the source directory of the test being executed) which makes it possible to use relative paths to specify the location of dependency files. After Lit copies
-       all the dependent files to the directory specified by the ``%T`` substitution, that directory should contain *all* the necessary inputs to run. In other words,
-       it should be possible to copy the contents of the directory specified by the ``%T`` substitution to a remote host where the execution of the test will actually occur.
+       all the dependent files to the directory specified by the ``%{temp}`` substitution, that directory should contain *all* the necessary inputs to run. In other words,
+       it should be possible to copy the contents of the directory specified by the ``%{temp}`` substitution to a remote host where the execution of the test will actually occur.
    * - ``ADDITIONAL_COMPILE_FLAGS``
      - ``// ADDITIONAL_COMPILE_FLAGS: flag1 flag2 ...``
      - The additional compiler flags specified by a space-separated list to the ``ADDITIONAL_COMPILE_FLAGS`` libc++-specific Lit directive will be added to the end of the ``%{compile_flags}``

--- a/libcxx/docs/TestingLibcxx.rst
+++ b/libcxx/docs/TestingLibcxx.rst
@@ -415,9 +415,6 @@ writing tests easier. See `libc++-specific Lit Directives`_ for more information
    * - Directive
      - Parameters
      - Usage
-   * - ``%{temp}``
-     - N/A
-     - This directive points to a temporary directory unique to the test.
    * - ``FILE_DEPENDENCIES``
      - ``// FILE_DEPENDENCIES: file, directory, /path/to/file, ...``
      - The paths given to the ``FILE_DEPENDENCIES`` directive can specify directories or specific files upon which a given test depend. For example, a test that requires some test

--- a/libcxx/test/benchmarks/spec.gen.py
+++ b/libcxx/test/benchmarks/spec.gen.py
@@ -8,13 +8,13 @@
 
 # REQUIRES: enable-spec-benchmarks
 
-# RUN: mkdir -p %T
-# RUN: echo "%{cxx}" > %T/cxx.subs
-# RUN: echo "%{compile_flags}" > %T/compile_flags.subs
-# RUN: echo "%{flags}" > %T/flags.subs
-# RUN: echo "%{link_flags}" > %T/link_flags.subs
-# RUN: echo "%{spec_dir}" > %T/spec_dir.subs
-# RUN: %{python} %s %T
+# RUN: mkdir -p %{temp}
+# RUN: echo "%{cxx}" > %{temp}/cxx.subs
+# RUN: echo "%{compile_flags}" > %{temp}/compile_flags.subs
+# RUN: echo "%{flags}" > %{temp}/flags.subs
+# RUN: echo "%{link_flags}" > %{temp}/link_flags.subs
+# RUN: echo "%{spec_dir}" > %{temp}/spec_dir.subs
+# RUN: %{python} %s %{temp}
 # END.
 
 import json
@@ -66,18 +66,18 @@ spec_benchmarks &= no_fortran
 
 for benchmark in spec_benchmarks:
     print(f'#--- {benchmark}.sh.test')
-    print(f'RUN: rm -rf %T') # clean up any previous (potentially incomplete) run
-    print(f'RUN: mkdir %T')
-    print(f'RUN: cp {spec_config} %T/spec-config.cfg')
-    print(f'RUN: %{{spec_dir}}/bin/runcpu --config %T/spec-config.cfg --size train --output-root %T --rebuild {benchmark}')
-    print(f'RUN: rm -rf %T/benchspec') # remove the temporary directory, which can become quite large
+    print(f'RUN: rm -rf %{temp}') # clean up any previous (potentially incomplete) run
+    print(f'RUN: mkdir %{temp}')
+    print(f'RUN: cp {spec_config} %{temp}/spec-config.cfg')
+    print(f'RUN: %{{spec_dir}}/bin/runcpu --config %{temp}/spec-config.cfg --size train --output-root %{temp} --rebuild {benchmark}')
+    print(f'RUN: rm -rf %{temp}/benchspec') # remove the temporary directory, which can become quite large
 
     # The `runcpu` command above doesn't fail even if the benchmark fails to run. To determine failure, parse the CSV
     # results and ensure there are no compilation errors or runtime errors in the status row. Also print the logs and
     # fail if there are no CSV files at all, which implies a SPEC error.
-    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results --extract "Base Status" --keep-failed %T/result/*.train.csv > %T/status || ! cat %T/result/*.log')
-    print(f'RUN: ! grep -E "CE|RE" %T/status || ! cat %T/result/*.log')
+    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results --extract "Base Status" --keep-failed %{temp}/result/*.train.csv > %{temp}/status || ! cat %{temp}/result/*.log')
+    print(f'RUN: ! grep -E "CE|RE" %{temp}/status || ! cat %{temp}/result/*.log')
 
     # If there were no errors, parse the results into LNT-compatible format and print them.
-    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results %T/result/*.train.csv --output-format=lnt > %T/results.lnt')
-    print(f'RUN: cat %T/results.lnt')
+    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results %{temp}/result/*.train.csv --output-format=lnt > %{temp}/results.lnt')
+    print(f'RUN: cat %{temp}/results.lnt')

--- a/libcxx/test/benchmarks/spec.gen.py
+++ b/libcxx/test/benchmarks/spec.gen.py
@@ -65,27 +65,19 @@ with open(spec_dir / 'benchspec' / 'CPU' / 'no_fortran.bset', 'r') as f:
 spec_benchmarks &= no_fortran
 
 for benchmark in spec_benchmarks:
-    print(f"#--- {benchmark}.sh.test")
-    print(f"RUN: rm -rf %{temp}")  # clean up any previous (potentially incomplete) run
-    print(f"RUN: mkdir %{temp}")
-    print(f"RUN: cp {spec_config} %{temp}/spec-config.cfg")
-    print(
-        f"RUN: %{{spec_dir}}/bin/runcpu --config %{temp}/spec-config.cfg --size train --output-root %{temp} --rebuild {benchmark}"
-    )
-    print(
-        f"RUN: rm -rf %{temp}/benchspec"
-    )  # remove the temporary directory, which can become quite large
+    print(f'#--- {benchmark}.sh.test')
+    print(f'RUN: rm -rf %{temp}') # clean up any previous (potentially incomplete) run
+    print(f'RUN: mkdir %{temp}')
+    print(f'RUN: cp {spec_config} %{temp}/spec-config.cfg')
+    print(f'RUN: %{{spec_dir}}/bin/runcpu --config %{temp}/spec-config.cfg --size train --output-root %{temp} --rebuild {benchmark}')
+    print(f'RUN: rm -rf %{temp}/benchspec') # remove the temporary directory, which can become quite large
 
     # The `runcpu` command above doesn't fail even if the benchmark fails to run. To determine failure, parse the CSV
     # results and ensure there are no compilation errors or runtime errors in the status row. Also print the logs and
     # fail if there are no CSV files at all, which implies a SPEC error.
-    print(
-        f'RUN: %{{libcxx-dir}}/utils/parse-spec-results --extract "Base Status" --keep-failed %{temp}/result/*.train.csv > %{temp}/status || ! cat %{temp}/result/*.log'
-    )
+    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results --extract "Base Status" --keep-failed %{temp}/result/*.train.csv > %{temp}/status || ! cat %{temp}/result/*.log')
     print(f'RUN: ! grep -E "CE|RE" %{temp}/status || ! cat %{temp}/result/*.log')
 
     # If there were no errors, parse the results into LNT-compatible format and print them.
-    print(
-        f"RUN: %{{libcxx-dir}}/utils/parse-spec-results %{temp}/result/*.train.csv --output-format=lnt > %{temp}/results.lnt"
-    )
-    print(f"RUN: cat %{temp}/results.lnt")
+    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results %{temp}/result/*.train.csv --output-format=lnt > %{temp}/results.lnt')
+    print(f'RUN: cat %{temp}/results.lnt')

--- a/libcxx/test/benchmarks/spec.gen.py
+++ b/libcxx/test/benchmarks/spec.gen.py
@@ -65,19 +65,27 @@ with open(spec_dir / 'benchspec' / 'CPU' / 'no_fortran.bset', 'r') as f:
 spec_benchmarks &= no_fortran
 
 for benchmark in spec_benchmarks:
-    print(f'#--- {benchmark}.sh.test')
-    print(f'RUN: rm -rf %{temp}') # clean up any previous (potentially incomplete) run
-    print(f'RUN: mkdir %{temp}')
-    print(f'RUN: cp {spec_config} %{temp}/spec-config.cfg')
-    print(f'RUN: %{{spec_dir}}/bin/runcpu --config %{temp}/spec-config.cfg --size train --output-root %{temp} --rebuild {benchmark}')
-    print(f'RUN: rm -rf %{temp}/benchspec') # remove the temporary directory, which can become quite large
+    print(f"#--- {benchmark}.sh.test")
+    print(f"RUN: rm -rf %{temp}")  # clean up any previous (potentially incomplete) run
+    print(f"RUN: mkdir %{temp}")
+    print(f"RUN: cp {spec_config} %{temp}/spec-config.cfg")
+    print(
+        f"RUN: %{{spec_dir}}/bin/runcpu --config %{temp}/spec-config.cfg --size train --output-root %{temp} --rebuild {benchmark}"
+    )
+    print(
+        f"RUN: rm -rf %{temp}/benchspec"
+    )  # remove the temporary directory, which can become quite large
 
     # The `runcpu` command above doesn't fail even if the benchmark fails to run. To determine failure, parse the CSV
     # results and ensure there are no compilation errors or runtime errors in the status row. Also print the logs and
     # fail if there are no CSV files at all, which implies a SPEC error.
-    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results --extract "Base Status" --keep-failed %{temp}/result/*.train.csv > %{temp}/status || ! cat %{temp}/result/*.log')
+    print(
+        f'RUN: %{{libcxx-dir}}/utils/parse-spec-results --extract "Base Status" --keep-failed %{temp}/result/*.train.csv > %{temp}/status || ! cat %{temp}/result/*.log'
+    )
     print(f'RUN: ! grep -E "CE|RE" %{temp}/status || ! cat %{temp}/result/*.log')
 
     # If there were no errors, parse the results into LNT-compatible format and print them.
-    print(f'RUN: %{{libcxx-dir}}/utils/parse-spec-results %{temp}/result/*.train.csv --output-format=lnt > %{temp}/results.lnt')
-    print(f'RUN: cat %{temp}/results.lnt')
+    print(
+        f"RUN: %{{libcxx-dir}}/utils/parse-spec-results %{temp}/result/*.train.csv --output-format=lnt > %{temp}/results.lnt"
+    )
+    print(f"RUN: cat %{temp}/results.lnt")

--- a/libcxx/test/configs/apple-libc++-shared.cfg.in
+++ b/libcxx/test/configs/apple-libc++-shared.cfg.in
@@ -38,7 +38,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -lc++ %{apple-system-shims}'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env DYLD_LIBRARY_PATH=%{lib-dir} -- '
+    '%{executor} --execdir %{temp} --env DYLD_LIBRARY_PATH=%{lib-dir} -- '
 ))
 
 config.stdlib = 'apple-libc++'

--- a/libcxx/test/configs/apple-libc++-system.cfg.in
+++ b/libcxx/test/configs/apple-libc++-system.cfg.in
@@ -19,7 +19,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -lc++'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 config.stdlib = 'apple-libc++'

--- a/libcxx/test/configs/armv7m-picolibc-libc++.cfg.in
+++ b/libcxx/test/configs/armv7m-picolibc-libc++.cfg.in
@@ -30,7 +30,7 @@ config.executor = (
     ' --cpu cortex-m3')
 config.substitutions.append(('%{exec}',
     '%{executor}'
-    ' --execdir %T'
+    ' --execdir %{temp}'
 ))
 
 import os, site

--- a/libcxx/test/configs/ibm-libc++-shared.cfg.in
+++ b/libcxx/test/configs/ibm-libc++-shared.cfg.in
@@ -18,7 +18,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -lc++ -lc++abi -latomic -Wl,-bbigtoc'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env LIBPATH=%{lib-dir} -- '
+    '%{executor} --execdir %{temp} --env LIBPATH=%{lib-dir} -- '
 ))
 
 # LIBCXX-AIX-FIXME is the feature name used to XFAIL the

--- a/libcxx/test/configs/llvm-libc++-android.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-android.cfg.in
@@ -36,7 +36,7 @@ config.substitutions.append(('%{link_flags}',
 config.substitutions.append(('%{exec}',
     '%{executor}' +
     ' --job-limit-socket ' + libcxx.test.android.adb_job_limit_socket() +
-    ' --prepend-path-env LD_LIBRARY_PATH /data/local/tmp/libc++ --execdir %T -- '
+    ' --prepend-path-env LD_LIBRARY_PATH /data/local/tmp/libc++ --execdir %{temp} -- '
 ))
 
 libcxx.test.config.configure(

--- a/libcxx/test/configs/llvm-libc++-mingw.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-mingw.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -lc++'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{install-prefix}/bin -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/llvm-libc++-shared-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-clangcl.cfg.in
@@ -25,7 +25,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib -L %{lib-dir} -lc++ -l' + cxx_lib
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{install-prefix}/bin -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/llvm-libc++-shared-gcc.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-gcc.cfg.in
@@ -12,7 +12,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -Wl,-rpath,%{lib-dir} -lc++ -lm'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/llvm-libc++-shared-no-vcruntime-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-no-vcruntime-clangcl.cfg.in
@@ -26,7 +26,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib -L %{lib-dir} -lc++ -l' + cxx_lib
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{install-prefix}/bin -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/llvm-libc++-shared.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared.cfg.in
@@ -13,7 +13,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -Wl,-rpath,%{lib-dir} -lc++'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/llvm-libc++-static-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-static-clangcl.cfg.in
@@ -25,7 +25,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib -L %{lib-dir} -llibc++ -l' + cxx_lib
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/llvm-libc++-static.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-static.cfg.in
@@ -13,7 +13,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -lc++ -lc++abi'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/stdlib-libstdc++.cfg.in
+++ b/libcxx/test/configs/stdlib-libstdc++.cfg.in
@@ -51,7 +51,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{libstdcxx-install-prefix}/lib/gcc/%{libstdcxx-version} -Wl,-rpath,%{libstdcxx-install-prefix}/lib/gcc/%{libstdcxx-version} -lstdc++'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxx/test/configs/stdlib-native.cfg.in
+++ b/libcxx/test/configs/stdlib-native.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{flags}',
 ))
 config.substitutions.append(('%{compile_flags}', '-I %{libcxx-dir}/test/support'))
 config.substitutions.append(('%{link_flags}', ''))
-config.substitutions.append(('%{exec}', '%{executor} --execdir %T -- '))
+config.substitutions.append(('%{exec}', '%{executor} --execdir %{temp} -- '))
 
 import os, site
 site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))

--- a/libcxx/test/selftest/dsl/dsl.sh.py
+++ b/libcxx/test/selftest/dsl/dsl.sh.py
@@ -12,7 +12,7 @@
 
 # Note: We prepend arguments with 'x' to avoid thinking there are too few
 #       arguments in case an argument is an empty string.
-# RUN: %{python} %s x%S x%T x%{substitutions}
+# RUN: %{python} %s x%S x%{temp} x%{substitutions}
 
 import base64
 import copy

--- a/libcxx/test/selftest/dsl/lit.local.cfg
+++ b/libcxx/test/selftest/dsl/lit.local.cfg
@@ -1,8 +1,8 @@
 # Since we try to pass substitutions as-is to some tests, we must "escape"
 # them in case they contain other substitutions. Otherwise, the substitutions
 # will be fully expanded when passed to the tests. For example, we want an
-# %{exec} substitution that contains `--execdir %T` to be passed as-is, without
-# substituting the directory. This way, the test itself can populate %T as it
+# %{exec} substitution that contains `--execdir %{temp}` to be passed as-is, without
+# substituting the directory. This way, the test itself can populate %{temp} as it
 # sees fit, and %{exec} will respect it.
 #
 # To solve this problem, we pickle the substitutions and base64 encode that

--- a/libcxx/test/selftest/file_dependencies/absolute-and-relative-paths.sh.cpp
+++ b/libcxx/test/selftest/file_dependencies/absolute-and-relative-paths.sh.cpp
@@ -9,7 +9,7 @@
 // Make sure that FILE_DEPENDENCIES work with relative AND absolute paths.
 
 // FILE_DEPENDENCIES: %S/a.txt
-// RUN: test -e %T/a.txt
+// RUN: test -e %{temp}/a.txt
 
 // FILE_DEPENDENCIES: dir/b.txt
-// RUN: test -e %T/b.txt
+// RUN: test -e %{temp}/b.txt

--- a/libcxx/test/selftest/file_dependencies/substitute-in-dependencies.sh.cpp
+++ b/libcxx/test/selftest/file_dependencies/substitute-in-dependencies.sh.cpp
@@ -9,4 +9,4 @@
 // Make sure that lit substitutions are expanded inside FILE_DEPENDENCIES lines.
 
 // FILE_DEPENDENCIES: %s
-// RUN: test -e %T/substitute-in-dependencies.sh.cpp
+// RUN: test -e %{temp}/substitute-in-dependencies.sh.cpp

--- a/libcxx/test/selftest/tmpdir-exists.sh.cpp
+++ b/libcxx/test/selftest/tmpdir-exists.sh.cpp
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Make sure that the directory represented by %T exists when we run the test.
+// Make sure that the directory represented by %{temp} exists when we run the test.
 
-// RUN: test -d %T
+// RUN: test -d %{temp}

--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -111,8 +111,8 @@ def _makeConfigTest(config):
             os.makedirs(supportDir)
 
     # Create a dummy test suite and single dummy test inside it. As part of
-    # the Lit configuration, automatically do the equivalent of 'mkdir %T'
-    # and 'rm -r %T' to avoid cluttering the build directory.
+    # the Lit configuration, automatically do the equivalent of 'mkdir %{temp}'
+    # and 'rm -r %{temp}' to avoid cluttering the build directory.
     suite = lit.Test.TestSuite("__config__", sourceRoot, execRoot, config)
     tmp = tempfile.NamedTemporaryFile(dir=sourceRoot, delete=False, suffix=".cpp")
     tmp.close()

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -178,14 +178,11 @@ def parseScript(test, preamble):
                 "%dbg(MODULE std.compat) %{cxx} %{flags} "
                 f"{compileFlags} "
                 "-Wno-reserved-module-identifier -Wno-reserved-user-defined-literal "
-                "-fmodule-file=std=%{temp}/std.pcm "  # The std.compat module imports std.
+                "-fmodule-file=std=%{temp}/std.pcm " # The std.compat module imports std.
                 "--precompile -o %{temp}/std.compat.pcm -c %{module-dir}/std.compat.cppm",
             )
             moduleCompileFlags.extend(
-                [
-                    "-fmodule-file=std.compat=%{temp}/std.compat.pcm",
-                    "%{temp}/std.compat.pcm",
-                ]
+                ["-fmodule-file=std.compat=%{temp}/std.compat.pcm", "%{temp}/std.compat.pcm"]
             )
 
         # Make sure the std module is built before std.compat. Libc++'s
@@ -200,9 +197,7 @@ def parseScript(test, preamble):
             "-Wno-reserved-module-identifier -Wno-reserved-user-defined-literal "
             "--precompile -o %{temp}/std.pcm -c %{module-dir}/std.cppm",
         )
-        moduleCompileFlags.extend(
-            ["-fmodule-file=std=%{temp}/std.pcm", "%{temp}/std.pcm"]
-        )
+        moduleCompileFlags.extend(["-fmodule-file=std=%{temp}/std.pcm", "%{temp}/std.pcm"])
 
         # Add compile flags required for the modules.
         substitutions = config._appendToSubstitution(
@@ -360,15 +355,9 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
                 "%dbg(COMPILED WITH) %{cxx} %s %{flags} %{compile_flags} %{benchmark_flags} %{link_flags} -o %t.exe",
             ]
             if "enable-benchmarks=run" in test.config.available_features:
-                steps += [
-                    "%dbg(EXECUTED AS) %{exec} %t.exe --benchmark_out=%{temp}/benchmark-result.json --benchmark_out_format=json"
-                ]
-                parse_results = os.path.join(
-                    LIBCXX_UTILS, "parse-google-benchmark-results"
-                )
-                steps += [
-                    f"{parse_results} %{temp}/benchmark-result.json --output-format=lnt > %{temp}/results.lnt"
-                ]
+                steps += ["%dbg(EXECUTED AS) %{exec} %t.exe --benchmark_out=%{temp}/benchmark-result.json --benchmark_out_format=json"]
+                parse_results = os.path.join(LIBCXX_UTILS, 'parse-google-benchmark-results')
+                steps += [f"{parse_results} %{temp}/benchmark-result.json --output-format=lnt > %{temp}/results.lnt"]
             return self._executeShTest(test, litConfig, steps)
         elif re.search('[.]gen[.][^.]+$', filename): # This only happens when a generator test is not supported
             return self._executeShTest(test, litConfig, [])

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -261,6 +261,10 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
         %{run}
             Equivalent to `%{exec} %t.exe`. This is intended to be used
             in conjunction with the %{build} substitution.
+
+        %{temp}
+            This substitution expands to a non-existent temporary path unique to the test.
+            It is typically used to create a temporary directory.
     """
 
     def getTestsForPath(self, testSuite, pathInSuite, litConfig, localConfig):

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -17,10 +17,10 @@ LIBCXX_UTILS = os.path.dirname(os.path.dirname(os.path.dirname(THIS_FILE)))
 
 def _getTempPaths(test):
     """
-    Return the values to use for the %T and %t substitutions, respectively.
+    Return the values to use for the %{temp} and %t substitutions, respectively.
 
     The difference between this and Lit's default behavior is that we guarantee
-    that %T is a path unique to the test being run.
+    that %{temp} is a path unique to the test being run.
     """
     tmpDir, _ = lit.TestRunner.getTempPaths(test)
     _, testName = os.path.split(test.getExecPath())
@@ -92,7 +92,7 @@ def parseScript(test, preamble):
     #       errors, which doesn't make sense for clang-verify tests because we may want to check
     #       for specific warning diagnostics.
     _checkBaseSubstitutions(substitutions)
-    substitutions.append(("%T", tmpDir))
+    substitutions.append(("%{temp}", tmpDir))
     substitutions.append(
         ("%{build}", "%{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe")
     )
@@ -150,7 +150,7 @@ def parseScript(test, preamble):
     # that file to the execution directory. Execute the copy from %S to allow
     # relative paths from the test directory.
     for dep in fileDependencies:
-        script += ["%dbg(SETUP) cd %S && cp {} %T".format(dep)]
+        script += ["%dbg(SETUP) cd %S && cp {} %{{temp}}".format(dep)]
     script += preamble
     script += scriptInTest
 
@@ -178,11 +178,11 @@ def parseScript(test, preamble):
                 "%dbg(MODULE std.compat) %{cxx} %{flags} "
                 f"{compileFlags} "
                 "-Wno-reserved-module-identifier -Wno-reserved-user-defined-literal "
-                "-fmodule-file=std=%T/std.pcm " # The std.compat module imports std.
-                "--precompile -o %T/std.compat.pcm -c %{module-dir}/std.compat.cppm",
+                "-fmodule-file=std=%{temp}/std.pcm " # The std.compat module imports std.
+                "--precompile -o %{temp}/std.compat.pcm -c %{module-dir}/std.compat.cppm",
             )
             moduleCompileFlags.extend(
-                ["-fmodule-file=std.compat=%T/std.compat.pcm", "%T/std.compat.pcm"]
+                ["-fmodule-file=std.compat=%{temp}/std.compat.pcm", "%{temp}/std.compat.pcm"]
             )
 
         # Make sure the std module is built before std.compat. Libc++'s
@@ -195,9 +195,9 @@ def parseScript(test, preamble):
             "%dbg(MODULE std) %{cxx} %{flags} "
             f"{compileFlags} "
             "-Wno-reserved-module-identifier -Wno-reserved-user-defined-literal "
-            "--precompile -o %T/std.pcm -c %{module-dir}/std.cppm",
+            "--precompile -o %{temp}/std.pcm -c %{module-dir}/std.cppm",
         )
-        moduleCompileFlags.extend(["-fmodule-file=std=%T/std.pcm", "%T/std.pcm"])
+        moduleCompileFlags.extend(["-fmodule-file=std=%{temp}/std.pcm", "%{temp}/std.pcm"])
 
         # Add compile flags required for the modules.
         substitutions = config._appendToSubstitution(
@@ -355,9 +355,9 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
                 "%dbg(COMPILED WITH) %{cxx} %s %{flags} %{compile_flags} %{benchmark_flags} %{link_flags} -o %t.exe",
             ]
             if "enable-benchmarks=run" in test.config.available_features:
-                steps += ["%dbg(EXECUTED AS) %{exec} %t.exe --benchmark_out=%T/benchmark-result.json --benchmark_out_format=json"]
+                steps += ["%dbg(EXECUTED AS) %{exec} %t.exe --benchmark_out=%{temp}/benchmark-result.json --benchmark_out_format=json"]
                 parse_results = os.path.join(LIBCXX_UTILS, 'parse-google-benchmark-results')
-                steps += [f"{parse_results} %T/benchmark-result.json --output-format=lnt > %T/results.lnt"]
+                steps += [f"{parse_results} %{temp}/benchmark-result.json --output-format=lnt > %{temp}/results.lnt"]
             return self._executeShTest(test, litConfig, steps)
         elif re.search('[.]gen[.][^.]+$', filename): # This only happens when a generator test is not supported
             return self._executeShTest(test, litConfig, [])

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -178,11 +178,14 @@ def parseScript(test, preamble):
                 "%dbg(MODULE std.compat) %{cxx} %{flags} "
                 f"{compileFlags} "
                 "-Wno-reserved-module-identifier -Wno-reserved-user-defined-literal "
-                "-fmodule-file=std=%{temp}/std.pcm " # The std.compat module imports std.
+                "-fmodule-file=std=%{temp}/std.pcm "  # The std.compat module imports std.
                 "--precompile -o %{temp}/std.compat.pcm -c %{module-dir}/std.compat.cppm",
             )
             moduleCompileFlags.extend(
-                ["-fmodule-file=std.compat=%{temp}/std.compat.pcm", "%{temp}/std.compat.pcm"]
+                [
+                    "-fmodule-file=std.compat=%{temp}/std.compat.pcm",
+                    "%{temp}/std.compat.pcm",
+                ]
             )
 
         # Make sure the std module is built before std.compat. Libc++'s
@@ -197,7 +200,9 @@ def parseScript(test, preamble):
             "-Wno-reserved-module-identifier -Wno-reserved-user-defined-literal "
             "--precompile -o %{temp}/std.pcm -c %{module-dir}/std.cppm",
         )
-        moduleCompileFlags.extend(["-fmodule-file=std=%{temp}/std.pcm", "%{temp}/std.pcm"])
+        moduleCompileFlags.extend(
+            ["-fmodule-file=std=%{temp}/std.pcm", "%{temp}/std.pcm"]
+        )
 
         # Add compile flags required for the modules.
         substitutions = config._appendToSubstitution(
@@ -355,9 +360,15 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
                 "%dbg(COMPILED WITH) %{cxx} %s %{flags} %{compile_flags} %{benchmark_flags} %{link_flags} -o %t.exe",
             ]
             if "enable-benchmarks=run" in test.config.available_features:
-                steps += ["%dbg(EXECUTED AS) %{exec} %t.exe --benchmark_out=%{temp}/benchmark-result.json --benchmark_out_format=json"]
-                parse_results = os.path.join(LIBCXX_UTILS, 'parse-google-benchmark-results')
-                steps += [f"{parse_results} %{temp}/benchmark-result.json --output-format=lnt > %{temp}/results.lnt"]
+                steps += [
+                    "%dbg(EXECUTED AS) %{exec} %t.exe --benchmark_out=%{temp}/benchmark-result.json --benchmark_out_format=json"
+                ]
+                parse_results = os.path.join(
+                    LIBCXX_UTILS, "parse-google-benchmark-results"
+                )
+                steps += [
+                    f"{parse_results} %{temp}/benchmark-result.json --output-format=lnt > %{temp}/results.lnt"
+                ]
             return self._executeShTest(test, litConfig, steps)
         elif re.search('[.]gen[.][^.]+$', filename): # This only happens when a generator test is not supported
             return self._executeShTest(test, litConfig, [])

--- a/libcxx/utils/ssh.py
+++ b/libcxx/utils/ssh.py
@@ -57,7 +57,7 @@ def main():
         return subprocess.run(command, *args_, **kwargs)
 
     # Create a temporary directory where the test will be run.
-    # That is effectively the value of %T on the remote host.
+    # That is effectively the value of %{temp} on the remote host.
     tmp = runCommand(
         ssh("mktemp -d {}/libcxx.XXXXXXXXXX".format(args.tempdir)),
         universal_newlines=True,

--- a/libcxx/utils/test-at-commit
+++ b/libcxx/utils/test-at-commit
@@ -22,7 +22,7 @@ config.substitutions.append(('%{{flags}}',
 ))
 config.substitutions.append(('%{{compile_flags}}', '-nostdinc++ -I {INSTALL_ROOT}/include/c++/v1 -I %{{libcxx-dir}}/test/support'))
 config.substitutions.append(('%{{link_flags}}', '-nostdlib++ -L {INSTALL_ROOT}/lib -Wl,-rpath,{INSTALL_ROOT}/lib -lc++'))
-config.substitutions.append(('%{{exec}}', '%{{executor}} --execdir %T -- '))
+config.substitutions.append(('%{{exec}}', '%{{executor}} --execdir %{temp} -- '))
 
 import os, site
 site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))

--- a/libcxxabi/test/configs/apple-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/apple-libc++abi-shared.cfg.in
@@ -36,7 +36,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++ %{apple-system-shims}'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env DYLD_LIBRARY_PATH=%{lib} -- '
+    '%{executor} --execdir %{temp} --env DYLD_LIBRARY_PATH=%{lib} -- '
 ))
 
 config.stdlib = 'apple-libc++'

--- a/libcxxabi/test/configs/apple-libc++abi-system.cfg.in
+++ b/libcxxabi/test/configs/apple-libc++abi-system.cfg.in
@@ -20,7 +20,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 config.stdlib = 'apple-libc++'

--- a/libcxxabi/test/configs/armv7m-picolibc-libc++abi.cfg.in
+++ b/libcxxabi/test/configs/armv7m-picolibc-libc++abi.cfg.in
@@ -25,7 +25,7 @@ config.executor = (
     ' --cpu cortex-m3')
 config.substitutions.append(('%{exec}',
     '%{executor}'
-    ' --execdir %T'
+    ' --execdir %{temp}'
 ))
 
 import os, site

--- a/libcxxabi/test/configs/ibm-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/ibm-libc++abi-shared.cfg.in
@@ -19,7 +19,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++ -lc++abi -Wl,-bbigtoc'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env LIBPATH=%{lib} -- '
+    '%{executor} --execdir %{temp} --env LIBPATH=%{lib} -- '
 ))
 
 import os, site

--- a/libcxxabi/test/configs/llvm-libc++abi-android.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-android.cfg.in
@@ -29,7 +29,7 @@ config.substitutions.append(('%{link_flags}',
 config.substitutions.append(('%{exec}',
     '%{executor}' +
     ' --job-limit-socket ' + libcxx.test.android.adb_job_limit_socket() +
-    ' --prepend-path-env LD_LIBRARY_PATH /data/local/tmp/libc++ --execdir %T -- '
+    ' --prepend-path-env LD_LIBRARY_PATH /data/local/tmp/libc++ --execdir %{temp} -- '
 ))
 
 libcxx.test.config.configure(

--- a/libcxxabi/test/configs/llvm-libc++abi-merged.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-merged.cfg.in
@@ -13,7 +13,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -Wl,-rpath,%{lib} -lc++ -pthread'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxxabi/test/configs/llvm-libc++abi-mingw.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-mingw.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{install-prefix}/bin -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '
 ))
 
 import os, site

--- a/libcxxabi/test/configs/llvm-libc++abi-shared-clangcl.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-shared-clangcl.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib -L %{lib} -lc++ -lc++abi -lmsvcrt -lmsvcprt -loldnames'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{lib} -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{lib} -- '
 ))
 
 import os, site

--- a/libcxxabi/test/configs/llvm-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-shared.cfg.in
@@ -13,7 +13,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -Wl,-rpath,%{lib} -lc++ -lc++abi -pthread'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libcxxabi/test/configs/llvm-libc++abi-static-clangcl.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-static-clangcl.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib -L %{lib} -llibc++ -llibc++abi -lmsvcrt -lmsvcprt -loldnames'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{lib} -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{lib} -- '
 ))
 
 import os, site

--- a/libcxxabi/test/configs/llvm-libc++abi-static.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-static.cfg.in
@@ -13,7 +13,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++ -lc++abi -pthread'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/apple-libunwind-system.cfg.in
+++ b/libunwind/test/configs/apple-libunwind-system.cfg.in
@@ -19,7 +19,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++ -lunwind'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 config.stdlib = 'apple-libc++'

--- a/libunwind/test/configs/armv7m-picolibc-libunwind.cfg.in
+++ b/libunwind/test/configs/armv7m-picolibc-libunwind.cfg.in
@@ -25,7 +25,7 @@ config.executor = (
     ' --cpu cortex-m3')
 config.substitutions.append(('%{exec}',
     '%{executor}'
-    ' --execdir %T'
+    ' --execdir %{temp}'
 ))
 
 import os, site

--- a/libunwind/test/configs/ibm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/ibm-libunwind-shared.cfg.in
@@ -17,7 +17,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lunwind -ldl -Wl,-bbigtoc'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env LIBPATH=%{lib} -- '
+    '%{executor} --execdir %{temp} --env LIBPATH=%{lib} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-merged.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-merged.cfg.in
@@ -35,7 +35,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{{lib}} -Wl,-rpath,%{{lib}} -lc++ {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-shared-mingw.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared-mingw.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{lib} -lunwind'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{install-prefix}/bin -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared.cfg.in
@@ -34,7 +34,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{{lib}} -Wl,-rpath,%{{lib}} -lunwind {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-static-mingw.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static-mingw.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{lib} -lunwind'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{lib} -- '
+    '%{executor} --execdir %{temp} --prepend_env PATH=%{lib} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-static.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static.cfg.in
@@ -37,7 +37,7 @@ config.substitutions.append(('%{link_flags}',
     '%{{lib}}/libunwind.a {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site


### PR DESCRIPTION
Based on review feedback in #160026.

This makes the substitution a lot more clear now that there is no documentation around %T.