### PR TITLE
[AArch64] Bump default CPUs for iOS 18/watchOS 26 to A10/S9.

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -57,6 +57,9 @@ std::string aarch64::getAArch64TargetCPU(const ArgList &Args,
     // iOS 26 only runs on apple-a12 and later CPUs.
     if (!Triple.isOSVersionLT(26))
       return "apple-a12";
+    // arm64 (non-e) iOS 18 only runs on apple-a10 and later CPUs.
+    if (!Triple.isOSVersionLT(18) && !Triple.isArm64e())
+      return "apple-a10";
   }
 
   if (Triple.isWatchOS()) {
@@ -64,8 +67,8 @@ std::string aarch64::getAArch64TargetCPU(const ArgList &Args,
     // arm64_32/arm64e watchOS requires S4 before watchOS 26, S6 after.
     if (Triple.getArch() == llvm::Triple::aarch64_32 || Triple.isArm64e())
       return Triple.isOSVersionLT(26) ? "apple-s4" : "apple-s6";
-    // arm64 (non-e, non-32) watchOS comes later, and requires S6 anyway.
-    return "apple-s6";
+    // arm64 (non-e, non-32) watchOS comes later, and requires S9 anyway.
+    return "apple-s9";
   }
 
   if (Triple.isXROS()) {

--- a/clang/test/Driver/aarch64-cpu-defaults-appleos26.c
+++ b/clang/test/Driver/aarch64-cpu-defaults-appleos26.c
@@ -4,12 +4,16 @@
 // RUN: %clang -target arm64-apple-ios26  -### -c %s 2>&1 | FileCheck %s --check-prefix=A12
 // RUN: %clang -target arm64e-apple-ios26 -### -c %s 2>&1 | FileCheck %s --check-prefix=A12
 
+/// iOS 18 came before iOS 26, compare its defaults.
+// RUN: %clang -target arm64-apple-ios18  -### -c %s 2>&1 | FileCheck %s --check-prefix=A10
+// RUN: %clang -target arm64e-apple-ios18 -### -c %s 2>&1 | FileCheck %s --check-prefix=A12
+
 /// arm64e/arm64_32 watchOS 26 default to apple-s6.
 // RUN: %clang -target arm64e-apple-watchos26   -### -c %s 2>&1 | FileCheck %s --check-prefix=S6
 // RUN: %clang -target arm64_32-apple-watchos26 -### -c %s 2>&1 | FileCheck %s --check-prefix=S6
 
-/// arm64 is new in watchOS 26, and defaults to apple-s6.
-// RUN: %clang -target arm64-apple-watchos26  -### -c %s 2>&1 | FileCheck %s --check-prefix=S6
+/// arm64 is new in watchOS 26, and defaults to apple-s9.
+// RUN: %clang -target arm64-apple-watchos26  -### -c %s 2>&1 | FileCheck %s --check-prefix=S9
 
 /// llvm usually treats tvOS like iOS, but it runs on different hardware.
 // RUN: %clang -target arm64-apple-tvos26  -### -c %s 2>&1 | FileCheck %s --check-prefix=A7
@@ -18,5 +22,7 @@
 /// Simulators are tested with other Mac-like targets in aarch64-mac-cpus.c.
 
 // A12: "-target-cpu" "apple-a12"
+// A10: "-target-cpu" "apple-a10"
 // S6:  "-target-cpu" "apple-s6"
+// S9:  "-target-cpu" "apple-s9"
 // A7:  "-target-cpu" "apple-a7"


### PR DESCRIPTION
We previously bumped the defaults for 26.0 Apple OS targets to conservative CPU targets in 69d141712a10.

We can further bump it for watchOS arm64 (which lets us be a little bit more aggressive than arm64e/arm64_32), as well as for the iOS predecessor, iOS 18.