### PR TITLE
[LLDB] Require target-x86/x86_64 for MSVC C mangling test

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/c-calling-conventions.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/c-calling-conventions.cpp
@@ -1,5 +1,5 @@
 // clang-format off
-// REQUIRES: lld, x86
+// REQUIRES: lld, (target-x86 || target-x86_64)
 
 // RUN: %build --compiler=clang-cl --arch=32 --nodefaultlib --output=%t-32.exe %s
 // RUN: lldb-test symbols %t-32.exe | FileCheck --check-prefixes CHECK-32,CHECK-BOTH %s


### PR DESCRIPTION
Fixes the test failure from https://github.com/llvm/llvm-project/pull/161678#issuecomment-3377949862.