### PR TITLE
[MLIR][Python] hide globals in ir.py

### DIFF
--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -12,7 +12,7 @@ from ._mlir_libs._mlir.ir import _GlobalDebug
 from ._mlir_libs._mlir import (
     register_type_caster,
     register_value_caster,
-    globals,
+    globals as _globals,
 )
 from ._mlir_libs import (
     get_dialect_registry,
@@ -32,17 +32,17 @@ def loc_tracebacks(*, max_depth: int | None = None) -> Iterable[None]:
       max_depth: Maximum number of frames to include in the location.
         If None, the default limit is used.
     """
-    old_enabled = globals.loc_tracebacks_enabled()
-    old_limit = globals.loc_tracebacks_frame_limit()
+    old_enabled = _globals.loc_tracebacks_enabled()
+    old_limit = _globals.loc_tracebacks_frame_limit()
     try:
-        globals.set_loc_tracebacks_frame_limit(max_depth)
+        _globals.set_loc_tracebacks_frame_limit(max_depth)
         if not old_enabled:
-            globals.set_loc_tracebacks_enabled(True)
+            _globals.set_loc_tracebacks_enabled(True)
             yield
     finally:
         if not old_enabled:
-            globals.set_loc_tracebacks_enabled(False)
-        globals.set_loc_tracebacks_frame_limit(old_limit)
+            _globals.set_loc_tracebacks_enabled(False)
+        _globals.set_loc_tracebacks_frame_limit(old_limit)
 
 
 # Convenience decorator for registering user-friendly Attribute builders.


### PR DESCRIPTION
We're shadowing the Python builtin function `globals` in `ir.py` and therefore anywhere someone does `from mlir.ir import *`. So hide it.