### PR TITLE
[tests] Split up darwin-macatalyst test

### DIFF
--- a/clang/test/Driver/darwin-maccatalyst-error.c
+++ b/clang/test/Driver/darwin-maccatalyst-error.c
@@ -1,0 +1,6 @@
+// RUN: not %clang -target x86_64-apple-ios13.0-macabi -c %s -### 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-ERROR %s
+// RUN: not %clang -target x86_64-apple-ios12.0-macabi -c %s -### 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-ERROR %s
+
+// CHECK-ERROR: error: invalid version number in '-target x86_64-apple-ios

--- a/clang/test/Driver/darwin-maccatalyst.c
+++ b/clang/test/Driver/darwin-maccatalyst.c
@@ -2,11 +2,6 @@
 // RUN:   FileCheck --check-prefix=CHECK-VERSION1 %s
 // RUN: %clang -target x86_64-apple-ios-macabi -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION1 %s
-// RUN: not %clang -target x86_64-apple-ios13.0-macabi -c %s -### 2>&1 | \
-// RUN:   FileCheck --check-prefix=CHECK-ERROR %s
-// RUN: not %clang -target x86_64-apple-ios12.0-macabi -c %s -### 2>&1 | \
-// RUN:   FileCheck --check-prefix=CHECK-ERROR %s
 
 // CHECK-VERSION1-NOT: error:
 // CHECK-VERSION1: "x86_64-apple-ios13.1.0-macabi"
-// CHECK-ERROR: error: invalid version number in '-target x86_64-apple-ios


### PR DESCRIPTION
The way this test was constructed made it difficult to test downstream divergence correctly; instead split the error case.