### PR TITLE
[flang] Rework component KIND= values in PDT instantiations

### DIFF
--- a/flang/include/flang/Evaluate/common.h
+++ b/flang/include/flang/Evaluate/common.h
@@ -231,14 +231,20 @@ public:
       : messages_{that.messages_}, defaults_{that.defaults_},
         intrinsics_{that.intrinsics_},
         targetCharacteristics_{that.targetCharacteristics_},
-        pdtInstance_{that.pdtInstance_}, impliedDos_{that.impliedDos_},
+        pdtInstance_{that.pdtInstance_},
+        analyzingPDTComponentKindSelector_{
+            that.analyzingPDTComponentKindSelector_},
+        impliedDos_{that.impliedDos_},
         languageFeatures_{that.languageFeatures_}, tempNames_{that.tempNames_} {
   }
   FoldingContext(
       const FoldingContext &that, const parser::ContextualMessages &m)
       : messages_{m}, defaults_{that.defaults_}, intrinsics_{that.intrinsics_},
         targetCharacteristics_{that.targetCharacteristics_},
-        pdtInstance_{that.pdtInstance_}, impliedDos_{that.impliedDos_},
+        pdtInstance_{that.pdtInstance_},
+        analyzingPDTComponentKindSelector_{
+            that.analyzingPDTComponentKindSelector_},
+        impliedDos_{that.impliedDos_},
         languageFeatures_{that.languageFeatures_}, tempNames_{that.tempNames_} {
   }
 
@@ -248,6 +254,9 @@ public:
     return defaults_;
   }
   const semantics::DerivedTypeSpec *pdtInstance() const { return pdtInstance_; }
+  bool analyzingPDTComponentKindSelector() const {
+    return analyzingPDTComponentKindSelector_;
+  }
   const IntrinsicProcTable &intrinsics() const { return intrinsics_; }
   const TargetCharacteristics &targetCharacteristics() const {
     return targetCharacteristics_;
@@ -290,6 +299,10 @@ public:
     return common::ScopedSet(pdtInstance_, nullptr);
   }
 
+  common::Restorer<bool> AnalyzingPDTComponentKindSelector() {
+    return common::ScopedSet(analyzingPDTComponentKindSelector_, true);
+  }
+
   parser::CharBlock SaveTempName(std::string &&name) {
     return {*tempNames_.emplace(std::move(name)).first};
   }
@@ -300,6 +313,7 @@ private:
   const IntrinsicProcTable &intrinsics_;
   const TargetCharacteristics &targetCharacteristics_;
   const semantics::DerivedTypeSpec *pdtInstance_{nullptr};
+  bool analyzingPDTComponentKindSelector_{false};
   std::optional<parser::CharBlock> moduleFileName_;
   std::map<parser::CharBlock, ConstantSubscript> impliedDos_;
   const common::LanguageFeatureControl &languageFeatures_;

--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -535,6 +535,7 @@ public:
     return true;
   }
   void Post(const parser::ComponentDefStmt &) { inComponentDefStmt_ = false; }
+  bool Pre(const parser::KindSelector &) { return !inComponentDefStmt_; }
   bool Pre(const parser::Initialization &x) {
     // Default component initialization expressions (but not DATA-like ones
     // as in DEC STRUCTUREs) were already analyzed in name resolution

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -510,6 +510,11 @@ public:
   const std::list<SourceName> &componentNames() const {
     return componentNames_;
   }
+  const std::map<SourceName, const parser::Expr *> &
+  originalKindParameterMap() const {
+    return originalKindParameterMap_;
+  }
+  void add_originalKindParameter(SourceName, const parser::Expr *);
 
   // If this derived type extends another, locate the parent component's symbol.
   const Symbol *GetParentComponent(const Scope &) const;
@@ -538,6 +543,8 @@ private:
   bool sequence_{false};
   bool isDECStructure_{false};
   bool isForwardReferenced_{false};
+  std::map<SourceName, const parser::Expr *> originalKindParameterMap_;
+
   friend llvm::raw_ostream &operator<<(
       llvm::raw_ostream &, const DerivedTypeDetails &);
 };

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -769,6 +769,11 @@ void DerivedTypeDetails::add_component(const Symbol &symbol) {
   componentNames_.push_back(symbol.name());
 }
 
+void DerivedTypeDetails::add_originalKindParameter(
+    SourceName name, const parser::Expr *expr) {
+  originalKindParameterMap_.emplace(name, expr);
+}
+
 const Symbol *DerivedTypeDetails::GetParentComponent(const Scope &scope) const {
   if (auto extends{GetParentComponentName()}) {
     if (auto iter{scope.find(*extends)}; iter != scope.cend()) {

--- a/flang/test/Semantics/kinds03.f90
+++ b/flang/test/Semantics/kinds03.f90
@@ -5,7 +5,7 @@
  type :: ipdt(k)
   !REF: /MainProgram1/ipdt/k
   integer, kind :: k
-  !REF: /MainProgram1/ipdt/k
+  !DEF: /MainProgram1/DerivedType9/k TypeParam INTEGER(4)
   !DEF: /MainProgram1/ipdt/x ObjectEntity INTEGER(int(int(k,kind=4),kind=8))
   integer(kind=k) :: x
  end type ipdt
@@ -14,7 +14,7 @@
  type :: rpdt(k)
   !REF: /MainProgram1/rpdt/k
   integer, kind :: k
-  !REF: /MainProgram1/rpdt/k
+  !DEF: /MainProgram1/DerivedType13/k TypeParam INTEGER(4)
   !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(int(int(k,kind=4),kind=8))
   real(kind=k) :: x
  end type rpdt
@@ -23,7 +23,7 @@
  type :: zpdt(k)
   !REF: /MainProgram1/zpdt/k
   integer, kind :: k
-  !REF: /MainProgram1/zpdt/k
+  !DEF: /MainProgram1/DerivedType17/k TypeParam INTEGER(4)
   !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(int(int(k,kind=4),kind=8))
   complex(kind=k) :: x
  end type zpdt
@@ -32,7 +32,7 @@
  type :: lpdt(k)
   !REF: /MainProgram1/lpdt/k
   integer, kind :: k
-  !REF: /MainProgram1/lpdt/k
+  !DEF: /MainProgram1/DerivedType21/k TypeParam INTEGER(4)
   !DEF: /MainProgram1/lpdt/x ObjectEntity LOGICAL(int(int(k,kind=4),kind=8))
   logical(kind=k) :: x
  end type lpdt

--- a/flang/test/Semantics/pdt05.f90
+++ b/flang/test/Semantics/pdt05.f90
@@ -1,0 +1,24 @@
+!RUN: %flang_fc1 -fdebug-unparse %s | FileCheck %s
+
+module pdt05
+  type base(k1,k2)
+    integer(1),kind :: k1
+    integer(k1),kind :: k2
+    integer(kind(int(k1,1)+int(k2,k1))) j
+    integer(kind(int(k1,1)+int(k2,kind(k2)))) k
+  end type
+end
+
+use pdt05
+type(base(2,7)) x27
+type(base(8,7)) x87
+print *, 'x27%j', kind(x27%j)
+print *, 'x27%k', kind(x27%k)
+print *, 'x87%j', kind(x87%j)
+print *, 'x87%k', kind(x87%k)
+end
+
+!CHECK: PRINT *, "x27%j", 2_4
+!CHECK: PRINT *, "x27%k", 2_4
+!CHECK: PRINT *, "x87%j", 8_4
+!CHECK: PRINT *, "x87%k", 8_4

--- a/flang/test/Semantics/real10-x86-01.f90
+++ b/flang/test/Semantics/real10-x86-01.f90
@@ -6,7 +6,7 @@
  type :: rpdt(k)
   !REF: /MainProgram1/rpdt/k
   integer, kind :: k
-  !REF: /MainProgram1/rpdt/k
+  !DEF: /MainProgram1/DerivedType3/k TypeParam INTEGER(4)
   !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(int(int(k,kind=4),kind=8))
   real(kind=k) :: x
  end type rpdt
@@ -15,7 +15,7 @@
  type :: zpdt(k)
   !REF: /MainProgram1/zpdt/k
   integer, kind :: k
-  !REF: /MainProgram1/zpdt/k
+  !DEF: /MainProgram1/DerivedType4/k TypeParam INTEGER(4)
   !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(int(int(k,kind=4),kind=8))
   complex(kind=k) :: x
  end type zpdt

--- a/flang/test/Semantics/symbol17.f90
+++ b/flang/test/Semantics/symbol17.f90
@@ -79,7 +79,7 @@ type(fwdpdt(kind(0))) function f2(n)
  type :: fwdpdt(k)
   !REF: /f2/fwdpdt/k
   integer, kind :: k
-  !REF: /f2/fwdpdt/k
+  !DEF: /f2/DerivedType2/k TypeParam INTEGER(4)
   !DEF: /f2/fwdpdt/n ObjectEntity INTEGER(int(int(k,kind=4),kind=8))
   integer(kind=k) :: n
  end type
@@ -99,7 +99,7 @@ subroutine s2 (q1)
  type :: fwdpdt(k)
   !REF: /s2/fwdpdt/k
   integer, kind :: k
-  !REF: /s2/fwdpdt/k
+  !DEF: /s2/DerivedType2/k TypeParam INTEGER(4)
   !DEF: /s2/fwdpdt/n ObjectEntity INTEGER(int(int(k,kind=4),kind=8))
   integer(kind=k) :: n
  end type
@@ -110,31 +110,31 @@ end subroutine
 !DEF: /m1 Module
 module m1
  !DEF: /m1/forward PRIVATE DerivedType
-  private :: forward
+ private :: forward
  !DEF: /m1/base PUBLIC DerivedType
-  type :: base
+ type :: base
   !REF: /m1/forward
   !DEF: /m1/base/p POINTER ObjectEntity CLASS(forward)
-    class(forward), pointer :: p
-  end type
+  class(forward), pointer :: p
+ end type
  !REF: /m1/base
  !REF: /m1/forward
-  type, extends(base) :: forward
+ type, extends(base) :: forward
   !DEF: /m1/forward/n ObjectEntity INTEGER(4)
-    integer :: n
-  end type
- contains
+  integer :: n
+ end type
+contains
  !DEF: /m1/test PUBLIC (Subroutine) Subprogram
-  subroutine test
+ subroutine test
   !REF: /m1/forward
   !DEF: /m1/test/object TARGET ObjectEntity TYPE(forward)
-    type(forward), target :: object
+  type(forward), target :: object
   !REF: /m1/test/object
   !REF: /m1/base/p
-    object%p => object
+  object%p => object
   !REF: /m1/test/object
   !REF: /m1/base/p
   !REF: /m1/forward/n
-    object%p%n = 666
-  end subroutine
+  object%p%n = 666
+ end subroutine
 end module

--- a/flang/test/Semantics/type-parameter-constant.f90
+++ b/flang/test/Semantics/type-parameter-constant.f90
@@ -10,6 +10,6 @@ end type
    !ERROR: Value of KIND type parameter 'r' must be constant
    !WARNING: specification expression refers to local object 'six' (initialized and saved) [-Wsaved-local-in-spec-expr]
    !WARNING: specification expression refers to local object 'twenty_three' (initialized and saved) [-Wsaved-local-in-spec-expr]
-   type(a(six, twenty_three)) :: a2 
+   type(a(six, twenty_three)) :: a2
    print *, a1%data%kind
 end


### PR DESCRIPTION
When processing the KIND= values of type specifications in parameterized derived type component declarations, it turns out to be necessary to analyze their expressions' parse trees rather than to just fold their typed expression representations. The types of the subexpressions may depend on the values of KIND parameters.

Further, when checking the values of KIND= actual arguments to type conversion intrinsic functions (e.g., INT(..., KIND=)) that appear in KIND specifiers for PDT component declarations, don't emit an error for the derived type definition, but instead emit them for derived type instantiations.

Fixes https://github.com/llvm/llvm-project/issues/161961.