### PR TITLE
[Clang][Sema] Add a nullptr check in template name

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -319,7 +319,7 @@ TemplateNameKind Sema::isTemplateName(Scope *S,
   }
 
   if (isPackProducingBuiltinTemplateName(Template) &&
-      S->getTemplateParamParent() == nullptr)
+      S && S->getTemplateParamParent() == nullptr)
     Diag(Name.getBeginLoc(), diag::err_builtin_pack_outside_template) << TName;
   // Recover by returning the template, even though we would never be able to
   // substitute it.

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -318,8 +318,8 @@ TemplateNameKind Sema::isTemplateName(Scope *S,
     }
   }
 
-  if (isPackProducingBuiltinTemplateName(Template) &&
-      S && S->getTemplateParamParent() == nullptr)
+  if (isPackProducingBuiltinTemplateName(Template) && S &&
+      S->getTemplateParamParent() == nullptr)
     Diag(Name.getBeginLoc(), diag::err_builtin_pack_outside_template) << TName;
   // Recover by returning the template, even though we would never be able to
   // substitute it.


### PR DESCRIPTION
Static analysis flagged that when calling ActOnTemplateName, `S` can be a `nullptr`
and we call `isTemplateName` which unconditionally dereferences the `S` argument at
some point. I added a `nullptr` check to assure we don't dereference `S` in
`isTemplateName` if it is a `nullptr`.
