### PR TITLE
[FMV][AArch64] Fix build after edb43192516a55165cc4c158eb4fd4b2d81a8fce

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/android.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/android.inc
@@ -25,11 +25,16 @@ void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
   if (__isExynos9810())
     return;
 
+  unsigned long hwcap = getauxval(AT_HWCAP);
+  unsigned long hwcap2 = getauxval(AT_HWCAP2);
+  unsigned long hwcap2 = getauxval(AT_HWCAP3);
+  unsigned long hwcap2 = getauxval(AT_HWCAP4);
+
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);
-  arg._hwcap = getauxval(AT_HWCAP);
-  arg._hwcap2 = getauxval(AT_HWCAP2);
-  arg._hwcap3 = getauxval(AT_HWCAP3);
-  arg._hwcap4 = getauxval(AT_HWCAP4);
+  arg._hwcap = hwcap;
+  arg._hwcap2 = hwcap2;
+  arg._hwcap3 = hwcap3;
+  arg._hwcap4 = hwcap4;
   __init_cpu_features_constructor(hwcap | _IFUNC_ARG_HWCAP, &arg);
 }

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/getauxval.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/getauxval.inc
@@ -10,11 +10,16 @@ void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
   if (__atomic_load_n(&__aarch64_cpu_features.features, __ATOMIC_RELAXED))
     return;
 
+  unsigned long hwcap = getauxval(AT_HWCAP);
+  unsigned long hwcap2 = getauxval(AT_HWCAP2);
+  unsigned long hwcap2 = getauxval(AT_HWCAP3);
+  unsigned long hwcap2 = getauxval(AT_HWCAP4);
+
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);
-  arg._hwcap = getauxval(AT_HWCAP);
-  arg._hwcap2 = getauxval(AT_HWCAP2);
-  arg._hwcap3 = getauxval(AT_HWCAP3);
-  arg._hwcap4 = getauxval(AT_HWCAP4);
+  arg._hwcap = hwcap;
+  arg._hwcap2 = hwcap2;
+  arg._hwcap3 = hwcap3;
+  arg._hwcap4 = hwcap4;
   __init_cpu_features_constructor(hwcap | _IFUNC_ARG_HWCAP, &arg);
 }


### PR DESCRIPTION
Revert removal of local variables.