### PR TITLE
[lldb] Enforce that only the LLDB API unit tests can link liblldb

### DIFF
--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -3,6 +3,8 @@ add_lldb_unittest(APITests
   SBLineEntryTest.cpp
   SBMutexTest.cpp
 
+  SBAPITEST
+
   LINK_LIBS
     liblldb
   )

--- a/lldb/unittests/CMakeLists.txt
+++ b/lldb/unittests/CMakeLists.txt
@@ -12,13 +12,17 @@ endif()
 
 function(add_lldb_unittest test_name)
   cmake_parse_arguments(ARG
-    ""
+    "SBAPITEST"
     ""
     "LINK_LIBS;LINK_COMPONENTS"
     ${ARGN})
 
   if (NOT ${test_name} MATCHES "Tests$")
     message(FATAL_ERROR "Unit test name must end with 'Tests' for lit to find it.")
+  endif()
+
+  if ("liblldb" IN_LIST ARG_LINK_LIBS AND NOT ARG_SBAPITEST)
+    message(FATAL_ERROR "The ${test_name} are not allowed to link liblldb.")
   endif()
 
   list(APPEND LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS})

--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -12,6 +12,8 @@ add_lldb_unittest(DAPTests
   TestBase.cpp
   VariablesTest.cpp
 
+  SBAPITEST
+
   LINK_COMPONENTS
     Support
   LINK_LIBS


### PR DESCRIPTION
Enforce that only specific tests can link liblldb. All the other unit tests statically link the private libraries. Linking both the static libraries and liblldb results in duplicated symbols.

Fixes #162378