### PR TITLE
[UEFI] Add driver path to program paths list

### DIFF
--- a/clang/lib/Driver/ToolChains/UEFI.cpp
+++ b/clang/lib/Driver/ToolChains/UEFI.cpp
@@ -24,7 +24,9 @@ using namespace clang;
 using namespace llvm::opt;
 
 UEFI::UEFI(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
-    : ToolChain(D, Triple, Args) {}
+    : ToolChain(D, Triple, Args) {
+  getProgramPaths().push_back(getDriver().Dir);
+}
 
 Tool *UEFI::buildLinker() const { return new tools::uefi::Linker(*this); }
 

--- a/clang/test/Driver/fuse-ld.c
+++ b/clang/test/Driver/fuse-ld.c
@@ -101,3 +101,8 @@
 // RUN:   | FileCheck %s --check-prefix CHECK-WINDOWS-MSVC-BFD
 // CHECK-WINDOWS-MSVC-BFD: "{{.*}}ld.bfd"
 // CHECK-WINDOWS-MSVC-BFD-SAME: "-o"
+
+// RUN: %clang %s -### -fuse-ld=lld \
+// RUN:     --target=x86_64-unknown-uefi 2>&1 \
+// RUN:   | FileCheck %s --check-prefix CHECK-UEFI-LLD-LINK
+// CHECK-UEFI-LLD-LINK: "{{.*}}lld-link

--- a/clang/test/Driver/uefi-constructed-args.c
+++ b/clang/test/Driver/uefi-constructed-args.c
@@ -13,7 +13,7 @@
 // CHECK-SAME: "/tsaware:no"
 // CHECK-SAME: "/debug"
 
-// RUN: %clang -### --target=x86_64-unknown-uefi -print-search-dirs 2>&1
+// RUN: %clang -### --target=x86_64-unknown-uefi -print-search-dirs 2>&1 \
 // RUN:     | FileCheck -check-prefixes=PROGPATH %s
 // PROGPATH-DAG: InstalledDir: [[DRIVER_INSTALLED_DIR:.*]]
 // PROGPATH: programs: =[[DRIVER_INSTALLED_DIR]]

--- a/clang/test/Driver/uefi-constructed-args.c
+++ b/clang/test/Driver/uefi-constructed-args.c
@@ -12,3 +12,8 @@
 // CHECK-SAME: "/entry:EfiMain"
 // CHECK-SAME: "/tsaware:no"
 // CHECK-SAME: "/debug"
+
+// RUN: %clang -### --target=x86_64-unknown-uefi -print-search-dirs 2>&1
+// RUN:     | FileCheck -check-prefixes=PROGPATH %s
+// PROGPATH-DAG: InstalledDir: [[DRIVER_INSTALLED_DIR:.*]]
+// PROGPATH: programs: =[[DRIVER_INSTALLED_DIR]]

--- a/clang/test/Driver/uefi-constructed-args.c
+++ b/clang/test/Driver/uefi-constructed-args.c
@@ -15,5 +15,5 @@
 
 // RUN: %clang -### --target=x86_64-unknown-uefi -print-search-dirs 2>&1 \
 // RUN:     | FileCheck -check-prefixes=PROGPATH %s
-// PROGPATH-DAG: InstalledDir: [[DRIVER_INSTALLED_DIR:.*]]
+// PROGPATH: InstalledDir: [[DRIVER_INSTALLED_DIR:.*]]
 // PROGPATH: programs: =[[DRIVER_INSTALLED_DIR]]


### PR DESCRIPTION
UEFI toolchain driver implementation does not set the path where tools
such as lld-link can be found. This patch fixes that.
