### PR TITLE
[FMV][AArch64] Fix build after edb43192516a55165cc4c158eb4fd4b2d81a8fce, try 2

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/android.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/android.inc
@@ -27,8 +27,8 @@ void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
 
   unsigned long hwcap = getauxval(AT_HWCAP);
   unsigned long hwcap2 = getauxval(AT_HWCAP2);
-  unsigned long hwcap2 = getauxval(AT_HWCAP3);
-  unsigned long hwcap2 = getauxval(AT_HWCAP4);
+  unsigned long hwcap3 = getauxval(AT_HWCAP3);
+  unsigned long hwcap4 = getauxval(AT_HWCAP4);
 
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/getauxval.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/getauxval.inc
@@ -12,8 +12,8 @@ void CONSTRUCTOR_ATTRIBUTE __init_cpu_features(void) {
 
   unsigned long hwcap = getauxval(AT_HWCAP);
   unsigned long hwcap2 = getauxval(AT_HWCAP2);
-  unsigned long hwcap2 = getauxval(AT_HWCAP3);
-  unsigned long hwcap2 = getauxval(AT_HWCAP4);
+  unsigned long hwcap3 = getauxval(AT_HWCAP3);
+  unsigned long hwcap4 = getauxval(AT_HWCAP4);
 
   __ifunc_arg_t arg;
   arg._size = sizeof(__ifunc_arg_t);


### PR DESCRIPTION
Correct the variable names