### PR TITLE
[NFC][SpecialCaseList] Make default version 2 instead of max()

### DIFF
--- a/llvm/lib/Support/SpecialCaseList.cpp
+++ b/llvm/lib/Support/SpecialCaseList.cpp
@@ -150,7 +150,7 @@ SpecialCaseList::addSection(StringRef SectionStr, unsigned FileNo,
 
 bool SpecialCaseList::parse(unsigned FileIdx, const MemoryBuffer *MB,
                             std::string &Error) {
-  unsigned long long Version = std::numeric_limits<unsigned long long>::max();
+  unsigned long long Version = 2;
 
   StringRef Header = MB->getBuffer();
   if (Header.consume_front("#!special-case-list-v"))


### PR DESCRIPTION
This way we can roll out new breaking features as opt-int.
E.g. "#!special-case-list-v3" will enabled something new.

Nothing to enabled yet, but with pinpointed default it's an option.

Follow up #162350.