### PR TITLE
[lldb] Add a blurb about not including private headers

### DIFF
--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -8,7 +8,8 @@ add_lldb_unittest(APITests
   )
 
 # Build with -Wdocumentation. This relies on the tests including all the API
-# headers through API/LLDB.h.
+# headers through API/LLDB.h. It also means that the API tests cannot include
+# private headers.
 check_cxx_compiler_flag("-Wdocumentation"
                         CXX_SUPPORTS_DOCUMENTATION)
 if (CXX_SUPPORTS_DOCUMENTATION)


### PR DESCRIPTION
Add a blurb about not including private headers in the API tests.