### PR TITLE
[llvm] Add support for building LLVM on SerenityOS

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -334,7 +334,7 @@ endif()
 
 # Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO
 # build might work on ELF but fail on MachO/COFF.
-if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390|Emscripten" OR
+if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390|Emscripten|SerenityOS" OR
         WIN32 OR CYGWIN) AND
    NOT LLVM_USE_SANITIZER)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
@@ -572,6 +572,11 @@ elseif(MINGW OR CYGWIN)
   if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     append("-Wa,-mbig-obj" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
   endif()
+endif()
+
+# SerenityOS sets a very low default stack size value, so increase it to 4MB.
+if(SERENITYOS)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=4194304")
 endif()
 
 option(LLVM_ENABLE_WARNINGS "Enable compiler warnings." ON)

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -30,7 +30,8 @@
 
 #if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__) ||            \
     defined(__Fuchsia__) || defined(__EMSCRIPTEN__) || defined(__NetBSD__) ||  \
-    defined(__OpenBSD__) || defined(__DragonFly__) || defined(__managarm__)
+    defined(__OpenBSD__) || defined(__DragonFly__) || defined(__managarm__) || \
+    defined(__serenity__)
 #include <endian.h>
 #elif defined(_AIX)
 #include <sys/machine.h>

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp
@@ -52,7 +52,9 @@ static DWORD getWindowsProtectionFlags(MemProt MP) {
 
 Expected<std::pair<ExecutorAddr, std::string>>
 ExecutorSharedMemoryMapperService::reserve(uint64_t Size) {
-#if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)
+#if (defined(LLVM_ON_UNIX) &&                                                  \
+     !(defined(__ANDROID__) || defined(__serenity__))) ||                      \
+    defined(_WIN32)
 
 #if defined(LLVM_ON_UNIX)
 
@@ -141,7 +143,9 @@ ExecutorSharedMemoryMapperService::reserve(uint64_t Size) {
 
 Expected<ExecutorAddr> ExecutorSharedMemoryMapperService::initialize(
     ExecutorAddr Reservation, tpctypes::SharedMemoryFinalizeRequest &FR) {
-#if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)
+#if (defined(LLVM_ON_UNIX) &&                                                  \
+     !(defined(__ANDROID__) || defined(__serenity__))) ||                      \
+    defined(_WIN32)
 
   ExecutorAddr MinAddr(~0ULL);
 
@@ -245,7 +249,9 @@ Error ExecutorSharedMemoryMapperService::deinitialize(
 
 Error ExecutorSharedMemoryMapperService::release(
     const std::vector<ExecutorAddr> &Bases) {
-#if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)
+#if (defined(LLVM_ON_UNIX) &&                                                  \
+     !(defined(__ANDROID__) || defined(__serenity__))) ||                      \
+    defined(_WIN32)
   Error Err = Error::success();
 
   for (auto Base : Bases) {

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -108,7 +108,7 @@ typedef uint_t uint;
 #endif
 
 #if defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__) ||       \
-    defined(__MVS__)
+    defined(__MVS__) || defined(__serenity__)
 #define STATVFS_F_FLAG(vfs) (vfs).f_flag
 #else
 #define STATVFS_F_FLAG(vfs) (vfs).f_flags
@@ -510,6 +510,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
   return true;
 #elif defined(__HAIKU__)
   // Haiku doesn't expose this information.
+  return false;
+#elif defined(__serenity__)
+  // Serenity doesn't yet support remote filesystem mounts.
   return false;
 #elif defined(__sun)
   // statvfs::f_basetype contains a null-terminated FSType name of the mounted

--- a/llvm/lib/Support/Unix/Program.inc
+++ b/llvm/lib/Support/Unix/Program.inc
@@ -337,7 +337,7 @@ namespace sys {
 
 #if defined(_AIX)
 static pid_t(wait4)(pid_t pid, int *status, int options, struct rusage *usage);
-#elif !defined(__Fuchsia__)
+#elif !defined(__Fuchsia__) && !defined(__serenity__)
 using ::wait4;
 #endif
 
@@ -375,6 +375,12 @@ pid_t(llvm::sys::wait4)(pid_t pid, int *status, int options,
   // absence of indiscriminate `wait` calls from the current process (which
   // would cause the call here to fail with ECHILD).
   return ::wait4(pid, status, options & ~WNOHANG, usage);
+}
+#endif
+
+#ifdef __serenity__
+pid_t(llvm::sys::wait4)(pid_t pid, int *status, int options, struct *rusage) {
+  return ::waitpid(pid, status, options);
 }
 #endif
 


### PR DESCRIPTION
Stub out wait4, as SerenityOS does not support querying a child
processes resource usage information.

POSIX shm is not supported by SerenityOS yet, so disable it in Orc.

Serenity gives each thread a default of 1MB of stack. Increase the
default stack size for LLVM applications when running on SerenityOS.