### PR TITLE
[SPARC] Fix-forward #154950 by returning true if SP::V8BAR is handled

### DIFF
--- a/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
@@ -668,6 +668,7 @@ bool SparcInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
              .addImm(-1);
     MIBundleBuilder(MBB, InstSTBAR, InstLDSTUB);
     MBB.erase(MI);
+    return true;
   }
   }
   return false;


### PR DESCRIPTION
Use-after-poison happens because after SP::V8BAR is handled, it erases MI, which should therefore not be inspected by `ExpandPostRA::run()`.

This fixes a buildbot reported issue from #154950 (https://lab.llvm.org/buildbot/#/builders/24/builds/13433).