### PR TITLE
[llvm-dwarfdump] Support for DW_AT_language_name and DW_AT_language_version

### DIFF
--- a/llvm/lib/BinaryFormat/Dwarf.cpp
+++ b/llvm/lib/BinaryFormat/Dwarf.cpp
@@ -893,6 +893,8 @@ StringRef llvm::dwarf::AttributeValueString(uint16_t Attr, unsigned Val) {
     return DefaultedMemberString(Val);
   case DW_AT_APPLE_enum_kind:
     return EnumKindString(Val);
+  case DW_AT_language_name:
+    return SourceLanguageNameString(static_cast<SourceLanguageName>(Val));
   }
 
   return StringRef();

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -149,7 +149,8 @@ static void dumpAttribute(raw_ostream &OS, const DWARFDie &Die,
   if (!Name.empty())
     WithColor(OS, Color) << Name;
   else if (Attr == DW_AT_decl_line || Attr == DW_AT_decl_column ||
-           Attr == DW_AT_call_line || Attr == DW_AT_call_column) {
+           Attr == DW_AT_call_line || Attr == DW_AT_call_column ||
+           Attr == DW_AT_language_version) {
     if (std::optional<uint64_t> Val = FormValue.getAsUnsignedConstant())
       OS << *Val;
     else

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_name.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_name.s
@@ -1,0 +1,35 @@
+# Demonstrate dumping DW_AT_language_name.
+# RUN: llvm-mc -triple=x86_64--linux -filetype=obj < %s | \
+# RUN:     llvm-dwarfdump -v - | FileCheck %s
+
+# CHECK: .debug_abbrev contents:
+# CHECK: DW_AT_language_name DW_FORM_data2
+# CHECK: DW_AT_language_name DW_FORM_data2
+# CHECK: .debug_info contents:
+# CHECK: DW_AT_language_name [DW_FORM_data2] (DW_LNAME_C)
+# CHECK: DW_AT_language_name [DW_FORM_data2] (0x0000)
+
+        .section        .debug_abbrev,"",@progbits
+        .byte   1                       # Abbreviation Code
+        .byte   17                      # DW_TAG_compile_unit
+        .byte   1                       # DW_CHILDREN_no 
+        .ascii  "\220\001"              # DW_AT_language_name
+        .byte   5                       # DW_FORM_data2
+        .ascii  "\220\001"              # DW_AT_language_name
+        .byte   5                       # DW_FORM_data2
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+        .byte   0                       # EOM(3)
+
+        .section        .debug_info,"",@progbits
+        .long   .Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
+.Ldebug_info_start0:
+        .short  5                       # DWARF version number
+        .byte   1                       # Unit type
+        .byte   8                       # Address Size (in bytes)
+        .long   .debug_abbrev           # Offset Into Abbrev. Section
+        .byte   1                       # Abbrev [1] DW_TAG_compile_unit
+        .short  3                       # DW_AT_language_name
+        .short  0                       # DW_AT_language_name
+        .byte   0 
+.Ldebug_info_end0:

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version.s
@@ -1,0 +1,35 @@
+# Demonstrate dumping DW_AT_language_version.
+# RUN: llvm-mc -triple=x86_64--linux -filetype=obj < %s | \
+# RUN:     llvm-dwarfdump -v - | FileCheck %s
+
+# CHECK: .debug_abbrev contents:
+# CHECK: DW_AT_language_version DW_FORM_data4
+# CHECK: DW_AT_language_version DW_FORM_data2
+# CHECK: .debug_info contents:
+# CHECK: DW_AT_language_version [DW_FORM_data4] (201402)
+# CHECK: DW_AT_language_version [DW_FORM_data2] (0)
+
+        .section        .debug_abbrev,"",@progbits
+        .byte   1                       # Abbreviation Code
+        .byte   17                      # DW_TAG_compile_unit
+        .byte   1                       # DW_CHILDREN_no 
+        .ascii  "\221\001"              # DW_AT_language_version
+        .byte   6                       # DW_FORM_data4
+        .ascii  "\221\001"              # DW_AT_language_version
+        .byte   5                       # DW_FORM_data2
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+        .byte   0                       # EOM(3)
+
+        .section        .debug_info,"",@progbits
+        .long   .Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
+.Ldebug_info_start0:
+        .short  5                       # DWARF version number
+        .byte   1                       # Unit type
+        .byte   8                       # Address Size (in bytes)
+        .long   .debug_abbrev           # Offset Into Abbrev. Section
+        .byte   1                       # Abbrev [1] DW_TAG_compile_unit
+        .long   201402                  # DW_AT_language_version
+        .short  0                       # DW_AT_language_version
+        .byte   0 
+.Ldebug_info_end0:


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/162434
* https://github.com/llvm/llvm-project/pull/162446

Makes sure we dump the attributes in a user-friendly way.

More info on the attributes here: https://dwarfstd.org/languages-v6.html