### PR TITLE
[LLVM-C] Upstream `LLVMBuildAtomicLoad/Store` from rustc

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -147,6 +147,7 @@ Changes to the C API
 --------------------
 
 * Add `LLVMGetOrInsertFunction` to get or insert a function, replacing the combination of `LLVMGetNamedFunction` and `LLVMAddFunction`.
+* Add `LLVMBuildAtomicLoad` and `LLVMBuildAtomicStore` to build atomic load and store instructions by specifying the ordering and whether the operation is single-threaded.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -4906,6 +4906,34 @@ LLVM_C_ABI LLVMValueRef LLVMBuildAtomicCmpXchgSyncScope(
     unsigned SSID);
 
 /**
+ * Builds an atomic load instruction.
+ *
+ * This is similar to LLVMBuildLoad2, but allows specifying the atomic
+ * ordering and whether the operation is single-threaded.
+ *
+ * @see llvm::IRBuilder::CreateLoad()
+ * @see llvm::LoadInst::setAtomic()
+ */
+LLVM_C_ABI LLVMValueRef LLVMBuildAtomicLoad(
+    LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Source, const char *Name,
+    LLVMAtomicOrdering Order, LLVMBool SingleThread);
+
+/**
+ * Builds an atomic store instruction.
+ *
+ * This is similar to LLVMBuildStore, but allows specifying the atomic
+ * ordering and whether the operation is single-threaded.
+ *
+ * @see llvm::IRBuilder::CreateStore()
+ * @see llvm::StoreInst::setAtomic()
+ */
+LLVM_C_ABI LLVMValueRef LLVMBuildAtomicStore(LLVMBuilderRef B,
+                                                 LLVMValueRef V,
+                                                 LLVMValueRef Target,
+                                                 LLVMAtomicOrdering Order,
+                                                 LLVMBool SingleThread);
+
+/**
  * Get the number of elements in the mask of a ShuffleVector instruction.
  */
 LLVM_C_ABI unsigned LLVMGetNumMaskElements(LLVMValueRef ShuffleVectorInst);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -4440,6 +4440,26 @@ LLVMValueRef LLVMBuildAtomicCmpXchgSyncScope(LLVMBuilderRef B, LLVMValueRef Ptr,
       mapFromLLVMOrdering(FailureOrdering), SSID));
 }
 
+LLVMValueRef LLVMBuildAtomicLoad(LLVMBuilderRef B, LLVMTypeRef Ty,
+                                 LLVMValueRef Source, const char *Name,
+                                 LLVMAtomicOrdering Order,
+                                 LLVMBool SingleThread) {
+  LoadInst *LI = unwrap(B)->CreateLoad(unwrap(Ty), unwrap(Source), Name);
+  LI->setAtomic(mapFromLLVMOrdering(Order),
+                SingleThread ? SyncScope::SingleThread : SyncScope::System);
+  return wrap(LI);
+}
+
+LLVMValueRef LLVMBuildAtomicStore(LLVMBuilderRef B, LLVMValueRef V,
+                                      LLVMValueRef Target,
+                                      LLVMAtomicOrdering Order,
+                                      LLVMBool SingleThread) {
+  StoreInst *SI = unwrap(B)->CreateStore(unwrap(V), unwrap(Target));
+  SI->setAtomic(mapFromLLVMOrdering(Order),
+                SingleThread ? SyncScope::SingleThread : SyncScope::System);
+  return wrap(SI);
+}
+
 unsigned LLVMGetNumMaskElements(LLVMValueRef SVInst) {
   Value *P = unwrap(SVInst);
   ShuffleVectorInst *I = cast<ShuffleVectorInst>(P);


### PR DESCRIPTION
Adds `LLVMBuildAtomicLoad` and `LLVMBuildAtomicStore` functions originally from rustc. [rustc LLVMRustBuildAtomicLoad](https://github.com/rust-lang/rust/blob/5767910cbcc9d199bf261a468574d45aa3857599/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp#L627), [rustc LLVMRustBuildAtomicStore](https://github.com/rust-lang/rust/blob/5767910cbcc9d199bf261a468574d45aa3857599/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp#L635)

Unlike the original I add the option to specify whether the operation is single-threaded similar to how  other `LLVMBuildAtomic` functions do in LLVM-C.