### PR TITLE
[lldb][test] Remove class level packetLog in MockGDBServerResponder

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
+++ b/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
@@ -87,7 +87,6 @@ class MockGDBServerResponder:
     """
 
     registerCount = 40
-    packetLog = None
 
     class RESPONSE_DISCONNECT:
         pass


### PR DESCRIPTION
Added in 1902ffd9a4914d4cd03e200ca9050bf3b1564c19 but appears to be leftover code from some older design.

I can't find any code that reads packetLog via the class itself, or checks whether it is None.

No tests failed on AArch64 Linux after removing it.