### PR TITLE
[CI] Add dyung and c-rhodes to the Release Asset List

### DIFF
--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -54,6 +54,8 @@ def _get_uploaders(release_version):
                 "tru",
                 "tstellar",
                 "github-actions[bot]",
+                "c-rhodes",
+                "dyung",
             ]
         )
 


### PR DESCRIPTION
We have a list of people authorized to create release assets to prevent someone adding a release asset to a release without someone getting alerted. Add dyung and c-rhodes now that they are also release managers.

Fixes #162463 (maybe after backport).