### PR TITLE
[llvm][nfc] Ignore OpenAI Codex artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ autoconf/autom4te.cache
 .claude/
 /GEMINI.md
 .gemini/
+AGENTS.md
+.codex/
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).


### PR DESCRIPTION
Follow-up to #153853 to also ignore Codex artifacts [1]. AGENTS.md may be at the root or in sub-directories, so unlike other Markdown config files I've not prefixed it with '/'.

[1] https://github.com/openai/codex/blob/main/docs/getting-started.md#memory-with-agentsmd