### PR TITLE
[libc] Refactor internal auxv usage to reduce getauxval dependencies

### DIFF
--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -70,11 +70,11 @@ add_object_library(
     libc.src.__support.CPP.string_view
     libc.src.__support.threads.callonce
     libc.src.__support.threads.linux.futex_word_type
+    libc.src.__support.libc_errno
+    libc.src.__support.OSUtil.linux.auxv
     libc.hdr.types.struct_timeval
     libc.hdr.types.struct_timespec
     libc.hdr.types.clockid_t
     libc.hdr.types.time_t
     libc.hdr.link_macros
-    libc.src.errno.errno
-    libc.src.sys.auxv.getauxval
 )

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -70,7 +70,6 @@ add_object_library(
     libc.src.__support.CPP.string_view
     libc.src.__support.threads.callonce
     libc.src.__support.threads.linux.futex_word_type
-    libc.src.__support.libc_errno
     libc.src.__support.OSUtil.linux.auxv
     libc.hdr.types.struct_timeval
     libc.hdr.types.struct_timespec

--- a/libc/src/__support/OSUtil/linux/vdso.cpp
+++ b/libc/src/__support/OSUtil/linux/vdso.cpp
@@ -11,10 +11,10 @@
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/CPP/string_view.h"
+#include "src/__support/OSUtil/linux/auxv.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/threads/callonce.h"
 #include "src/__support/threads/linux/futex_word.h"
-#include "src/sys/auxv/getauxval.h"
 #include <linux/auxvec.h>
 
 // TODO: This is a temporary workaround to avoid including elf.h
@@ -192,7 +192,8 @@ void Symbol::initialize_vdso_global_cache() {
   // get the address of the VDSO, protect errno since getauxval may change
   // it
   int errno_backup = libc_errno;
-  uintptr_t vdso_ehdr_addr = getauxval(AT_SYSINFO_EHDR);
+  cpp::optional<unsigned long> auxv_res = auxv::get(AT_SYSINFO_EHDR);
+  uintptr_t vdso_ehdr_addr = auxv_res ? static_cast<uintptr_t>(*auxv_res) : 0;
   // Get the memory address of the vDSO ELF header.
   auto vdso_ehdr = reinterpret_cast<ElfW(Ehdr) *>(vdso_ehdr_addr);
   // leave the table unpopulated if we don't have vDSO

--- a/libc/src/__support/OSUtil/linux/vdso.cpp
+++ b/libc/src/__support/OSUtil/linux/vdso.cpp
@@ -12,7 +12,6 @@
 #include "src/__support/CPP/optional.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/OSUtil/linux/auxv.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/threads/callonce.h"
 #include "src/__support/threads/linux/futex_word.h"
 #include <linux/auxvec.h>
@@ -189,18 +188,13 @@ void Symbol::initialize_vdso_global_cache() {
   for (auto &i : global_cache)
     i = nullptr;
 
-  // get the address of the VDSO, protect errno since getauxval may change
-  // it
-  int errno_backup = libc_errno;
   cpp::optional<unsigned long> auxv_res = auxv::get(AT_SYSINFO_EHDR);
   uintptr_t vdso_ehdr_addr = auxv_res ? static_cast<uintptr_t>(*auxv_res) : 0;
   // Get the memory address of the vDSO ELF header.
   auto vdso_ehdr = reinterpret_cast<ElfW(Ehdr) *>(vdso_ehdr_addr);
   // leave the table unpopulated if we don't have vDSO
-  if (vdso_ehdr == nullptr) {
-    libc_errno = errno_backup;
+  if (vdso_ehdr == nullptr)
     return;
-  }
 
   // locate the section header inside the elf using the section header
   // offset

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -563,8 +563,8 @@ add_entrypoint_object(
   DEPENDS
     libc.include.unistd
     libc.include.sys_auxv
-    libc.src.errno.errno
-    libc.src.sys.auxv.getauxval
+    libc.src.__support.libc_errno
+    libc.src.__support.OSUtil.linux.auxv
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -11,17 +11,20 @@
 #include "src/__support/common.h"
 
 #include "hdr/unistd_macros.h"
+#include "src/__support/OSUtil/linux/auxv.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/sys/auxv/getauxval.h"
-#include <sys/auxv.h>
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(long, sysconf, (int name)) {
   long ret = 0;
-  if (name == _SC_PAGESIZE)
-    return static_cast<long>(getauxval(AT_PAGESZ));
+  if (name == _SC_PAGESIZE) {
+    cpp::optional<unsigned long> page_size = auxv::get(AT_PAGESZ);
+    if (page_size)
+      return static_cast<long>(*page_size);
+    ret = -1;
+  }
 
   // TODO: Complete the rest of the sysconf options.
   if (ret < 0) {


### PR DESCRIPTION
### Core Refactoring: Remove dependencies on external getauxval across libc

**Replaced direct getauxval() calls with internal auxv interface:**

**Modified files:**
   - `libc/src/__support/OSUtil/linux/vdso.cpp`:
     - Replaced `getauxval(AT_SYSINFO_EHDR)` with `auxv::get(AT_SYSINFO_EHDR)`
     - Added proper error handling with optional return type
     - Remove obsolete errno protection logic

   - `libc/src/unistd/linux/sysconf.cpp`:
     - Replaced `getauxval(AT_PAGESZ)` with `auxv::get(AT_PAGESZ)`
     - Added error handling for page size retrieval


**Purpose:** This refactoring removes direct dependencies on the `getauxval` entrypoint from internal libc code, making the implementation more modular and reducing coupling.

## Remaining Uses of libc.src.sys.auxv.getauxval

The following CMake files still reference `libc.src.sys.auxv.getauxval`:

### Test Infrastructure:
1. **`libc/test/IntegrationTest/CMakeLists.txt`** (line 3):
   - Sets `arch_specific_deps` for integration tests
   
2. **`libc/test/integration/scudo/CMakeLists.txt`** (line 24):
   - Scudo integration test dependencies

3. **`libc/cmake/modules/LLVMLibCTestRules.cmake`** (lines 839-845):
   - Temporary workaround for AArch64 hermetic tests
   - Comment indicates "dependency chain is broken" for getauxval propagation

### Unit Tests:
4. **`libc/test/src/sys/auxv/linux/CMakeLists.txt`** (line 11):
   - Unit test for the getauxval function itself
