### PR TITLE
[Clang][ASTImporter] Fix cycle in importing template specialization on auto type with typename

### DIFF
--- a/clang/include/clang/AST/ASTImporter.h
+++ b/clang/include/clang/AST/ASTImporter.h
@@ -190,7 +190,15 @@ class TypeSourceInfo;
       llvm::SmallDenseMap<Decl *, int, 32> Aux;
     };
 
-    class FunctionDeclImportCycleDetector;
+    class FunctionDeclImportCycleDetector {
+    public:
+      auto makeScopedCycleDetection(const FunctionDecl *D);
+
+      bool isCycle(const FunctionDecl *D) const;
+
+    private:
+      llvm::DenseSet<const FunctionDecl *> FunctionDeclsWithImportInProgress;
+    };
 
   private:
     std::shared_ptr<ASTImporterSharedState> SharedState = nullptr;
@@ -261,8 +269,7 @@ class TypeSourceInfo;
     /// can come for example from auto return type or when template parameters
     /// are used in the return type or parameters. This member is used to detect
     /// cyclic import of FunctionDecl objects to avoid infinite recursion.
-    std::unique_ptr<FunctionDeclImportCycleDetector>
-        FindFunctionDeclImportCycle;
+    FunctionDeclImportCycleDetector FindFunctionDeclImportCycle;
 
     using FoundDeclsTy = SmallVector<NamedDecl *, 2>;
     FoundDeclsTy findDeclsInToCtx(DeclContext *DC, DeclarationName Name);

--- a/clang/include/clang/AST/ASTImporter.h
+++ b/clang/include/clang/AST/ASTImporter.h
@@ -254,6 +254,7 @@ class TypeSourceInfo;
     /// Declaration (from, to) pairs that are known not to be equivalent
     /// (which we have already complained about).
     NonEquivalentDeclSet NonEquivalentDecls;
+    llvm::DenseSet<const Decl *> DeclTypeCycles;
 
     using FoundDeclsTy = SmallVector<NamedDecl *, 2>;
     FoundDeclsTy findDeclsInToCtx(DeclContext *DC, DeclarationName Name);

--- a/clang/include/clang/AST/ASTImporter.h
+++ b/clang/include/clang/AST/ASTImporter.h
@@ -190,7 +190,7 @@ class TypeSourceInfo;
       llvm::SmallDenseMap<Decl *, int, 32> Aux;
     };
 
-    class FunctionReturnTypeDeclCycleDetector;
+    class FunctionDeclImportCycleDetector;
 
   private:
     std::shared_ptr<ASTImporterSharedState> SharedState = nullptr;
@@ -261,8 +261,8 @@ class TypeSourceInfo;
     /// can come for example from auto return type or when template parameters
     /// are used in the return type or parameters. This member is used to detect
     /// cyclic import of FunctionDecl objects to avoid infinite recursion.
-    std::unique_ptr<FunctionReturnTypeDeclCycleDetector>
-        FunctionReturnTypeCycleDetector;
+    std::unique_ptr<FunctionDeclImportCycleDetector>
+        FindFunctionDeclImportCycle;
 
     using FoundDeclsTy = SmallVector<NamedDecl *, 2>;
     FoundDeclsTy findDeclsInToCtx(DeclContext *DC, DeclarationName Name);

--- a/clang/include/clang/AST/ASTImporter.h
+++ b/clang/include/clang/AST/ASTImporter.h
@@ -256,14 +256,11 @@ class TypeSourceInfo;
     /// Declaration (from, to) pairs that are known not to be equivalent
     /// (which we have already complained about).
     NonEquivalentDeclSet NonEquivalentDecls;
-    // When template function return type is auto and return type is declared as
-    // typename from template params, there could be cycles in function
-    // importing when function decaration is still the need for return type
-    // declaration import. We have code path for nested types inside function
-    // (see hasReturnTypeDeclaredInside): assuming return type as VoidTy and
-    // calculate it later under UsedDifferentProtoType boolean. This class is
-    // reuse of this approach and make logic lazy - detect cycle - calculate
-    // return type later on.
+    /// A FunctionDecl can have properties that have a reference to the
+    /// function itself and are imported before the function is created. This
+    /// can come for example from auto return type or when template parameters
+    /// are used in the return type or parameters. This member is used to detect
+    /// cyclic import of FunctionDecl objects to avoid infinite recursion.
     std::unique_ptr<FunctionReturnTypeDeclCycleDetector>
         FunctionReturnTypeCycleDetector;
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -4073,7 +4073,7 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
     // To avoid an infinite recursion when importing, create the FunctionDecl
     // with a simplified return type.
     // Reuse this approach for auto return types declared as typenames from
-    // template pamams, tracked in FunctionReturnTypeCycleDetector.
+    // template params, tracked in FunctionReturnTypeCycleDetector.
     if (hasReturnTypeDeclaredInside(D) ||
         Importer.FunctionReturnTypeCycleDetector->isCycle(D)) {
       FromReturnTy = Importer.getFromContext().VoidTy;

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -1293,7 +1293,7 @@ public:
   public:
     // Do not track cycles on D == nullptr.
     ScopedReturnTypeImport(FunctionReturnTypeDeclCycleDetector &owner,
-                           const Decl *D)
+                           const FunctionDecl *D)
         : CycleDetector(owner), D(D) {
       if (D)
         CycleDetector.FunctionReturnTypeDeclCycles.insert(D);
@@ -1307,22 +1307,22 @@ public:
 
   private:
     FunctionReturnTypeDeclCycleDetector &CycleDetector;
-    const Decl *D;
+    const FunctionDecl *D;
   };
 
-  ScopedReturnTypeImport DetectImportCycles(const Decl *D) {
+  ScopedReturnTypeImport DetectImportCycles(const FunctionDecl *D) {
     if (!IsCycle(D))
       return ScopedReturnTypeImport(*this, D);
     return ScopedReturnTypeImport(*this, nullptr);
   }
 
-  bool IsCycle(const Decl *D) const {
+  bool IsCycle(const FunctionDecl *D) const {
     return FunctionReturnTypeDeclCycles.find(D) !=
            FunctionReturnTypeDeclCycles.end();
   }
 
 private:
-  llvm::DenseSet<const Decl *> FunctionReturnTypeDeclCycles;
+  llvm::DenseSet<const FunctionDecl *> FunctionReturnTypeDeclCycles;
 };
 
 ExpectedType ASTNodeImporter::VisitType(const Type *T) {

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -4035,7 +4035,7 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
     // To avoid an infinite recursion when importing, create the FunctionDecl
     // with a simplified return type.
     if (hasReturnTypeDeclaredInside(D) ||
-      Importer.DeclTypeCycles.find(D) != Importer.DeclTypeCycles.end()) {
+        Importer.DeclTypeCycles.find(D) != Importer.DeclTypeCycles.end()) {
       FromReturnTy = Importer.getFromContext().VoidTy;
       UsedDifferentProtoType = true;
     }
@@ -4058,13 +4058,11 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
   }
 
   Error Err = Error::success();
-  if (!UsedDifferentProtoType) {
+  if (!UsedDifferentProtoType)
     Importer.DeclTypeCycles.insert(D);
-  }
   auto T = importChecked(Err, FromTy);
-  if (!UsedDifferentProtoType) {
+  if (!UsedDifferentProtoType)
     Importer.DeclTypeCycles.erase(D);
-  }
   auto TInfo = importChecked(Err, FromTSI);
   auto ToInnerLocStart = importChecked(Err, D->getInnerLocStart());
   auto ToEndLoc = importChecked(Err, D->getEndLoc());

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -744,13 +744,8 @@ namespace clang {
     Error ImportOverriddenMethods(CXXMethodDecl *ToMethod,
                                   CXXMethodDecl *FromMethod);
 
-    Expected<FunctionDecl *> FindFunctionTemplateSpecialization(
-        FunctionDecl *FromFD);
-
-    // Returns true if the given function has a placeholder return type and
-    // that type is declared inside the body of the function.
-    // E.g. auto f() { struct X{}; return X(); }
-    bool hasReturnTypeDeclaredInside(FunctionDecl *D);
+    Expected<FunctionDecl *>
+    FindFunctionTemplateSpecialization(FunctionDecl *FromFD);
   };
 
 template <typename InContainerTy>
@@ -3901,30 +3896,6 @@ private:
 };
 } // namespace
 
-/// This function checks if the given function has a return type that contains
-/// a reference (in any way) to a declaration inside the same function.
-bool ASTNodeImporter::hasReturnTypeDeclaredInside(FunctionDecl *D) {
-  QualType FromTy = D->getType();
-  const auto *FromFPT = FromTy->getAs<FunctionProtoType>();
-  assert(FromFPT && "Must be called on FunctionProtoType");
-
-  auto IsCXX11Lambda = [&]() {
-    if (Importer.FromContext.getLangOpts().CPlusPlus14) // C++14 or later
-      return false;
-
-    return isLambdaMethod(D);
-  };
-
-  QualType RetT = FromFPT->getReturnType();
-  if (isa<AutoType>(RetT.getTypePtr()) || IsCXX11Lambda()) {
-    FunctionDecl *Def = D->getDefinition();
-    IsTypeDeclaredInsideVisitor Visitor(Def ? Def : D);
-    return Visitor.CheckType(RetT);
-  }
-
-  return false;
-}
-
 ExplicitSpecifier
 ASTNodeImporter::importExplicitSpecifier(Error &Err, ExplicitSpecifier ESpec) {
   Expr *ExplicitExpr = ESpec.getExpr();
@@ -4073,9 +4044,8 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
     // To avoid an infinite recursion when importing, create the FunctionDecl
     // with a simplified return type.
     // Reuse this approach for auto return types declared as typenames from
-    // template pamams, tracked in FunctionReturnTypeCycleDetector.
-    if (hasReturnTypeDeclaredInside(D) ||
-        Importer.FunctionReturnTypeCycleDetector->isCycle(D)) {
+    // template params, tracked in FunctionReturnTypeCycleDetector.
+    if (Importer.FunctionReturnTypeCycleDetector->isCycle(D)) {
       FromReturnTy = Importer.getFromContext().VoidTy;
       UsedDifferentProtoType = true;
     }

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3204,6 +3204,56 @@ TEST_P(ImportExpr, UnresolvedMemberExpr) {
                  compoundStmt(has(callExpr(has(unresolvedMemberExpr())))))))));
 }
 
+TEST_P(ImportExpr, CycleInAutoTemplateSpec) {
+  MatchVerifier<Decl> Verifier;
+  const char *Code = R"(
+  template <class _CharT>
+  struct basic_string {
+    using value_type = _CharT;
+  };
+
+  template<typename T>
+  struct basic_string_view {
+    using value_type = T;
+  };
+
+  using string_view = basic_string_view<char>;
+  using string = basic_string<char>;
+
+  template<typename T>
+  struct span {
+  };
+
+  template <typename StringT>
+  auto StrCatT(span<const StringT> pieces) {
+    basic_string<typename StringT::value_type> result;
+    return result;
+  }
+
+  string StrCat(span<const string_view> pieces) {
+      return StrCatT(pieces);
+  }
+
+  string StrCat(span<const string> pieces) {
+      return StrCatT(pieces);
+  }
+
+  template <typename T>
+  auto declToImport(T pieces) {
+    return StrCat(pieces);
+  }
+
+  void test() {
+    span<const string> pieces;
+    auto result = declToImport(pieces);
+  }
+)";
+  // This test reproduces the StrCatT recursion pattern with concepts and span
+  // that may cause infinite recursion during AST import due to circular dependencies
+  testImport(Code, Lang_CXX20, "", Lang_CXX20, Verifier,
+             functionTemplateDecl(hasName("declToImport")));
+}
+
 TEST_P(ImportExpr, ConceptNoRequirement) {
   MatchVerifier<Decl> Verifier;
   const char *Code = R"(

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3249,7 +3249,8 @@ TEST_P(ImportExpr, CycleInAutoTemplateSpec) {
   }
 )";
   // This test reproduces the StrCatT recursion pattern with concepts and span
-  // that may cause infinite recursion during AST import due to circular dependencies
+  // that may cause infinite recursion during AST import due to circular
+  // dependencies
   testImport(Code, Lang_CXX20, "", Lang_CXX20, Verifier,
              functionTemplateDecl(hasName("declToImport")));
 }

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3204,7 +3204,7 @@ TEST_P(ImportExpr, UnresolvedMemberExpr) {
                  compoundStmt(has(callExpr(has(unresolvedMemberExpr())))))))));
 }
 
-TEST_P(ImportExpr, CycleInAutoTemplateSpec) {
+TEST_P(ImportDecl, CycleInAutoTemplateSpec) {
   MatchVerifier<Decl> Verifier;
   const char *Code = R"(
   template <class _CharT>


### PR DESCRIPTION
ASTImporter on importing template specialization with auto return type faces cycle when return type is not nested one, but typename from template arguments and other template.
There is code, that prevents cycle to auto return types when nested type declared. Solved case differs somehow from nested types, but have same solution with UsedDifferentProtoType - with delayed return type determining.