### PR TITLE
Revert "[lldb] Cortex-M exception unwind API test cleanup"

### DIFF
--- a/lldb/test/API/functionalities/unwind/cortex-m-exception/TestCortexMExceptionUnwind.py
+++ b/lldb/test/API/functionalities/unwind/cortex-m-exception/TestCortexMExceptionUnwind.py
@@ -12,6 +12,21 @@ from lldbsuite.test import lldbutil
 class TestCortexMExceptionUnwind(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    # on the lldb-remote-linux-ubuntu CI, the binary.json's triple of
+    # armv7m-apple is not being set in the Target triple, and we're
+    # picking the wrong ABI plugin, ABISysV_arm.
+    # ABISysV_arm::CreateDefaultUnwindPlan() doesn't have a way to detect
+    # arm/thumb for a stack frame, or even the Target's triple for a
+    # Cortex-M part that is always thumb.  It hardcodes r11 as the frame
+    # pointer register, which is correct for arm code but not thumb.
+    # It is never correct # on a Cortex-M target.
+    # The Darwin ABIMacOSX_arm diverges from AAPCS and always uses r7 for
+    # the frame pointer -- the thumb convention -- whether executing arm or
+    # thumb.  So its CreateDefaultUnwindPlan picks the correct register for
+    # the frame pointer, and we can walk the stack.
+    # ABISysV_arm::CreateDefaultUnwindPlan will only get one frame and
+    # not be able to continue.
+    @skipIfRemote
     def test_no_fpu(self):
         """Test that we can backtrace correctly through an ARM Cortex-M Exception return stack"""
 
@@ -44,8 +59,9 @@ class TestCortexMExceptionUnwind(TestBase):
         # frames above that.  The topmost two stack frames
         # were not interesting for this test, so I didn't
         # create symbols for them.
-        self.assertEqual(thread.GetNumFrames(), 3)
+        self.assertEqual(thread.GetNumFrames(), 6)
         stackframe_names = [
+            "exception_catcher",
             "exception_catcher",
             "exception_thrower",
             "main",

--- a/lldb/test/API/functionalities/unwind/cortex-m-exception/armv7m-nofpu-exception.yaml
+++ b/lldb/test/API/functionalities/unwind/cortex-m-exception/armv7m-nofpu-exception.yaml
@@ -2,8 +2,8 @@ cpu: armv7m
 threads:
   - regsets:
       - flavor: gpr
-        registers: [{name: sp, value: 0x2000fe88}, {name: r7, value: 0x2000fe88}, 
-                    {name: pc, value: 0x00203916}, {name: lr, value: 0x0020392d}]
+        registers: [{name: sp, value: 0x2000fe70}, {name: r7, value: 0x2000fe80}, 
+                    {name: pc, value: 0x0020392c}, {name: lr, value: 0x0020392d}]
 memory-regions:
   # stack memory fetched via 
   # (lldb) p/x $sp
@@ -14,7 +14,7 @@ memory-regions:
       0x0000002a, 0x20010e58, 0x00203923, 0x00000001,
       0x2000fe88, 0x00203911, 0x2000ffdc, 0xfffffff9,
       0x00000102, 0x00000002, 0x000003f0, 0x0000002a,
-      0x20012620, 0x00203215, 0x00202a92, 0x81000200,
+      0x20012620, 0x00203215, 0x00203366, 0x81000200,
       0x00203215, 0x200128b0, 0x0024928d, 0x2000fecc,
       0x002491ed, 0x20010e58, 0x20010e4c, 0x2000ffa0,
       0x200107a0, 0x0000003c, 0x200116e8, 0x200108b0,
@@ -62,26 +62,3 @@ memory-regions:
       0x98, 0xae, 0x28, 0x00
     ]
 
-  # exception_thrower
-  # (lldb) disass -b -c 12 -n exception_thrower
-  # 0x202a88 <+0>:  0xb5f0       push   {r4, r5, r6, r7, lr}
-  # 0x202a8a <+2>:  0xaf03       add    r7, sp, #0xc
-  # 0x202a8c <+4>:  0xe92d0f00   push.w {r8, r9, r10, r11}
-  # 0x202a90 <+8>:  0xb0c3       sub    sp, #0x10c
-  # 0x202a92 <+10>: 0xf7ffffd9   bl     0x202a48                 
-  - addr: 0x202a88
-    UInt8: [
-      0xf0, 0xb5, 0x03, 0xaf, 0x2d, 0xe9, 0x00, 0x0f,
-      0xc3, 0xb0, 0xff, 0xf7, 0xd9, 0xff, 0xff, 0xf7
-    ]
-
-  # main:
-  # 0x202a7e <+0>: push   {r7, lr}
-  # 0x202a80 <+2>: mov    r7, sp
-  # 0x202a82 <+4>: bl     0x202a88                  ; exception_thrower
-  # 0x202a86 <+8>: nop
-  - addr: 0x202a7e
-    UInt8: [
-      0x80, 0xb5, 0x6f, 0x46, 0x00, 0xf0, 0x01, 0xf8,
-      0x00, 0xbf
-    ]

--- a/lldb/test/API/functionalities/unwind/cortex-m-exception/binary.json
+++ b/lldb/test/API/functionalities/unwind/cortex-m-exception/binary.json
@@ -1,5 +1,5 @@
 {
-  "triple": "armv7m--",
+  "triple": "armv7m-apple",
   "uuid": "2D157DBA-53C9-3AC7-B5A1-9D336EC831CB",
   "type": "executable",
   "sections": [
@@ -28,13 +28,13 @@
     {
       "name": "exception_catcher",
       "type": "code",
-      "size": 32,
+      "size": 44,
       "address": 2111760
     },
     {
       "name": "exception_thrower",
       "type": "code",
-      "size": 16,
+      "size": 2652,
       "address": 2108040
     }
   ]


### PR DESCRIPTION
This reverts commit 01a8f9b81870ac9bfe26d80fa3313d56cb8cbe13.

The reason is "lldb-remote-linux-win" buildbot breakage (https://lab.llvm.org/buildbot/#/builders/197/builds/9625).