### PR TITLE
[bazel] fix: add dependency for SCFToEmitC due to c3aa1584e098

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -7800,6 +7800,7 @@ cc_library(
         ":SCFDialect",
         ":TransformUtils",
         ":Transforms",
+        "//llvm:Support"
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -7800,7 +7800,7 @@ cc_library(
         ":SCFDialect",
         ":TransformUtils",
         ":Transforms",
-        "//llvm:Support"
+        "//llvm:Support",
     ],
 )
 


### PR DESCRIPTION
Adding dependency changes due to bazel build failing since https://github.com/llvm/llvm-project/pull/143008/files