### PR TITLE
[MLIR] [NFC] Add static assert to subclass AbstractSparseLattice

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -518,6 +518,10 @@ private:
 template <typename StateT>
 class SparseBackwardDataFlowAnalysis
     : public AbstractSparseBackwardDataFlowAnalysis {
+  static_assert(
+      std::is_base_of<AbstractSparseLattice, StateT>::value,
+      "analysis state class expected to subclass AbstractSparseLattice");
+
 public:
   explicit SparseBackwardDataFlowAnalysis(DataFlowSolver &solver,
                                           SymbolTableCollection &symbolTable)


### PR DESCRIPTION
SparseForwardDataFlowAnalysis, with the comments specifying that StateT must be subclassing AbstractSparseLattice, also places a static assert in the class itself.

This commit adds the same missing assert for SparseBackwardDataFlowAnalysis.