### PR TITLE
[orc-rt] Enable SPS transparent conversion for reference arguments.

### DIFF
--- a/orc-rt/include/orc-rt/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/SPSWrapperFunction.h
@@ -102,7 +102,8 @@ private:
 public:
   template <typename... ArgTs>
   std::optional<WrapperFunctionBuffer> serialize(ArgTs &&...Args) {
-    return serializeImpl(Serializable<ArgTs>::to(std::forward<ArgTs>(Args))...);
+    return serializeImpl(
+        Serializable<std::decay_t<ArgTs>>::to(std::forward<ArgTs>(Args))...);
   }
 
   template <typename ArgTuple>

--- a/orc-rt/unittests/SPSWrapperFunctionTest.cpp
+++ b/orc-rt/unittests/SPSWrapperFunctionTest.cpp
@@ -190,6 +190,17 @@ TEST(SPSWrapperFunctionUtilsTest, TransparentConversionPointers) {
   EXPECT_EQ(P, &X);
 }
 
+TEST(SPSWrapperFunctionUtilsTest, TransparentConversionReferenceArguments) {
+  int X = 42;
+  int *P = nullptr;
+  SPSWrapperFunction<SPSExecutorAddr(SPSExecutorAddr)>::call(
+      DirectCaller(nullptr, round_trip_int_pointer_sps_wrapper),
+      [&](Expected<int32_t *> R) { P = cantFail(std::move(R)); },
+      static_cast<int *const &>(&X));
+
+  EXPECT_EQ(P, &X);
+}
+
 static void
 expected_int_pointer_sps_wrapper(orc_rt_SessionRef Session, void *CallCtx,
                                  orc_rt_WrapperFunctionReturn Return,


### PR DESCRIPTION
Ensures that SPS transparent conversion will apply to arguments passed by reference.