### PR TITLE
[CIR][NFC] Remove dead member function from EHScopeStack::Cleanup

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -891,12 +891,6 @@ public:
     assert(!cir::MissingFeatures::ehCleanupFlags());
     cgf.emitDestroy(lv.getAddress(), field->getType(), destroyer);
   }
-
-  // This is a placeholder until EHCleanupScope is implemented.
-  size_t getSize() const override {
-    assert(!cir::MissingFeatures::ehCleanupScope());
-    return sizeof(DestroyField);
-  }
 };
 } // namespace
 

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -695,12 +695,6 @@ struct DestroyObject final : EHScopeStack::Cleanup {
   void emit(CIRGenFunction &cgf) override {
     cgf.emitDestroy(addr, type, destroyer);
   }
-
-  // This is a placeholder until EHCleanupScope is implemented.
-  size_t getSize() const override {
-    assert(!cir::MissingFeatures::ehCleanupScope());
-    return sizeof(DestroyObject);
-  }
 };
 } // namespace
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -463,12 +463,6 @@ struct CallObjectDelete final : EHScopeStack::Cleanup {
   void emit(CIRGenFunction &cgf) override {
     cgf.emitDeleteCall(operatorDelete, ptr, elementType);
   }
-
-  // This is a placeholder until EHCleanupScope is implemented.
-  size_t getSize() const override {
-    assert(!cir::MissingFeatures::ehCleanupScope());
-    return sizeof(CallObjectDelete);
-  }
 };
 } // namespace
 

--- a/clang/lib/CIR/CodeGen/EHScopeStack.h
+++ b/clang/lib/CIR/CodeGen/EHScopeStack.h
@@ -108,9 +108,6 @@ public:
     ///
     // \param flags cleanup kind.
     virtual void emit(CIRGenFunction &cgf) = 0;
-
-    // This is a placeholder until EHScope is implemented.
-    virtual size_t getSize() const = 0;
   };
 
 private:


### PR DESCRIPTION
This removes the `getSize()` member function from EHScopeStack::Cleanup and all its subclasses. This function had originally been added as a temporary measure before EHCleanupScope was implemented, but it is no longer used.