### PR TITLE
[Github][CI] Add quotes to 'find' command argument

### DIFF
--- a/.github/workflows/build-ci-container-tooling.yml
+++ b/.github/workflows/build-ci-container-tooling.yml
@@ -101,7 +101,7 @@ jobs:
           }
 
           podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
-          for f in $(find . -iname *.tar); do
+          for f in $(find . -iname '*.tar'); do
             image_name=$(podman load -q -i $f | sed 's/Loaded image: //g')
             push_container $image_name
 

--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -103,7 +103,7 @@ jobs:
           }
 
           podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
-          for f in $(find . -iname *.tar); do
+          for f in $(find . -iname '*.tar'); do
             image_name=$(podman load -q -i $f | sed 's/Loaded image: //g')
             push_container $image_name
 


### PR DESCRIPTION
It appears that new [Build Tooling CI Containers](https://github.com/llvm/llvm-project/actions/runs/18359418540/job/52299833688) job run didn't actually push containers, but failed with error:

```
find: paths must precede expression: `ghcr.io-llvm-amd64-ci-ubuntu-24.04-lint-f1eb7e55428e.tar'
find: possible unquoted pattern after predicate `-iname'?
```

Proposed fix is in error message and I confirmed locally with such setup:
```bash
$ ls -la
a.sh
ghcr.io-ci-a.tar
ghcr.io-ci-b.tar

$ cat a.sh 
for f in $(find . -iname '*.tar'); do
    echo $f
done

$ ./a.sh # lists fine with quotes but fails without.
```

Thought not sure how `Build CI Container` job push successfully: I manually downloaded 900MB `tar` AMD-archive with two containers and failed to `for`-loop over them without quotes, hence I add them to that script as well.
