### PR TITLE
[lldb/cmake] unittests: Breakpoint: remove liblldb dep

### DIFF
--- a/lldb/unittests/Breakpoint/CMakeLists.txt
+++ b/lldb/unittests/Breakpoint/CMakeLists.txt
@@ -5,7 +5,6 @@ add_lldb_unittest(LLDBBreakpointTests
   LINK_COMPONENTS
     Support
   LINK_LIBS
-    liblldb
     lldbBreakpoint
     lldbCore
     LLVMTestingSupport


### PR DESCRIPTION
Remove the `liblldb` link target for these tests to fix CI failures.

Commit 02572c6e9bbb ("[lldb] Enforce that only the LLDB API unit tests can link liblldb") disallows linking against liblldb for most tests. Then, Commit f3e2c20a23b1 ("Make
SBBreakpoint/SBBreakpointLocation.SetCondition(nullptr) work again") got merged just after this commit (but before CI could report the regression).

The tests still pass for me with ` $ ./tools/lldb/unittests/Breakpoint/LLDBBreakpointTests`.

The [CI failures](https://github.com/llvm/llvm-project/actions/runs/18357440587/job/52292987620?pr=162428) (like from https://github.com/llvm/llvm-project/pull/162428) seem to also be fixed. I tested locally with:

```
$ cmake -S ../llvm -B . \
  -G Ninja \
  -D LLVM_ENABLE_PROJECTS="lldb" \
  -D CMAKE_BUILD_TYPE=Release \
  -D LLVM_ENABLE_ASSERTIONS=ON \
  -D LLDB_ENABLE_PYTHON=OFF
```

Closes: https://github.com/llvm/llvm-project/issues/162566