### PR TITLE
[mlir][Transforms] Handle attributes in 1-to-many function conversions

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -3830,7 +3830,7 @@ static LogicalResult convertFuncOpTypes(FunctionOpInterface funcOp,
   auto newType = FunctionType::get(rewriter.getContext(),
                                    result.getConvertedTypes(), newResults);
 
-  // If using 1-to-n type conversion, we must re-map argument attributes 
+  // If using 1-to-n type conversion, we must re-map argument attributes
   // to the corresponding new argument index.
   auto newArgAttrs = convertFuncOpAttrs(funcOp, result, newType);
 


### PR DESCRIPTION
Function attributes are associated to the argument index, which may change during a 1-to-many type conversion but is currently not being updated by the conversion pattern.

The results is that attributes get applied to the wrong arguments after the conversion.

Happy to add a lit test, if you can suggest a good place for it.