### PR TITLE
[MLIR][Python] Make the TypeID allocator globally defined in `PassManager.add`

### DIFF
--- a/mlir/lib/Bindings/Python/Globals.h
+++ b/mlir/lib/Bindings/Python/Globals.h
@@ -151,6 +151,25 @@ public:
 
   TracebackLoc &getTracebackLoc() { return tracebackLoc; }
 
+  class TypeIDAllocator {
+  public:
+    TypeIDAllocator() : allocator(mlirTypeIDAllocatorCreate()) {}
+    ~TypeIDAllocator() {
+      if (!allocator.ptr)
+        mlirTypeIDAllocatorDestroy(allocator);
+    }
+
+    MlirTypeIDAllocator get() { return allocator; }
+    MlirTypeID allocate() {
+      return mlirTypeIDAllocatorAllocateTypeID(allocator);
+    }
+
+  private:
+    MlirTypeIDAllocator allocator;
+  };
+
+  MlirTypeID allocateTypeID() { return typeIDAllocator.allocate(); }
+
 private:
   static PyGlobals *instance;
 
@@ -173,6 +192,7 @@ private:
   llvm::StringSet<> loadedDialectModules;
 
   TracebackLoc tracebackLoc;
+  TypeIDAllocator typeIDAllocator;
 };
 
 } // namespace python

--- a/mlir/lib/Bindings/Python/Globals.h
+++ b/mlir/lib/Bindings/Python/Globals.h
@@ -17,6 +17,7 @@
 
 #include "NanobindUtils.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 #include "mlir/CAPI/Support.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
@@ -155,8 +156,12 @@ public:
   public:
     TypeIDAllocator() : allocator(mlirTypeIDAllocatorCreate()) {}
     ~TypeIDAllocator() {
-      if (!allocator.ptr)
+      if (allocator.ptr)
         mlirTypeIDAllocatorDestroy(allocator);
+    }
+    TypeIDAllocator(const TypeIDAllocator &) = delete;
+    TypeIDAllocator(TypeIDAllocator &&other) : allocator(other.allocator) {
+      other.allocator.ptr = nullptr;
     }
 
     MlirTypeIDAllocator get() { return allocator; }

--- a/mlir/lib/Bindings/Python/Pass.cpp
+++ b/mlir/lib/Bindings/Python/Pass.cpp
@@ -8,6 +8,7 @@
 
 #include "Pass.h"
 
+#include "Globals.h"
 #include "IRModule.h"
 #include "mlir-c/Pass.h"
 // clang-format off
@@ -51,23 +52,6 @@ public:
 private:
   MlirPassManager passManager;
 };
-
-class PyTypeIDAllocator {
-public:
-  PyTypeIDAllocator() : allocator(mlirTypeIDAllocatorCreate()) {}
-  ~PyTypeIDAllocator() {
-    if (!allocator.ptr)
-      mlirTypeIDAllocatorDestroy(allocator);
-  }
-
-  MlirTypeIDAllocator get() { return allocator; }
-  MlirTypeID allocate() { return mlirTypeIDAllocatorAllocateTypeID(allocator); }
-
-private:
-  MlirTypeIDAllocator allocator;
-};
-
-PyTypeIDAllocator globalTypeIDAllocator;
 
 } // namespace
 
@@ -198,7 +182,7 @@ void mlir::python::populatePassManagerSubmodule(nb::module_ &m) {
               name = nb::cast<std::string>(
                   nb::borrow<nb::str>(run.attr("__name__")));
             }
-            MlirTypeID passID = globalTypeIDAllocator.allocate();
+            MlirTypeID passID = PyGlobals::get().allocateTypeID();
             MlirExternalPassCallbacks callbacks;
             callbacks.construct = [](void *obj) {
               (void)nb::handle(static_cast<PyObject *>(obj)).inc_ref();


### PR DESCRIPTION
Previously, each time we called `PassManager.add(python_pass_callable)`, a new `TypeID` allocator was created and never released afterward. This approach could potentially lead to some issues. In this PR, we introduce a global `TypeIDAllocator` that is shared across all `add` calls to allocate IDs.
