### PR TITLE
[clang][docs] Update doc and release note for probe instrumentation

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -2780,6 +2780,25 @@ usual build cycle when using sample profilers for optimization:
        /clang:-fdebug-info-for-profiling /clang:-funique-internal-linkage-names ^
        code.cc /Fe:code /fuse-ld=lld /link /debug:dwarf
 
+   [OPTIONAL] Pseudo instrumentation can be used as the anchor for accurate
+   profile mapping with the ``-fpseudo-probe-for-profiling`` option.
+
+   On Linux:
+
+   .. code-block:: console
+
+     $ clang++ -O2 -gline-tables-only \
+       -fpseudo-probe-for-profiling -funique-internal-linkage-names \
+       code.cc -o code
+
+   On Windows:
+
+   .. code-block:: winbatch
+
+     > clang-cl /O2 -gdwarf -gline-tables-only ^
+       -fpseudo-probe-for-profiling /clang:-funique-internal-linkage-names ^
+       code.cc /Fe:code -fuse-ld=lld /link /debug:dwarf
+
 .. note::
 
    :ref:`-funique-internal-linkage-names <funique_internal_linkage_names>`
@@ -2878,6 +2897,25 @@ usual build cycle when using sample profilers for optimization:
      > clang-cl /O2 -gdwarf -gline-tables-only ^
        /clang:-fdebug-info-for-profiling /clang:-funique-internal-linkage-names ^
        -fprofile-sample-use=code.prof code.cc /Fe:code -fuse-ld=lld /link /debug:dwarf
+
+   [OPTIONAL] Pseudo instrumentation can be used as the anchor for accurate
+   profile mapping with the ``-fpseudo-probe-for-profiling`` option.
+
+   On Linux:
+
+   .. code-block:: console
+
+     $ clang++ -O2 \
+        -fpseudo-probe-for-profiling -funique-internal-linkage-names \
+       -fprofile-sample-use=code.prof code.cc -o code
+
+   On Windows:
+
+   .. code-block:: winbatch
+
+     > clang-cl /O2 ^
+       -fpseudo-probe-for-profiling /clang:-funique-internal-linkage-names ^
+       -fprofile-sample-use=code.prof code.cc /Fe:code
 
    [OPTIONAL] Sampling-based profiles can have inaccuracies or missing block/
    edge counters. The profile inference algorithm (profi) can be used to infer

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -134,6 +134,8 @@ Changes to the WebAssembly Backend
 Changes to the Windows Target
 -----------------------------
 
+* `-fpseudo-probe-for-profiling` is now supported for COFF.
+
 Changes to the X86 Backend
 --------------------------
 
@@ -159,6 +161,8 @@ Changes to the Debug Info
 
 Changes to the LLVM tools
 ---------------------------------
+
+* `llvm-profgen` now supports decoding pseudo probe for COFF binaries.
 
 * `llvm-readelf` now dumps all hex format values in lower-case mode.
 * Some code paths for supporting Python 2.7 in `llvm-lit` have been removed.


### PR DESCRIPTION
-fpseudo-probe-for-profiling is supported for COFF in #123870.
llvm-profgen supports decoding pseudo probe in #158207.

This PR updates release note and adds an example to use it in
UsersManual.rst.