### PR TITLE
[Clang] Fix a regression introduced by #161163.

### DIFF
--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -1167,16 +1167,22 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
       return true;
     if (!(RD->hasTrivialDestructor() && (!Dtor || !Dtor->isDeleted())))
       return false;
+    if (RD->hasTrivialDefaultConstructor())
+      return true;
     bool FoundCopyCtr = false;
     bool FoundMoveCtr = false;
+    bool FoundDefaultCtr = false;
     for (CXXConstructorDecl *Ctr : RD->ctors()) {
-      FoundCopyCtr = Ctr->isCopyConstructor();
-      FoundMoveCtr = Ctr->isMoveConstructor();
       if (Ctr->isIneligibleOrNotSelected() || Ctr->isDeleted())
         continue;
       if (Ctr->isTrivial())
         return true;
+      FoundCopyCtr = Ctr->isCopyConstructor();
+      FoundMoveCtr = Ctr->isMoveConstructor();
+      FoundDefaultCtr = Ctr->isDefaultConstructor();
     }
+    if (!FoundDefaultCtr && RD->hasTrivialDefaultConstructor())
+      return true;
     if (!FoundCopyCtr && RD->hasTrivialCopyConstructor() &&
         !RD->defaultedCopyConstructorIsDeleted())
       return true;

--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -1076,8 +1076,7 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
     if (T.isPODType(C) || T->isObjCLifetimeType())
       return true;
     if (CXXRecordDecl *RD = C.getBaseElementType(T)->getAsCXXRecordDecl()) {
-      if (RD->hasTrivialDefaultConstructor() &&
-          !RD->hasNonTrivialDefaultConstructor())
+      if (RD->hasTrivialDefaultConstructor())
         return true;
 
       bool FoundConstructor = false;

--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -1164,7 +1164,9 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
     const CXXDestructorDecl *Dtor = RD->getDestructor();
     if (UnqualT->isAggregateType() && (!Dtor || !Dtor->isUserProvided()))
       return true;
-    if (!(RD->hasTrivialDestructor() && (!Dtor || !Dtor->isDeleted())))
+    bool HasTrivialNonDeletedDtr =
+        RD->hasTrivialDestructor() && (!Dtor || !Dtor->isDeleted());
+    if (!HasTrivialNonDeletedDtr)
       return false;
     for (CXXConstructorDecl *Ctr : RD->ctors()) {
       if (Ctr->isIneligibleOrNotSelected() || Ctr->isDeleted())

--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -1167,26 +1167,20 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
       return true;
     if (!(RD->hasTrivialDestructor() && (!Dtor || !Dtor->isDeleted())))
       return false;
-    if (RD->hasTrivialDefaultConstructor())
-      return true;
-    bool FoundCopyCtr = false;
-    bool FoundMoveCtr = false;
-    bool FoundDefaultCtr = false;
     for (CXXConstructorDecl *Ctr : RD->ctors()) {
       if (Ctr->isIneligibleOrNotSelected() || Ctr->isDeleted())
         continue;
       if (Ctr->isTrivial())
         return true;
-      FoundCopyCtr = Ctr->isCopyConstructor();
-      FoundMoveCtr = Ctr->isMoveConstructor();
-      FoundDefaultCtr = Ctr->isDefaultConstructor();
     }
-    if (!FoundDefaultCtr && RD->hasTrivialDefaultConstructor())
+    if (RD->needsImplicitDefaultConstructor() &&
+        RD->hasTrivialDefaultConstructor() &&
+        !RD->hasNonTrivialDefaultConstructor())
       return true;
-    if (!FoundCopyCtr && RD->hasTrivialCopyConstructor() &&
+    if (RD->needsImplicitCopyConstructor() && RD->hasTrivialCopyConstructor() &&
         !RD->defaultedCopyConstructorIsDeleted())
       return true;
-    if (!FoundMoveCtr && RD->hasTrivialMoveConstructor() &&
+    if (RD->needsImplicitMoveConstructor() && RD->hasTrivialMoveConstructor() &&
         !RD->defaultedMoveConstructorIsDeleted())
       return true;
     return false;

--- a/clang/test/SemaCXX/type-traits.cpp
+++ b/clang/test/SemaCXX/type-traits.cpp
@@ -2099,7 +2099,25 @@ class Tpl {
 };
 static_assert(__builtin_is_implicit_lifetime(Tpl<int>));
 
+template <typename>
+class MultipleDefaults {
+  MultipleDefaults() {};
+  MultipleDefaults() requires true = default;
+};
+static_assert(__builtin_is_implicit_lifetime(MultipleDefaults<int>));
+template <typename>
+class MultipleDefaults2 {
+  MultipleDefaults2() requires true {};
+  MultipleDefaults2() = default;
+};
+
+static_assert(__builtin_is_implicit_lifetime(MultipleDefaults2<int>));
+
+
 #endif
+
+
+
 }
 
 void is_signed()

--- a/clang/test/SemaCXX/type-traits.cpp
+++ b/clang/test/SemaCXX/type-traits.cpp
@@ -2075,7 +2075,17 @@ private:
   NoEligibleTrivialContructor inner;
 };
 
+struct NonCopyable{
+    NonCopyable() = default;
+    NonCopyable(const NonCopyable&) = delete;
+};
+
+class C {
+    NonCopyable nc;
+};
+
 static_assert(__builtin_is_implicit_lifetime(Ctr));
+static_assert(__builtin_is_implicit_lifetime(C));
 static_assert(!__builtin_is_implicit_lifetime(NoEligibleTrivialContructor));
 static_assert(__builtin_is_implicit_lifetime(NonAggregate));
 static_assert(!__builtin_is_implicit_lifetime(DataMemberInitializer));

--- a/clang/test/SemaCXX/type-traits.cpp
+++ b/clang/test/SemaCXX/type-traits.cpp
@@ -2067,10 +2067,10 @@ public:
     UserProvidedConstructor& operator=(const UserProvidedConstructor&) = delete;
 };
 struct Ctr {
-    Ctr();
+  Ctr();
 };
 struct Ctr2 {
-    Ctr2();
+  Ctr2();
 private:
   NoEligibleTrivialContructor inner;
 };
@@ -2085,6 +2085,7 @@ class C {
 };
 
 static_assert(__builtin_is_implicit_lifetime(Ctr));
+static_assert(!__builtin_is_implicit_lifetime(Ctr2));
 static_assert(__builtin_is_implicit_lifetime(C));
 static_assert(!__builtin_is_implicit_lifetime(NoEligibleTrivialContructor));
 static_assert(__builtin_is_implicit_lifetime(NonAggregate));

--- a/clang/test/SemaCXX/type-traits.cpp
+++ b/clang/test/SemaCXX/type-traits.cpp
@@ -2066,7 +2066,17 @@ public:
     UserProvidedConstructor(const UserProvidedConstructor&)            = delete;
     UserProvidedConstructor& operator=(const UserProvidedConstructor&) = delete;
 };
+struct Ctr {
+    Ctr();
+};
+struct Ctr2 {
+    Ctr2();
+private:
+  NoEligibleTrivialContructor inner;
+};
 
+static_assert(__builtin_is_implicit_lifetime(Ctr));
+static_assert(!__builtin_is_implicit_lifetime(NoEligibleTrivialContructor));
 static_assert(__builtin_is_implicit_lifetime(NonAggregate));
 static_assert(!__builtin_is_implicit_lifetime(DataMemberInitializer));
 static_assert(!__builtin_is_implicit_lifetime(UserProvidedConstructor));
@@ -2076,7 +2086,7 @@ template <typename T>
 class Tpl {
     Tpl() requires false = default ;
 };
-static_assert(!__builtin_is_implicit_lifetime(Tpl<int>));
+static_assert(__builtin_is_implicit_lifetime(Tpl<int>));
 
 #endif
 }


### PR DESCRIPTION
Classes with a user provided constructor are still implicit lifetime if they have an implicit, trivial copy ctr.