### PR TITLE
[Utils][vim] Match hexadecimal constants with u or s prefixes

### DIFF
--- a/llvm/utils/vim/syntax/llvm.vim
+++ b/llvm/utils/vim/syntax/llvm.vim
@@ -220,7 +220,7 @@ syn keyword llvmError  getresult begin end
 syn match   llvmNoName /[%@!]\d\+\>/
 syn match   llvmNumber /-\?\<\d\+\>/
 syn match   llvmFloat  /-\?\<\d\+\.\d*\(e[+-]\d\+\)\?\>/
-syn match   llvmFloat  /\<0x[KLMHR]\?\x\+\>/
+syn match   llvmFloat  /\<\(u\|s\)\?0x[KLMHR]\?\x\+\>/
 syn keyword llvmBoolean true false
 syn keyword llvmConstant zeroinitializer undef null none poison vscale
 syn match   llvmComment /;.*$/


### PR DESCRIPTION
We can add 's' or 'u' before the hexadecimal constants to denote its signedness.

See https://llvm.org/docs/LangRef.html#simple-constants for reference.