### PR TITLE
[lldb-dap] expand tilde in dap executable path

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs/promises";
 import { ConfigureButton, OpenSettingsButton } from "./ui/show-error-message";
 import { ErrorWithNotification } from "./ui/error-with-notification";
 import { LogFilePathProvider, LogType } from "./logging";
+import { expandUser } from "./utils";
 
 const exec = util.promisify(child_process.execFile);
 
@@ -116,8 +117,9 @@ async function getDAPExecutable(
   configuration: vscode.DebugConfiguration,
 ): Promise<string> {
   // Check if the executable was provided in the launch configuration.
-  const launchConfigPath = configuration["debugAdapterExecutable"];
+  let launchConfigPath = configuration["debugAdapterExecutable"];
   if (typeof launchConfigPath === "string" && launchConfigPath.length !== 0) {
+    launchConfigPath = expandUser(launchConfigPath);
     if (!(await isExecutable(launchConfigPath))) {
       throw new ErrorWithNotification(
         `Debug adapter path "${launchConfigPath}" is not a valid file. The path comes from your launch configuration.`,
@@ -129,7 +131,7 @@ async function getDAPExecutable(
 
   // Check if the executable was provided in the extension's configuration.
   const config = vscode.workspace.getConfiguration("lldb-dap", workspaceFolder);
-  const configPath = config.get<string>("executable-path");
+  const configPath = expandUser(config.get<string>("executable-path") ?? "");
   if (configPath && configPath.length !== 0) {
     if (!(await isExecutable(configPath))) {
       throw new ErrorWithNotification(

--- a/lldb/tools/lldb-dap/src-ts/utils.ts
+++ b/lldb/tools/lldb-dap/src-ts/utils.ts
@@ -1,0 +1,41 @@
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Expands the character `~` to the user's home directory
+ */
+export function expandUser(file_path: string): string {
+  if (os.platform() == "win32") {
+    return file_path;
+  }
+
+  if (!file_path) {
+    return "";
+  }
+
+  if (!file_path.startsWith("~")) {
+    return file_path;
+  }
+
+  const path_len = file_path.length;
+  if (path_len == 1) {
+    return os.homedir();
+  }
+
+  if (file_path.charAt(1) == path.sep) {
+    return path.join(os.homedir(), file_path.substring(1));
+  }
+
+  const sep_index = file_path.indexOf(path.sep);
+  const user_name_end = sep_index == -1 ? file_path.length : sep_index;
+  const user_name = file_path.substring(1, user_name_end);
+  try {
+    if (user_name == os.userInfo().username) {
+      return path.join(os.homedir(), file_path.substring(user_name_end));
+    }
+  } catch (err) {
+    return file_path;
+  }
+
+  return file_path;
+}


### PR DESCRIPTION
Users may have multiple devices and would like to resolve the homepath based on the machine they are on.

expands the tilde `~` character at the front of the given file path. 