### PR TITLE
[Clang-tidy][NFC] Fix potential constant overflow

### DIFF
--- a/clang-tools-extra/clang-tidy/objc/PropertyDeclarationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/objc/PropertyDeclarationCheck.cpp
@@ -39,8 +39,11 @@ static FixItHint generateFixItHint(const ObjCPropertyDecl *Decl,
   auto NewName = Decl->getName().str();
   size_t Index = 0;
   if (Style == CategoryProperty) {
-    Index = Name.find_first_of('_') + 1;
-    NewName.replace(0, Index - 1, Name.substr(0, Index - 1).lower());
+    size_t UnderScorePos = Name.find_first_of('_');
+    if (UnderScorePos != llvm::StringRef::npos) {
+      Index = UnderScorePos + 1;
+      NewName.replace(0, Index - 1, Name.substr(0, Index - 1).lower());
+    }
   }
   if (Index < Name.size()) {
     NewName[Index] = tolower(NewName[Index]);


### PR DESCRIPTION
This is a find from static analysis tool complaining about potential constant overflow for `Index`. 