### PR TITLE
[libc] skip sysconf test for rv32

### DIFF
--- a/libc/test/src/unistd/sysconf_test.cpp
+++ b/libc/test/src/unistd/sysconf_test.cpp
@@ -13,5 +13,9 @@
 
 TEST(LlvmLibcSysconfTest, PagesizeTest) {
   long pagesize = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+  // TODO: fix page size support on RV32
+  // (https://github.com/llvm/llvm-project/issues/162671)
+#ifndef LIBC_TARGET_ARCH_IS_RISCV32
   ASSERT_GT(pagesize, 0l);
+#endif
 }


### PR DESCRIPTION
The issue is being investigated. For now, let's skip the test to keep the bot running

see https://github.com/llvm/llvm-project/issues/162671