### PR TITLE
[debugserver] Implement MultiMemRead packet

### DIFF
--- a/lldb/test/API/macosx/debugserver-multimemread/Makefile
+++ b/lldb/test/API/macosx/debugserver-multimemread/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/macosx/debugserver-multimemread/TestDebugserverMultiMemRead.py
+++ b/lldb/test/API/macosx/debugserver-multimemread/TestDebugserverMultiMemRead.py
@@ -1,5 +1,5 @@
 """
-Tests the exit code/description coming from the debugserver.
+Tests debugserver support for MultiMemRead.
 """
 
 import lldb
@@ -17,12 +17,16 @@ class TestCase(TestBase):
         #  packet: <packet_str>
         #  response: <response>
         reply = self.res.GetOutput().split("\n")
-        reply[0] = reply[0].strip()
-        reply[1] = reply[1].strip()
+        packet = reply[0].strip()
+        response = reply[1].strip()
 
-        self.assertTrue(reply[0].startswith("packet: "), reply[0])
-        self.assertTrue(reply[1].startswith("response: "))
-        return reply[1][len("response: ") :]
+        self.assertTrue(packet.startswith("packet: "))
+        self.assertTrue(response.startswith("response: "))
+        return response[len("response: ") :]
+
+    def check_invalid_packet(self, packet_str):
+        reply = self.send_process_packet("packet_str")
+        self.assertEqual(reply, "E03")
 
     def test_packets(self):
         self.build()
@@ -36,29 +40,40 @@ class TestCase(TestBase):
 
         mem_address_var = thread.frames[0].FindVariable("memory")
         self.assertTrue(mem_address_var)
-        mem_address = int(mem_address_var.GetValue(), 16)
+        mem_address = mem_address_var.GetValueAsUnsigned() + 42
 
-        reply = self.send_process_packet("MultiMemRead:")
-        self.assertEqual(reply, "E03")
-        reply = self.send_process_packet("MultiMemRead:ranges:")
-        self.assertEqual(reply, "E03")
-        reply = self.send_process_packet("MultiMemRead:ranges:10")
-        self.assertEqual(reply, "E03")
-        reply = self.send_process_packet("MultiMemRead:ranges:10,")
-        self.assertEqual(reply, "E03")
-        reply = self.send_process_packet("MultiMemRead:ranges:10,2")
-        self.assertEqual(reply, "E03")
-        reply = self.send_process_packet("MultiMemRead:ranges:10,2,")
-        self.assertEqual(reply, "E03")
+        # no ":"
+        self.check_invalid_packet("MultiMemRead")
+        # missing ranges
+        self.check_invalid_packet("MultiMemRead:")
+        # needs at least one range
+        self.check_invalid_packet("MultiMemRead:ranges:")
+        # needs at least one range
+        self.check_invalid_packet("MultiMemRead:ranges:,")
+        # a range is a pair of numbers
+        self.check_invalid_packet("MultiMemRead:ranges:10")
+        # a range is a pair of numbers
+        self.check_invalid_packet("MultiMemRead:ranges:10,")
+        # range list must end with ;
+        self.check_invalid_packet("MultiMemRead:ranges:10,2")
+        self.check_invalid_packet("MultiMemRead:ranges:10,2,")
+        self.check_invalid_packet("MultiMemRead:ranges:10,2,3")
+        # ranges are pairs of numbers.
+        self.check_invalid_packet("MultiMemRead:ranges:10,2,3;")
+        # unrecognized field
+        self.check_invalid_packet("MultiMemRead:ranges:10,2;blah:;")
+        # unrecognized field
+        self.check_invalid_packet("MultiMemRead:blah:;ranges:10,2;")
+
+        # This is a valid way of testing for MultiMemRead support
+        reply = self.send_process_packet("MultiMemRead:ranges:0,0;")
+        self.assertEqual(reply, "0;")
+        # Debugserver is permissive with trailing commas.
         reply = self.send_process_packet("MultiMemRead:ranges:10,2,;")
-        self.assertEqual(reply, "0;")  # Debugserver is permissive with trailing commas.
+        self.assertEqual(reply, "0;")
         reply = self.send_process_packet("MultiMemRead:ranges:10,2;")
         self.assertEqual(reply, "0;")
         reply = self.send_process_packet(f"MultiMemRead:ranges:{mem_address:x},0;")
-        self.assertEqual(reply, "0;")
-        reply = self.send_process_packet(
-            f"MultiMemRead:ranges:{mem_address:x},0;options:;"
-        )
         self.assertEqual(reply, "0;")
         reply = self.send_process_packet(f"MultiMemRead:ranges:{mem_address:x},2;")
         self.assertEqual(reply, "2;ab")
@@ -70,3 +85,14 @@ class TestCase(TestBase):
             f"MultiMemRead:ranges:{mem_address:x},2,{mem_address+2:x},4,{mem_address+6:x},8;"
         )
         self.assertEqual(reply, "2,4,8;abcdefghijklmn")
+
+        # Test zero length in the middle.
+        reply = self.send_process_packet(
+            f"MultiMemRead:ranges:{mem_address:x},2,{mem_address+2:x},0,{mem_address+6:x},8;"
+        )
+        self.assertEqual(reply, "2,0,8;abghijklmn")
+        # Test zero length in the end.
+        reply = self.send_process_packet(
+            f"MultiMemRead:ranges:{mem_address:x},2,{mem_address+2:x},4,{mem_address+6:x},0;"
+        )
+        self.assertEqual(reply, "2,4,0;abcdef")

--- a/lldb/test/API/macosx/debugserver-multimemread/TestDebugserverMultiMemRead.py
+++ b/lldb/test/API/macosx/debugserver-multimemread/TestDebugserverMultiMemRead.py
@@ -1,0 +1,72 @@
+"""
+Tests the exit code/description coming from the debugserver.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+@skipUnlessDarwin
+@skipIfOutOfTreeDebugserver
+class TestCase(TestBase):
+    def send_process_packet(self, packet_str):
+        self.runCmd(f"proc plugin packet send {packet_str}", check=False)
+        # The output is of the form:
+        #  packet: <packet_str>
+        #  response: <response>
+        reply = self.res.GetOutput().split("\n")
+        reply[0] = reply[0].strip()
+        reply[1] = reply[1].strip()
+
+        self.assertTrue(reply[0].startswith("packet: "), reply[0])
+        self.assertTrue(reply[1].startswith("response: "))
+        return reply[1][len("response: ") :]
+
+    def test_packets(self):
+        self.build()
+        source_file = lldb.SBFileSpec("main.c")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", source_file
+        )
+
+        reply = self.send_process_packet("qSupported")
+        self.assertIn("MultiMemRead+", reply)
+
+        mem_address_var = thread.frames[0].FindVariable("memory")
+        self.assertTrue(mem_address_var)
+        mem_address = int(mem_address_var.GetValue(), 16)
+
+        reply = self.send_process_packet("MultiMemRead:")
+        self.assertEqual(reply, "E03")
+        reply = self.send_process_packet("MultiMemRead:ranges:")
+        self.assertEqual(reply, "E03")
+        reply = self.send_process_packet("MultiMemRead:ranges:10")
+        self.assertEqual(reply, "E03")
+        reply = self.send_process_packet("MultiMemRead:ranges:10,")
+        self.assertEqual(reply, "E03")
+        reply = self.send_process_packet("MultiMemRead:ranges:10,2")
+        self.assertEqual(reply, "E03")
+        reply = self.send_process_packet("MultiMemRead:ranges:10,2,")
+        self.assertEqual(reply, "E03")
+        reply = self.send_process_packet("MultiMemRead:ranges:10,2,;")
+        self.assertEqual(reply, "0;")  # Debugserver is permissive with trailing commas.
+        reply = self.send_process_packet("MultiMemRead:ranges:10,2;")
+        self.assertEqual(reply, "0;")
+        reply = self.send_process_packet(f"MultiMemRead:ranges:{mem_address:x},0;")
+        self.assertEqual(reply, "0;")
+        reply = self.send_process_packet(
+            f"MultiMemRead:ranges:{mem_address:x},0;options:;"
+        )
+        self.assertEqual(reply, "0;")
+        reply = self.send_process_packet(f"MultiMemRead:ranges:{mem_address:x},2;")
+        self.assertEqual(reply, "2;ab")
+        reply = self.send_process_packet(
+            f"MultiMemRead:ranges:{mem_address:x},2,{mem_address+2:x},4;"
+        )
+        self.assertEqual(reply, "2,4;abcdef")
+        reply = self.send_process_packet(
+            f"MultiMemRead:ranges:{mem_address:x},2,{mem_address+2:x},4,{mem_address+6:x},8;"
+        )
+        self.assertEqual(reply, "2,4,8;abcdefghijklmn")

--- a/lldb/test/API/macosx/debugserver-multimemread/TestDebugserverMultiMemRead.py
+++ b/lldb/test/API/macosx/debugserver-multimemread/TestDebugserverMultiMemRead.py
@@ -65,12 +65,16 @@ class TestCase(TestBase):
         # unrecognized field
         self.check_invalid_packet("MultiMemRead:blah:;ranges:10,2;")
 
-        # This is a valid way of testing for MultiMemRead support
+        # Zero-length reads are ok.
         reply = self.send_process_packet("MultiMemRead:ranges:0,0;")
         self.assertEqual(reply, "0;")
+
         # Debugserver is permissive with trailing commas.
         reply = self.send_process_packet("MultiMemRead:ranges:10,2,;")
         self.assertEqual(reply, "0;")
+        reply = self.send_process_packet(f"MultiMemRead:ranges:{mem_address:x},2,;")
+        self.assertEqual(reply, "2;ab")
+
         reply = self.send_process_packet("MultiMemRead:ranges:10,2;")
         self.assertEqual(reply, "0;")
         reply = self.send_process_packet(f"MultiMemRead:ranges:{mem_address:x},0;")

--- a/lldb/test/API/macosx/debugserver-multimemread/main.c
+++ b/lldb/test/API/macosx/debugserver-multimemread/main.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+  char *memory = malloc(1024);
+  memset(memory, '-', 1024);
+  for (int i = 0; i < 50; i++)
+    memory[i] = 'a' + i;
+  return 0; // break here
+}

--- a/lldb/test/API/macosx/debugserver-multimemread/main.c
+++ b/lldb/test/API/macosx/debugserver-multimemread/main.c
@@ -4,7 +4,11 @@
 int main(int argc, char **argv) {
   char *memory = malloc(1024);
   memset(memory, '-', 1024);
-  for (int i = 0; i < 50; i++)
-    memory[i] = 'a' + i;
+  // Write "interesting" characters at an offset from the memory filled with
+  // `-`. This way, if we read outside the range in either direction, we should
+  // find `-`s`.
+  int offset = 42;
+  for (int i = offset; i < offset + 14; i++)
+    memory[i] = 'a' + (i - offset);
   return 0; // break here
 }

--- a/lldb/tools/debugserver/source/RNBRemote.h
+++ b/lldb/tools/debugserver/source/RNBRemote.h
@@ -136,6 +136,7 @@ public:
     query_transfer,                     // 'qXfer:'
     json_query_dyld_process_state,      // 'jGetDyldProcessState'
     enable_error_strings,               // 'QEnableErrorStrings'
+    multi_mem_read,                     // 'MultiMemRead'
     unknown_type
   };
   // clang-format on
@@ -216,6 +217,7 @@ public:
   rnb_err_t HandlePacket_last_signal(const char *p);
   rnb_err_t HandlePacket_m(const char *p);
   rnb_err_t HandlePacket_M(const char *p);
+  rnb_err_t HandlePacket_MultiMemRead(const char *p);
   rnb_err_t HandlePacket_x(const char *p);
   rnb_err_t HandlePacket_X(const char *p);
   rnb_err_t HandlePacket_z(const char *p);


### PR DESCRIPTION
This commit implements, in debugserver, the packet as discussed in the RFC [1].

[1]: https://discourse.llvm.org/t/rfc-a-new-vectorized-memory-read-packet/88441