### PR TITLE
[gdbremote] Document MultiMemRead packet in protocol extensions

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -2530,3 +2530,41 @@ read packet: $e0030100#b9
 
 **Priority to Implement:** Only required for Wasm support. Necessary to show
 variables.
+
+### MultiMemRead
+
+Read memory from multiple memory addresses.
+
+There are two arguments to the request:
+
+* `ranges`: a list of base-16 pairs of numbers. Each pair is separated by a
+`,`, as is each number in the pair. The first number of the pair denotes the
+base address of the memory read, the second denotes the number of bytes to be
+read.
+* `options`: an optional string of options. If present, it may be empty. If
+present, it is the last argument of the request.
+
+Both arguments must end with a `;`.
+
+The reply packet starts with a comma-separated list of base-16 numbers,
+denoting how many bytes were read from each address, followed by a `;`,
+followed by a sequence of bytes containing the memory data. The length of this
+sequence must be equal to the sum of the numbers provided at the start of the
+reply.
+
+If the stub is unable to read from any individual address, it should return a
+length of "zero" for that address in the reply packet.
+
+A stub that supports this packet should return `MultiMemRead+` in the reply to
+`qSupported`.
+
+```
+send packet: $MultiMemRead:ranges:100a00,4,200200,a0,400000,4;
+read packet: $4,0,2;<binary encoding of abcd1000><binary encoding of eeff>
+```
+
+In the example above, the first read produced `abcd1000`, the read of `a0`
+bytes from address `200200` failed, and the third read produced two bytes –
+`eeff` – out of the four requested.
+
+**Priority to Implement:** Only required for performance.

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -735,6 +735,44 @@ This is a performance optimization, which speeds up debugging by avoiding
 multiple round-trips for retrieving thread information. The information from this
 packet can be retrieved using a combination of `qThreadStopInfo` and `m` packets.
 
+### MultiMemRead
+
+Read memory from multiple memory addresses.
+
+There are two arguments to the request:
+
+* `ranges`: a list of base-16 pairs of numbers. Each pair is separated by a
+`,`, as is each number in the pair. The first number of the pair denotes the
+base address of the memory read, the second denotes the number of bytes to be
+read.
+* `options`: an optional string of options. If present, it may be empty. If
+present, it is the last argument of the request.
+
+Both arguments must end with a `;`.
+
+The reply packet starts with a comma-separated list of base-16 numbers,
+denoting how many bytes were read from each address, followed by a `;`,
+followed by a sequence of bytes containing the memory data. The length of this
+sequence must be equal to the sum of the numbers provided at the start of the
+reply.
+
+If the stub is unable to read from any individual address, it should return a
+length of "zero" for that address in the reply packet.
+
+A stub that supports this packet should return `MultiMemRead+` in the reply to
+`qSupported`.
+
+```
+send packet: $MultiMemRead:ranges:100a00,4,200200,a0,400000,4;
+read packet: $4,0,2;<binary encoding of abcd1000><binary encoding of eeff>
+```
+
+In the example above, the first read produced `abcd1000`, the read of `a0`
+bytes from address `200200` failed, and the third read produced two bytes –
+`eeff` – out of the four requested.
+
+**Priority to Implement:** Only required for performance.
+
 ## QEnvironment:NAME=VALUE
 
 Setup the environment up for a new child process that will soon be
@@ -2530,41 +2568,3 @@ read packet: $e0030100#b9
 
 **Priority to Implement:** Only required for Wasm support. Necessary to show
 variables.
-
-### MultiMemRead
-
-Read memory from multiple memory addresses.
-
-There are two arguments to the request:
-
-* `ranges`: a list of base-16 pairs of numbers. Each pair is separated by a
-`,`, as is each number in the pair. The first number of the pair denotes the
-base address of the memory read, the second denotes the number of bytes to be
-read.
-* `options`: an optional string of options. If present, it may be empty. If
-present, it is the last argument of the request.
-
-Both arguments must end with a `;`.
-
-The reply packet starts with a comma-separated list of base-16 numbers,
-denoting how many bytes were read from each address, followed by a `;`,
-followed by a sequence of bytes containing the memory data. The length of this
-sequence must be equal to the sum of the numbers provided at the start of the
-reply.
-
-If the stub is unable to read from any individual address, it should return a
-length of "zero" for that address in the reply packet.
-
-A stub that supports this packet should return `MultiMemRead+` in the reply to
-`qSupported`.
-
-```
-send packet: $MultiMemRead:ranges:100a00,4,200200,a0,400000,4;
-read packet: $4,0,2;<binary encoding of abcd1000><binary encoding of eeff>
-```
-
-In the example above, the first read produced `abcd1000`, the read of `a0`
-bytes from address `200200` failed, and the third read produced two bytes –
-`eeff` – out of the four requested.
-
-**Priority to Implement:** Only required for performance.

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -750,16 +750,19 @@ The reply packet starts with a comma-separated list of numbers formatted in
 base-16, denoting how many bytes were read from each range, in the same order
 as the request packet. The list is followed by a `;`, followed by a sequence of
 bytes containing binary encoded data for all memory that was read. The length
-of this sequence must be equal to the sum of the numbers provided at the start
-of the reply. The order of the binary data is the same as the order of the
-ranges in the request packet.
+of the binary encodeed data, after being decoded as required by the GDB remote
+protocol, must be equal to the sum of the numbers provided at the start of the
+reply. The order of the binary data is the same as the order of the ranges in
+the request packet.
 
-If an entire range is not readable, the stub may perform a partial read of a
-prefix of the range.
+If some part of a range is not readable, the stub may perform a partial read of
+a prefix of the range. In other words, partial reads will only ever be from the
+start of the range, never the middle or end. Support for partial reads depends
+on the debug stub.
 
-If the stub is unable to read any bytes from a particular range, it must return
-a length of "zero" for that range in the reply packet; no bytes for this memory
-range are included in the sequence of bytes that follows.
+If, by applying the rules above, the stub has read zero bytes from a range, it
+must return a length of zero for that range in the reply packet; no bytes for
+this memory range are included in the sequence of bytes that follows.
 
 A stub that supports this packet must include `MultiMemRead+` in the reply to
 `qSupported`.
@@ -778,9 +781,7 @@ send packet: $MultiMemRead:ranges:100a00,0;
 read packet: $0;
 ```
 
-In the example above, a read of zero bytes was requested. A zero-length request
-provides an alternative way of testing whether the stub supports
-`MultiMemRead`.
+In the example above, a read of zero bytes was requested.
 
 **Priority to Implement:** Only required for performance, the debugger will
 fall back to doing separate read requests if this packet is unavailable.


### PR DESCRIPTION
This adds a specification for the new packet discussed in the RFC [1].

[1]: https://discourse.llvm.org/t/rfc-a-new-vectorized-memory-read-packet/88441/12