### PR TITLE
[SimplifyCFG] Remove all incoming values from OtherDest if OtherDest is unreachable

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5959,7 +5959,11 @@ bool SimplifyCFGOpt::turnSwitchRangeIntoICmp(SwitchInst *SI,
     unsigned PreviousEdges = OtherCases->size();
     if (OtherDest == SI->getDefaultDest())
       ++PreviousEdges;
-    for (unsigned I = 0, E = PreviousEdges - 1; I != E; ++I)
+    unsigned E = PreviousEdges - 1;
+    // Remove all incoming values from OtherDest if OtherDest is unreachable.
+    if (NewBI->isUnconditional())
+      ++E;
+    for (unsigned I = 0; I != E; ++I)
       cast<PHINode>(BBI)->removeIncomingValue(SI->getParent());
   }
 

--- a/llvm/test/Transforms/SimplifyCFG/switch-range-to-icmp.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-range-to-icmp.ll
@@ -401,4 +401,27 @@ b:
   ret i32 %1
 }
 
+define i32 @else_will_be_unreachable(i1 %arg) {
+; CHECK-LABEL: @else_will_be_unreachable(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[I:%.*]] = select i1 [[ARG:%.*]], i32 0, i32 1
+; CHECK-NEXT:    ret i32 [[I]]
+;
+entry:
+  switch i1 %arg, label %else [
+  i1 false, label %if
+  i1 true, label %if
+  ]
+
+if:
+  br i1 %arg, label %else, label %bb
+
+bb:
+  br label %else
+
+else:
+  %i = phi i32 [ 0, %entry ], [ 0, %if ], [ 1, %bb ]
+  ret i32 %i
+}
+
 declare void @bar(ptr nonnull dereferenceable(4))


### PR DESCRIPTION
Fixes #162585.

#161000 changed `br i1 true, label %if, label %else` to `br label %if`, so we should remove one more incoming value.