### PR TITLE
[SPIRV] Do not emit @llvm.compiler.used

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -139,8 +139,8 @@ void SPIRVAsmPrinter::emitEndOfAsmFile(Module &M) {
 // anymore.
 void SPIRVAsmPrinter::cleanUp(Module &M) {
   // Verifier disallows uses of intrinsic global variables.
-  for (StringRef GVName : {"llvm.global_ctors", "llvm.global_dtors",
-                           "llvm.used", "llvm.compiler.used"}) {
+  for (StringRef GVName :
+       {"llvm.global_ctors", "llvm.global_dtors", "llvm.used"}) {
     if (GlobalVariable *GV = M.getNamedGlobal(GVName))
       GV->setName("");
   }

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2029,7 +2029,7 @@ Instruction *SPIRVEmitIntrinsics::visitUnreachableInst(UnreachableInst &I) {
 
 void SPIRVEmitIntrinsics::processGlobalValue(GlobalVariable &GV,
                                              IRBuilder<> &B) {
-  // Skip special artifical variables
+  // Skip special artificial variables.
   static const StringSet<> ArtificialGlobals{"llvm.global.annotations",
                                              "llvm.compiler.used"};
 

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -17,6 +17,7 @@
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstVisitor.h"
@@ -2028,9 +2029,13 @@ Instruction *SPIRVEmitIntrinsics::visitUnreachableInst(UnreachableInst &I) {
 
 void SPIRVEmitIntrinsics::processGlobalValue(GlobalVariable &GV,
                                              IRBuilder<> &B) {
-  // Skip special artifical variable llvm.global.annotations.
-  if (GV.getName() == "llvm.global.annotations")
+  // Skip special artifical variables
+  static const StringSet<> ArtificialGlobals{"llvm.global.annotations",
+                                             "llvm.compiler.used"};
+
+  if (ArtificialGlobals.contains(GV.getName()))
     return;
+
   Constant *Init = nullptr;
   if (hasInitializer(&GV)) {
     // Deduce element type and store results in Global Registry.

--- a/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
@@ -1,0 +1,19 @@
+; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Verify that llvm.compiler.used is not lowered
+; Currently we do lower it.
+; CHECK: OpName %[[UNUSED:[0-9]+]] "unused"
+; CHECK: OpName %[[LLVM_COMPILER_USED_NAME:[0-9]+]] "llvm.compiler.used"
+
+; Check that the type of llvm.compiler.used is not emited too
+; Currently we do lower it.
+; CHECK: OpTypeArray
+
+@unused = private addrspace(3) global i32 0
+@llvm.compiler.used = appending addrspace(2) global [1 x ptr addrspace (4)] [ptr addrspace(4) addrspacecast (ptr addrspace(3) @unused to ptr addrspace(4))]
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
@@ -4,8 +4,8 @@
 ; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
 
 ; Verify that llvm.compiler.used is not lowered.
-; CHECK: OpName %[[UNUSED:[0-9]+]] "unused"
-; CHECK-NOT: OpName %[[LLVM_COMPILER_USED_NAME:[0-9]+]] "llvm.compiler.used"
+; CHECK: OpName %{{[0-9]+}} "unused"
+; CHECK-NOT: OpName %{{[0-9]+}} "llvm.compiler.used"
 
 ; Check that the type of llvm.compiler.used is not emitted too.
 ; CHECK-NOT: OpTypeArray

--- a/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
@@ -1,12 +1,11 @@
 ; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; Verify that llvm.compiler.used is not lowered
-; Currently we do lower it.
+; Verify that llvm.compiler.used is not lowered.
 ; CHECK: OpName %[[UNUSED:[0-9]+]] "unused"
 ; CHECK-NOT: OpName %[[LLVM_COMPILER_USED_NAME:[0-9]+]] "llvm.compiler.used"
 
-; Check that the type of llvm.compiler.used is not emited too
+; Check that the type of llvm.compiler.used is not emitted too.
 ; CHECK-NOT: OpTypeArray
 
 @unused = private addrspace(3) global i32 0

--- a/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
@@ -1,5 +1,7 @@
 ; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
 
 ; Verify that llvm.compiler.used is not lowered.
 ; CHECK: OpName %[[UNUSED:[0-9]+]] "unused"
@@ -11,7 +13,7 @@
 @unused = private addrspace(3) global i32 0
 @llvm.compiler.used = appending addrspace(2) global [1 x ptr addrspace (4)] [ptr addrspace(4) addrspacecast (ptr addrspace(3) @unused to ptr addrspace(4))]
 
-define spir_kernel void @foo() {
+define spir_func void @foo() {
 entry:
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-compiler-used.ll
@@ -4,11 +4,10 @@
 ; Verify that llvm.compiler.used is not lowered
 ; Currently we do lower it.
 ; CHECK: OpName %[[UNUSED:[0-9]+]] "unused"
-; CHECK: OpName %[[LLVM_COMPILER_USED_NAME:[0-9]+]] "llvm.compiler.used"
+; CHECK-NOT: OpName %[[LLVM_COMPILER_USED_NAME:[0-9]+]] "llvm.compiler.used"
 
 ; Check that the type of llvm.compiler.used is not emited too
-; Currently we do lower it.
-; CHECK: OpTypeArray
+; CHECK-NOT: OpTypeArray
 
 @unused = private addrspace(3) global i32 0
 @llvm.compiler.used = appending addrspace(2) global [1 x ptr addrspace (4)] [ptr addrspace(4) addrspacecast (ptr addrspace(3) @unused to ptr addrspace(4))]


### PR DESCRIPTION
`@llvm.compiler.used` holds a series of global values and prevents the compiler
from optimizing it out.

However, the symbols in the variable can be optimized after compilation
as usual by a linker (notice that `@llvm.used` instead doesn't allow for
the linker to optimize-out the global variables referenced in it).

This was already done for `@llvm.global.annotations`.