### PR TITLE
[NFC][LLVM] Code cleanup in LowerInvoke.cpp

### DIFF
--- a/llvm/lib/Transforms/Utils/LowerInvoke.cpp
+++ b/llvm/lib/Transforms/Utils/LowerInvoke.cpp
@@ -27,15 +27,15 @@ using namespace llvm;
 STATISTIC(NumInvokes, "Number of invokes replaced");
 
 namespace {
-  class LowerInvokeLegacyPass : public FunctionPass {
-  public:
-    static char ID; // Pass identification, replacement for typeid
-    explicit LowerInvokeLegacyPass() : FunctionPass(ID) {
-      initializeLowerInvokeLegacyPassPass(*PassRegistry::getPassRegistry());
-    }
-    bool runOnFunction(Function &F) override;
-  };
-}
+class LowerInvokeLegacyPass : public FunctionPass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  explicit LowerInvokeLegacyPass() : FunctionPass(ID) {
+    initializeLowerInvokeLegacyPassPass(*PassRegistry::getPassRegistry());
+  }
+  bool runOnFunction(Function &F) override;
+};
+} // namespace
 
 char LowerInvokeLegacyPass::ID = 0;
 INITIALIZE_PASS(LowerInvokeLegacyPass, "lowerinvoke",
@@ -78,11 +78,12 @@ bool LowerInvokeLegacyPass::runOnFunction(Function &F) {
   return runImpl(F);
 }
 
-namespace llvm {
-char &LowerInvokePassID = LowerInvokeLegacyPass::ID;
+char &llvm::LowerInvokePassID = LowerInvokeLegacyPass::ID;
 
 // Public Interface To the LowerInvoke pass.
-FunctionPass *createLowerInvokePass() { return new LowerInvokeLegacyPass(); }
+FunctionPass *llvm::createLowerInvokePass() {
+  return new LowerInvokeLegacyPass();
+}
 
 PreservedAnalyses LowerInvokePass::run(Function &F,
                                        FunctionAnalysisManager &AM) {
@@ -91,5 +92,4 @@ PreservedAnalyses LowerInvokePass::run(Function &F,
     return PreservedAnalyses::all();
 
   return PreservedAnalyses::none();
-}
 }


### PR DESCRIPTION
Fix indentation for `LowerInvokeLegacyPass` and use namespace qualifiers for defining variables and functions in `llvm` namespace.