### PR TITLE
[MLIR][Python] Support Python-defined rewrite patterns

### DIFF
--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -329,17 +329,28 @@ mlirPatternRewriterAsBase(MlirPatternRewriter rewriter);
 /// RewritePattern API
 //===----------------------------------------------------------------------===//
 
+/// PatternBenefit represents the benefit of a pattern match.
 typedef unsigned short MlirPatternBenefit;
 
+/// Callbacks to construct a rewrite pattern.
 typedef struct {
+  /// Optional constructor for the user data.
+  /// Set to nullptr to disable it.
   void (*construct)(void *userData);
+  /// Optional destructor for the user data.
+  /// Set to nullptr to disable it.
   void (*destruct)(void *userData);
+  /// The callback function to match against code rooted at the specified
+  /// operation, and perform the rewrite if the match is successful,
+  /// corresponding to RewritePattern::matchAndRewrite.
   MlirLogicalResult (*matchAndRewrite)(MlirRewritePattern pattern,
                                        MlirOperation op,
                                        MlirPatternRewriter rewriter,
                                        void *userData);
 } MlirRewritePatternCallbacks;
 
+/// Create a rewrite pattern that matches the operation
+/// with the given rootName, corresponding to mlir::OpRewritePattern.
 MLIR_CAPI_EXPORTED MlirRewritePattern mlirOpRewritePattenCreate(
     MlirStringRef rootName, MlirPatternBenefit benefit, MlirContext context,
     MlirRewritePatternCallbacks callbacks, void *userData,
@@ -349,11 +360,14 @@ MLIR_CAPI_EXPORTED MlirRewritePattern mlirOpRewritePattenCreate(
 /// RewritePatternSet API
 //===----------------------------------------------------------------------===//
 
+/// Create an empty MlirRewritePatternSet.
 MLIR_CAPI_EXPORTED MlirRewritePatternSet
 mlirRewritePatternSetCreate(MlirContext context);
 
+/// Destruct the given MlirRewritePatternSet.
 MLIR_CAPI_EXPORTED void mlirRewritePatternSetDestroy(MlirRewritePatternSet set);
 
+/// Add the given MlirRewritePattern into a MlirRewritePatternSet.
 MLIR_CAPI_EXPORTED void mlirRewritePatternSetAdd(MlirRewritePatternSet set,
                                                  MlirRewritePattern pattern);
 

--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -38,6 +38,7 @@ DEFINE_C_API_STRUCT(MlirFrozenRewritePatternSet, void);
 DEFINE_C_API_STRUCT(MlirGreedyRewriteDriverConfig, void);
 DEFINE_C_API_STRUCT(MlirRewritePatternSet, void);
 DEFINE_C_API_STRUCT(MlirPatternRewriter, void);
+DEFINE_C_API_STRUCT(MlirRewritePattern, const void);
 
 //===----------------------------------------------------------------------===//
 /// RewriterBase API inherited from OpBuilder
@@ -323,6 +324,38 @@ MLIR_CAPI_EXPORTED MlirLogicalResult mlirApplyPatternsAndFoldGreedily(
 /// Cast the PatternRewriter to a RewriterBase
 MLIR_CAPI_EXPORTED MlirRewriterBase
 mlirPatternRewriterAsBase(MlirPatternRewriter rewriter);
+
+//===----------------------------------------------------------------------===//
+/// RewritePattern API
+//===----------------------------------------------------------------------===//
+
+typedef unsigned short MlirPatternBenefit;
+
+typedef struct {
+  void (*construct)(void *userData);
+  void (*destruct)(void *userData);
+  MlirLogicalResult (*matchAndRewrite)(MlirRewritePattern pattern,
+                                       MlirOperation op,
+                                       MlirPatternRewriter rewriter,
+                                       void *userData);
+} MlirRewritePatternCallbacks;
+
+MLIR_CAPI_EXPORTED MlirRewritePattern mlirOpRewritePattenCreate(
+    MlirStringRef rootName, MlirPatternBenefit benefit, MlirContext context,
+    MlirRewritePatternCallbacks callbacks, void *userData,
+    size_t nGeneratedNames, MlirStringRef *generatedNames);
+
+//===----------------------------------------------------------------------===//
+/// RewritePatternSet API
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirRewritePatternSet
+mlirRewritePatternSetCreate(MlirContext context);
+
+MLIR_CAPI_EXPORTED void mlirRewritePatternSetDestroy(MlirRewritePatternSet set);
+
+MLIR_CAPI_EXPORTED void mlirRewritePatternSetAdd(MlirRewritePatternSet set,
+                                                 MlirRewritePattern pattern);
 
 //===----------------------------------------------------------------------===//
 /// PDLPatternModule API

--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -333,9 +333,6 @@ mlirPatternRewriterAsBase(MlirPatternRewriter rewriter);
 /// RewritePattern API
 //===----------------------------------------------------------------------===//
 
-/// PatternBenefit represents the benefit of a pattern match.
-typedef unsigned short MlirPatternBenefit;
-
 /// Callbacks to construct a rewrite pattern.
 typedef struct {
   /// Optional constructor for the user data.
@@ -356,7 +353,7 @@ typedef struct {
 /// Create a rewrite pattern that matches the operation
 /// with the given rootName, corresponding to mlir::OpRewritePattern.
 MLIR_CAPI_EXPORTED MlirRewritePattern mlirOpRewritePattenCreate(
-    MlirStringRef rootName, MlirPatternBenefit benefit, MlirContext context,
+    MlirStringRef rootName, unsigned benefit, MlirContext context,
     MlirRewritePatternCallbacks callbacks, void *userData,
     size_t nGeneratedNames, MlirStringRef *generatedNames);
 

--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -303,11 +303,15 @@ MLIR_CAPI_EXPORTED void mlirIRRewriterDestroy(MlirRewriterBase rewriter);
 /// FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 
+/// Freeze the given MlirRewritePatternSet to a MlirFrozenRewritePatternSet.
+/// Note that the ownership of the input set is transferred into the frozen set
+/// after this call.
 MLIR_CAPI_EXPORTED MlirFrozenRewritePatternSet
-mlirFreezeRewritePattern(MlirRewritePatternSet op);
+mlirFreezeRewritePattern(MlirRewritePatternSet set);
 
+/// Destroy the given MlirFrozenRewritePatternSet.
 MLIR_CAPI_EXPORTED void
-mlirFrozenRewritePatternSetDestroy(MlirFrozenRewritePatternSet op);
+mlirFrozenRewritePatternSetDestroy(MlirFrozenRewritePatternSet set);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult mlirApplyPatternsAndFoldGreedilyWithOp(
     MlirOperation op, MlirFrozenRewritePatternSet patterns,
@@ -368,6 +372,8 @@ mlirRewritePatternSetCreate(MlirContext context);
 MLIR_CAPI_EXPORTED void mlirRewritePatternSetDestroy(MlirRewritePatternSet set);
 
 /// Add the given MlirRewritePattern into a MlirRewritePatternSet.
+/// Note that the ownership of the pattern is transferred to the set after this
+/// call.
 MLIR_CAPI_EXPORTED void mlirRewritePatternSetAdd(MlirRewritePatternSet set,
                                                  MlirRewritePattern pattern);
 

--- a/mlir/include/mlir/CAPI/Rewrite.h
+++ b/mlir/include/mlir/CAPI/Rewrite.h
@@ -20,5 +20,7 @@
 #include "mlir/IR/PatternMatch.h"
 
 DEFINE_C_API_PTR_METHODS(MlirRewriterBase, mlir::RewriterBase)
+DEFINE_C_API_PTR_METHODS(MlirRewritePattern, const mlir::RewritePattern)
+DEFINE_C_API_PTR_METHODS(MlirRewritePatternSet, mlir::RewritePatternSet)
 
 #endif // MLIR_CAPIREWRITER_H

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -184,7 +184,7 @@ public:
       mlirRewritePatternSetDestroy(set);
   }
 
-  void add(MlirStringRef rootName, MlirPatternBenefit benefit,
+  void add(MlirStringRef rootName, unsigned benefit,
            const nb::callable &matchAndRewrite) {
     MlirRewritePatternCallbacks callbacks;
     callbacks.construct = [](void *userData) {

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -250,7 +250,7 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
               nb::sig("def replace_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation")
                 ", values: list[" MAKE_MLIR_PYTHON_QUALNAME("ir.Value") "]) -> None")
               // clang-format on
-              )
+              nb::arg("op"), nb::arg("values"))
           .def("erase_op", &PyPatternRewriter::eraseOp, "Erase an operation.",
                // clang-format off
                 nb::sig("def erase_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ") -> None")

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -202,7 +202,11 @@ public:
     mlirRewritePatternSetAdd(set, pattern);
   }
 
-  PyFrozenRewritePatternSet freeze() { return mlirFreezeRewritePattern(set); }
+  PyFrozenRewritePatternSet freeze() {
+    MlirRewritePatternSet s = set;
+    set.ptr = nullptr;
+    return mlirFreezeRewritePattern(s);
+  }
 
 private:
   MlirRewritePatternSet set;

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -193,11 +193,11 @@ public:
     callbacks.destruct = [](void *userData) {
       nb::handle(static_cast<PyObject *>(userData)).dec_ref();
     };
-    callbacks.matchAndRewrite = [](MlirRewritePattern pattern, MlirOperation op,
+    callbacks.matchAndRewrite = [](MlirRewritePattern, MlirOperation op,
                                    MlirPatternRewriter rewriter,
                                    void *userData) -> MlirLogicalResult {
       nb::handle f(static_cast<PyObject *>(userData));
-      nb::object res = f(op, PyPatternRewriter(rewriter), pattern);
+      nb::object res = f(op, PyPatternRewriter(rewriter));
       return logicalResultFromObject(res);
     };
     MlirRewritePattern pattern = mlirOpRewritePattenCreate(

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -233,10 +233,10 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
               "replace_op",
               [](PyPatternRewriter &self, MlirOperation op,
                  MlirOperation newOp) { self.replaceOp(op, newOp); },
-              "Replace an operation with a new operation.",
+              "Replace an operation with a new operation.", nb::arg("op"),
+              nb::arg("new_op"),
               // clang-format off
-              nb::sig("def replace_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation")
-                ", new_op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ") -> None")
+              nb::sig("def replace_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ", new_op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ") -> None")
               // clang-format on
               )
           .def(
@@ -245,13 +245,14 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
                  const std::vector<MlirValue> &values) {
                 self.replaceOp(op, values);
               },
-              "Replace an operation with a list of values.",
+              "Replace an operation with a list of values.", nb::arg("op"),
+              nb::arg("values"),
               // clang-format off
-              nb::sig("def replace_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation")
-                ", values: list[" MAKE_MLIR_PYTHON_QUALNAME("ir.Value") "]) -> None")
+              nb::sig("def replace_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ", values: list[" MAKE_MLIR_PYTHON_QUALNAME("ir.Value") "]) -> None")
               // clang-format on
-              nb::arg("op"), nb::arg("values"))
+              )
           .def("erase_op", &PyPatternRewriter::eraseOp, "Erase an operation.",
+               nb::arg("op"),
                // clang-format off
                 nb::sig("def erase_op(self, op: " MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ") -> None")
                // clang-format on

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -270,15 +270,6 @@ void mlirIRRewriterDestroy(MlirRewriterBase rewriter) {
 /// RewritePatternSet and FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 
-static inline mlir::RewritePatternSet *unwrap(MlirRewritePatternSet module) {
-  assert(module.ptr && "unexpected null module");
-  return static_cast<mlir::RewritePatternSet *>(module.ptr);
-}
-
-static inline MlirRewritePatternSet wrap(mlir::RewritePatternSet *module) {
-  return {module};
-}
-
 static inline mlir::FrozenRewritePatternSet *
 unwrap(MlirFrozenRewritePatternSet module) {
   assert(module.ptr && "unexpected null module");
@@ -336,15 +327,6 @@ MlirRewriterBase mlirPatternRewriterAsBase(MlirPatternRewriter rewriter) {
 //===----------------------------------------------------------------------===//
 /// RewritePattern API
 //===----------------------------------------------------------------------===//
-
-inline const mlir::RewritePattern *unwrap(MlirRewritePattern pattern) {
-  assert(pattern.ptr && "expected non-null pattern");
-  return static_cast<const mlir::RewritePattern *>(pattern.ptr);
-}
-
-inline MlirRewritePattern wrap(const mlir::RewritePattern *pattern) {
-  return {pattern};
-}
 
 namespace mlir {
 

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -17,7 +17,6 @@
 #include "mlir/IR/PDLPatternMatch.h.inc"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
-#include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace mlir;

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -291,15 +291,16 @@ wrap(mlir::FrozenRewritePatternSet *module) {
   return {module};
 }
 
-MlirFrozenRewritePatternSet mlirFreezeRewritePattern(MlirRewritePatternSet op) {
-  auto *m = new mlir::FrozenRewritePatternSet(std::move(*unwrap(op)));
-  op.ptr = nullptr;
+MlirFrozenRewritePatternSet
+mlirFreezeRewritePattern(MlirRewritePatternSet set) {
+  auto *m = new mlir::FrozenRewritePatternSet(std::move(*unwrap(set)));
+  set.ptr = nullptr;
   return wrap(m);
 }
 
-void mlirFrozenRewritePatternSetDestroy(MlirFrozenRewritePatternSet op) {
-  delete unwrap(op);
-  op.ptr = nullptr;
+void mlirFrozenRewritePatternSetDestroy(MlirFrozenRewritePatternSet set) {
+  delete unwrap(set);
+  set.ptr = nullptr;
 }
 
 MlirLogicalResult

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -380,7 +380,7 @@ private:
 } // namespace mlir
 
 MlirRewritePattern mlirOpRewritePattenCreate(
-    MlirStringRef rootName, MlirPatternBenefit benefit, MlirContext context,
+    MlirStringRef rootName, unsigned benefit, MlirContext context,
     MlirRewritePatternCallbacks callbacks, void *userData,
     size_t nGeneratedNames, MlirStringRef *generatedNames) {
   std::vector<mlir::StringRef> generatedNamesVec;

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -338,7 +338,7 @@ MlirRewriterBase mlirPatternRewriterAsBase(MlirPatternRewriter rewriter) {
 //===----------------------------------------------------------------------===//
 
 inline const mlir::RewritePattern *unwrap(MlirRewritePattern pattern) {
-  assert(pattern.ptr && "unexpected null pattern");
+  assert(pattern.ptr && "expected non-null pattern");
   return static_cast<const mlir::RewritePattern *>(pattern.ptr);
 }
 

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -1,6 +1,5 @@
 # RUN: %PYTHON %s 2>&1 | FileCheck %s
 
-import gc, sys
 from mlir.ir import *
 from mlir.passmanager import *
 from mlir.dialects.builtin import ModuleOp
@@ -11,8 +10,6 @@ from mlir.rewrite import *
 def run(f):
     print("\nTEST:", f.__name__)
     f()
-    gc.collect()
-    assert Context._get_live_count() == 0
 
 
 # CHECK-LABEL: TEST: testRewritePattern

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -31,7 +31,7 @@ def testRewritePattern():
     def constant_1_to_2(op, rewriter, pattern):
         c = op.attributes["value"].value
         if c != 1:
-            return True # failed to match
+            return True  # failed to match
         with rewriter.ip:
             new_op = arith.constant(op.result.type, 2, loc=op.location)
         rewriter.replace_op(op, [new_op])

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -8,13 +8,8 @@ from mlir.dialects import arith
 from mlir.rewrite import *
 
 
-def log(*args):
-    print(*args, file=sys.stderr)
-    sys.stderr.flush()
-
-
 def run(f):
-    log("\nTEST:", f.__name__)
+    print("\nTEST:", f.__name__)
     f()
     gc.collect()
     assert Context._get_live_count() == 0

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -15,12 +15,12 @@ def run(f):
 # CHECK-LABEL: TEST: testRewritePattern
 @run
 def testRewritePattern():
-    def to_muli(op, rewriter, pattern):
+    def to_muli(op, rewriter):
         with rewriter.ip:
             new_op = arith.muli(op.operands[0], op.operands[1], loc=op.location)
         rewriter.replace_op(op, new_op.owner)
 
-    def constant_1_to_2(op, rewriter, pattern):
+    def constant_1_to_2(op, rewriter):
         c = op.attributes["value"].value
         if c != 1:
             return True  # failed to match

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -1,0 +1,49 @@
+# RUN: %PYTHON %s 2>&1 | FileCheck %s
+
+import gc, sys
+from mlir.ir import *
+from mlir.passmanager import *
+from mlir.dialects.builtin import ModuleOp
+from mlir.dialects import arith
+from mlir.rewrite import *
+
+
+def log(*args):
+    print(*args, file=sys.stderr)
+    sys.stderr.flush()
+
+
+def run(f):
+    log("\nTEST:", f.__name__)
+    f()
+    gc.collect()
+    assert Context._get_live_count() == 0
+
+# CHECK-LABEL: TEST: testRewritePattern
+@run
+def testRewritePattern():
+    def to_muli(op, rewriter, pattern):
+        with rewriter.ip:
+            new_op = arith.muli(op.operands[0], op.operands[1], loc=op.location)
+        rewriter.replace_op(op, new_op.owner)
+
+    with Context():
+        patterns = RewritePatternSet()
+        patterns.add(arith.AddIOp, to_muli)
+        frozen = patterns.freeze()
+
+        module = ModuleOp.parse(
+            r"""
+            module {
+              func.func @add(%a: i64, %b: i64) -> i64 {
+                %sum = arith.addi %a, %b : i64
+                return %sum : i64
+              }
+            }
+            """
+        )
+
+        apply_patterns_and_fold_greedily(module, frozen)
+        # CHECK: %0 = arith.muli %arg0, %arg1 : i64
+        # CHECK: return %0 : i64
+        print(module)

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -19,6 +19,7 @@ def run(f):
     gc.collect()
     assert Context._get_live_count() == 0
 
+
 # CHECK-LABEL: TEST: testRewritePattern
 @run
 def testRewritePattern():

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -28,9 +28,18 @@ def testRewritePattern():
             new_op = arith.muli(op.operands[0], op.operands[1], loc=op.location)
         rewriter.replace_op(op, new_op.owner)
 
+    def constant_1_to_2(op, rewriter, pattern):
+        c = op.attributes["value"].value
+        if c != 1:
+            return True # failed to match
+        with rewriter.ip:
+            new_op = arith.constant(op.result.type, 2, loc=op.location)
+        rewriter.replace_op(op, [new_op])
+
     with Context():
         patterns = RewritePatternSet()
         patterns.add(arith.AddIOp, to_muli)
+        patterns.add(arith.ConstantOp, constant_1_to_2)
         frozen = patterns.freeze()
 
         module = ModuleOp.parse(
@@ -47,4 +56,22 @@ def testRewritePattern():
         apply_patterns_and_fold_greedily(module, frozen)
         # CHECK: %0 = arith.muli %arg0, %arg1 : i64
         # CHECK: return %0 : i64
+        print(module)
+
+        module = ModuleOp.parse(
+            r"""
+            module {
+              func.func @const() -> (i64, i64) {
+                %0 = arith.constant 1 : i64
+                %1 = arith.constant 3 : i64
+                return %0, %1 : i64, i64
+              }
+            }
+            """
+        )
+
+        apply_patterns_and_fold_greedily(module, frozen)
+        # CHECK: %c2_i64 = arith.constant 2 : i64
+        # CHECK: %c3_i64 = arith.constant 3 : i64
+        # CHECK: return %c2_i64, %c3_i64 : i64, i64
         print(module)


### PR DESCRIPTION
This PR adds support for defining custom **`RewritePattern`** implementations directly in the Python bindings.

Previously, users could define similar patterns using the PDL dialect’s bindings. However, for more complex patterns, this often required writing multiple Python callbacks as PDL native constraints or rewrite functions, which made the overall logic less intuitive—though it could be more performant than a pure Python implementation (especially for simple patterns).

With this change, we introduce an additional, straightforward way to define patterns purely in Python, complementing the existing PDL-based approach.

### Example

```python
def to_muli(op, rewriter):
    with rewriter.ip:
        new_op = arith.muli(op.operands[0], op.operands[1], loc=op.location)
    rewriter.replace_op(op, new_op.owner)

with Context():
    patterns = RewritePatternSet()
    patterns.add(arith.AddIOp, to_muli) # a pattern that rewrites arith.addi to arith.muli
    frozen = patterns.freeze()

    module = ...
    apply_patterns_and_fold_greedily(module, frozen)
```
