### PR TITLE
[X86] Add missing isel pattern for VCVTTPD2UDQSZ128rm. Remove duplicate pattern.

### DIFF
--- a/llvm/lib/Target/X86/X86InstrAVX10.td
+++ b/llvm/lib/Target/X86/X86InstrAVX10.td
@@ -592,10 +592,10 @@ def : Pat<(X86mcvttp2sis (v2f64 (X86VBroadcastld64 addr:$src)),
           (VCVTTPD2DQSZ128rmbkz VK2WM:$mask, addr:$src)>;
 
 // Patterns VCVTTPD2UDQSZ128
-def : Pat<(v4i32 (X86cvttp2uis (v2f64 (X86VBroadcastld64 addr:$src)))),
-          (VCVTTPD2UDQSZ128rmb addr:$src)>;
 def : Pat<(v4i32 (X86cvttp2uis (v2f64 VR128X:$src))),
           (VCVTTPD2UDQSZ128rr VR128X:$src)>;
+def : Pat<(v4i32 (X86cvttp2uis (loadv2f64 addr:$src))),
+          (VCVTTPD2UDQSZ128rm addr:$src)>;
 def : Pat<(v4i32 (X86cvttp2uis (v2f64 (X86VBroadcastld64 addr:$src)))),
           (VCVTTPD2UDQSZ128rmb addr:$src)>;
 def : Pat<(X86mcvttp2uis (v2f64 VR128X:$src), (v4i32 VR128X:$src0),


### PR DESCRIPTION
Addresses my comment here https://github.com/llvm/llvm-project/pull/162036#issuecomment-3386628215

I didn't look into testing. I assume foldMemoryOperand is making up for this if we have existing tests.