### PR TITLE
ADT: Add constructor from uint64_t array for Bitset

### DIFF
--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -45,7 +45,18 @@ private:
   StorageType Bits{};
 
 protected:
-  constexpr Bitset(const StorageType &B) : Bits{B} {}
+  constexpr Bitset(const std::array<uint64_t, (NumBits + 63) / 64> &B) {
+    if (sizeof(BitWord) == sizeof(uint64_t)) {
+      for (size_t I = 0; I != B.size(); ++I)
+        Bits[I] = B[I];
+    } else {
+      for (size_t I = 0; I != B.size(); ++I) {
+        uint64_t Elt = B[I];
+        Bits[2 * I] = static_cast<uint32_t>(Elt);
+        Bits[2 * I + 1] = static_cast<uint32_t>(Elt >> 32);
+      }
+    }
+  }
 
 public:
   constexpr Bitset() = default;

--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -38,10 +38,7 @@ class Bitset {
   static constexpr unsigned NumWords =
       (NumBits + BitwordBits - 1) / BitwordBits;
 
-protected:
   using StorageType = std::array<BitWord, NumWords>;
-
-private:
   StorageType Bits{};
 
 protected:

--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -46,7 +46,7 @@ private:
 
 protected:
   constexpr Bitset(const std::array<uint64_t, (NumBits + 63) / 64> &B) {
-    if (sizeof(BitWord) == sizeof(uint64_t)) {
+    if constexpr (sizeof(BitWord) == sizeof(uint64_t)) {
       for (size_t I = 0; I != B.size(); ++I)
         Bits[I] = B[I];
     } else {

--- a/llvm/unittests/ADT/BitsetTest.cpp
+++ b/llvm/unittests/ADT/BitsetTest.cpp
@@ -1,0 +1,44 @@
+//===- llvm/unittest/Support/BitsetTest.cpp -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/Bitset.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+template <unsigned NumBits>
+class TestBitsetUInt64Array : public Bitset<NumBits> {
+  static constexpr unsigned NumElts = (NumBits + 63) / 64;
+
+public:
+  TestBitsetUInt64Array(const std::array<uint64_t, NumElts> &B)
+      : Bitset<NumBits>(B) {}
+
+  bool verifyValue(const std::array<uint64_t, NumElts> &B) const {
+    for (unsigned I = 0; I != NumBits; ++I) {
+      bool ReferenceVal =
+          (B[(I / 64)] & (static_cast<uint64_t>(1) << (I % 64))) != 0;
+      if (ReferenceVal != this->test(I))
+        return false;
+    }
+
+    return true;
+  }
+};
+
+TEST(BitsetTest, Construction) {
+  std::array<uint64_t, 2> TestVals = {0x123456789abcdef3, 0x1337d3a0b22c24};
+  TestBitsetUInt64Array<96> Test(TestVals);
+  EXPECT_TRUE(Test.verifyValue(TestVals));
+
+  TestBitsetUInt64Array<65> Test1(TestVals);
+  EXPECT_TRUE(Test1.verifyValue(TestVals));
+}
+} // namespace

--- a/llvm/unittests/ADT/CMakeLists.txt
+++ b/llvm/unittests/ADT/CMakeLists.txt
@@ -12,6 +12,7 @@ add_llvm_unittest(ADTTests
   BitFieldsTest.cpp
   BitmaskEnumTest.cpp
   BitTest.cpp
+  BitsetTest.cpp
   BitVectorTest.cpp
   BreadthFirstIteratorTest.cpp
   BumpPtrListTest.cpp


### PR DESCRIPTION
Avoids exposing the implementation detail of uintptr_t to
the constructor.

This is a replacement of b738f630f73975bc591a82fdcb4858ae5da67477
which avoids needing tablegen to know the underlying storage type.