### PR TITLE
[OpenMP][mlir] Add Groupprivate op in omp dialect.

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2535,7 +2535,8 @@ def IteratorOp : OpenMP_Op<"iterator",
 // [6.0] groupprivate Directive
 //===----------------------------------------------------------------------===//
 
-def GroupprivateOp : OpenMP_Op<"groupprivate", [Pure]> {
+def GroupprivateOp : OpenMP_Op<"groupprivate",
+    [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "groupprivate directive";
   let description = [{
     The groupprivate directive specifies that variables are replicated, with
@@ -2555,9 +2556,8 @@ def GroupprivateOp : OpenMP_Op<"groupprivate", [Pure]> {
   );
   let results = (outs OpenMP_PointerLikeType:$gp_addr);
   let assemblyFormat = [{
-    $sym_name `:` type($gp_addr) (`,` `device_type` $device_type^)? attr-dict
+    $sym_name (`device_type` $device_type^)? `:` type($gp_addr) attr-dict
   }];
-  let hasVerifier = 1;
 }
 
 #endif // OPENMP_OPS

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2543,12 +2543,15 @@ def GroupprivateOp : OpenMP_Op<"groupprivate",
     each group having its own copy.
 
     This operation takes in the address of a symbol that represents the original
-    variable, optional DeviceTypeAttr and returns the address of its groupprivate copy.
-    All occurrences of groupprivate variables in a parallel region should
-    use the groupprivate copy returned by this operation.
+    variable and returns the address of its groupprivate copy. The symbol must
+    refer to a global variable so that type information can be obtained from it.
 
     The `sym_addr` refers to the address of the symbol, which is a pointer to
-    the original variable.
+    the original variable. It must be obtained via `llvm.mlir.addressof` from
+    a global variable.
+
+    The optional `device_type` attribute specifies where the groupprivate
+    storage should be allocated (host, nohost, or any).
   }];
 
   let arguments = (ins

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2531,4 +2531,34 @@ def IteratorOp : OpenMP_Op<"iterator",
   let hasVerifier = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// [6.0] groupprivate Directive
+//===----------------------------------------------------------------------===//
+
+def GroupprivateOp : OpenMP_Op<"groupprivate",
+                      [AllTypesMatch<["sym_addr", "gp_addr"]>]> {
+  let summary = "groupprivate directive";
+  let description = [{
+    The groupprivate directive specifies that variables are replicated, with
+    each group having its own copy.
+
+    This operation takes in the address of a symbol that represents the original
+    variable, optional DeviceTypeAttr and returns the address of its groupprivate copy.
+    All occurrences of groupprivate variables in a parallel region should
+    use the groupprivate copy returned by this operation.
+
+    The `sym_addr` refers to the address of the symbol, which is a pointer to
+    the original variable.
+  }];
+
+  let arguments = (ins
+    OpenMP_PointerLikeType:$sym_addr,
+    OptionalAttr<DeclareTargetDeviceTypeAttr>:$device_type
+  );
+  let results = (outs OpenMP_PointerLikeType:$gp_addr);
+  let assemblyFormat = [{
+    $sym_addr `:` type($sym_addr) ( `,` `device_type` $device_type^ )? `->` type($gp_addr) attr-dict
+  }];
+}
+
 #endif // OPENMP_OPS

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2535,33 +2535,29 @@ def IteratorOp : OpenMP_Op<"iterator",
 // [6.0] groupprivate Directive
 //===----------------------------------------------------------------------===//
 
-def GroupprivateOp : OpenMP_Op<"groupprivate",
-                      [AllTypesMatch<["sym_addr", "gp_addr"]>]> {
+def GroupprivateOp : OpenMP_Op<"groupprivate", [Pure]> {
   let summary = "groupprivate directive";
   let description = [{
     The groupprivate directive specifies that variables are replicated, with
     each group having its own copy.
 
-    This operation takes in the address of a symbol that represents the original
-    variable and returns the address of its groupprivate copy. The symbol must
-    refer to a global variable so that type information can be obtained from it.
-
-    The `sym_addr` refers to the address of the symbol, which is a pointer to
-    the original variable. It must be obtained via `llvm.mlir.addressof` from
-    a global variable.
+    This operation takes a symbol reference to a global variable and returns
+    the address of its groupprivate copy. The referenced symbol must exist and
+    must not be a function.
 
     The optional `device_type` attribute specifies where the groupprivate
     storage should be allocated (host, nohost, or any).
   }];
 
   let arguments = (ins
-    OpenMP_PointerLikeType:$sym_addr,
+    FlatSymbolRefAttr:$sym_name,
     OptionalAttr<DeclareTargetDeviceTypeAttr>:$device_type
   );
   let results = (outs OpenMP_PointerLikeType:$gp_addr);
   let assemblyFormat = [{
-    $sym_addr `:` type($sym_addr) ( `,` `device_type` $device_type^ )? `->` type($gp_addr) attr-dict
+    $sym_name `:` type($gp_addr) (`,` `device_type` $device_type^)? attr-dict
   }];
+  let hasVerifier = 1;
 }
 
 #endif // OPENMP_OPS

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -5033,6 +5033,23 @@ LogicalResult IteratorOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// GroupprivateOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult GroupprivateOp::verify() {
+  auto *symbol = SymbolTable::lookupNearestSymbolFrom(*this, getSymNameAttr());
+  if (!symbol)
+    return emitOpError() << "expected symbol reference '" << getSymName()
+                         << "' to point to a global variable";
+
+  if (isa<FunctionOpInterface>(symbol))
+    return emitOpError() << "expected symbol reference '" << getSymName()
+                         << "' to point to a global variable, not a function";
+
+  return success();
+}
+
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.cpp.inc"
 

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -5037,8 +5037,9 @@ LogicalResult IteratorOp::verify() {
 // GroupprivateOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult GroupprivateOp::verify() {
-  auto *symbol = SymbolTable::lookupNearestSymbolFrom(*this, getSymNameAttr());
+LogicalResult
+GroupprivateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto *symbol = symbolTable.lookupNearestSymbolFrom(*this, getSymNameAttr());
   if (!symbol)
     return emitOpError() << "expected symbol reference '" << getSymName()
                          << "' to point to a global variable";

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4909,26 +4909,6 @@ convertOmpCancellationPoint(omp::CancellationPointOp op,
   return success();
 }
 
-static LLVM::GlobalOp
-getGlobalFromSymbol(Operation *symOp,
-                    LLVM::ModuleTranslation &moduleTranslation,
-                    Operation *opInst) {
-
-  // Handle potential address space cast
-  if (auto asCast = dyn_cast<LLVM::AddrSpaceCastOp>(symOp))
-    symOp = asCast.getOperand().getDefiningOp();
-
-  // Check if we have an AddressOfOp
-  if (!isa<LLVM::AddressOfOp>(symOp)) {
-    if (opInst)
-      opInst->emitError("Addressing symbol not found");
-    return nullptr;
-  }
-
-  LLVM::AddressOfOp addressOfOp = cast<LLVM::AddressOfOp>(symOp);
-  return addressOfOp.getGlobal(moduleTranslation.symbolTable());
-}
-
 /// Converts an OpenMP Threadprivate operation into LLVM IR using
 /// OpenMPIRBuilder.
 static LogicalResult
@@ -4944,8 +4924,15 @@ convertOmpThreadprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   Value symAddr = threadprivateOp.getSymAddr();
   auto *symOp = symAddr.getDefiningOp();
 
+  if (auto asCast = dyn_cast<LLVM::AddrSpaceCastOp>(symOp))
+    symOp = asCast.getOperand().getDefiningOp();
+
+  if (!isa<LLVM::AddressOfOp>(symOp))
+    return opInst.emitError("Addressing symbol not found");
+
+  LLVM::AddressOfOp addressOfOp = cast<LLVM::AddressOfOp>(symOp);
   LLVM::GlobalOp global =
-      getGlobalFromSymbol(symOp, moduleTranslation, &opInst);
+      addressOfOp.getGlobal(moduleTranslation.symbolTable());
   if (!global)
     return failure();
   llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
@@ -8138,7 +8125,7 @@ convertFreeSharedMemOp(omp::FreeSharedMemOp freeMemOp,
   return success();
 }
 
-/// Converts an OpenMP Groupprivate operation into LLVM IR.
+/// Converts an OpenMP groupprivate operation into LLVM IR.
 static LogicalResult
 convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
                        LLVM::ModuleTranslation &moduleTranslation) {
@@ -8149,81 +8136,56 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
     return failure();
 
   bool isTargetDevice = ompBuilder->Config.isTargetDevice();
-  auto deviceType = groupprivateOp.getDeviceType();
 
-  // Skip allocation based on device_type
+  // Determine whether group-private storage should be allocated based on
+  // device_type. When not specified, default to 'any' (allocate on both).
   bool shouldAllocate = true;
-  if (deviceType.has_value()) {
-    switch (*deviceType) {
-    case mlir::omp::DeclareTargetDeviceType::host:
-      // Only allocate on host
-      shouldAllocate = !isTargetDevice;
-      break;
-    case mlir::omp::DeclareTargetDeviceType::nohost:
-      // Only allocate on device
-      shouldAllocate = isTargetDevice;
-      break;
-    case mlir::omp::DeclareTargetDeviceType::any:
-      // Allocate on both
-      shouldAllocate = true;
-      break;
-    }
+  switch (groupprivateOp.getDeviceType().value_or(
+      mlir::omp::DeclareTargetDeviceType::any)) {
+  case mlir::omp::DeclareTargetDeviceType::host:
+    shouldAllocate = !isTargetDevice;
+    break;
+  case mlir::omp::DeclareTargetDeviceType::nohost:
+    shouldAllocate = isTargetDevice;
+    break;
+  case mlir::omp::DeclareTargetDeviceType::any:
+    shouldAllocate = true;
+    break;
   }
 
-  Value symAddr = groupprivateOp.getSymAddr();
-  llvm::Value *symValue = moduleTranslation.lookupValue(symAddr);
-  llvm::Value *resultPtr;
-
-  // Get the element type and variable name from the global.
-  // Groupprivate requires sym_addr to come from a global variable.
-  llvm::Type *varType = nullptr;
-  std::string varName = "omp.groupprivate";
-
-  if (Operation *symOp = symAddr.getDefiningOp()) {
-    if (LLVM::GlobalOp global =
-            getGlobalFromSymbol(symOp, moduleTranslation, nullptr)) {
-      // Get type from the global
-      varType = moduleTranslation.convertType(global.getType());
-      // Get name from the global
-      if (llvm::GlobalValue *globalValue =
-              moduleTranslation.lookupGlobal(global)) {
-        varName = globalValue->getName().str();
-      }
-    }
-  }
-
-  if (!varType) {
+  // Look up the global variable directly by symbol name.
+  LLVM::GlobalOp global = SymbolTable::lookupNearestSymbolFrom<LLVM::GlobalOp>(
+      &opInst, groupprivateOp.getSymNameAttr());
+  if (!global)
     return opInst.emitError()
-           << "Groupprivate requires sym_addr to reference a global variable";
-  }
+           << "expected symbol '" << groupprivateOp.getSymName()
+           << "' to reference an LLVM global variable";
 
-  if (shouldAllocate) {
-    if (isTargetDevice) {
-      llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
-      llvm::Triple targetTriple = llvm::Triple(llvmModule->getTargetTriple());
-      if (targetTriple.isAMDGCN() || targetTriple.isNVPTX()) {
-        // Shared address space is 3 for AMDGPU and NVPTX targets.
-        unsigned sharedAddressSpace = 3;
-        llvm::GlobalVariable *sharedVar = new llvm::GlobalVariable(
-            *llvmModule, varType, /*isConstant=*/false,
-            llvm::GlobalValue::InternalLinkage, llvm::PoisonValue::get(varType),
-            varName, /*InsertBefore=*/nullptr,
-            llvm::GlobalValue::NotThreadLocal, sharedAddressSpace,
-            /*isExternallyInitialized=*/false);
-        resultPtr = sharedVar;
-      } else {
-        return opInst.emitError()
-               << "Groupprivate operation is not supported for this target: "
-               << targetTriple.str();
-      }
+  llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
+  llvm::Type *varType = moduleTranslation.convertType(global.getType());
+  std::string varName = globalValue->getName().str();
+
+  llvm::Value *resultPtr;
+  if (shouldAllocate && isTargetDevice) {
+    llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+    llvm::Triple targetTriple(llvmModule->getTargetTriple());
+    if (targetTriple.isAMDGCN() || targetTriple.isNVPTX()) {
+      unsigned sharedAddressSpace = 3;
+      llvm::GlobalVariable *sharedVar = new llvm::GlobalVariable(
+          *llvmModule, varType, /*isConstant=*/false,
+          llvm::GlobalValue::InternalLinkage, llvm::PoisonValue::get(varType),
+          varName, /*InsertBefore=*/nullptr, llvm::GlobalValue::NotThreadLocal,
+          sharedAddressSpace,
+          /*isExternallyInitialized=*/false);
+      resultPtr = sharedVar;
     } else {
-      // Use original address when allocating on host device.
-      // TODO: Add support for allocating group-private storage on host device.
-      resultPtr = symValue;
+      return opInst.emitError() << "groupprivate is not supported for target: "
+                                << targetTriple.str();
     }
   } else {
-    // Use original address when not allocating group-private storage.
-    resultPtr = symValue;
+    // Use original global address on host or when not allocating
+    // group-private storage.
+    resultPtr = globalValue;
   }
 
   moduleTranslation.mapValue(opInst.getResult(0), resultPtr);
@@ -8238,8 +8200,8 @@ LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertOperation(
   llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
 
   if (ompBuilder->Config.isTargetDevice() &&
-      !isa<omp::TargetOp, omp::MapInfoOp, omp::TerminatorOp, omp::YieldOp,
-           omp::GroupprivateOp>(op) &&
+      !isa<omp::TargetOp, omp::MapInfoOp, omp::TerminatorOp, omp::YieldOp>(
+          op) &&
       isHostDeviceOp(op))
     return op->emitOpError() << "unsupported host op found in device";
 

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -34,7 +34,9 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/ReplaceConstant.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/NVPTXAddrSpace.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
@@ -8167,19 +8169,21 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   if (shouldAllocate && isTargetDevice) {
     llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
     llvm::Triple targetTriple(llvmModule->getTargetTriple());
-    if (targetTriple.isAMDGCN() || targetTriple.isNVPTX()) {
-      unsigned sharedAddressSpace = 3;
-      llvm::GlobalVariable *sharedVar = new llvm::GlobalVariable(
-          *llvmModule, varType, /*isConstant=*/false,
-          llvm::GlobalValue::InternalLinkage, llvm::PoisonValue::get(varType),
-          varName, /*InsertBefore=*/nullptr, llvm::GlobalValue::NotThreadLocal,
-          sharedAddressSpace,
-          /*isExternallyInitialized=*/false);
-      resultPtr = sharedVar;
-    } else {
+    unsigned sharedAddressSpace;
+    if (targetTriple.isAMDGCN())
+      sharedAddressSpace = llvm::AMDGPUAS::LOCAL_ADDRESS;
+    else if (targetTriple.isNVPTX())
+      sharedAddressSpace = llvm::NVPTXAS::ADDRESS_SPACE_SHARED;
+    else
       return opInst.emitError() << "groupprivate is not supported for target: "
                                 << targetTriple.str();
-    }
+    llvm::GlobalVariable *sharedVar = new llvm::GlobalVariable(
+        *llvmModule, varType, /*isConstant=*/false,
+        llvm::GlobalValue::InternalLinkage, llvm::PoisonValue::get(varType),
+        varName, /*InsertBefore=*/nullptr, llvm::GlobalValue::NotThreadLocal,
+        sharedAddressSpace,
+        /*isExternallyInitialized=*/false);
+    resultPtr = sharedVar;
   } else {
     // Use original global address on host or when not allocating
     // group-private storage.

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8151,7 +8151,7 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   bool isTargetDevice = ompBuilder->Config.isTargetDevice();
   auto deviceType = groupprivateOp.getDeviceType();
 
-  // skip allocation based on device_type
+  // Skip allocation based on device_type
   bool shouldAllocate = true;
   if (deviceType.has_value()) {
     switch (*deviceType) {
@@ -8171,30 +8171,45 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   }
 
   Value symAddr = groupprivateOp.getSymAddr();
-  Operation *symOp = symAddr.getDefiningOp();
-
-  LLVM::GlobalOp global =
-      getGlobalFromSymbol(symOp, moduleTranslation, &opInst);
-  if (!global)
-    return failure();
-
-  llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
+  llvm::Value *symValue = moduleTranslation.lookupValue(symAddr);
   llvm::Value *resultPtr;
+
+  // Get the element type and variable name from the global.
+  // Groupprivate requires sym_addr to come from a global variable.
+  llvm::Type *varType = nullptr;
+  std::string varName = "omp.groupprivate";
+
+  if (Operation *symOp = symAddr.getDefiningOp()) {
+    if (LLVM::GlobalOp global =
+            getGlobalFromSymbol(symOp, moduleTranslation, nullptr)) {
+      // Get type from the global
+      varType = moduleTranslation.convertType(global.getType());
+      // Get name from the global
+      if (llvm::GlobalValue *globalValue =
+              moduleTranslation.lookupGlobal(global)) {
+        varName = globalValue->getName().str();
+      }
+    }
+  }
+
+  if (!varType) {
+    return opInst.emitError()
+           << "Groupprivate requires sym_addr to reference a global variable";
+  }
 
   if (shouldAllocate) {
     if (isTargetDevice) {
-      // Get the size of the variable
-      llvm::Type *varType = globalValue->getValueType();
       llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
-      // Create a llvm global variable in shared memory
       llvm::Triple targetTriple = llvm::Triple(llvmModule->getTargetTriple());
       if (targetTriple.isAMDGCN() || targetTriple.isNVPTX()) {
-        // Shared address space is 3 for amdgpu and nvptx targets.
+        // Shared address space is 3 for AMDGPU and NVPTX targets.
         unsigned sharedAddressSpace = 3;
         llvm::GlobalVariable *sharedVar = new llvm::GlobalVariable(
-            *llvmModule, varType, false, llvm::GlobalValue::InternalLinkage,
-            llvm::PoisonValue::get(varType), globalValue->getName(), nullptr,
-            llvm::GlobalValue::NotThreadLocal, sharedAddressSpace, false);
+            *llvmModule, varType, /*isConstant=*/false,
+            llvm::GlobalValue::InternalLinkage, llvm::PoisonValue::get(varType),
+            varName, /*InsertBefore=*/nullptr,
+            llvm::GlobalValue::NotThreadLocal, sharedAddressSpace,
+            /*isExternallyInitialized=*/false);
         resultPtr = sharedVar;
       } else {
         return opInst.emitError()
@@ -8202,13 +8217,13 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
                << targetTriple.str();
       }
     } else {
-      // Use original global address when allocating on host device.
+      // Use original address when allocating on host device.
       // TODO: Add support for allocating group-private storage on host device.
-      resultPtr = globalValue;
+      resultPtr = symValue;
     }
   } else {
-    // Use original global address when not allocating group-private storage.
-    resultPtr = globalValue;
+    // Use original address when not allocating group-private storage.
+    resultPtr = symValue;
   }
 
   moduleTranslation.mapValue(opInst.getResult(0), resultPtr);
@@ -8223,8 +8238,8 @@ LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertOperation(
   llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
 
   if (ompBuilder->Config.isTargetDevice() &&
-      !isa<omp::TargetOp, omp::MapInfoOp, omp::TerminatorOp, omp::YieldOp>(
-          op) &&
+      !isa<omp::TargetOp, omp::MapInfoOp, omp::TerminatorOp, omp::YieldOp,
+           omp::GroupprivateOp>(op) &&
       isHostDeviceOp(op))
     return op->emitOpError() << "unsupported host op found in device";
 

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8185,8 +8185,9 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
         /*isExternallyInitialized=*/false);
     resultPtr = sharedVar;
   } else {
-    // Use original global address on host or when not allocating
-    // group-private storage.
+    if (shouldAllocate && !isTargetDevice)
+      opInst.emitWarning("groupprivate directive is currently ignored on the "
+                         "host, using original global");
     resultPtr = globalValue;
   }
 

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8123,6 +8123,74 @@ convertFreeSharedMemOp(omp::FreeSharedMemOp freeMemOp,
   return success();
 }
 
+/// Converts an OpenMP Groupprivate operation into LLVM IR.
+static LogicalResult
+convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
+                       LLVM::ModuleTranslation &moduleTranslation) {
+  llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
+  auto groupprivateOp = cast<omp::GroupprivateOp>(opInst);
+
+  if (failed(checkImplementationStatus(opInst)))
+    return failure();
+
+  bool isTargetDevice = ompBuilder->Config.isTargetDevice();
+  auto deviceType = groupprivateOp.getDeviceType();
+
+  // skip allocation based on device_type
+  bool shouldAllocate = true;
+  if (deviceType.has_value()) {
+    switch (*deviceType) {
+    case mlir::omp::DeclareTargetDeviceType::host:
+      // Only allocate on host
+      shouldAllocate = !isTargetDevice;
+      break;
+    case mlir::omp::DeclareTargetDeviceType::nohost:
+      // Only allocate on device
+      shouldAllocate = isTargetDevice;
+      break;
+    case mlir::omp::DeclareTargetDeviceType::any:
+      // Allocate on both
+      shouldAllocate = true;
+      break;
+    }
+  }
+
+  Value symAddr = groupprivateOp.getSymAddr();
+  auto *symOp = symAddr.getDefiningOp();
+
+  if (auto asCast = dyn_cast<LLVM::AddrSpaceCastOp>(symOp))
+    symOp = asCast.getOperand().getDefiningOp();
+
+  if (!isa<LLVM::AddressOfOp>(symOp))
+    return opInst.emitError("Addressing symbol not found");
+  LLVM::AddressOfOp addressOfOp = dyn_cast<LLVM::AddressOfOp>(symOp);
+
+  LLVM::GlobalOp global =
+      addressOfOp.getGlobal(moduleTranslation.symbolTable());
+  llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
+  llvm::Value *resultPtr;
+
+  if (shouldAllocate) {
+    // Get the size of the variable
+    llvm::Type *varType = globalValue->getValueType();
+    llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+    llvm::DataLayout DL = llvmModule->getDataLayout();
+    uint64_t typeSize = DL.getTypeAllocSize(varType);
+    // Call omp_alloc_shared to allocate memory for groupprivate variable.
+    llvm::FunctionCallee allocSharedFn = ompBuilder->getOrCreateRuntimeFunction(
+        *llvmModule, llvm::omp::OMPRTL___kmpc_alloc_shared);
+    // Call runtime to allocate shared memory for this group
+    resultPtr = builder.CreateCall(allocSharedFn, {builder.getInt64(typeSize)});
+  } else {
+    // Use original global address when not allocating group-private storage
+    resultPtr = moduleTranslation.lookupValue(symAddr);
+    if (!resultPtr)
+      resultPtr = globalValue;
+  }
+  moduleTranslation.mapValue(opInst.getResult(0), resultPtr);
+  return success();
+}
+
 /// Given an OpenMP MLIR operation, create the corresponding LLVM IR (including
 /// OpenMP runtime calls).
 LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertOperation(
@@ -8348,6 +8416,9 @@ LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertOperation(
           })
           .Case([&](omp::FreeSharedMemOp op) {
             return convertFreeSharedMemOp(op, builder, moduleTranslation);
+          })
+          .Case([&](omp::GroupprivateOp) {
+            return convertOmpGroupprivate(*op, builder, moduleTranslation);
           })
           .Default([&](Operation *inst) {
             return inst->emitError()

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8182,21 +8182,33 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   llvm::Value *resultPtr;
 
   if (shouldAllocate) {
-    // Get the size of the variable
-    llvm::Type *varType = globalValue->getValueType();
-    llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
-    llvm::DataLayout DL = llvmModule->getDataLayout();
-    uint64_t typeSize = DL.getTypeAllocSize(varType);
-    // Call omp_alloc_shared to allocate memory for groupprivate variable.
-    llvm::FunctionCallee allocSharedFn = ompBuilder->getOrCreateRuntimeFunction(
-        *llvmModule, llvm::omp::OMPRTL___kmpc_alloc_shared);
-    // Call runtime to allocate shared memory for this group
-    resultPtr = builder.CreateCall(allocSharedFn, {builder.getInt64(typeSize)});
-  } else {
-    // Use original global address when not allocating group-private storage
-    resultPtr = moduleTranslation.lookupValue(symAddr);
-    if (!resultPtr)
+    if (isTargetDevice) {
+      // Get the size of the variable
+      llvm::Type *varType = globalValue->getValueType();
+      llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+      // Create a llvm global variable in shared memory
+      llvm::Triple targetTriple = llvm::Triple(llvmModule->getTargetTriple());
+      if (targetTriple.isAMDGCN() || targetTriple.isNVPTX()) {
+        // Shared address space is 3 for amdgpu and nvptx targets.
+        unsigned sharedAddressSpace = 3;
+        llvm::GlobalVariable *sharedVar = new llvm::GlobalVariable(
+            *llvmModule, varType, false, llvm::GlobalValue::InternalLinkage,
+            llvm::PoisonValue::get(varType), globalValue->getName(), nullptr,
+            llvm::GlobalValue::NotThreadLocal, sharedAddressSpace, false);
+        resultPtr = sharedVar;
+      } else {
+        return opInst.emitError()
+               << "Groupprivate operation is not supported for this target: "
+               << targetTriple.str();
+      }
+    } else {
+      // Use original global address when allocating on host device.
+      // TODO: Add support for allocating group-private storage on host device.
       resultPtr = globalValue;
+    }
+  } else {
+    // Use original global address when not allocating group-private storage.
+    resultPtr = globalValue;
   }
 
   moduleTranslation.mapValue(opInst.getResult(0), resultPtr);

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4929,12 +4929,9 @@ convertOmpThreadprivate(Operation &opInst, llvm::IRBuilderBase &builder,
 
   if (!isa<LLVM::AddressOfOp>(symOp))
     return opInst.emitError("Addressing symbol not found");
-
   LLVM::AddressOfOp addressOfOp = cast<LLVM::AddressOfOp>(symOp);
   LLVM::GlobalOp global =
       addressOfOp.getGlobal(moduleTranslation.symbolTable());
-  if (!global)
-    return failure();
   llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
   llvm::Type *type = globalValue->getValueType();
   llvm::TypeSize typeSize =

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8199,10 +8199,6 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
       resultPtr = globalValue;
   }
 
-  llvm::Type *ptrTy = builder.getPtrTy();
-  if (resultPtr->getType() != ptrTy)
-    resultPtr = builder.CreateBitCast(resultPtr, ptrTy);
-
   moduleTranslation.mapValue(opInst.getResult(0), resultPtr);
   return success();
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4909,6 +4909,26 @@ convertOmpCancellationPoint(omp::CancellationPointOp op,
   return success();
 }
 
+static LLVM::GlobalOp
+getGlobalFromSymbol(Operation *symOp,
+                    LLVM::ModuleTranslation &moduleTranslation,
+                    Operation *opInst) {
+
+  // Handle potential address space cast
+  if (auto asCast = dyn_cast<LLVM::AddrSpaceCastOp>(symOp))
+    symOp = asCast.getOperand().getDefiningOp();
+
+  // Check if we have an AddressOfOp
+  if (!isa<LLVM::AddressOfOp>(symOp)) {
+    if (opInst)
+      opInst->emitError("Addressing symbol not found");
+    return nullptr;
+  }
+
+  LLVM::AddressOfOp addressOfOp = cast<LLVM::AddressOfOp>(symOp);
+  return addressOfOp.getGlobal(moduleTranslation.symbolTable());
+}
+
 /// Converts an OpenMP Threadprivate operation into LLVM IR using
 /// OpenMPIRBuilder.
 static LogicalResult
@@ -4924,15 +4944,10 @@ convertOmpThreadprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   Value symAddr = threadprivateOp.getSymAddr();
   auto *symOp = symAddr.getDefiningOp();
 
-  if (auto asCast = dyn_cast<LLVM::AddrSpaceCastOp>(symOp))
-    symOp = asCast.getOperand().getDefiningOp();
-
-  if (!isa<LLVM::AddressOfOp>(symOp))
-    return opInst.emitError("Addressing symbol not found");
-  LLVM::AddressOfOp addressOfOp = dyn_cast<LLVM::AddressOfOp>(symOp);
-
   LLVM::GlobalOp global =
-      addressOfOp.getGlobal(moduleTranslation.symbolTable());
+      getGlobalFromSymbol(symOp, moduleTranslation, &opInst);
+  if (!global)
+    return failure();
   llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
   llvm::Type *type = globalValue->getValueType();
   llvm::TypeSize typeSize =
@@ -8156,17 +8171,13 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
   }
 
   Value symAddr = groupprivateOp.getSymAddr();
-  auto *symOp = symAddr.getDefiningOp();
-
-  if (auto asCast = dyn_cast<LLVM::AddrSpaceCastOp>(symOp))
-    symOp = asCast.getOperand().getDefiningOp();
-
-  if (!isa<LLVM::AddressOfOp>(symOp))
-    return opInst.emitError("Addressing symbol not found");
-  LLVM::AddressOfOp addressOfOp = dyn_cast<LLVM::AddressOfOp>(symOp);
+  Operation *symOp = symAddr.getDefiningOp();
 
   LLVM::GlobalOp global =
-      addressOfOp.getGlobal(moduleTranslation.symbolTable());
+      getGlobalFromSymbol(symOp, moduleTranslation, &opInst);
+  if (!global)
+    return failure();
+
   llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);
   llvm::Value *resultPtr;
 
@@ -8187,6 +8198,11 @@ convertOmpGroupprivate(Operation &opInst, llvm::IRBuilderBase &builder,
     if (!resultPtr)
       resultPtr = globalValue;
   }
+
+  llvm::Type *ptrTy = builder.getPtrTy();
+  if (resultPtr->getType() != ptrTy)
+    resultPtr = builder.CreateBitCast(resultPtr, ptrTy);
+
   moduleTranslation.mapValue(opInst.getResult(0), resultPtr);
   return success();
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4929,7 +4929,8 @@ convertOmpThreadprivate(Operation &opInst, llvm::IRBuilderBase &builder,
 
   if (!isa<LLVM::AddressOfOp>(symOp))
     return opInst.emitError("Addressing symbol not found");
-  LLVM::AddressOfOp addressOfOp = cast<LLVM::AddressOfOp>(symOp);
+  LLVM::AddressOfOp addressOfOp = dyn_cast<LLVM::AddressOfOp>(symOp);
+
   LLVM::GlobalOp global =
       addressOfOp.getGlobal(moduleTranslation.symbolTable());
   llvm::GlobalValue *globalValue = moduleTranslation.lookupGlobal(global);

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -3957,3 +3957,39 @@ func.func @omp_free_shared_mem(%n: i64) {
   omp.free_shared_mem [%n x f32 : (i64) align(32)] %1 : !llvm.ptr
   return
 }
+
+// CHECK-LABEL: func.func @omp_groupprivate_device_type
+func.func @omp_groupprivate_device_type() {
+  %0 = arith.constant 1 : i32
+  %1 = arith.constant 2 : i32
+  // CHECK: [[ARG0:%.*]] = llvm.mlir.addressof @gp : !llvm.ptr
+  %gp_addr = llvm.mlir.addressof @gp : !llvm.ptr
+  // CHECK: [[ARG1:%.*]] = llvm.mlir.addressof @any : !llvm.ptr
+  %any_addr = llvm.mlir.addressof @any : !llvm.ptr
+  // CHECK: [[ARG2:%.*]] = llvm.mlir.addressof @host : !llvm.ptr
+  %host_addr = llvm.mlir.addressof @host : !llvm.ptr
+  // CHECK: [[ARG3:%.*]] = llvm.mlir.addressof @nohost : !llvm.ptr
+  %nohost_addr = llvm.mlir.addressof @nohost : !llvm.ptr
+
+  // CHECK: {{.*}} = omp.groupprivate [[ARG0]] : !llvm.ptr -> !llvm.ptr
+  %group_private_addr = omp.groupprivate %gp_addr : !llvm.ptr -> !llvm.ptr
+
+  // CHECK: {{.*}} = omp.groupprivate [[ARG1]] : !llvm.ptr, device_type (any) -> !llvm.ptr
+  %group_private_any = omp.groupprivate %any_addr : !llvm.ptr, device_type(any) -> !llvm.ptr
+  llvm.store %1, %group_private_any : i32, !llvm.ptr
+
+  // CHECK: {{.*}} = omp.groupprivate [[ARG2]] : !llvm.ptr, device_type (host) -> !llvm.ptr
+  %group_private_host = omp.groupprivate %host_addr : !llvm.ptr, device_type(host) -> !llvm.ptr
+  llvm.store %1, %group_private_host : i32, !llvm.ptr
+
+  // CHECK: {{.*}} = omp.groupprivate [[ARG3]] : !llvm.ptr, device_type (nohost) -> !llvm.ptr
+  %group_private_nohost = omp.groupprivate %nohost_addr : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  llvm.store %1, %group_private_nohost : i32, !llvm.ptr
+
+  return
+}
+
+llvm.mlir.global internal @gp() : i32
+llvm.mlir.global internal @any() : i32
+llvm.mlir.global internal @host() : i32
+llvm.mlir.global internal @nohost() : i32

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -3965,16 +3965,16 @@ func.func @omp_groupprivate_device_type() {
   // CHECK: {{.*}} = omp.groupprivate @gp : !llvm.ptr
   %group_private_addr = omp.groupprivate @gp : !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate @any : !llvm.ptr, device_type (any)
-  %group_private_any = omp.groupprivate @any : !llvm.ptr, device_type(any)
+  // CHECK: {{.*}} = omp.groupprivate @any device_type (any) : !llvm.ptr
+  %group_private_any = omp.groupprivate @any device_type(any) : !llvm.ptr
   llvm.store %1, %group_private_any : i32, !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate @host : !llvm.ptr, device_type (host)
-  %group_private_host = omp.groupprivate @host : !llvm.ptr, device_type(host)
+  // CHECK: {{.*}} = omp.groupprivate @host device_type (host) : !llvm.ptr
+  %group_private_host = omp.groupprivate @host device_type(host) : !llvm.ptr
   llvm.store %1, %group_private_host : i32, !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate @nohost : !llvm.ptr, device_type (nohost)
-  %group_private_nohost = omp.groupprivate @nohost : !llvm.ptr, device_type(nohost)
+  // CHECK: {{.*}} = omp.groupprivate @nohost device_type (nohost) : !llvm.ptr
+  %group_private_nohost = omp.groupprivate @nohost device_type(nohost) : !llvm.ptr
   llvm.store %1, %group_private_nohost : i32, !llvm.ptr
 
   return

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -3960,30 +3960,21 @@ func.func @omp_free_shared_mem(%n: i64) {
 
 // CHECK-LABEL: func.func @omp_groupprivate_device_type
 func.func @omp_groupprivate_device_type() {
-  %0 = arith.constant 1 : i32
   %1 = arith.constant 2 : i32
-  // CHECK: [[ARG0:%.*]] = llvm.mlir.addressof @gp : !llvm.ptr
-  %gp_addr = llvm.mlir.addressof @gp : !llvm.ptr
-  // CHECK: [[ARG1:%.*]] = llvm.mlir.addressof @any : !llvm.ptr
-  %any_addr = llvm.mlir.addressof @any : !llvm.ptr
-  // CHECK: [[ARG2:%.*]] = llvm.mlir.addressof @host : !llvm.ptr
-  %host_addr = llvm.mlir.addressof @host : !llvm.ptr
-  // CHECK: [[ARG3:%.*]] = llvm.mlir.addressof @nohost : !llvm.ptr
-  %nohost_addr = llvm.mlir.addressof @nohost : !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate [[ARG0]] : !llvm.ptr -> !llvm.ptr
-  %group_private_addr = omp.groupprivate %gp_addr : !llvm.ptr -> !llvm.ptr
+  // CHECK: {{.*}} = omp.groupprivate @gp : !llvm.ptr
+  %group_private_addr = omp.groupprivate @gp : !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate [[ARG1]] : !llvm.ptr, device_type (any) -> !llvm.ptr
-  %group_private_any = omp.groupprivate %any_addr : !llvm.ptr, device_type(any) -> !llvm.ptr
+  // CHECK: {{.*}} = omp.groupprivate @any : !llvm.ptr, device_type (any)
+  %group_private_any = omp.groupprivate @any : !llvm.ptr, device_type(any)
   llvm.store %1, %group_private_any : i32, !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate [[ARG2]] : !llvm.ptr, device_type (host) -> !llvm.ptr
-  %group_private_host = omp.groupprivate %host_addr : !llvm.ptr, device_type(host) -> !llvm.ptr
+  // CHECK: {{.*}} = omp.groupprivate @host : !llvm.ptr, device_type (host)
+  %group_private_host = omp.groupprivate @host : !llvm.ptr, device_type(host)
   llvm.store %1, %group_private_host : i32, !llvm.ptr
 
-  // CHECK: {{.*}} = omp.groupprivate [[ARG3]] : !llvm.ptr, device_type (nohost) -> !llvm.ptr
-  %group_private_nohost = omp.groupprivate %nohost_addr : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  // CHECK: {{.*}} = omp.groupprivate @nohost : !llvm.ptr, device_type (nohost)
+  %group_private_nohost = omp.groupprivate @nohost : !llvm.ptr, device_type(nohost)
   llvm.store %1, %group_private_nohost : i32, !llvm.ptr
 
   return

--- a/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
@@ -31,11 +31,15 @@ module attributes {omp.is_target_device = true, llvm.target_triple = "amdgcn-amd
   llvm.mlir.global internal @global_nohost() : i32
 }
 
+// CHECK-DAG: @global_a = internal global i32 undef
+// CHECK-DAG: @global_any = internal global i32 undef
+// CHECK-DAG: @global_host = internal global i32 undef
+// CHECK-DAG: @global_nohost = internal global i32 undef
+// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
+// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
 // CHECK: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_{{.*}}__QQmain_{{.*}}(ptr %{{.*}}, ptr %{{.*}}) #{{[0-9]+}} {
 // CHECK-LABEL:  omp.target:
 // CHECK-NEXT :    %[[LOAD:.*]] = load i32, ptr %{{.*}}, align 4
-// CHECK-NEXT :    %[[ALLOC_any:.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK-NEXT :    store i32 %[[LOAD]], ptr %[[ALLOC_any]], align 4
+// CHECK-NEXT :    store i32 %[[LOAD]], ptr addrspace(3) {{.*}}, align 4
 // CHECK-NEXT :    store i32 %[[LOAD]], ptr @global_host, align 4
-// CHECK-NEXT :    %[[ALLOC_NOHOST:.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK-NEXT :    store i32 %[[LOAD]], ptr %[[ALLOC_NOHOST]], align 4
+// CHECK-NEXT :    store i32 %[[LOAD]], ptr addrspace(3) {{.*}}, align 4

--- a/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
@@ -33,7 +33,7 @@ module attributes {omp.is_target_device = true, llvm.target_triple = "amdgcn-amd
 
 // CHECK: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_{{.*}}__QQmain_{{.*}}(ptr %{{.*}}, ptr %{{.*}}) #{{[0-9]+}} {
 // CHECK-LABEL:  omp.target:
-// CHECK-NEXT :    %[[LOAD:.*]] = load i32, ptr %3, align 4
+// CHECK-NEXT :    %[[LOAD:.*]] = load i32, ptr %{{.*}}, align 4
 // CHECK-NEXT :    %[[ALLOC_any:.*]] = call ptr @__kmpc_alloc_shared(i64 4)
 // CHECK-NEXT :    store i32 %[[LOAD]], ptr %[[ALLOC_any]], align 4
 // CHECK-NEXT :    store i32 %[[LOAD]], ptr @global_host, align 4

--- a/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
@@ -1,0 +1,41 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+module attributes {omp.is_target_device = true, llvm.target_triple = "amdgcn-amd-amdhsa",
+                    dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memory_space", 5 : ui32>>} {
+  llvm.func @_QQmain() attributes {fir.bindc_name = "main"} {
+
+    %ga = llvm.mlir.addressof @global_a : !llvm.ptr
+    %map_a = omp.map.info var_ptr(%ga : !llvm.ptr, i32) map_clauses(tofrom) capture(ByCopy) -> !llvm.ptr {name = "i"}
+    omp.target map_entries(%map_a -> %arg1 : !llvm.ptr) {
+      %loaded = llvm.load %arg1 : !llvm.ptr -> i32
+
+      %any_addr = llvm.mlir.addressof @global_any : !llvm.ptr
+      %any_gp = omp.groupprivate %any_addr : !llvm.ptr, device_type(any) -> !llvm.ptr
+      llvm.store %loaded, %any_gp : i32, !llvm.ptr
+
+      %host_addr = llvm.mlir.addressof @global_host : !llvm.ptr
+      %host_gp = omp.groupprivate %host_addr : !llvm.ptr, device_type(host) -> !llvm.ptr
+      llvm.store %loaded, %host_gp : i32, !llvm.ptr
+
+      %nohost_addr = llvm.mlir.addressof @global_nohost : !llvm.ptr
+      %nohost_gp = omp.groupprivate %nohost_addr : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+      llvm.store %loaded, %nohost_gp : i32, !llvm.ptr
+
+      omp.terminator
+    }
+    llvm.return
+  }
+  llvm.mlir.global internal @global_a() : i32
+  llvm.mlir.global internal @global_any() : i32
+  llvm.mlir.global internal @global_host() : i32
+  llvm.mlir.global internal @global_nohost() : i32
+}
+
+// CHECK: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_{{.*}}__QQmain_{{.*}}(ptr %{{.*}}, ptr %{{.*}}) #{{[0-9]+}} {
+// CHECK-LABEL:  omp.target:
+// CHECK-NEXT :    %[[LOAD:.*]] = load i32, ptr %3, align 4
+// CHECK-NEXT :    %[[ALLOC_any:.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK-NEXT :    store i32 %[[LOAD]], ptr %[[ALLOC_any]], align 4
+// CHECK-NEXT :    store i32 %[[LOAD]], ptr @global_host, align 4
+// CHECK-NEXT :    %[[ALLOC_NOHOST:.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK-NEXT :    store i32 %[[LOAD]], ptr %[[ALLOC_NOHOST]], align 4

--- a/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
@@ -9,13 +9,13 @@ module attributes {omp.is_target_device = true, llvm.target_triple = "amdgcn-amd
     omp.target map_entries(%map_a -> %arg1 : !llvm.ptr) {
       %loaded = llvm.load %arg1 : !llvm.ptr -> i32
 
-      %any_gp = omp.groupprivate @global_any : !llvm.ptr, device_type(any)
+      %any_gp = omp.groupprivate @global_any device_type(any) : !llvm.ptr
       llvm.store %loaded, %any_gp : i32, !llvm.ptr
 
-      %host_gp = omp.groupprivate @global_host : !llvm.ptr, device_type(host)
+      %host_gp = omp.groupprivate @global_host device_type(host) : !llvm.ptr
       llvm.store %loaded, %host_gp : i32, !llvm.ptr
 
-      %nohost_gp = omp.groupprivate @global_nohost : !llvm.ptr, device_type(nohost)
+      %nohost_gp = omp.groupprivate @global_nohost device_type(nohost) : !llvm.ptr
       llvm.store %loaded, %nohost_gp : i32, !llvm.ptr
 
       omp.terminator
@@ -32,11 +32,10 @@ module attributes {omp.is_target_device = true, llvm.target_triple = "amdgcn-amd
 // CHECK-DAG: @global_any = internal global i32 undef
 // CHECK-DAG: @global_host = internal global i32 undef
 // CHECK-DAG: @global_nohost = internal global i32 undef
-// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
-// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
+// CHECK-DAG: @[[SHARED_ANY:global_any.*]] = internal addrspace(3) global i32 poison
+// CHECK-DAG: @[[SHARED_NOHOST:global_nohost.*]] = internal addrspace(3) global i32 poison
 // CHECK: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_{{.*}}__QQmain_{{.*}}(ptr %{{.*}}, ptr %{{.*}}) #{{[0-9]+}} {
-// CHECK-LABEL:  omp.target:
-// CHECK-NEXT :    %[[LOAD:.*]] = load i32, ptr %{{.*}}, align 4
-// CHECK-NEXT :    store i32 %[[LOAD]], ptr addrspace(3) {{.*}}, align 4
-// CHECK-NEXT :    store i32 %[[LOAD]], ptr @global_host, align 4
-// CHECK-NEXT :    store i32 %[[LOAD]], ptr addrspace(3) {{.*}}, align 4
+// CHECK:        %[[LOAD:.*]] = load i32, ptr %{{.*}}, align 4
+// CHECK-NEXT :  store i32 %[[LOAD]], ptr addrspace(3) @[[SHARED_ANY]], align 4
+// CHECK-NEXT :  store i32 %[[LOAD]], ptr @global_host, align 4
+// CHECK-NEXT :  store i32 %[[LOAD]], ptr addrspace(3) @[[SHARED_NOHOST]], align 4

--- a/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-groupprivate.mlir
@@ -9,16 +9,13 @@ module attributes {omp.is_target_device = true, llvm.target_triple = "amdgcn-amd
     omp.target map_entries(%map_a -> %arg1 : !llvm.ptr) {
       %loaded = llvm.load %arg1 : !llvm.ptr -> i32
 
-      %any_addr = llvm.mlir.addressof @global_any : !llvm.ptr
-      %any_gp = omp.groupprivate %any_addr : !llvm.ptr, device_type(any) -> !llvm.ptr
+      %any_gp = omp.groupprivate @global_any : !llvm.ptr, device_type(any)
       llvm.store %loaded, %any_gp : i32, !llvm.ptr
 
-      %host_addr = llvm.mlir.addressof @global_host : !llvm.ptr
-      %host_gp = omp.groupprivate %host_addr : !llvm.ptr, device_type(host) -> !llvm.ptr
+      %host_gp = omp.groupprivate @global_host : !llvm.ptr, device_type(host)
       llvm.store %loaded, %host_gp : i32, !llvm.ptr
 
-      %nohost_addr = llvm.mlir.addressof @global_nohost : !llvm.ptr
-      %nohost_gp = omp.groupprivate %nohost_addr : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+      %nohost_gp = omp.groupprivate @global_nohost : !llvm.ptr, device_type(nohost)
       llvm.store %loaded, %nohost_gp : i32, !llvm.ptr
 
       omp.terminator

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -3733,40 +3733,7 @@ llvm.func @task_affinity_plain(%arr: !llvm.ptr {llvm.nocapture}) {
 
 // -----
 
-module attributes {omp.is_target_device = false} {
-llvm.mlir.global internal @any() : i32
-llvm.mlir.global internal @host() : i32
-llvm.mlir.global internal @nohost() : i32
-llvm.func @omp_groupprivate_host() {
-  %0 = llvm.mlir.constant(1 : i32) : i32
-  %1 = llvm.mlir.addressof @any : !llvm.ptr
-  %2 = omp.groupprivate %1 : !llvm.ptr, device_type(any) -> !llvm.ptr
-  llvm.store %0, %2 : i32, !llvm.ptr
-
-  %3 = llvm.mlir.addressof @host : !llvm.ptr
-  %4 = omp.groupprivate %3 : !llvm.ptr, device_type(host) -> !llvm.ptr
-  llvm.store %0, %4 : i32, !llvm.ptr
-
-  %5 = llvm.mlir.addressof @nohost : !llvm.ptr
-  %6 = omp.groupprivate %5 : !llvm.ptr, device_type(nohost) -> !llvm.ptr
-  llvm.store %0, %6 : i32, !llvm.ptr
-  llvm.return
-}
-}
-
-// CHECK: @any = internal global i32 undef
-// CHECK: @host = internal global i32 undef
-// CHECK: @nohost = internal global i32 undef
-// CHECK-LABEL: @omp_groupprivate_host
-// CHECK:  [[TMP1:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK:  store i32 1, ptr [[TMP1]], align 4
-// CHECK:  [[TMP2:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK:  store i32 1, ptr [[TMP2]], align 4
-// CHECK:  store i32 1, ptr @nohost, align 4
-
-// -----
-
-module attributes {omp.is_target_device = true} {
+module attributes {omp.is_target_device = true, llvm.target_triple = "nvptx64-nvidia-cuda"} {
 llvm.mlir.global internal @any() : i32
 llvm.mlir.global internal @host() : i32
 llvm.mlir.global internal @nohost() : i32
@@ -3787,15 +3754,16 @@ llvm.func @omp_groupprivate_device() {
 }
 }
 
-// CHECK: @any = internal global i32 undef
-// CHECK: @host = internal global i32 undef
-// CHECK: @nohost = internal global i32 undef
-// CHECK-LABEL: @omp_groupprivate_device
-// CHECK:  [[TMP1:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK:  store i32 1, ptr [[TMP1]], align 4
-// CHECK:  store i32 1, ptr @host, align 4
-// CHECK:  [[TMP2:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK:  store i32 1, ptr [[TMP2]], align 4
+// CHECK-DAG: @any = internal global i32 undef
+// CHECK-DAG: @host = internal global i32 undef
+// CHECK-DAG: @nohost = internal global i32 undef
+// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
+// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
+// CHECK-LABEL: define void @omp_groupprivate_device()
+// CHECK: store i32 1, ptr addrspace(3) {{.*}}, align 4
+// CHECK: store i32 1, ptr @host, align 4
+// CHECK: store i32 1, ptr addrspace(3) {{.*}}, align 4
+// CHECK: ret void
 
 // -----
 
@@ -3820,14 +3788,13 @@ llvm.func @omp_groupprivate_host() {
 }
 }
 
-// CHECK: @any1 = internal global i32 undef
-// CHECK: @host1 = internal global i32 undef
-// CHECK: @nohost1 = internal global i32 undef
-// CHECK-LABEL: @omp_groupprivate_host
-// CHECK:  [[TMP1:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK:  store i32 1, ptr [[TMP1]], align 4
-// CHECK:  [[TMP2:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
-// CHECK:  store i32 1, ptr [[TMP2]], align 4
-// CHECK:  store i32 1, ptr @nohost1, align 4
+// CHECK-DAG: @any1 = internal global i32 undef
+// CHECK-DAG: @host1 = internal global i32 undef
+// CHECK-DAG: @nohost1 = internal global i32 undef
+// CHECK-LABEL: define void @omp_groupprivate_host()
+// CHECK: store i32 1, ptr @any1, align 4
+// CHECK: store i32 1, ptr @host1, align 4
+// CHECK: store i32 1, ptr @nohost1, align 4
+// CHECK: ret void
 
 // -----

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -3730,3 +3730,104 @@ llvm.func @task_affinity_plain(%arr: !llvm.ptr {llvm.nocapture}) {
 // CHECK: [[FLAGGEP:%.*]] = getelementptr inbounds nuw { i64, i64, i32 }, ptr [[ENTRY]], i32 0, i32 2
 // CHECK: store i32 0, ptr [[FLAGGEP]]
 // CHECK: call i32 @__kmpc_omp_reg_task_with_affinity{{.*}}i32 1, ptr [[AFFLIST]]
+
+// -----
+
+module attributes {omp.is_target_device = false} {
+llvm.mlir.global internal @any() : i32
+llvm.mlir.global internal @host() : i32
+llvm.mlir.global internal @nohost() : i32
+llvm.func @omp_groupprivate_host() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.mlir.addressof @any : !llvm.ptr
+  %2 = omp.groupprivate %1 : !llvm.ptr, device_type(any) -> !llvm.ptr
+  llvm.store %0, %2 : i32, !llvm.ptr
+
+  %3 = llvm.mlir.addressof @host : !llvm.ptr
+  %4 = omp.groupprivate %3 : !llvm.ptr, device_type(host) -> !llvm.ptr
+  llvm.store %0, %4 : i32, !llvm.ptr
+
+  %5 = llvm.mlir.addressof @nohost : !llvm.ptr
+  %6 = omp.groupprivate %5 : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  llvm.store %0, %6 : i32, !llvm.ptr
+  llvm.return
+}
+}
+
+// CHECK: @any = internal global i32 undef
+// CHECK: @host = internal global i32 undef
+// CHECK: @nohost = internal global i32 undef
+// CHECK-LABEL: @omp_groupprivate_host
+// CHECK:  [[TMP1:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK:  store i32 1, ptr [[TMP1]], align 4
+// CHECK:  [[TMP2:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK:  store i32 1, ptr [[TMP2]], align 4
+// CHECK:  store i32 1, ptr @nohost, align 4
+
+// -----
+
+module attributes {omp.is_target_device = true} {
+llvm.mlir.global internal @any() : i32
+llvm.mlir.global internal @host() : i32
+llvm.mlir.global internal @nohost() : i32
+llvm.func @omp_groupprivate_device() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.mlir.addressof @any : !llvm.ptr
+  %2 = omp.groupprivate %1 : !llvm.ptr, device_type(any) -> !llvm.ptr
+  llvm.store %0, %2 : i32, !llvm.ptr
+
+  %3 = llvm.mlir.addressof @host : !llvm.ptr
+  %4 = omp.groupprivate %3 : !llvm.ptr, device_type(host) -> !llvm.ptr
+  llvm.store %0, %4 : i32, !llvm.ptr
+
+  %5 = llvm.mlir.addressof @nohost : !llvm.ptr
+  %6 = omp.groupprivate %5 : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  llvm.store %0, %6 : i32, !llvm.ptr
+  llvm.return
+}
+}
+
+// CHECK: @any = internal global i32 undef
+// CHECK: @host = internal global i32 undef
+// CHECK: @nohost = internal global i32 undef
+// CHECK-LABEL: @omp_groupprivate_device
+// CHECK:  [[TMP1:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK:  store i32 1, ptr [[TMP1]], align 4
+// CHECK:  store i32 1, ptr @host, align 4
+// CHECK:  [[TMP2:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK:  store i32 1, ptr [[TMP2]], align 4
+
+// -----
+
+module attributes {omp.is_target_device = false} {
+llvm.mlir.global internal @any1() : i32
+llvm.mlir.global internal @host1() : i32
+llvm.mlir.global internal @nohost1() : i32
+llvm.func @omp_groupprivate_host() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.mlir.addressof @any1 : !llvm.ptr
+  %2 = omp.groupprivate %1 : !llvm.ptr, device_type(any) -> !llvm.ptr
+  llvm.store %0, %2 : i32, !llvm.ptr
+
+  %3 = llvm.mlir.addressof @host1 : !llvm.ptr
+  %4 = omp.groupprivate %3 : !llvm.ptr, device_type(host) -> !llvm.ptr
+  llvm.store %0, %4 : i32, !llvm.ptr
+
+  %5 = llvm.mlir.addressof @nohost1 : !llvm.ptr
+  %6 = omp.groupprivate %5 : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  llvm.store %0, %6 : i32, !llvm.ptr
+  llvm.return
+}
+}
+
+// CHECK: @any1 = internal global i32 undef
+// CHECK: @host1 = internal global i32 undef
+// CHECK: @nohost1 = internal global i32 undef
+// CHECK-LABEL: @omp_groupprivate_host
+// CHECK:  [[TMP1:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK:  store i32 1, ptr [[TMP1]], align 4
+// CHECK:  [[TMP2:%.*]] = call ptr @__kmpc_alloc_shared(i64 4)
+// CHECK:  store i32 1, ptr [[TMP2]], align 4
+// CHECK:  store i32 1, ptr @nohost1, align 4
+
+// -----

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -3740,13 +3740,13 @@ llvm.mlir.global internal @nohost() : i32
 llvm.func @omp_groupprivate_device() attributes {
     omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} {
   %0 = llvm.mlir.constant(1 : i32) : i32
-  %2 = omp.groupprivate @any : !llvm.ptr, device_type(any)
+  %2 = omp.groupprivate @any device_type(any) : !llvm.ptr
   llvm.store %0, %2 : i32, !llvm.ptr
 
-  %4 = omp.groupprivate @host : !llvm.ptr, device_type(host)
+  %4 = omp.groupprivate @host device_type(host) : !llvm.ptr
   llvm.store %0, %4 : i32, !llvm.ptr
 
-  %6 = omp.groupprivate @nohost : !llvm.ptr, device_type(nohost)
+  %6 = omp.groupprivate @nohost device_type(nohost) : !llvm.ptr
   llvm.store %0, %6 : i32, !llvm.ptr
   llvm.return
 }
@@ -3755,12 +3755,12 @@ llvm.func @omp_groupprivate_device() attributes {
 // CHECK-DAG: @any = internal global i32 undef
 // CHECK-DAG: @host = internal global i32 undef
 // CHECK-DAG: @nohost = internal global i32 undef
-// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
-// CHECK-DAG: {{.*}} = internal addrspace(3) global i32 poison
-// CHECK-LABEL: define void @omp_groupprivate_device()
-// CHECK: store i32 1, ptr addrspace(3) {{.*}}, align 4
+// CHECK-DAG: @[[SHARED_ANY:any.*]] = internal addrspace(3) global i32 poison
+// CHECK-DAG: @[[SHARED_NOHOST:nohost.*]] = internal addrspace(3) global i32 poison
+// CHECK: define void @omp_groupprivate_device()
+// CHECK: store i32 1, ptr addrspace(3) @[[SHARED_ANY]], align 4
 // CHECK: store i32 1, ptr @host, align 4
-// CHECK: store i32 1, ptr addrspace(3) {{.*}}, align 4
+// CHECK: store i32 1, ptr addrspace(3) @[[SHARED_NOHOST]], align 4
 // CHECK: ret void
 
 // -----
@@ -3771,13 +3771,13 @@ llvm.mlir.global internal @host1() : i32
 llvm.mlir.global internal @nohost1() : i32
 llvm.func @omp_groupprivate_host() {
   %0 = llvm.mlir.constant(1 : i32) : i32
-  %2 = omp.groupprivate @any1 : !llvm.ptr, device_type(any)
+  %2 = omp.groupprivate @any1 device_type(any) : !llvm.ptr
   llvm.store %0, %2 : i32, !llvm.ptr
 
-  %4 = omp.groupprivate @host1 : !llvm.ptr, device_type(host)
+  %4 = omp.groupprivate @host1 device_type(host) : !llvm.ptr
   llvm.store %0, %4 : i32, !llvm.ptr
 
-  %6 = omp.groupprivate @nohost1 : !llvm.ptr, device_type(nohost)
+  %6 = omp.groupprivate @nohost1 device_type(nohost) : !llvm.ptr
   llvm.store %0, %6 : i32, !llvm.ptr
   llvm.return
 }

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -3737,18 +3737,16 @@ module attributes {omp.is_target_device = true, llvm.target_triple = "nvptx64-nv
 llvm.mlir.global internal @any() : i32
 llvm.mlir.global internal @host() : i32
 llvm.mlir.global internal @nohost() : i32
-llvm.func @omp_groupprivate_device() {
+llvm.func @omp_groupprivate_device() attributes {
+    omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} {
   %0 = llvm.mlir.constant(1 : i32) : i32
-  %1 = llvm.mlir.addressof @any : !llvm.ptr
-  %2 = omp.groupprivate %1 : !llvm.ptr, device_type(any) -> !llvm.ptr
+  %2 = omp.groupprivate @any : !llvm.ptr, device_type(any)
   llvm.store %0, %2 : i32, !llvm.ptr
 
-  %3 = llvm.mlir.addressof @host : !llvm.ptr
-  %4 = omp.groupprivate %3 : !llvm.ptr, device_type(host) -> !llvm.ptr
+  %4 = omp.groupprivate @host : !llvm.ptr, device_type(host)
   llvm.store %0, %4 : i32, !llvm.ptr
 
-  %5 = llvm.mlir.addressof @nohost : !llvm.ptr
-  %6 = omp.groupprivate %5 : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  %6 = omp.groupprivate @nohost : !llvm.ptr, device_type(nohost)
   llvm.store %0, %6 : i32, !llvm.ptr
   llvm.return
 }
@@ -3773,16 +3771,13 @@ llvm.mlir.global internal @host1() : i32
 llvm.mlir.global internal @nohost1() : i32
 llvm.func @omp_groupprivate_host() {
   %0 = llvm.mlir.constant(1 : i32) : i32
-  %1 = llvm.mlir.addressof @any1 : !llvm.ptr
-  %2 = omp.groupprivate %1 : !llvm.ptr, device_type(any) -> !llvm.ptr
+  %2 = omp.groupprivate @any1 : !llvm.ptr, device_type(any)
   llvm.store %0, %2 : i32, !llvm.ptr
 
-  %3 = llvm.mlir.addressof @host1 : !llvm.ptr
-  %4 = omp.groupprivate %3 : !llvm.ptr, device_type(host) -> !llvm.ptr
+  %4 = omp.groupprivate @host1 : !llvm.ptr, device_type(host)
   llvm.store %0, %4 : i32, !llvm.ptr
 
-  %5 = llvm.mlir.addressof @nohost1 : !llvm.ptr
-  %6 = omp.groupprivate %5 : !llvm.ptr, device_type(nohost) -> !llvm.ptr
+  %6 = omp.groupprivate @nohost1 : !llvm.ptr, device_type(nohost)
   llvm.store %0, %6 : i32, !llvm.ptr
   llvm.return
 }


### PR DESCRIPTION
This PR adds omp.groupprivate mlir op to omp dialect. 

The groupprivate directive specifies that variables are replicated, with each group having its own copy. The operation takes a symbol reference to a global variable and an optional device_type attribute, and returns the address of its groupprivate copy.
Op representation:
`%gp = omp.groupprivate @global_var : !llvm.ptr`
`%gp = omp.groupprivate @global_var device_type(any) : !llvm.ptr`

LLVM IR translation: 
On target devices (AMDGCN/NVPTX), the op is lowered to a new global variable in the shared address space
On the host, the original global address is used as a fallback.