### PR TITLE
[lldb][windows] fix undeclared identifier error

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -433,7 +433,7 @@ SBError Driver::ProcessArgs(const opt::InputArgList &args, bool &exiting) {
   return error;
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(LLDB_PYTHON_DLL_RELATIVE_PATH)
 /// Returns the full path to the lldb.exe executable.
 inline std::wstring GetPathToExecutableW() {
   // Iterate until we reach the Windows API maximum path length (32,767).


### PR DESCRIPTION
This patch fixes the `'LLDB_PYTHON_DLL_RELATIVE_PATH': undeclared identifier` error introduced by https://github.com/llvm/llvm-project/pull/162509.