### PR TITLE
[BOLT] Support fragment symbol mapped to the parent address

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1514,6 +1514,12 @@ void RewriteInstance::registerFragments() {
       }
       if (BD) {
         BinaryFunction *BF = BC->getFunctionForSymbol(BD->getSymbol());
+        if (BF == &Function) {
+          BC->errs()
+              << "BOLT-WARNING: fragment maps to the same function as parent: "
+              << Function << '\n';
+          continue;
+        }
         if (BF) {
           BC->registerFragment(Function, *BF);
           continue;

--- a/bolt/test/X86/fragment-alias.s
+++ b/bolt/test/X86/fragment-alias.s
@@ -1,0 +1,13 @@
+## This test reproduces the issue where a fragment has the same address as
+## parent function.
+# RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t
+# RUN: llvm-bolt %t -o %t.out 2>&1 | FileCheck %s
+# CHECK: BOLT-WARNING: fragment maps to the same function as parent: main/1(*2)
+.type main, @function
+.type main.cold, @function
+main.cold:
+main:
+  ret
+.size main, .-main
+.size main.cold, .-main.cold


### PR DESCRIPTION
Observed in GCC-produced binary. Emit a warning for the user.

Test Plan: added bolt/test/X86/fragment-alias.s
