### PR TITLE
[lldb][mcp] Get the running MCP server connection information

### DIFF
--- a/lldb/source/Commands/CommandObjectProtocolServer.cpp
+++ b/lldb/source/Commands/CommandObjectProtocolServer.cpp
@@ -164,10 +164,9 @@ protected:
       return;
     }
 
-    std::string address =
-        llvm::join(socket->GetListeningConnectionURI(), ", ");
-    result.AppendMessageWithFormatv(
-        "{0} server connection listeners: {1}", protocol, address);
+    std::string address = llvm::join(socket->GetListeningConnectionURI(), ", ");
+    result.AppendMessageWithFormatv("{0} server connection listeners: {1}",
+                                    protocol, address);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 };
@@ -181,8 +180,8 @@ CommandObjectProtocolServer::CommandObjectProtocolServer(
                               interpreter)));
   LoadSubCommand("stop", CommandObjectSP(
                              new CommandObjectProtocolServerStop(interpreter)));
-  LoadSubCommand("get", CommandObjectSP(
-                            new CommandObjectProtocolServerGet(interpreter)));
+  LoadSubCommand(
+      "get", CommandObjectSP(new CommandObjectProtocolServerGet(interpreter)));
 }
 
 CommandObjectProtocolServer::~CommandObjectProtocolServer() = default;

--- a/lldb/source/Commands/CommandObjectProtocolServer.cpp
+++ b/lldb/source/Commands/CommandObjectProtocolServer.cpp
@@ -131,15 +131,58 @@ protected:
   }
 };
 
+class CommandObjectProtocolServerGet : public CommandObjectParsed {
+public:
+  CommandObjectProtocolServerGet(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "protocol-server get",
+                            "get protocol server connection information",
+                            "protocol-server get <protocol>") {
+    AddSimpleArgumentList(lldb::eArgTypeProtocol, eArgRepeatPlain);
+  }
+
+  ~CommandObjectProtocolServerGet() override = default;
+
+protected:
+  void DoExecute(Args &args, CommandReturnObject &result) override {
+    if (args.GetArgumentCount() < 1) {
+      result.AppendError("no protocol specified");
+      return;
+    }
+
+    llvm::StringRef protocol = args.GetArgumentAtIndex(0);
+    ProtocolServer *server = ProtocolServer::GetOrCreate(protocol);
+    if (!server) {
+      result.AppendErrorWithFormatv(
+          "unsupported protocol: {0}. Supported protocols are: {1}", protocol,
+          llvm::join(ProtocolServer::GetSupportedProtocols(), ", "));
+      return;
+    }
+
+    Socket *socket = server->GetSocket();
+    if (!socket) {
+      result.AppendErrorWithFormatv("{0} server is not running", protocol);
+      return;
+    }
+
+    std::string address =
+        llvm::join(socket->GetListeningConnectionURI(), ", ");
+    result.AppendMessageWithFormatv(
+        "{0} server connection listeners: {1}", protocol, address);
+    result.SetStatus(eReturnStatusSuccessFinishNoResult);
+  }
+};
+
 CommandObjectProtocolServer::CommandObjectProtocolServer(
     CommandInterpreter &interpreter)
     : CommandObjectMultiword(interpreter, "protocol-server",
-                             "Start and stop a protocol server.",
+                             "Start, stop, and query protocol servers.",
                              "protocol-server") {
   LoadSubCommand("start", CommandObjectSP(new CommandObjectProtocolServerStart(
                               interpreter)));
   LoadSubCommand("stop", CommandObjectSP(
                              new CommandObjectProtocolServerStop(interpreter)));
+  LoadSubCommand("get", CommandObjectSP(
+                            new CommandObjectProtocolServerGet(interpreter)));
 }
 
 CommandObjectProtocolServer::~CommandObjectProtocolServer() = default;

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -144,6 +144,7 @@ llvm::Error ProtocolServerMCP::Stop() {
 
   m_server.reset(nullptr);
   m_server_info_handle.Remove();
+  m_listener.reset();
 
   return llvm::Error::success();
 }

--- a/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
+++ b/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
@@ -32,3 +32,16 @@ class MCPUnixSocketCommandTestCase(TestBase):
             startstr="MCP server started with connection listeners:",
             substrs=[f"unix-connect://{socket_file}"],
         )
+
+        self.expect(
+            "protocol-server get MCP",
+            startstr="MCP server connection listeners:",
+            substrs=[f"unix-connect://{socket_file}"],
+        )
+
+        self.runCmd("protocol-server stop MCP", check=False)
+        self.expect(
+            "protocol-server get MCP",
+            error=True,
+            substrs=["MCP server is not running"],
+        )


### PR DESCRIPTION
Currently AFAICT we don't have a way to get the MCP server socket after it started. So this change introduces a new `protocol-server` subcommand that allows us to query the location of a running server:

```
(lldb) protocol-server start MCP listen://localhost:0
MCP server started with connection listeners: connection://[::1]:36051, connection://[127.0.0.1]:36051
(lldb) protocol-server get MCP
MCP server connection listeners: connection://[::1]:36051, connection://[127.0.0.1]:36051
(lldb) protocol-server stop MCP
(lldb) protocol-server get MCP
error: MCP server is not running
```