### PR TITLE
[clang] Remove support for really old Ubuntu releases

### DIFF
--- a/clang/include/clang/Driver/Distro.h
+++ b/clang/include/clang/Driver/Distro.h
@@ -48,11 +48,6 @@ public:
     Fedora,
     Gentoo,
     OpenSUSE,
-    UbuntuHardy,
-    UbuntuIntrepid,
-    UbuntuJaunty,
-    UbuntuKarmic,
-    UbuntuLucid,
     UbuntuMaverick,
     UbuntuNatty,
     UbuntuOneiric,
@@ -135,7 +130,7 @@ public:
   }
 
   bool IsUbuntu() const {
-    return DistroVal >= UbuntuHardy && DistroVal <= UbuntuQuesting;
+    return DistroVal >= UbuntuMaverick && DistroVal <= UbuntuQuesting;
   }
 
   bool IsAlpineLinux() const { return DistroVal == AlpineLinux; }

--- a/clang/lib/Driver/Distro.cpp
+++ b/clang/lib/Driver/Distro.cpp
@@ -61,11 +61,6 @@ static Distro::DistroType DetectLsbRelease(llvm::vfs::FileSystem &VFS) {
     if (Version == Distro::UnknownDistro &&
         Line.starts_with("DISTRIB_CODENAME="))
       Version = llvm::StringSwitch<Distro::DistroType>(Line.substr(17))
-                    .Case("hardy", Distro::UbuntuHardy)
-                    .Case("intrepid", Distro::UbuntuIntrepid)
-                    .Case("jaunty", Distro::UbuntuJaunty)
-                    .Case("karmic", Distro::UbuntuKarmic)
-                    .Case("lucid", Distro::UbuntuLucid)
                     .Case("maverick", Distro::UbuntuMaverick)
                     .Case("natty", Distro::UbuntuNatty)
                     .Case("oneiric", Distro::UbuntuOneiric)


### PR DESCRIPTION
After 07ca4db1e1f53876b14e5773e8b9d77c20774fca remove support
for really old and older Ubunutu (Hardy and Intrepid) releases.