### PR TITLE
[OpenCL] update address-spaces.cl

### DIFF
--- a/clang/test/SemaOpenCL/address-spaces.cl
+++ b/clang/test/SemaOpenCL/address-spaces.cl
@@ -265,7 +265,8 @@ void func_multiple_addr2(void) {
   __attribute__((opencl_private)) private_int_t var5;  // expected-warning {{multiple identical address spaces specified for type}}
   __attribute__((opencl_private)) private_int_t *var6; // expected-warning {{multiple identical address spaces specified for type}}
 #if __OPENCL_CPP_VERSION__
-  __global int [[clang::opencl_private]] var7;         // expected-error {{multiple address spaces specified for type}}
+  __global int [[clang::opencl_private]] var7;         // expected-error {{multiple address spaces specified for type}} \
+                                                       // expected-error {{function scope variable cannot be declared in global address space}}
   __global int [[clang::opencl_private]] *var8;        // expected-error {{multiple address spaces specified for type}}
   private_int_t [[clang::opencl_private]] var9;        // expected-warning {{multiple identical address spaces specified for type}}
   private_int_t [[clang::opencl_private]] *var10;      // expected-warning {{multiple identical address spaces specified for type}}


### PR DESCRIPTION
This test was broken by https://github.com/llvm/llvm-project/pull/162714. Previously the `[[clang::opencl_private]]` attribute was applied first, resulting in the clashing `__global` attribute being ignored. Now that `__global` is applied first, it results in an error, and then `[[clang::opencl_private]]` is applied, resulting in another error.