### PR TITLE
[orc-rt] Enable span<const char> use in SPSWrapperFunctions.

### DIFF
--- a/orc-rt/include/orc-rt/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/SPSWrapperFunction.h
@@ -110,7 +110,7 @@ public:
   }
 
   template <typename ArgTuple>
-  std::optional<ArgTuple> deserialize(WrapperFunctionBuffer ArgBytes) {
+  std::optional<ArgTuple> deserialize(const WrapperFunctionBuffer &ArgBytes) {
     assert(!ArgBytes.getOutOfBandError() &&
            "Should not attempt to deserialize out-of-band error");
     SPSInputBuffer IB(ArgBytes.data(), ArgBytes.size());

--- a/orc-rt/include/orc-rt/WrapperFunction.h
+++ b/orc-rt/include/orc-rt/WrapperFunction.h
@@ -382,8 +382,7 @@ struct WrapperFunction {
     if (ArgBytes.getOutOfBandError())
       return Return(Session, CallCtx, ArgBytes.release());
 
-    if (auto Args =
-            S.arguments().template deserialize<ArgTuple>(std::move(ArgBytes)))
+    if (auto Args = S.arguments().template deserialize<ArgTuple>(ArgBytes))
       std::apply(HandlerTraits::forwardArgsAsRequested(bind_front(
                      std::forward<Handler>(H),
                      detail::StructuredYield<RetTupleType, Serializer>(


### PR DESCRIPTION
SPS deserialization for span<const char> produces a value that points directly into the argument buffer for efficiency. This was broken by an unnecessary std::move of the buffer inside WrapperFunction, which this commit removes.