### PR TITLE
[clang] Updates for support for Ubuntu, Debian and RHEL

### DIFF
--- a/clang/include/clang/Driver/Distro.h
+++ b/clang/include/clang/Driver/Distro.h
@@ -30,9 +30,6 @@ public:
     // the first and last known member in the family, e.g. IsRedHat().
     AlpineLinux,
     ArchLinux,
-    DebianLenny,
-    DebianSqueeze,
-    DebianWheezy,
     DebianJessie,
     DebianStretch,
     DebianBuster,
@@ -42,16 +39,13 @@ public:
     DebianForky,
     DebianDuke,
     Exherbo,
-    RHEL5,
-    RHEL6,
     RHEL7,
+    RHEL8,
+    RHEL9,
+    RHEL10,
     Fedora,
     Gentoo,
     OpenSUSE,
-    UbuntuMaverick,
-    UbuntuNatty,
-    UbuntuOneiric,
-    UbuntuPrecise,
     UbuntuQuantal,
     UbuntuRaring,
     UbuntuSaucy,
@@ -121,17 +115,17 @@ public:
   /// @{
 
   bool IsRedhat() const {
-    return DistroVal == Fedora || (DistroVal >= RHEL5 && DistroVal <= RHEL7);
+    return DistroVal == Fedora || (DistroVal >= RHEL7 && DistroVal <= RHEL10);
   }
 
   bool IsOpenSUSE() const { return DistroVal == OpenSUSE; }
 
   bool IsDebian() const {
-    return DistroVal >= DebianLenny && DistroVal <= DebianDuke;
+    return DistroVal >= DebianJessie && DistroVal <= DebianDuke;
   }
 
   bool IsUbuntu() const {
-    return DistroVal >= UbuntuMaverick && DistroVal <= UbuntuResolute;
+    return DistroVal >= UbuntuQuantal && DistroVal <= UbuntuResolute;
   }
 
   bool IsAlpineLinux() const { return DistroVal == AlpineLinux; }

--- a/clang/lib/Driver/Distro.cpp
+++ b/clang/lib/Driver/Distro.cpp
@@ -61,10 +61,6 @@ static Distro::DistroType DetectLsbRelease(llvm::vfs::FileSystem &VFS) {
     if (Version == Distro::UnknownDistro &&
         Line.starts_with("DISTRIB_CODENAME="))
       Version = llvm::StringSwitch<Distro::DistroType>(Line.substr(17))
-                    .Case("maverick", Distro::UbuntuMaverick)
-                    .Case("natty", Distro::UbuntuNatty)
-                    .Case("oneiric", Distro::UbuntuOneiric)
-                    .Case("precise", Distro::UbuntuPrecise)
                     .Case("quantal", Distro::UbuntuQuantal)
                     .Case("raring", Distro::UbuntuRaring)
                     .Case("saucy", Distro::UbuntuSaucy)
@@ -120,13 +116,17 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS) {
     if (Data.starts_with("Fedora release"))
       return Distro::Fedora;
     if (Data.starts_with("Red Hat Enterprise Linux") ||
-        Data.starts_with("CentOS") || Data.starts_with("Scientific Linux")) {
+        Data.starts_with("CentOS") || Data.starts_with("AlmaLinux") ||
+        Data.starts_with("Rocky Linux") ||
+        Data.starts_with("Scientific Linux")) {
+      if (Data.contains("release 10"))
+        return Distro::RHEL10;
+      if (Data.contains("release 9"))
+        return Distro::RHEL9;
+      if (Data.contains("release 8"))
+        return Distro::RHEL8;
       if (Data.contains("release 7"))
         return Distro::RHEL7;
-      else if (Data.contains("release 6"))
-        return Distro::RHEL6;
-      else if (Data.contains("release 5"))
-        return Distro::RHEL5;
     }
     return Distro::UnknownDistro;
   }
@@ -139,12 +139,6 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS) {
     int MajorVersion;
     if (!Data.split('.').first.getAsInteger(10, MajorVersion)) {
       switch (MajorVersion) {
-      case 5:
-        return Distro::DebianLenny;
-      case 6:
-        return Distro::DebianSqueeze;
-      case 7:
-        return Distro::DebianWheezy;
       case 8:
         return Distro::DebianJessie;
       case 9:
@@ -166,8 +160,6 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS) {
       }
     }
     return llvm::StringSwitch<Distro::DistroType>(Data.split("\n").first)
-        .Case("squeeze/sid", Distro::DebianSqueeze)
-        .Case("wheezy/sid", Distro::DebianWheezy)
         .Case("jessie/sid", Distro::DebianJessie)
         .Case("stretch/sid", Distro::DebianStretch)
         .Case("buster/sid", Distro::DebianBuster)


### PR DESCRIPTION
Remove support for long unsupported Ubuntu, Debian and RHEL.

Add support for RHEL 8, 9 and 10 and recognize Rocky and AlmaLinux
as RHEL.