### PR TITLE
[libc++] Add an initial modulemap for the test support headers

### DIFF
--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -2361,7 +2361,10 @@ module std [system] {
   module hash_table           { header "__hash_table" }
   module node_handle          { header "__node_handle" }
   module split_buffer         { header "__split_buffer" }
-  module tree                 { header "__tree" }
+  module tree                 {
+    header "__tree"
+    export std.memory.unique_ptr
+  }
   module std_mbstate_t {
     header "__std_mbstate_t.h"
     export *

--- a/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_unwrap_reverse.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_unwrap_reverse.pass.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 
 #include "test_iterators.h"
 

--- a/libcxx/test/libcxx/memory/allocation_guard.pass.cpp
+++ b/libcxx/test/libcxx/memory/allocation_guard.pass.cpp
@@ -17,6 +17,8 @@
 
 #include <__memory/allocation_guard.h>
 #include <cassert>
+#include <climits>
+#include <memory>
 #include <type_traits>
 #include <utility>
 

--- a/libcxx/test/libcxx/memory/uninitialized_allocator_copy.pass.cpp
+++ b/libcxx/test/libcxx/memory/uninitialized_allocator_copy.pass.cpp
@@ -11,6 +11,7 @@
 // ensure that __uninitialized_allocator_copy calls the proper construct and destruct functions
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <memory>
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains_subrange.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains_subrange.pass.cpp
@@ -32,6 +32,7 @@
 
 #include "almost_satisfies_types.h"
 #include "test_iterators.h"
+#include "type_algorithms.h"
 
 struct NotEqualityComparable {};
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/count.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/count.pass.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "sized_allocator.h"

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/ranges.count.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/ranges.count.pass.cpp
@@ -26,6 +26,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <ranges>
 #include <vector>
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp
@@ -25,8 +25,10 @@
 #include <array>
 #include <chrono>
 #include <ranges>
+
 #include "almost_satisfies_types.h"
 #include "test_iterators.h"
+#include "type_algorithms.h"
 
 using namespace std::chrono;
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.starts_with/ranges.starts_with.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.starts_with/ranges.starts_with.pass.cpp
@@ -27,6 +27,7 @@
 
 #include "almost_satisfies_types.h"
 #include "test_iterators.h"
+#include "type_algorithms.h"
 
 template <class Iter1, class Sent1 = Iter1, class Iter2 = int*, class Sent2 = Iter2>
 concept HasStartsWithIt = requires(Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2) {

--- a/libcxx/test/std/algorithms/alg.sorting/alg.partitions/pstl.is_partitioned.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.partitions/pstl.is_partitioned.pass.cpp
@@ -20,6 +20,7 @@
 
 #include "test_iterators.h"
 #include "test_execution_policies.h"
+#include "type_algorithms.h"
 
 template <class Iter>
 struct Test {

--- a/libcxx/test/std/containers/associative/map/map.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <map>
 #include <cassert>
+#include <map>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <map>
 #include <cassert>
+#include <map>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/associative/multiset/multiset.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/associative/multiset/multiset.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <set>
 #include <cassert>
+#include <set>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/associative/set/set.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/set.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <set>
 #include <cassert>
+#include <set>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp
@@ -12,6 +12,7 @@
 
 // flat_map& operator=(const flat_map& m);
 
+#include <cassert>
 #include <deque>
 #include <flat_map>
 #include <functional>

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/dtor_noexcept.pass.cpp
@@ -17,6 +17,7 @@
 #include <flat_map>
 #include <functional>
 #include <vector>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.map/helpers.h
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/helpers.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <flat_map>
 #include <ranges>
+#include <type_traits>
 
 #include "../flat_helpers.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/copy_assign.pass.cpp
@@ -12,6 +12,7 @@
 
 // flat_multimap& operator=(const flat_multimap& m);
 
+#include <cassert>
 #include <deque>
 #include <flat_map>
 #include <functional>

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/dtor_noexcept.pass.cpp
@@ -16,6 +16,7 @@
 #include <deque>
 #include <flat_map>
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/helpers.h
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/helpers.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <flat_map>
 #include <ranges>
+#include <type_traits>
 
 #include "../flat_helpers.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/compare.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/compare.pass.cpp
@@ -14,6 +14,7 @@
 // template <class Alloc>
 //   flat_multiset(const key_compare& comp, const Alloc& a);
 
+#include <cassert>
 #include <deque>
 #include <flat_set>
 #include <functional>

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/copy_assign.pass.cpp
@@ -13,9 +13,11 @@
 // flat_multiset& operator=(const flat_multiset& m);
 
 #include <algorithm>
+#include <cassert>
 #include <deque>
 #include <flat_set>
 #include <functional>
+#include <utility>
 #include <vector>
 
 #include "operator_hijacker.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/dtor_noexcept.pass.cpp
@@ -16,6 +16,7 @@
 #include <deque>
 #include <flat_set>
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/copy_assign.pass.cpp
@@ -13,6 +13,7 @@
 // flat_set& operator=(const flat_set& m);
 
 #include <algorithm>
+#include <cassert>
 #include <deque>
 #include <flat_set>
 #include <functional>

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/dtor_noexcept.pass.cpp
@@ -16,6 +16,7 @@
 #include <deque>
 #include <flat_set>
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/container.adaptors/stack/stack.cons/ctor_iterators.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/stack/stack.cons/ctor_iterators.pass.cpp
@@ -15,6 +15,7 @@
 
 #include <cassert>
 #include <stack>
+#include <type_traits>
 
 #include "test_allocator.h"
 

--- a/libcxx/test/std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp
+++ b/libcxx/test/std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp
@@ -13,6 +13,7 @@
 //   belonging to the container being moved. Such move construction of the
 //   allocator shall not exit via an exception.
 
+#include <cassert>
 #include <vector>
 #include <deque>
 #include <list>

--- a/libcxx/test/std/containers/sequences/deque/deque.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <deque>
 #include <cassert>
+#include <deque>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <forward_list>
 #include <cassert>
+#include <forward_list>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/sequences/list/list.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <list>
 #include <cassert>
+#include <list>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/sequences/vector.bool/assign_move.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/assign_move.pass.cpp
@@ -14,6 +14,7 @@
 // vector& operator=(vector&& c);
 
 #include <cassert>
+#include <utility>
 #include <vector>
 
 #include "min_allocator.h"

--- a/libcxx/test/std/containers/sequences/vector.bool/default_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/default_noexcept.pass.cpp
@@ -16,8 +16,9 @@
 // For vector<>, this was added to the standard by N4258,
 //   but vector<bool> was not changed.
 
-#include <vector>
 #include <cassert>
+#include <vector>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/containers/sequences/vector.bool/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <vector>
 #include <cassert>
+#include <vector>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/containers/sequences/vector.bool/move_assign_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/move_assign_noexcept.pass.cpp
@@ -17,8 +17,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <vector>
 #include <cassert>
+#include <vector>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/containers/sequences/vector.bool/move_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/move_noexcept.pass.cpp
@@ -15,8 +15,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <vector>
 #include <cassert>
+#include <vector>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <vector>
 #include <cassert>
+#include <vector>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <unordered_map>
 #include <cassert>
+#include <unordered_map>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <unordered_map>
 #include <cassert>
+#include <unordered_map>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <unordered_set>
 #include <cassert>
+#include <unordered_set>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/dtor_noexcept.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/dtor_noexcept.pass.cpp
@@ -12,8 +12,9 @@
 
 // UNSUPPORTED: c++03
 
-#include <unordered_set>
 #include <cassert>
+#include <unordered_set>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "MoveOnly.h"

--- a/libcxx/test/std/input.output/filesystems/class.path/path.member/path.append.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.path/path.member/path.append.pass.cpp
@@ -32,6 +32,7 @@
 #include <type_traits>
 #include <string_view>
 #include <cassert>
+#include <utility>
 
 // On Windows, the append function converts all inputs (pointers, iterators)
 // to an intermediate path object, causing allocations in cases where no

--- a/libcxx/test/std/input.output/filesystems/class.path/path.member/path.concat.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.path/path.member/path.concat.pass.cpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <string_view>
 #include <cassert>
+#include <utility>
 
 // On Windows, charset conversions cause allocations in the path class in
 // cases where no allocations are done on other platforms.

--- a/libcxx/test/std/numerics/c.math/signbit.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/signbit.pass.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <type_traits>
 
 #include "test_macros.h"
 #include "type_algorithms.h"

--- a/libcxx/test/std/ranges/range.factories/range.iota.view/indices.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.iota.view/indices.pass.cpp
@@ -12,6 +12,9 @@
 
 // inline constexpr unspecified indices = unspecified;
 
+// FIXME: This test shouldn't define TEST_HAS_NO_INT128
+// ADDITIONAL_COMPILE_FLAGS(clang-modules-build): -fno-modules
+
 #include <cassert>
 #include <cstddef>
 #include <ranges>

--- a/libcxx/test/std/re/re.results/re.results.const/move.pass.cpp
+++ b/libcxx/test/std/re/re.results/re.results.const/move.pass.cpp
@@ -14,8 +14,10 @@
 //
 //  Additionally, the stored Allocator value is move constructed from m.get_allocator().
 
-#include <regex>
 #include <cassert>
+#include <regex>
+#include <utility>
+
 #include "test_macros.h"
 #include "test_allocator.h"
 

--- a/libcxx/test/std/strings/basic.string/string.cons/dtor.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/dtor.pass.cpp
@@ -12,11 +12,12 @@
 
 // ~basic_string() // implied noexcept; // constexpr since C++20
 
-#include <string>
 #include <cassert>
+#include <string>
+#include <type_traits>
 
-#include "test_macros.h"
 #include "test_allocator.h"
+#include "test_macros.h"
 
 template <class T>
 struct throwing_alloc {

--- a/libcxx/test/std/strings/basic.string/string.cons/iter_alloc_deduction.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/iter_alloc_deduction.pass.cpp
@@ -25,6 +25,7 @@
 #include <iterator>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 #include "test_allocator.h"

--- a/libcxx/test/std/strings/basic.string/string.cons/string_view_deduction.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/string_view_deduction.pass.cpp
@@ -19,17 +19,18 @@
 //  The deduction guide shall not participate in overload resolution if Allocator
 //  is a type that does not qualify as an allocator.
 
-#include <string>
-#include <string_view>
-#include <iterator>
-#include <memory>
-#include <type_traits>
 #include <cassert>
 #include <cstddef>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
 
-#include "test_macros.h"
-#include "test_allocator.h"
 #include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
 
 template <class StringView, class Allocator, class = void>
 struct CanDeduce : std::false_type {};

--- a/libcxx/test/std/strings/basic.string/string.cons/string_view_size_size_deduction.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/string_view_size_size_deduction.pass.cpp
@@ -25,15 +25,16 @@
 //  The deduction guide shall not participate in overload resolution if Allocator
 //  is a type that does not qualify as an allocator.
 
-#include <string>
-#include <string_view>
-#include <iterator>
 #include <cassert>
 #include <cstddef>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
 
-#include "test_macros.h"
-#include "test_allocator.h"
 #include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
 
 template <class StringView, class Size, class Allocator, class = void>
 struct CanDeduce : std::false_type {};

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/make_obj_using_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/make_obj_using_allocator.pass.cpp
@@ -14,6 +14,7 @@
 // test_memory_resource requires RTTI for dynamic_cast
 // UNSUPPORTED: no-rtti
 
+#include <cassert>
 #include <concepts>
 #include <memory>
 #include <tuple>

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uninitialized_construct_using_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uninitialized_construct_using_allocator.pass.cpp
@@ -14,6 +14,7 @@
 // test_memory_resource requires RTTI for dynamic_cast
 // UNSUPPORTED: no-rtti
 
+#include <cassert>
 #include <concepts>
 #include <memory>
 #include <tuple>

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uses_allocator_construction_args.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uses_allocator_construction_args.pass.cpp
@@ -14,10 +14,12 @@
 // test_memory_resource requires RTTI for dynamic_cast
 // UNSUPPORTED: no-rtti
 
+#include <cassert>
 #include <concepts>
 #include <memory>
 #include <ranges>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include "common.h"

--- a/libcxx/test/support/module.modulemap
+++ b/libcxx/test/support/module.modulemap
@@ -1,0 +1,10 @@
+
+module test_config {
+  module test_macros { textual header "test_macros.h" }
+}
+
+module test {
+  module double_move_tracker    { header "double_move_tracker.h" }
+  module test_allocator         { header "test_allocator.h" }
+  module type_algorithms        { header "type_algorithms.h" }
+}


### PR DESCRIPTION
This should improve the time it takes to run the test suite a bit. Right now there are only a handful of headers in the modulemap because we're missing a lot of includes in the tests. New headers should be added there from the start, and we should fill up the modulemap over time until it contains all the test support headers.
