### PR TITLE
[clangd] Fix code action kind for readability-identifier-naming fixes

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -81,7 +81,7 @@ CodeAction toCodeAction(const ClangdServer::CodeActionResult::Rename &R,
                         const URIForFile &File) {
   CodeAction CA;
   CA.title = R.FixMessage;
-  CA.kind = std::string(CodeAction::REFACTOR_KIND);
+  CA.kind = std::string(CodeAction::QUICKFIX_KIND);
   CA.command.emplace();
   CA.command->title = R.FixMessage;
   CA.command->command = std::string(ApplyRenameCommand);

--- a/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
@@ -235,7 +235,8 @@ TEST_F(LSPTest, ClangTidyRename) {
             .takeValue()
             .getAsArray())[0];
 
-  ASSERT_EQ((*RenameCommand.getAsObject())["title"], "change 'foo' to 'Foo'");
+  ASSERT_EQ((*RenameCommand.getAsObject())["title"],
+            "Apply fix: change 'foo' to 'Foo'");
 
   Client.expectServerCall("workspace/applyEdit");
   Client.call("workspace/executeCommand", RenameCommand);


### PR DESCRIPTION
Commit a45df47375e50914900dcc07abd2fa67bfa0dd3b (https://github.com/llvm/llvm-project/pull/78454) converted readability-identifier-naming fixes to use rename mechanism to leverage the index for better results. However, it set the code action kind to "refactor" instead of "quickfix", which caused the fixes to be filtered out when editors (like VS Code) request quick fixes for diagnostics. On VS Code, for example, users would see "No quick fixes available" despite the diagnostic indicating "(fix available)", and the following warning would appear in the output console:

    [warning] llvm-vs-code-extensions.vscode-clangd - Code actions of kind 'quickfix' requested but returned code action is of kind 'refactor'. Code action will be dropped. Please check 'CodeActionContext.only' to only return requested code actions.

Fix that by changing the code action kind back to "quickfix".

Addresses https://github.com/llvm/llvm-project/pull/78454#issuecomment-1937918144.

CC @tom-anders @HighCommander4.
