### PR TITLE
[lldb] Add a missing <atomic> include. NFC.

### DIFF
--- a/lldb/include/lldb/Host/JSONTransport.h
+++ b/lldb/include/lldb/Host/JSONTransport.h
@@ -26,6 +26,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
+#include <atomic>
 #include <functional>
 #include <mutex>
 #include <optional>


### PR DESCRIPTION
This fixes building LLDB for mingw with libstdc++, after 8ae30a3facd25c9c7c2cfb96b69466a6c4d22baa.

Previously, building errored out with errors like these:

    In file included from llvm-project/lldb/include/lldb/Protocol/MCP/Transport.h:12,
                     from llvm-project/lldb/include/lldb/Protocol/MCP/Server.h:16,
                     from llvm-project/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h:15,
                     from llvm-project/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp:9:
    llvm-project/lldb/include/lldb/Host/JSONTransport.h:608:23: error: field ‘replied’ has incomplete type ‘std::atomic<bool>’
      608 |     std::atomic<bool> replied = {false};
          |                       ^~~~~~~
    In file included from gcc-mingw/x86_64-w64-mingw32/include/c++/12.1.0/bits/shared_ptr_atomic.h:33,
                     from gcc-mingw/x86_64-w64-mingw32/include/c++/12.1.0/memory:78,
                     from llvm-project/lldb/include/lldb/Host/Socket.h:12,
                     from llvm-project/lldb/include/lldb/Core/ProtocolServer.h:13,
                     from llvm-project/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h:12:
    gcc-mingw/x86_64-w64-mingw32/include/c++/12.1.0/bits/atomic_base.h:162:12: note: declaration of ‘struct std::atomic<bool>’
      162 |     struct atomic;
          |            ^~~~~~