### PR TITLE
[LLVM-C] Allow `LLVM{Get,Set}Volatile` to work on memory intrinsics

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -147,6 +147,7 @@ Changes to the C API
 --------------------
 
 * Add `LLVMGetOrInsertFunction` to get or insert a function, replacing the combination of `LLVMGetNamedFunction` and `LLVMAddFunction`.
+* Allow `LLVMGetVolatile` and `LLVMSetVolatile` to work on memory intrinsics like `memset`, `memcpy`, and `memmove`.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -4106,6 +4106,8 @@ LLVMBool LLVMGetVolatile(LLVMValueRef MemAccessInst) {
     return SI->isVolatile();
   if (AtomicRMWInst *AI = dyn_cast<AtomicRMWInst>(P))
     return AI->isVolatile();
+  if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(P))
+    return MI->isVolatile();
   return cast<AtomicCmpXchgInst>(P)->isVolatile();
 }
 
@@ -4117,6 +4119,8 @@ void LLVMSetVolatile(LLVMValueRef MemAccessInst, LLVMBool isVolatile) {
     return SI->setVolatile(isVolatile);
   if (AtomicRMWInst *AI = dyn_cast<AtomicRMWInst>(P))
     return AI->setVolatile(isVolatile);
+  if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(P))
+    return MI->setVolatile(ConstantInt::getBool(P->getContext(), isVolatile));
   return cast<AtomicCmpXchgInst>(P)->setVolatile(isVolatile);
 }
 


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/147474 it was discovered that `LLVMSetVolatile` does not work with memory intrinsic functions like `memset`, `memcpy` and `memmove`.

To quote @nikic [source](https://github.com/rust-lang/rust/pull/147474#pullrequestreview-3314829835)
> LLVMSetVolatile does not support volatile on intrinsics. It only works on the instruction-level volatile flag.

This patch fixes that so that getting and setting the volatile flag now works with these memory intrinsic functions.