### PR TITLE
[clang][analyzer] Remove boolean per-entry-point metrics

### DIFF
--- a/clang/docs/analyzer/developer-docs/Statistics.rst
+++ b/clang/docs/analyzer/developer-docs/Statistics.rst
@@ -22,7 +22,6 @@ However, note that with ``LLVM_ENABLE_STATS`` disabled, only storage of the valu
 If you want to define a statistic only for entry point, EntryPointStats.h has four classes at your disposal:
 
 
-- ``BoolEPStat`` - a boolean value assigned at most once per entry point. For example: "has the inline limit been reached".
 - ``UnsignedEPStat`` - an unsigned value assigned at most once per entry point. For example: "the number of source characters in an entry-point body".
 - ``CounterEPStat`` - an additive statistic. It starts with 0 and you can add to it as many times as needed. For example: "the number of bugs discovered".
 - ``UnsignedMaxEPStat`` - a maximizing statistic. It starts with 0 and when you join it with a value, it picks the maximum of the previous value and the new one. For example, "the longest execution path of a bug".

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/EntryPointStats.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/EntryPointStats.h
@@ -42,19 +42,6 @@ private:
   llvm::StringLiteral Name;
 };
 
-class BoolEPStat : public EntryPointStat {
-  std::optional<bool> Value = {};
-
-public:
-  explicit BoolEPStat(llvm::StringLiteral Name);
-  unsigned value() const { return Value && *Value; }
-  void set(bool V) {
-    assert(!Value.has_value());
-    Value = V;
-  }
-  void reset() { Value = {}; }
-};
-
 // used by CounterEntryPointTranslationUnitStat
 class CounterEPStat : public EntryPointStat {
   using EntryPointStat::EntryPointStat;


### PR DESCRIPTION
The complexity of maintaining an extra kind of metrics have not justified itself, as it is not used upstream, and we have only a single use of boolean stats per entrypoint downstream.

As I will do downstream, you can use an unsigned statistic type with values 0 and 1 to model a boolean flag.

--

CPP-7097