### PR TITLE
[cmake] Unconditionally use -Wno-pass-failed with Clang

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -948,6 +948,15 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
   # Enable -Wstring-conversion to catch misuse of string literals.
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     append("-Wstring-conversion" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+    # Disable -Wno-pass-failed flag, which reports failure to perform
+    # optimizations suggested by pragmas. This warning is not relevant for LLVM
+    # projects and may be injected by pragmas in libstdc++.
+    # FIXME: Reconsider this choice if warnings from STL headers can be reliably
+    # avoided (https://github.com/llvm/llvm-project/issues/157666).
+    # This option has been available since Clang 3.5, and we do require a newer
+    # version.
+    append("-Wno-pass-failed" CMAKE_CXX_FLAGS)
   endif()
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -962,13 +971,6 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
 
   # Enable -Wctad-maybe-unsupported to catch unintended use of CTAD.
   add_flag_if_supported("-Wctad-maybe-unsupported" CTAD_MAYBE_UNSPPORTED_FLAG)
-
-  # Disable -Wno-pass-failed flag, which reports failure to perform
-  # optimizations suggested by pragmas. This warning is not relevant for LLVM
-  # projects and may be injected by pragmas in libstdc++.
-  # FIXME: Reconsider this choice if warnings from STL headers can be reliably
-  # avoided (https://github.com/llvm/llvm-project/issues/157666).
-  add_flag_if_supported("-Wno-pass-failed" NO_PASS_FAILED_FLAG)
 endif (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
 
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT LLVM_ENABLE_WARNINGS)


### PR DESCRIPTION
Since 4feae05c6abda364a9295aecfa600d7d4e7dfeb6, most of the handling of warning options was rewritten to add such options based on hardcoded knowledge about what compilers support which options, and since which versions. This avoids a number of configure time checks, speeding up the cmake configuration.

This avoids erroneously adding this option with GCC, which doesn't really support it.

If testing for a warning option like -Wno-<foo> with GCC, GCC won't print any diagnostic at all, leading to the options being accepted incorrectly. However later, if compiling a file that actually prints another warning, GCC will also print warnings about these -Wno-<foo> options being unrecognized.

This avoids extra warning spam like this, for every source file that does produce warnings with GCC:

    At global scope:
    cc1plus: note: unrecognized command-line option ‘-Wno-pass-failed’ may have been intended to silence earlier diagnostics
