### PR TITLE
[clang-tidy][NFC] Migrate tests away from `--match-partial-fixes`

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-addition.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-addition.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-addition %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s abseil-duration-addition %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 
@@ -8,68 +8,68 @@ void f() {
 
   i = absl::ToUnixHours(t) + 5;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixHours(t + absl::Hours(5))
+  // CHECK-FIXES: i = absl::ToUnixHours(t + absl::Hours(5));
   i = absl::ToUnixMinutes(t) + 5;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMinutes(t + absl::Minutes(5))
+  // CHECK-FIXES: i = absl::ToUnixMinutes(t + absl::Minutes(5));
   i = absl::ToUnixSeconds(t) + 5;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixSeconds(t + absl::Seconds(5))
+  // CHECK-FIXES: i = absl::ToUnixSeconds(t + absl::Seconds(5));
   i = absl::ToUnixMillis(t) + 5;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMillis(t + absl::Milliseconds(5))
+  // CHECK-FIXES: i = absl::ToUnixMillis(t + absl::Milliseconds(5));
   i = absl::ToUnixMicros(t) + 5;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMicros(t + absl::Microseconds(5))
+  // CHECK-FIXES: i = absl::ToUnixMicros(t + absl::Microseconds(5));
   i = absl::ToUnixNanos(t) + 5;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixNanos(t + absl::Nanoseconds(5))
+  // CHECK-FIXES: i = absl::ToUnixNanos(t + absl::Nanoseconds(5));
 
   i = 3 + absl::ToUnixHours(t);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixHours(absl::Hours(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixHours(absl::Hours(3) + t);
   i = 3 + absl::ToUnixMinutes(t);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMinutes(absl::Minutes(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixMinutes(absl::Minutes(3) + t);
   i = 3 + absl::ToUnixSeconds(t);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixSeconds(absl::Seconds(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixSeconds(absl::Seconds(3) + t);
   i = 3 + absl::ToUnixMillis(t);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMillis(absl::Milliseconds(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixMillis(absl::Milliseconds(3) + t);
   i = 3 + absl::ToUnixMicros(t);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMicros(absl::Microseconds(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixMicros(absl::Microseconds(3) + t);
   i = 3 + absl::ToUnixNanos(t);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixNanos(absl::Nanoseconds(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixNanos(absl::Nanoseconds(3) + t);
 
   // Undoing inverse conversions
   i = absl::ToUnixMicros(t) + absl::ToInt64Microseconds(absl::Seconds(1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixMicros(t + absl::Seconds(1))
+  // CHECK-FIXES: i = absl::ToUnixMicros(t + absl::Seconds(1));
 
   // Parens
   i = 3 + (absl::ToUnixHours(t));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixHours(absl::Hours(3) + t)
+  // CHECK-FIXES: i = absl::ToUnixHours(absl::Hours(3) + t);
 
   // Float folding
   i = absl::ToUnixSeconds(t) + 5.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixSeconds(t + absl::Seconds(5))
+  // CHECK-FIXES: i = absl::ToUnixSeconds(t + absl::Seconds(5));
 
   // We can rewrite the argument of the duration conversion
 #define THIRTY absl::FromUnixSeconds(30)
   i = absl::ToUnixSeconds(THIRTY) + 1;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixSeconds(THIRTY + absl::Seconds(1))
+  // CHECK-FIXES: i = absl::ToUnixSeconds(THIRTY + absl::Seconds(1));
 #undef THIRTY
 
   // Some other contexts
   if (absl::ToUnixSeconds(t) + 1.0 > 10) {}
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixSeconds(t + absl::Seconds(1))
+  // CHECK-FIXES: if (absl::ToUnixSeconds(t + absl::Seconds(1)) > 10) {}
 
   // These should not match
   i = 5 + 6;
@@ -88,7 +88,7 @@ template<typename T>
 void foo(absl::Time t) {
   int i = absl::ToUnixNanos(t) + T{};
   // CHECK-MESSAGES: [[@LINE-1]]:11: warning: perform addition in the duration domain [abseil-duration-addition]
-  // CHECK-FIXES: absl::ToUnixNanos(t + absl::Nanoseconds(T{}))
+  // CHECK-FIXES: int i = absl::ToUnixNanos(t + absl::Nanoseconds(T{}));
 }
 
 void g() {

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-comparison.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-comparison %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s abseil-duration-comparison %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 
@@ -11,104 +11,104 @@ void f() {
   // Check against the RHS
   b = x > absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) > d1;
+  // CHECK-FIXES: b = absl::Seconds(x) > d1;
   b = x >= absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) >= d1;
+  // CHECK-FIXES: b = absl::Seconds(x) >= d1;
   b = x == absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) == d1;
+  // CHECK-FIXES: b = absl::Seconds(x) == d1;
   b = x <= absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) <= d1;
+  // CHECK-FIXES: b = absl::Seconds(x) <= d1;
   b = x < absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) < d1;
+  // CHECK-FIXES: b = absl::Seconds(x) < d1;
   b = x == absl::ToDoubleSeconds(t1 - t2);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) == t1 - t2;
+  // CHECK-FIXES: b = absl::Seconds(x) == t1 - t2;
   b = absl::ToDoubleSeconds(d1) > absl::ToDoubleSeconds(d2);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 > d2;
+  // CHECK-FIXES: b = d1 > d2;
 
   // Check against the LHS
   b = absl::ToDoubleSeconds(d1) < x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 < absl::Seconds(x);
+  // CHECK-FIXES: b = d1 < absl::Seconds(x);
   b = absl::ToDoubleSeconds(d1) <= x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 <= absl::Seconds(x);
+  // CHECK-FIXES: b = d1 <= absl::Seconds(x);
   b = absl::ToDoubleSeconds(d1) == x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 == absl::Seconds(x);
+  // CHECK-FIXES: b = d1 == absl::Seconds(x);
   b = absl::ToDoubleSeconds(d1) >= x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 >= absl::Seconds(x);
+  // CHECK-FIXES: b = d1 >= absl::Seconds(x);
   b = absl::ToDoubleSeconds(d1) > x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 > absl::Seconds(x);
+  // CHECK-FIXES: b = d1 > absl::Seconds(x);
 
   // Comparison against zero
   b = absl::ToDoubleSeconds(d1) < 0.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 < absl::ZeroDuration();
+  // CHECK-FIXES: b = d1 < absl::ZeroDuration();
   b = absl::ToDoubleSeconds(d1) < 0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: d1 < absl::ZeroDuration();
+  // CHECK-FIXES: b = d1 < absl::ZeroDuration();
 
   // Scales other than Seconds
   b = x > absl::ToDoubleMicroseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Microseconds(x) > d1;
+  // CHECK-FIXES: b = absl::Microseconds(x) > d1;
   b = x >= absl::ToDoubleMilliseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Milliseconds(x) >= d1;
+  // CHECK-FIXES: b = absl::Milliseconds(x) >= d1;
   b = x == absl::ToDoubleNanoseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Nanoseconds(x) == d1;
+  // CHECK-FIXES: b = absl::Nanoseconds(x) == d1;
   b = x <= absl::ToDoubleMinutes(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Minutes(x) <= d1;
+  // CHECK-FIXES: b = absl::Minutes(x) <= d1;
   b = x < absl::ToDoubleHours(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Hours(x) < d1;
+  // CHECK-FIXES: b = absl::Hours(x) < d1;
 
   // Integer comparisons
   b = x > absl::ToInt64Microseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Microseconds(x) > d1;
+  // CHECK-FIXES: b = absl::Microseconds(x) > d1;
   b = x >= absl::ToInt64Milliseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Milliseconds(x) >= d1;
+  // CHECK-FIXES: b = absl::Milliseconds(x) >= d1;
   b = x == absl::ToInt64Nanoseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Nanoseconds(x) == d1;
+  // CHECK-FIXES: b = absl::Nanoseconds(x) == d1;
   b = x == absl::ToInt64Seconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(x) == d1;
+  // CHECK-FIXES: b = absl::Seconds(x) == d1;
   b = x <= absl::ToInt64Minutes(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Minutes(x) <= d1;
+  // CHECK-FIXES: b = absl::Minutes(x) <= d1;
   b = x < absl::ToInt64Hours(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Hours(x) < d1;
+  // CHECK-FIXES: b = absl::Hours(x) < d1;
 
   // Other abseil-duration checks folded into this one
   b = static_cast<double>(5) > absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(5) > d1;
+  // CHECK-FIXES: b = absl::Seconds(5) > d1;
   b = double(5) > absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(5) > d1;
+  // CHECK-FIXES: b = absl::Seconds(5) > d1;
   b = float(5) > absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(5) > d1;
+  // CHECK-FIXES: b = absl::Seconds(5) > d1;
   b = ((double)5) > absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(5) > d1;
+  // CHECK-FIXES: b = absl::Seconds(5) > d1;
   b = 5.0 > absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Seconds(5) > d1;
+  // CHECK-FIXES: b = absl::Seconds(5) > d1;
 
   // A long expression
   bool some_condition;
@@ -125,20 +125,20 @@ void f() {
   int y;
   b = (y + 5) * 10 > absl::ToDoubleMilliseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: absl::Milliseconds((y + 5) * 10) > d1;
+  // CHECK-FIXES: b = absl::Milliseconds((y + 5) * 10) > d1;
 
   // We should still transform the expression inside this macro invocation
 #define VALUE_IF(v, e) v ? (e) : 0
   int a = VALUE_IF(1, 5 > absl::ToDoubleSeconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:23: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: VALUE_IF(1, absl::Seconds(5) > d1);
+  // CHECK-FIXES: int a = VALUE_IF(1, absl::Seconds(5) > d1);
 #undef VALUE_IF
 
 #define VALUE_IF_2(e) (e)
 #define VALUE_IF(v, e) v ? VALUE_IF_2(e) : VALUE_IF_2(0)
   int a2 = VALUE_IF(1, 5 > absl::ToDoubleSeconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:24: warning: perform comparison in the duration domain [abseil-duration-comparison]
-  // CHECK-FIXES: VALUE_IF(1, absl::Seconds(5) > d1);
+  // CHECK-FIXES: int a2 = VALUE_IF(1, absl::Seconds(5) > d1);
 #undef VALUE_IF
 #undef VALUE_IF_2
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-conversion-cast.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-conversion-cast.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-conversion-cast %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s abseil-duration-conversion-cast %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 
@@ -9,56 +9,56 @@ void f() {
 
   i = static_cast<int>(absl::ToDoubleHours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Hours(d1);
+  // CHECK-FIXES: i = absl::ToInt64Hours(d1);
   x = static_cast<float>(absl::ToInt64Hours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleHours(d1);
+  // CHECK-FIXES: x = absl::ToDoubleHours(d1);
   i = static_cast<int>(absl::ToDoubleMinutes(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Minutes(d1);
+  // CHECK-FIXES: i = absl::ToInt64Minutes(d1);
   x = static_cast<float>(absl::ToInt64Minutes(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleMinutes(d1);
+  // CHECK-FIXES: x = absl::ToDoubleMinutes(d1);
   i = static_cast<int>(absl::ToDoubleSeconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Seconds(d1);
+  // CHECK-FIXES: i = absl::ToInt64Seconds(d1);
   x = static_cast<float>(absl::ToInt64Seconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleSeconds(d1);
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(d1);
   i = static_cast<int>(absl::ToDoubleMilliseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Milliseconds(d1);
+  // CHECK-FIXES: i = absl::ToInt64Milliseconds(d1);
   x = static_cast<float>(absl::ToInt64Milliseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleMilliseconds(d1);
+  // CHECK-FIXES: x = absl::ToDoubleMilliseconds(d1);
   i = static_cast<int>(absl::ToDoubleMicroseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Microseconds(d1);
+  // CHECK-FIXES: i = absl::ToInt64Microseconds(d1);
   x = static_cast<float>(absl::ToInt64Microseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleMicroseconds(d1);
+  // CHECK-FIXES: x = absl::ToDoubleMicroseconds(d1);
   i = static_cast<int>(absl::ToDoubleNanoseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Nanoseconds(d1);
+  // CHECK-FIXES: i = absl::ToInt64Nanoseconds(d1);
   x = static_cast<float>(absl::ToInt64Nanoseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleNanoseconds(d1);
+  // CHECK-FIXES: x = absl::ToDoubleNanoseconds(d1);
 
   // Functional-style casts
   i = int(absl::ToDoubleHours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Hours(d1);
+  // CHECK-FIXES: i = absl::ToInt64Hours(d1);
   x = float(absl::ToInt64Microseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleMicroseconds(d1);
+  // CHECK-FIXES: x = absl::ToDoubleMicroseconds(d1);
 
   // C-style casts
   i = (int) absl::ToDoubleHours(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Hours(d1);
+  // CHECK-FIXES: i = absl::ToInt64Hours(d1);
   x = (float) absl::ToInt64Microseconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleMicroseconds(d1);
+  // CHECK-FIXES: x = absl::ToDoubleMicroseconds(d1);
 
   // Type aliasing
   typedef int FancyInt;
@@ -66,17 +66,17 @@ void f() {
 
   FancyInt j = static_cast<FancyInt>(absl::ToDoubleHours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:16: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToInt64Hours(d1);
+  // CHECK-FIXES: FancyInt j = absl::ToInt64Hours(d1);
   FancyFloat k = static_cast<FancyFloat>(absl::ToInt64Microseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:18: warning: duration should be converted directly to a floating-point number rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: absl::ToDoubleMicroseconds(d1);
+  // CHECK-FIXES: FancyFloat k = absl::ToDoubleMicroseconds(d1);
 
   // Macro handling
   // We want to transform things in macro arguments
 #define EXTERNAL(x) (x) + 5
   i = EXTERNAL(static_cast<int>(absl::ToDoubleSeconds(d1)));
   // CHECK-MESSAGES: [[@LINE-1]]:16: warning: duration should be converted directly to an integer rather than through a type cast [abseil-duration-conversion-cast]
-  // CHECK-FIXES: EXTERNAL(absl::ToInt64Seconds(d1));
+  // CHECK-FIXES: i = EXTERNAL(absl::ToInt64Seconds(d1));
 #undef EXTERNAL
 
   // We don't want to transform this which get split across macro boundaries

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-float.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-float.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-factory-float %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s abseil-duration-factory-float %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 
@@ -7,26 +7,26 @@ void ConvertFloatTest() {
 
   d = absl::Seconds(60.0);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(60);
+  // CHECK-FIXES: d = absl::Seconds(60);
   d = absl::Minutes(300.0);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Minutes [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Minutes(300);
+  // CHECK-FIXES: d = absl::Minutes(300);
 
   d = absl::Milliseconds(1e2);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Milliseconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Milliseconds(100);
+  // CHECK-FIXES: d = absl::Milliseconds(100);
   d = absl::Seconds(3.0f);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(3);
+  // CHECK-FIXES: d = absl::Seconds(3);
   d = absl::Seconds(3.);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(3);
+  // CHECK-FIXES: d = absl::Seconds(3);
   d = absl::Seconds(0x3.p0);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(3);
+  // CHECK-FIXES: d = absl::Seconds(3);
   d = absl::Seconds(0x3.p1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(6);
+  // CHECK-FIXES: d = absl::Seconds(6);
 
 
   // Ignored expressions
@@ -65,7 +65,7 @@ void InTemplate() {
 
   d = absl::Minutes(1.0);  // 2
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Minutes [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Minutes(1);  // 2
+  // CHECK-FIXES: d = absl::Minutes(1);  // 2
 }
 
 void Instantiate() {
@@ -78,27 +78,27 @@ void ConvertCastTest() {
 
   d = absl::Seconds(static_cast<double>(5));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(5);
+  // CHECK-FIXES: d = absl::Seconds(5);
 
   d = absl::Minutes(static_cast<float>(5));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Minutes [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Minutes(5);
+  // CHECK-FIXES: d = absl::Minutes(5);
 
   d = absl::Seconds((double) 5);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(5);
+  // CHECK-FIXES: d = absl::Seconds(5);
 
   d = absl::Minutes((float) 5);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Minutes [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Minutes(5);
+  // CHECK-FIXES: d = absl::Minutes(5);
 
   d = absl::Seconds(double(5));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Seconds [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Seconds(5);
+  // CHECK-FIXES: d = absl::Seconds(5);
 
   d = absl::Minutes(float(5));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: use the integer version of absl::Minutes [abseil-duration-factory-float]
-  // CHECK-FIXES: absl::Minutes(5);
+  // CHECK-FIXES: d = absl::Minutes(5);
 
   // This should not be flagged
   d = absl::Seconds(static_cast<int>(5.0));

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-scale.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-scale.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-factory-scale %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s abseil-duration-factory-scale %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 
@@ -11,87 +11,87 @@ void ScaleTest() {
   // Zeroes
   d = absl::Hours(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Minutes(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Seconds(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Milliseconds(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Microseconds(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Nanoseconds(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Seconds(0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Seconds(0x0.000001p-126f);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Seconds(int{0});
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Seconds(int64_t{0});
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
   d = absl::Seconds(float{0});
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use ZeroDuration() for zero-length time intervals [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::ZeroDuration();
+  // CHECK-FIXES: d = absl::ZeroDuration();
 
   // Fold seconds into minutes
   d = absl::Seconds(30 * 60);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Minutes(30);
+  // CHECK-FIXES: d = absl::Minutes(30);
   d = absl::Seconds(60 * 30);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Minutes(30);
+  // CHECK-FIXES: d = absl::Minutes(30);
 
   // Try a few more exotic multiplications
   d = absl::Seconds(60 * 30 * 60);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Minutes(60 * 30);
+  // CHECK-FIXES: d = absl::Minutes(60 * 30);
   d = absl::Seconds(1e-3 * 30);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Milliseconds(30);
+  // CHECK-FIXES: d = absl::Milliseconds(30);
   d = absl::Milliseconds(30 * 1000);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Seconds(30);
+  // CHECK-FIXES: d = absl::Seconds(30);
   d = absl::Milliseconds(30 * 0.001);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Microseconds(30);
+  // CHECK-FIXES: d = absl::Microseconds(30);
 
   // Multiple steps
   d = absl::Seconds(5 * 3600);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Hours(5);
+  // CHECK-FIXES: d = absl::Hours(5);
   d = absl::Microseconds(5 * 1e6);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Seconds(5);
+  // CHECK-FIXES: d = absl::Seconds(5);
   d = absl::Seconds(5 * 1e-6);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Microseconds(5);
+  // CHECK-FIXES: d = absl::Microseconds(5);
   d = absl::Microseconds(5 * 1000000);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Seconds(5);
+  // CHECK-FIXES: d = absl::Seconds(5);
 
   // Division
   d = absl::Hours(30 / 60.);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Minutes(30);
+  // CHECK-FIXES: d = absl::Minutes(30);
   d = absl::Seconds(30 / 1000.);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Milliseconds(30);
+  // CHECK-FIXES: d = absl::Milliseconds(30);
   d = absl::Milliseconds(30 / 1e3);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Microseconds(30);
+  // CHECK-FIXES: d = absl::Microseconds(30);
   d = absl::Seconds(30 / 1e6);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: internal duration scaling can be removed [abseil-duration-factory-scale]
-  // CHECK-FIXES: absl::Microseconds(30);
+  // CHECK-FIXES: d = absl::Microseconds(30);
 
   // None of these should trigger the check
   d = absl::Seconds(60);

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-subtraction.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-subtraction.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-subtraction %t -- -- -I %S/Inputs
+// RUN: %check_clang_tidy %s abseil-duration-subtraction %t -- -- -I %S/Inputs
 
 #include "absl/time/time.h"
 
@@ -8,34 +8,34 @@ void f() {
 
   x = absl::ToDoubleSeconds(d) - 1.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleSeconds(d - absl::Seconds(1))
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(d - absl::Seconds(1));
   x = absl::ToDoubleSeconds(d) - absl::ToDoubleSeconds(d1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleSeconds(d - d1);
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(d - d1);
   x = absl::ToDoubleSeconds(d) - 6.5 - 8.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleSeconds(d - absl::Seconds(6.5)) - 8.0;
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(d - absl::Seconds(6.5)) - 8.0;
   x = absl::ToDoubleHours(d) - 1.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleHours(d - absl::Hours(1))
+  // CHECK-FIXES: x = absl::ToDoubleHours(d - absl::Hours(1));
   x = absl::ToDoubleMinutes(d) - 1;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleMinutes(d - absl::Minutes(1))
+  // CHECK-FIXES: x = absl::ToDoubleMinutes(d - absl::Minutes(1));
   x = absl::ToDoubleMilliseconds(d) - 9;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleMilliseconds(d - absl::Milliseconds(9))
+  // CHECK-FIXES: x = absl::ToDoubleMilliseconds(d - absl::Milliseconds(9));
   x = absl::ToDoubleMicroseconds(d) - 9;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleMicroseconds(d - absl::Microseconds(9))
+  // CHECK-FIXES: x = absl::ToDoubleMicroseconds(d - absl::Microseconds(9));
   x = absl::ToDoubleNanoseconds(d) - 42;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleNanoseconds(d - absl::Nanoseconds(42))
+  // CHECK-FIXES: x = absl::ToDoubleNanoseconds(d - absl::Nanoseconds(42));
 
   // We can rewrite the argument of the duration conversion
 #define THIRTY absl::Seconds(30)
   x = absl::ToDoubleSeconds(THIRTY) - 1.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleSeconds(THIRTY - absl::Seconds(1))
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(THIRTY - absl::Seconds(1));
 #undef THIRTY
 
   // Some other contexts
@@ -46,10 +46,10 @@ void f() {
   // A nested occurrence
   x = absl::ToDoubleSeconds(d) - absl::ToDoubleSeconds(absl::Seconds(5));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleSeconds(d - absl::Seconds(5))
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(d - absl::Seconds(5));
   x = absl::ToDoubleSeconds(d) - absl::ToDoubleSeconds(absl::Seconds(absl::ToDoubleSeconds(d1)));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform subtraction in the duration domain [abseil-duration-subtraction]
-  // CHECK-FIXES: absl::ToDoubleSeconds(d - absl::Seconds(absl::ToDoubleSeconds(d1)))
+  // CHECK-FIXES: x = absl::ToDoubleSeconds(d - absl::Seconds(absl::ToDoubleSeconds(d1)));
 
   // These should not match
   x = 5 - 6;

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-unnecessary-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-unnecessary-conversion.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s abseil-duration-unnecessary-conversion %t -- -- -I %S/Inputs
+// RUN: %check_clang_tidy -std=c++11-or-later %s abseil-duration-unnecessary-conversion %t -- -- -I %S/Inputs
 
 #include "absl/time/time.h"
 
@@ -8,86 +8,86 @@ void f() {
   // Floating point
   d2 = absl::Hours(absl::ToDoubleHours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Minutes(absl::ToDoubleMinutes(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Seconds(absl::ToDoubleSeconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Milliseconds(absl::ToDoubleMilliseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Microseconds(absl::ToDoubleMicroseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Nanoseconds(absl::ToDoubleNanoseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
 
   // Integer point
   d2 = absl::Hours(absl::ToInt64Hours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Minutes(absl::ToInt64Minutes(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Seconds(absl::ToInt64Seconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Milliseconds(absl::ToInt64Milliseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Microseconds(absl::ToInt64Microseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Nanoseconds(absl::ToInt64Nanoseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
 
   d2 = absl::Hours(d1 / absl::Hours(1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Minutes(d1 / absl::Minutes(1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Seconds(d1 / absl::Seconds(1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Milliseconds(d1 / absl::Milliseconds(1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Microseconds(d1 / absl::Microseconds(1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Nanoseconds(d1 / absl::Nanoseconds(1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
 
   d2 = absl::Hours(absl::FDivDuration(d1, absl::Hours(1)));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Minutes(absl::FDivDuration(d1, absl::Minutes(1)));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Seconds(absl::FDivDuration(d1, absl::Seconds(1)));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Milliseconds(absl::FDivDuration(d1, absl::Milliseconds(1)));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Microseconds(absl::FDivDuration(d1, absl::Microseconds(1)));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
   d2 = absl::Nanoseconds(absl::FDivDuration(d1, absl::Nanoseconds(1)));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1
+  // CHECK-FIXES: d2 = d1;
 
   // As macro argument
 #define PLUS_FIVE_S(x) x + absl::Seconds(5)
   d2 = PLUS_FIVE_S(absl::Seconds(absl::ToInt64Seconds(d1)));
   // CHECK-MESSAGES: [[@LINE-1]]:20: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: PLUS_FIVE_S(d1)
+  // CHECK-FIXES: d2 = PLUS_FIVE_S(d1);
 #undef PLUS_FIVE_S
 
   // Split by macro: should not change
@@ -103,40 +103,40 @@ void f() {
   // Multiplication
   d2 = absl::Nanoseconds(absl::ToDoubleNanoseconds(d1) * 2);
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1 * 2
+  // CHECK-FIXES: d2 = d1 * 2;
   d2 = absl::Microseconds(absl::ToInt64Microseconds(d1) * 2);
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1 * 2
+  // CHECK-FIXES: d2 = d1 * 2;
   d2 = absl::Milliseconds(absl::ToDoubleMilliseconds(d1) * 2);
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1 * 2
+  // CHECK-FIXES: d2 = d1 * 2;
   d2 = absl::Seconds(absl::ToInt64Seconds(d1) * 2);
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1 * 2
+  // CHECK-FIXES: d2 = d1 * 2;
   d2 = absl::Minutes(absl::ToDoubleMinutes(d1) * 2);
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1 * 2
+  // CHECK-FIXES: d2 = d1 * 2;
   d2 = absl::Hours(absl::ToInt64Hours(d1) * 2);
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = d1 * 2
+  // CHECK-FIXES: d2 = d1 * 2;
   d2 = absl::Nanoseconds(2 * absl::ToDoubleNanoseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = 2 * d1
+  // CHECK-FIXES: d2 = 2 * d1;
   d2 = absl::Microseconds(2 * absl::ToInt64Microseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = 2 * d1
+  // CHECK-FIXES: d2 = 2 * d1;
   d2 = absl::Milliseconds(2 * absl::ToDoubleMilliseconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = 2 * d1
+  // CHECK-FIXES: d2 = 2 * d1;
   d2 = absl::Seconds(2 * absl::ToInt64Seconds(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = 2 * d1
+  // CHECK-FIXES: d2 = 2 * d1;
   d2 = absl::Minutes(2 * absl::ToDoubleMinutes(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = 2 * d1
+  // CHECK-FIXES: d2 = 2 * d1;
   d2 = absl::Hours(2 * absl::ToInt64Hours(d1));
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: remove unnecessary absl::Duration conversions [abseil-duration-unnecessary-conversion]
-  // CHECK-FIXES: d2 = 2 * d1
+  // CHECK-FIXES: d2 = 2 * d1;
 
   // These should not match
   d2 = absl::Seconds(absl::ToDoubleMilliseconds(d1));

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/redundant-strcat-calls.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/redundant-strcat-calls.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-redundant-strcat-calls %t -- -- -isystem %clang_tidy_headers
+// RUN: %check_clang_tidy %s abseil-redundant-strcat-calls %t -- -- -isystem %clang_tidy_headers
 #include <string>
 
 namespace absl {
@@ -69,7 +69,7 @@ using absl::StrCat;
 void Positives() {
   std::string S = StrCat(1, StrCat("A", StrCat(1.1)));
   // CHECK-MESSAGES: [[@LINE-1]]:19: warning: multiple calls to 'absl::StrCat' can be flattened into a single call
-  // CHECK-FIXES: string S = StrCat(1, "A", 1.1);
+  // CHECK-FIXES: std::string S = StrCat(1, "A", 1.1);
 
   S = StrCat(StrCat(StrCat(StrCat(StrCat(1)))));
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: multiple calls to 'absl::StrCat' can be flattened into a single call

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/time-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/time-comparison.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s abseil-time-comparison %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s abseil-time-comparison %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 
@@ -11,67 +11,67 @@ void f() {
   // Check against the RHS
   b = x > absl::ToUnixSeconds(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixSeconds(x) > t1;
+  // CHECK-FIXES: b = absl::FromUnixSeconds(x) > t1;
   b = x >= absl::ToUnixSeconds(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixSeconds(x) >= t1;
+  // CHECK-FIXES: b = absl::FromUnixSeconds(x) >= t1;
   b = x == absl::ToUnixSeconds(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixSeconds(x) == t1;
+  // CHECK-FIXES: b = absl::FromUnixSeconds(x) == t1;
   b = x <= absl::ToUnixSeconds(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixSeconds(x) <= t1;
+  // CHECK-FIXES: b = absl::FromUnixSeconds(x) <= t1;
   b = x < absl::ToUnixSeconds(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixSeconds(x) < t1;
+  // CHECK-FIXES: b = absl::FromUnixSeconds(x) < t1;
   b = x == absl::ToUnixSeconds(t1 - d2);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixSeconds(x) == t1 - d2;
+  // CHECK-FIXES: b = absl::FromUnixSeconds(x) == t1 - d2;
   b = absl::ToUnixSeconds(t1) > absl::ToUnixSeconds(t2);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 > t2;
+  // CHECK-FIXES: b = t1 > t2;
 
   // Check against the LHS
   b = absl::ToUnixSeconds(t1) < x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 < absl::FromUnixSeconds(x);
+  // CHECK-FIXES: b = t1 < absl::FromUnixSeconds(x);
   b = absl::ToUnixSeconds(t1) <= x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 <= absl::FromUnixSeconds(x);
+  // CHECK-FIXES: b = t1 <= absl::FromUnixSeconds(x);
   b = absl::ToUnixSeconds(t1) == x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 == absl::FromUnixSeconds(x);
+  // CHECK-FIXES: b = t1 == absl::FromUnixSeconds(x);
   b = absl::ToUnixSeconds(t1) >= x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 >= absl::FromUnixSeconds(x);
+  // CHECK-FIXES: b = t1 >= absl::FromUnixSeconds(x);
   b = absl::ToUnixSeconds(t1) > x;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 > absl::FromUnixSeconds(x);
+  // CHECK-FIXES: b = t1 > absl::FromUnixSeconds(x);
 
   // Comparison against zero
   b = absl::ToUnixSeconds(t1) < 0.0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 < absl::UnixEpoch();
+  // CHECK-FIXES: b = t1 < absl::UnixEpoch();
   b = absl::ToUnixSeconds(t1) < 0;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: t1 < absl::UnixEpoch();
+  // CHECK-FIXES: b = t1 < absl::UnixEpoch();
 
   // Scales other than Seconds
   b = x > absl::ToUnixMicros(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixMicros(x) > t1;
+  // CHECK-FIXES: b = absl::FromUnixMicros(x) > t1;
   b = x >= absl::ToUnixMillis(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixMillis(x) >= t1;
+  // CHECK-FIXES: b = absl::FromUnixMillis(x) >= t1;
   b = x == absl::ToUnixNanos(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixNanos(x) == t1;
+  // CHECK-FIXES: b = absl::FromUnixNanos(x) == t1;
   b = x <= absl::ToUnixMinutes(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixMinutes(x) <= t1;
+  // CHECK-FIXES: b = absl::FromUnixMinutes(x) <= t1;
   b = x < absl::ToUnixHours(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixHours(x) < t1;
+  // CHECK-FIXES: b = absl::FromUnixHours(x) < t1;
 
   // A long expression
   bool some_condition;
@@ -88,20 +88,20 @@ void f() {
   int y;
   b = (y + 5) * 10 > absl::ToUnixMillis(t1);
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: absl::FromUnixMillis((y + 5) * 10) > t1;
+  // CHECK-FIXES: b = absl::FromUnixMillis((y + 5) * 10) > t1;
 
   // We should still transform the expression inside this macro invocation
 #define VALUE_IF(v, e) v ? (e) : 0
   int a = VALUE_IF(1, 5 > absl::ToUnixSeconds(t1));
   // CHECK-MESSAGES: [[@LINE-1]]:23: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: VALUE_IF(1, absl::FromUnixSeconds(5) > t1);
+  // CHECK-FIXES: int a = VALUE_IF(1, absl::FromUnixSeconds(5) > t1);
 #undef VALUE_IF
 
 #define VALUE_IF_2(e) (e)
 #define VALUE_IF(v, e) v ? VALUE_IF_2(e) : VALUE_IF_2(0)
   int a2 = VALUE_IF(1, 5 > absl::ToUnixSeconds(t1));
   // CHECK-MESSAGES: [[@LINE-1]]:24: warning: perform comparison in the time domain [abseil-time-comparison]
-  // CHECK-FIXES: VALUE_IF(1, absl::FromUnixSeconds(5) > t1);
+  // CHECK-FIXES: int a2 = VALUE_IF(1, absl::FromUnixSeconds(5) > t1);
 #undef VALUE_IF
 #undef VALUE_IF_2
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/time-subtraction.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/time-subtraction.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s abseil-time-subtraction %t -- -- -I %S/Inputs
+// RUN: %check_clang_tidy -std=c++11-or-later %s abseil-time-subtraction %t -- -- -I %S/Inputs
 
 #include "absl/time/time.h"
 
@@ -89,7 +89,7 @@ void f() {
 #define SECONDS(z) absl::Seconds(z)
   d = SECONDS(x - absl::ToUnixSeconds(t));
   // CHECK-MESSAGES: [[@LINE-1]]:15: warning: perform subtraction in the time domain [abseil-time-subtraction]
-  // CHECK-FIXES: SECONDS(absl::ToInt64Seconds(absl::FromUnixSeconds(x) - t))
+  // CHECK-FIXES: d = SECONDS(absl::ToInt64Seconds(absl::FromUnixSeconds(x) - t));
 #undef SECONDS
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/upgrade-duration-conversions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/upgrade-duration-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s abseil-upgrade-duration-conversions %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy -std=c++11-or-later %s abseil-upgrade-duration-conversions %t -- -- -I%S/Inputs
 
 using int64_t = long long;
 
@@ -49,22 +49,22 @@ void arithmeticOperatorBasicPositive() {
   ConvertibleTo<int64_t> c;
   d *= (c + c) * c + c;
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: d *= static_cast<int64_t>((c + c) * c + c)
+  // CHECK-FIXES: d *= static_cast<int64_t>((c + c) * c + c);
   d /= (c + c) * c + c;
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: d /= static_cast<int64_t>((c + c) * c + c)
+  // CHECK-FIXES: d /= static_cast<int64_t>((c + c) * c + c);
   d = d * c * c;
   // CHECK-MESSAGES: [[@LINE-1]]:11: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
   // CHECK-MESSAGES: [[@LINE-2]]:15: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: d = d * static_cast<int64_t>(c) * static_cast<int64_t>(c)
+  // CHECK-FIXES: d = d * static_cast<int64_t>(c) * static_cast<int64_t>(c);
   d = c * d * c;
   // CHECK-MESSAGES: [[@LINE-1]]:7: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
   // CHECK-MESSAGES: [[@LINE-2]]:15: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: d = static_cast<int64_t>(c) * d * static_cast<int64_t>(c)
+  // CHECK-FIXES: d = static_cast<int64_t>(c) * d * static_cast<int64_t>(c);
   d = d / c * c;
   // CHECK-MESSAGES: [[@LINE-1]]:11: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
   // CHECK-MESSAGES: [[@LINE-2]]:15: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: d = d / static_cast<int64_t>(c) * static_cast<int64_t>(c)
+  // CHECK-FIXES: d = d / static_cast<int64_t>(c) * static_cast<int64_t>(c);
 }
 
 void arithmeticOperatorBasicNegative() {
@@ -407,7 +407,7 @@ template <typename T> void factoryTemplateAndMacro() {
   // CHECK-MESSAGES: [[@LINE-1]]:27: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
   (void)absl::Nanoseconds(CONVERTIBLE_TMP);
   // CHECK-MESSAGES: [[@LINE-1]]:27: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: (void)absl::Nanoseconds(static_cast<int64_t>(CONVERTIBLE_TMP))
+  // CHECK-FIXES: (void)absl::Nanoseconds(static_cast<int64_t>(CONVERTIBLE_TMP));
   T_CALL_FACTORTY_INSIDE_MACRO;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
 }
@@ -424,7 +424,7 @@ void factoryInMacros() {
   // CHECK-FIXES: (void)absl::Nanoseconds(static_cast<int64_t>(FUNCTION_MACRO(ConvertibleTo<int>())));
   (void)absl::Nanoseconds(CONVERTIBLE_TMP);
   // CHECK-MESSAGES: [[@LINE-1]]:27: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
-  // CHECK-FIXES: (void)absl::Nanoseconds(static_cast<int64_t>(CONVERTIBLE_TMP))
+  // CHECK-FIXES: (void)absl::Nanoseconds(static_cast<int64_t>(CONVERTIBLE_TMP));
   ONLY_WARN_INSIDE_MACRO_FACTORY;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: implicit conversion to 'int64_t' is deprecated in this context; use an explicit cast instead
   factoryTemplateAndMacro<ConvertibleTo<int>>();

--- a/clang-tools-extra/test/clang-tidy/checkers/altera/struct-pack-align.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/altera/struct-pack-align.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s altera-struct-pack-align %t -- -header-filter=.*
+// RUN: %check_clang_tidy %s altera-struct-pack-align %t -- -header-filter=.*
 
 // Struct needs both alignment and packing
 struct error {
@@ -10,8 +10,7 @@ struct error {
 // CHECK-MESSAGES: :[[@LINE-6]]:8: note: use "__attribute__((packed))" to reduce the amount of padding applied to struct 'error'
 // CHECK-MESSAGES: :[[@LINE-7]]:8: warning: accessing fields in struct 'error' is inefficient due to poor alignment; currently aligned to 8 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-8]]:8: note: use "__attribute__((aligned(16)))" to align struct 'error' to 16 bytes
-// CHECK-FIXES: __attribute__((packed))
-// CHECK-FIXES: __attribute__((aligned(16)));
+// CHECK-FIXES: } __attribute__((packed)) __attribute__((aligned(16)));
 
 // Struct is explicitly packed, but needs alignment
 struct error_packed {
@@ -21,7 +20,7 @@ struct error_packed {
 } __attribute__((packed));
 // CHECK-MESSAGES: :[[@LINE-5]]:8: warning: accessing fields in struct 'error_packed' is inefficient due to poor alignment; currently aligned to 1 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-6]]:8: note: use "__attribute__((aligned(16)))" to align struct 'error_packed' to 16 bytes
-// CHECK-FIXES: __attribute__((aligned(16)))
+// CHECK-FIXES: } __attribute__((aligned(16))) __attribute__((packed));
 
 // Struct is properly packed, but needs alignment
 struct align_only {
@@ -34,7 +33,7 @@ struct align_only {
 };
 // CHECK-MESSAGES: :[[@LINE-8]]:8: warning: accessing fields in struct 'align_only' is inefficient due to poor alignment; currently aligned to 8 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-9]]:8: note: use "__attribute__((aligned(16)))" to align struct 'align_only' to 16 bytes
-// CHECK-FIXES: __attribute__((aligned(16)));
+// CHECK-FIXES: } __attribute__((aligned(16)));
 
 // Struct is perfectly packed but wrongly aligned
 struct bad_align {
@@ -44,7 +43,7 @@ struct bad_align {
 } __attribute__((packed)) __attribute__((aligned(8)));
 // CHECK-MESSAGES: :[[@LINE-5]]:8: warning: accessing fields in struct 'bad_align' is inefficient due to poor alignment; currently aligned to 8 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-6]]:8: note: use "__attribute__((aligned(16)))" to align struct 'bad_align' to 16 bytes
-// CHECK-FIXES: __attribute__((aligned(16)));
+// CHECK-FIXES: } __attribute__((packed)) __attribute__((aligned(16)));
 
 struct bad_align2 {
   char a;
@@ -53,7 +52,7 @@ struct bad_align2 {
 } __attribute__((packed)) __attribute__((aligned(32)));
 // CHECK-MESSAGES: :[[@LINE-5]]:8: warning: accessing fields in struct 'bad_align2' is inefficient due to poor alignment; currently aligned to 32 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-6]]:8: note: use "__attribute__((aligned(16)))" to align struct 'bad_align2' to 16 bytes
-// CHECK-FIXES: __attribute__((aligned(16)));
+// CHECK-FIXES: } __attribute__((packed)) __attribute__((aligned(16)));
 
 struct bad_align3 {
   char a;
@@ -62,7 +61,7 @@ struct bad_align3 {
 } __attribute__((packed)) __attribute__((aligned(4)));
 // CHECK-MESSAGES: :[[@LINE-5]]:8: warning: accessing fields in struct 'bad_align3' is inefficient due to poor alignment; currently aligned to 4 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-6]]:8: note: use "__attribute__((aligned(16)))" to align struct 'bad_align3' to 16 bytes
-// CHECK-FIXES: __attribute__((aligned(16)));
+// CHECK-FIXES: } __attribute__((packed)) __attribute__((aligned(16)));
 
 // Struct is both perfectly packed and aligned
 struct success {
@@ -116,5 +115,4 @@ struct ContainsStructWithNoFields2 {
 // CHECK-MESSAGES: :[[@LINE-6]]:8: note: use "__attribute__((packed))" to reduce the amount of padding applied to struct 'ContainsStructWithNoFields2'
 // CHECK-MESSAGES: :[[@LINE-7]]:8: warning: accessing fields in struct 'ContainsStructWithNoFields2' is inefficient due to poor alignment; currently aligned to 8 bytes, but recommended alignment is 16 bytes [altera-struct-pack-align]
 // CHECK-MESSAGES: :[[@LINE-8]]:8: note: use "__attribute__((aligned(16)))" to align struct 'ContainsStructWithNoFields2' to 16 bytes
-// CHECK-FIXES: __attribute__((packed))
-// CHECK-FIXES: __attribute__((aligned(16)));
+// CHECK-FIXES: } __attribute__((packed)) __attribute__((aligned(16)));

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s android-cloexec-memfd-create %t
+// RUN: %check_clang_tidy %s android-cloexec-memfd-create %t
 
 #define MFD_ALLOW_SEALING 1
 #define __O_CLOEXEC 3
@@ -17,19 +17,19 @@ extern "C" int memfd_create(const char *name, unsigned int flags);
 void a() {
   memfd_create(NULL, MFD_ALLOW_SEALING);
   // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: 'memfd_create' should use MFD_CLOEXEC where possible [android-cloexec-memfd-create]
-  // CHECK-FIXES: memfd_create(NULL, MFD_ALLOW_SEALING | MFD_CLOEXEC)
+  // CHECK-FIXES: memfd_create(NULL, MFD_ALLOW_SEALING | MFD_CLOEXEC);
   TEMP_FAILURE_RETRY(memfd_create(NULL, MFD_ALLOW_SEALING));
   // CHECK-MESSAGES: :[[@LINE-1]]:58: warning: 'memfd_create'
-  // CHECK-FIXES: TEMP_FAILURE_RETRY(memfd_create(NULL, MFD_ALLOW_SEALING | MFD_CLOEXEC))
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(memfd_create(NULL, MFD_ALLOW_SEALING | MFD_CLOEXEC));
 }
 
 void f() {
   memfd_create(NULL, 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: 'memfd_create'
-  // CHECK-FIXES: memfd_create(NULL, 3 | MFD_CLOEXEC)
+  // CHECK-FIXES: memfd_create(NULL, 3 | MFD_CLOEXEC);
   TEMP_FAILURE_RETRY(memfd_create(NULL, 3));
   // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: 'memfd_create'
-  // CHECK-FIXES: TEMP_FAILURE_RETRY(memfd_create(NULL, 3 | MFD_CLOEXEC))
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(memfd_create(NULL, 3 | MFD_CLOEXEC));
 
   int flag = 3;
   memfd_create(NULL, flag);

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-open.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-open.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s android-cloexec-open %t
+// RUN: %check_clang_tidy %s android-cloexec-open %t
 
 #define O_RDWR 1
 #define O_EXCL 2
@@ -19,67 +19,67 @@ extern "C" int openat(int dirfd, const char *pathname, int flags, ...);
 void a() {
   open("filename", O_RDWR);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: 'open' should use O_CLOEXEC where possible [android-cloexec-open]
-  // CHECK-FIXES: O_RDWR | O_CLOEXEC
+  // CHECK-FIXES: open("filename", O_RDWR | O_CLOEXEC);
   TEMP_FAILURE_RETRY(open("filename", O_RDWR));
   // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: 'open' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(open("filename", O_RDWR | O_CLOEXEC));
   open("filename", O_RDWR | O_EXCL);
   // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: 'open' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_EXCL | O_CLOEXEC
+  // CHECK-FIXES: open("filename", O_RDWR | O_EXCL | O_CLOEXEC);
   TEMP_FAILURE_RETRY(open("filename", O_RDWR | O_EXCL));
   // CHECK-MESSAGES: :[[@LINE-1]]:54: warning: 'open' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_EXCL | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(open("filename", O_RDWR | O_EXCL | O_CLOEXEC));
 }
 
 void b() {
   open64("filename", O_RDWR);
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: 'open64' should use O_CLOEXEC where possible [android-cloexec-open]
-  // CHECK-FIXES: O_RDWR | O_CLOEXEC
+  // CHECK-FIXES: open64("filename", O_RDWR | O_CLOEXEC);
   TEMP_FAILURE_RETRY(open64("filename", O_RDWR));
   // CHECK-MESSAGES: :[[@LINE-1]]:47: warning: 'open64' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(open64("filename", O_RDWR | O_CLOEXEC));
   open64("filename", O_RDWR | O_EXCL);
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: 'open64' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_EXCL | O_CLOEXEC
+  // CHECK-FIXES: open64("filename", O_RDWR | O_EXCL | O_CLOEXEC);
   TEMP_FAILURE_RETRY(open64("filename", O_RDWR | O_EXCL));
   // CHECK-MESSAGES: :[[@LINE-1]]:56: warning: 'open64' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_EXCL | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(open64("filename", O_RDWR | O_EXCL | O_CLOEXEC));
 }
 
 void c() {
   openat(0, "filename", O_RDWR);
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: 'openat' should use O_CLOEXEC where possible [android-cloexec-open]
-  // CHECK-FIXES: O_RDWR | O_CLOEXEC
+  // CHECK-FIXES: openat(0, "filename", O_RDWR | O_CLOEXEC);
   TEMP_FAILURE_RETRY(openat(0, "filename", O_RDWR));
   // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: 'openat' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(openat(0, "filename", O_RDWR | O_CLOEXEC));
   openat(0, "filename", O_RDWR | O_EXCL);
   // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: 'openat' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_EXCL | O_CLOEXEC
+  // CHECK-FIXES: openat(0, "filename", O_RDWR | O_EXCL | O_CLOEXEC);
   TEMP_FAILURE_RETRY(openat(0, "filename", O_RDWR | O_EXCL));
   // CHECK-MESSAGES: :[[@LINE-1]]:59: warning: 'openat' should use O_CLOEXEC where
-  // CHECK-FIXES: O_RDWR | O_EXCL | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(openat(0, "filename", O_RDWR | O_EXCL | O_CLOEXEC));
 }
 
 void f() {
   open("filename", 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: 'open' should use O_CLOEXEC where possible [android-cloexec-open]
-  // CHECK-FIXES: 3 | O_CLOEXEC
+  // CHECK-FIXES: open("filename", 3 | O_CLOEXEC);
   TEMP_FAILURE_RETRY(open("filename", 3));
   // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: 'open' should use O_CLOEXEC where
-  // CHECK-FIXES: 3 | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(open("filename", 3 | O_CLOEXEC));
   open64("filename", 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: 'open64' should use O_CLOEXEC where possible [android-cloexec-open]
-  // CHECK-FIXES: 3 | O_CLOEXEC
+  // CHECK-FIXES: open64("filename", 3 | O_CLOEXEC);
   TEMP_FAILURE_RETRY(open64("filename", 3));
   // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: 'open64' should use O_CLOEXEC where
-  // CHECK-FIXES: 3 | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(open64("filename", 3 | O_CLOEXEC));
   openat(0, "filename", 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: 'openat' should use O_CLOEXEC where possible [android-cloexec-open]
-  // CHECK-FIXES: 3 | O_CLOEXEC
+  // CHECK-FIXES: openat(0, "filename", 3 | O_CLOEXEC);
   TEMP_FAILURE_RETRY(openat(0, "filename", 3));
   // CHECK-MESSAGES: :[[@LINE-1]]:45: warning: 'openat' should use O_CLOEXEC where
-  // CHECK-FIXES: 3 | O_CLOEXEC
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(openat(0, "filename", 3 | O_CLOEXEC));
 
   int flag = 3;
   open("filename", flag);

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-socket.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-socket.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s android-cloexec-socket %t
+// RUN: %check_clang_tidy %s android-cloexec-socket %t
 
 #define SOCK_STREAM 1
 #define SOCK_DGRAM 2
@@ -17,25 +17,25 @@ extern "C" int socket(int domain, int type, int protocol);
 void a() {
   socket(0, SOCK_STREAM, 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: 'socket' should use SOCK_CLOEXEC where possible [android-cloexec-socket]
-  // CHECK-FIXES: socket(0, SOCK_STREAM | SOCK_CLOEXEC, 0)
+  // CHECK-FIXES: socket(0, SOCK_STREAM | SOCK_CLOEXEC, 0);
   TEMP_FAILURE_RETRY(socket(0, SOCK_STREAM, 0));
   // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: 'socket'
-  // CHECK-FIXES: TEMP_FAILURE_RETRY(socket(0, SOCK_STREAM | SOCK_CLOEXEC, 0))
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(socket(0, SOCK_STREAM | SOCK_CLOEXEC, 0));
   socket(0, SOCK_STREAM | SOCK_DGRAM, 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: 'socket'
-  // CHECK-FIXES: socket(0, SOCK_STREAM | SOCK_DGRAM | SOCK_CLOEXEC, 0)
+  // CHECK-FIXES: socket(0, SOCK_STREAM | SOCK_DGRAM | SOCK_CLOEXEC, 0);
   TEMP_FAILURE_RETRY(socket(0, SOCK_STREAM | SOCK_DGRAM, 0));
   // CHECK-MESSAGES: :[[@LINE-1]]:56: warning: 'socket'
-  // CHECK-FIXES: TEMP_FAILURE_RETRY(socket(0, SOCK_STREAM | SOCK_DGRAM | SOCK_CLOEXEC, 0))
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(socket(0, SOCK_STREAM | SOCK_DGRAM | SOCK_CLOEXEC, 0));
 }
 
 void f() {
   socket(0, 3, 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: 'socket'
-  // CHECK-FIXES: socket(0, 3 | SOCK_CLOEXEC, 0)
+  // CHECK-FIXES: socket(0, 3 | SOCK_CLOEXEC, 0);
   TEMP_FAILURE_RETRY(socket(0, 3, 0));
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: 'socket'
-  // CHECK-FIXES: TEMP_FAILURE_RETRY(socket(0, 3 | SOCK_CLOEXEC, 0))
+  // CHECK-FIXES: TEMP_FAILURE_RETRY(socket(0, 3 | SOCK_CLOEXEC, 0));
 
   int flag = 3;
   socket(0, flag, 0);

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/incorrect-enable-shared-from-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/incorrect-enable-shared-from-this.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s bugprone-incorrect-enable-shared-from-this %t
+// RUN: %check_clang_tidy -std=c++11-or-later %s bugprone-incorrect-enable-shared-from-this %t
 
 // NOLINTBEGIN
 namespace std {
@@ -8,15 +8,15 @@ namespace std {
 
 class BadClassExample : std::enable_shared_from_this<BadClassExample> {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'BadClassExample' is not publicly inheriting from 'std::enable_shared_from_this', which will cause unintended behaviour when using 'shared_from_this'; make the inheritance public [bugprone-incorrect-enable-shared-from-this]
-// CHECK-FIXES: public std::enable_shared_from_this<BadClassExample>
+// CHECK-FIXES: class BadClassExample : public std::enable_shared_from_this<BadClassExample> {};
 
 class BadClass2Example : private std::enable_shared_from_this<BadClass2Example> {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'BadClass2Example' is not publicly inheriting from 'std::enable_shared_from_this', which will cause unintended behaviour when using 'shared_from_this'; make the inheritance public [bugprone-incorrect-enable-shared-from-this]
-// CHECK-FIXES: public std::enable_shared_from_this<BadClass2Example>
+// CHECK-FIXES: class BadClass2Example : public std::enable_shared_from_this<BadClass2Example> {};
 
 struct BadStructExample : private std::enable_shared_from_this<BadStructExample> {};
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: 'BadStructExample' is not publicly inheriting from 'std::enable_shared_from_this', which will cause unintended behaviour when using 'shared_from_this'; make the inheritance public [bugprone-incorrect-enable-shared-from-this]
-// CHECK-FIXES: public std::enable_shared_from_this<BadStructExample>
+// CHECK-FIXES: struct BadStructExample : public std::enable_shared_from_this<BadStructExample> {};
 
 class GoodClassExample : public std::enable_shared_from_this<GoodClassExample> {};
 
@@ -29,15 +29,15 @@ class dummy_class2 {};
 
 class BadMultiClassExample : std::enable_shared_from_this<BadMultiClassExample>, dummy_class1 {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'BadMultiClassExample' is not publicly inheriting from 'std::enable_shared_from_this', which will cause unintended behaviour when using 'shared_from_this'; make the inheritance public [bugprone-incorrect-enable-shared-from-this]
-// CHECK-FIXES: public std::enable_shared_from_this<BadMultiClassExample>, dummy_class1
+// CHECK-FIXES: class BadMultiClassExample : public std::enable_shared_from_this<BadMultiClassExample>, dummy_class1 {};
 
 class BadMultiClass2Example : dummy_class1, std::enable_shared_from_this<BadMultiClass2Example>, dummy_class2 {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'BadMultiClass2Example' is not publicly inheriting from 'std::enable_shared_from_this', which will cause unintended behaviour when using 'shared_from_this'; make the inheritance public [bugprone-incorrect-enable-shared-from-this]
-// CHECK-FIXES: dummy_class1, public std::enable_shared_from_this<BadMultiClass2Example>, dummy_class2
+// CHECK-FIXES: class BadMultiClass2Example : dummy_class1, public std::enable_shared_from_this<BadMultiClass2Example>, dummy_class2 {};
 
 class BadMultiClass3Example : dummy_class1, dummy_class2, std::enable_shared_from_this<BadMultiClass3Example> {};
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: 'BadMultiClass3Example' is not publicly inheriting from 'std::enable_shared_from_this', which will cause unintended behaviour when using 'shared_from_this'; make the inheritance public [bugprone-incorrect-enable-shared-from-this]
-// CHECK-FIXES: dummy_class1, dummy_class2, public std::enable_shared_from_this<BadMultiClass3Example>
+// CHECK-FIXES: class BadMultiClass3Example : dummy_class1, dummy_class2, public std::enable_shared_from_this<BadMultiClass3Example> {};
 
 class ClassBase : public std::enable_shared_from_this<ClassBase> {};
 class PrivateInheritClassBase : private ClassBase {};

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s bugprone-move-forwarding-reference %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy -std=c++14-or-later %s bugprone-move-forwarding-reference %t -- -- -fno-delayed-template-parsing
 
 namespace std {
 template <typename> struct remove_reference;
@@ -121,5 +121,5 @@ template <typename T, typename U> void f11(U &&SomeU) {
 template <typename T> void f12() {
   [] (auto&& x) { T SomeT(std::move(x)); };
   // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: forwarding reference passed to
-  // CHECK-FIXES: [] (auto&& x) { T SomeT(std::forward<decltype(x)>(x)); }
+  // CHECK-FIXES: [] (auto&& x) { T SomeT(std::forward<decltype(x)>(x)); };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-in-initialization-strlen.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-in-initialization-strlen.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -I %S/Inputs/not-null-terminated-result
 
 #include "not-null-terminated-result-c.h"
@@ -40,7 +40,7 @@ int bad_strncmp_1(char *str1, const char *str2) {
   int length = strlen(str1) + 1;
   return strncmp(str1, str2, length);
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: strncmp(str1, str2, length - 1);
+  // CHECK-FIXES: return strncmp(str1, str2, length - 1);
 }
 
 int good_strncmp_1(char *str1, const char *str2) {
@@ -51,13 +51,13 @@ int good_strncmp_1(char *str1, const char *str2) {
 int bad_strncmp_2(char *str2) {
   return strncmp(str2, "foobar", (strlen("foobar") + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: strncmp(str2, "foobar", (strlen("foobar")));
+  // CHECK-FIXES: return strncmp(str2, "foobar", (strlen("foobar")));
 }
 
 int bad_strncmp_3(char *str3) {
   return strncmp(str3, "foobar", 1 + strlen("foobar"));
   // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: strncmp(str3, "foobar", strlen("foobar"));
+  // CHECK-FIXES: return strncmp(str3, "foobar", strlen("foobar"));
 }
 
 int good_strncmp_2_3(char *str) {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-memcpy-safe-cxx.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-memcpy-safe-cxx.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -std=c++11 -I %S/Inputs/not-null-terminated-result
 
 #include "not-null-terminated-result-cxx.h"
@@ -27,7 +27,7 @@ void bad_memcpy_known_dest(const char *src) {
   char dest01[13];
   memcpy(dest01, src, strlen(src));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the result from calling 'memcpy' is not null-terminated [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: dest01[14];
+  // CHECK-FIXES: char dest01[14];
   // CHECK-FIXES-NEXT: strcpy_s(dest01, src);
 }
 
@@ -44,7 +44,7 @@ void bad_memcpy_full_source_length(std::string src) {
   char *dest20 = reinterpret_cast<char *>(malloc(src.size()));
   memcpy(dest20, src.data(), src.size());
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the result from calling 'memcpy' is not null-terminated [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: dest20 = reinterpret_cast<char *>(malloc(src.size() + 1));
+  // CHECK-FIXES: char *dest20 = reinterpret_cast<char *>(malloc(src.size() + 1));
   // CHECK-FIXES-NEXT: strcpy(dest20, src.data());
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-strlen.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-strlen.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -I %S/Inputs/not-null-terminated-result
 
 // FIXME: Something wrong with the APInt un/signed conversion on Windows:
@@ -70,13 +70,13 @@ void good_strerror_s(int errno) {
 int bad_strncmp_1(char *str0, const char *str1) {
   return strncmp(str0, str1, (strlen(str0) + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: strncmp(str0, str1, (strlen(str0)));
+  // CHECK-FIXES: return strncmp(str0, str1, (strlen(str0)));
 }
 
 int bad_strncmp_2(char *str2, const char *str3) {
   return strncmp(str2, str3, 1 + strlen(str2));
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: strncmp(str2, str3, strlen(str2));
+  // CHECK-FIXES: return strncmp(str2, str3, strlen(str2));
 }
 
 int good_strncmp_1_2(char *str4, const char *str5) {
@@ -86,7 +86,7 @@ int good_strncmp_1_2(char *str4, const char *str5) {
 int bad_strncmp_3(char *str6) {
   return strncmp(str6, "string", 7);
   // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: strncmp(str6, "string", 6);
+  // CHECK-FIXES: return strncmp(str6, "string", 6);
 }
 
 int good_strncmp_3(char *str7) {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-wcslen.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-wcslen.cpp
@@ -1,5 +1,5 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
-// RUN: -- -std=c++11 -I %S/Inputs/not-null-terminated-result
+// RUN: %check_clang_tidy -std=c++11-or-later %s bugprone-not-null-terminated-result %t -- \
+// RUN: -- -I %S/Inputs/not-null-terminated-result
 
 // FIXME: Something wrong with the APInt un/signed conversion on Windows:
 // in 'wcsncmp(wcs6, L"string", 7);' it tries to inject '4294967302' as length.
@@ -58,13 +58,13 @@ void good_wmemmove_s_1(wchar_t *dest, const wchar_t *src) {
 int bad_wcsncmp_1(wchar_t *wcs0, const wchar_t *wcs1) {
   return wcsncmp(wcs0, wcs1, (wcslen(wcs0) + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: wcsncmp(wcs0, wcs1, (wcslen(wcs0)));
+  // CHECK-FIXES: return wcsncmp(wcs0, wcs1, (wcslen(wcs0)));
 }
 
 int bad_wcsncmp_2(wchar_t *wcs2, const wchar_t *wcs3) {
   return wcsncmp(wcs2, wcs3, 1 + wcslen(wcs2));
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: wcsncmp(wcs2, wcs3, wcslen(wcs2));
+  // CHECK-FIXES: return wcsncmp(wcs2, wcs3, wcslen(wcs2));
 }
 
 int good_wcsncmp_1_2(wchar_t *wcs4, const wchar_t *wcs5) {
@@ -74,7 +74,7 @@ int good_wcsncmp_1_2(wchar_t *wcs4, const wchar_t *wcs5) {
 int bad_wcsncmp_3(wchar_t *wcs6) {
   return wcsncmp(wcs6, L"string", 7);
   // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: comparison length is too long and might lead to a buffer overflow [bugprone-not-null-terminated-result]
-  // CHECK-FIXES: wcsncmp(wcs6, L"string", 6);
+  // CHECK-FIXES: return wcsncmp(wcs6, L"string", 6);
 }
 
 int good_wcsncmp_3(wchar_t *wcs7) {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-posix-return %t
+// RUN: %check_clang_tidy %s bugprone-posix-return %t
 
 #define NULL nullptr
 #define ZERO 0
@@ -43,40 +43,40 @@ extern "C" int pthread_yield(void);
 void warningLessThanZero() {
   if (posix_fadvise(0, 0, 0, 0) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: the comparison always evaluates to false because posix_fadvise always returns non-negative values
-  // CHECK-FIXES: posix_fadvise(0, 0, 0, 0) > 0
+  // CHECK-FIXES: if (posix_fadvise(0, 0, 0, 0) > 0) {}
   if (posix_fallocate(0, 0, 0) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning:
-  // CHECK-FIXES: posix_fallocate(0, 0, 0) > 0
+  // CHECK-FIXES: if (posix_fallocate(0, 0, 0) > 0) {}
   if (posix_madvise(NULL, 0, 0) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning:
-  // CHECK-FIXES: posix_madvise(NULL, 0, 0) > 0
+  // CHECK-FIXES: if (posix_madvise(NULL, 0, 0) > 0) {}
   if (posix_memalign(NULL, 0, 0) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:34: warning:
-  // CHECK-FIXES: posix_memalign(NULL, 0, 0) > 0
+  // CHECK-FIXES: if (posix_memalign(NULL, 0, 0) > 0) {}
   if (posix_spawn(NULL, NULL, NULL, NULL, {NULL}, {NULL}) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:59: warning:
-  // CHECK-FIXES: posix_spawn(NULL, NULL, NULL, NULL, {NULL}, {NULL}) > 0
+  // CHECK-FIXES: if (posix_spawn(NULL, NULL, NULL, NULL, {NULL}, {NULL}) > 0) {}
   if (posix_spawnp(NULL, NULL, NULL, NULL, {NULL}, {NULL}) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:60: warning:
-  // CHECK-FIXES: posix_spawnp(NULL, NULL, NULL, NULL, {NULL}, {NULL}) > 0
+  // CHECK-FIXES: if (posix_spawnp(NULL, NULL, NULL, NULL, {NULL}, {NULL}) > 0) {}
   if (pthread_create(NULL, NULL, NULL, NULL) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:46: warning: the comparison always evaluates to false because pthread_create always returns non-negative values
-  // CHECK-FIXES: pthread_create(NULL, NULL, NULL, NULL) > 0
+  // CHECK-FIXES: if (pthread_create(NULL, NULL, NULL, NULL) > 0) {}
   if (pthread_attr_setaffinity_np(NULL, 0, NULL) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:50: warning:
-  // CHECK-FIXES: pthread_attr_setaffinity_np(NULL, 0, NULL) > 0
+  // CHECK-FIXES: if (pthread_attr_setaffinity_np(NULL, 0, NULL) > 0) {}
   if (pthread_attr_setschedpolicy(NULL, 0) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:44: warning:
-  // CHECK-FIXES: pthread_attr_setschedpolicy(NULL, 0) > 0)
+  // CHECK-FIXES: if (pthread_attr_setschedpolicy(NULL, 0) > 0) {}
   if (pthread_attr_init(NULL) < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning:
-  // CHECK-FIXES: pthread_attr_init(NULL) > 0
+  // CHECK-FIXES: if (pthread_attr_init(NULL) > 0) {}
   if (pthread_yield() < 0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning:
-  // CHECK-FIXES: pthread_yield() > 0
-  if (0 > pthread_yield() ) {}
+  // CHECK-FIXES: if (pthread_yield() > 0) {}
+  if (0 > pthread_yield()) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning:
-  // CHECK-FIXES: 0 < pthread_yield()
+  // CHECK-FIXES: if (0 < pthread_yield()) {}
 
 }
 
@@ -137,7 +137,7 @@ void warningEqualsNegative() {
 void WarningWithMacro() {
   if (posix_fadvise(0, 0, 0, 0) < ZERO) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning:
-  // CHECK-FIXES: posix_fadvise(0, 0, 0, 0) > ZERO
+  // CHECK-FIXES: if (posix_fadvise(0, 0, 0, 0) > ZERO) {}
   if (posix_fadvise(0, 0, 0, 0) >= ZERO) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning:
   if (posix_fadvise(0, 0, 0, 0) == NEGATIVE_ONE) {}
@@ -150,7 +150,7 @@ void WarningWithMacro() {
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning:
   if (pthread_create(NULL, NULL, NULL, NULL) < ZERO) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:46: warning:
-  // CHECK-FIXES: pthread_create(NULL, NULL, NULL, NULL) > ZERO
+  // CHECK-FIXES: if (pthread_create(NULL, NULL, NULL, NULL) > ZERO) {}
   if (pthread_create(NULL, NULL, NULL, NULL) >= ZERO) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:46: warning:
   if (pthread_create(NULL, NULL, NULL, NULL) == NEGATIVE_ONE) {}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/stringview-nullptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/stringview-nullptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-stringview-nullptr -std=c++17 %t
+// RUN: %check_clang_tidy %s bugprone-stringview-nullptr -std=c++17 %t
 
 namespace std {
 
@@ -148,7 +148,8 @@ void temporary_construction() /* a */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(std::string_view()) /* a4 */;
 
-    (void)(std::string_view({})) /* a5 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)(std::string_view({})) /* a5 */; 
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(std::string_view()) /* a5 */;
   }
@@ -171,7 +172,8 @@ void temporary_construction() /* a */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(std::string_view{}) /* a9 */;
 
-    (void)(std::string_view{{}}) /* a10 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)(std::string_view{{}}) /* a10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(std::string_view{}) /* a10 */;
   }
@@ -202,7 +204,8 @@ void temporary_construction() /* a */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)((std::string_view){}) /* a16 */;
 
-    (void)((std::string_view){{}}) /* a17 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)((std::string_view){{}}) /* a17 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)((std::string_view){}) /* a17 */;
 
@@ -230,7 +233,8 @@ void temporary_construction() /* a */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)((const std::string_view){}) /* a23 */;
 
-    (void)((const std::string_view){{}}) /* a24 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)((const std::string_view){{}}) /* a24 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)((const std::string_view){}) /* a24 */;
   }
@@ -316,7 +320,8 @@ void stack_construction() /* b */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view b13 = {};
 
-    std::string_view b14 = {{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    std::string_view b14 = {{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view b14 = {};
 
@@ -336,7 +341,8 @@ void stack_construction() /* b */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view b18 = {};
 
-    const std::string_view b19 = {{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    const std::string_view b19 = {{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view b19 = {};
   }
@@ -382,7 +388,8 @@ void stack_construction() /* b */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view b28;
 
-    std::string_view b29({}); // Default `const CharT*`
+    // Default `const CharT*`
+    std::string_view b29({});
     // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view b29;
 
@@ -402,7 +409,8 @@ void stack_construction() /* b */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view b33;
 
-    const std::string_view b34({}); // Default `const CharT*`
+    // Default `const CharT*`
+    const std::string_view b34({});
     // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view b34;
   }
@@ -448,7 +456,8 @@ void stack_construction() /* b */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view b43{};
 
-    std::string_view b44{{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    std::string_view b44{{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view b44{};
 
@@ -468,7 +477,8 @@ void stack_construction() /* b */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view b48{};
 
-    const std::string_view b49{{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    const std::string_view b49{{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view b49{};
   }
@@ -557,7 +567,8 @@ void field_construction() /* c */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view c13 = {};
 
-    std::string_view c14 = {{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    std::string_view c14 = {{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view c14 = {};
 
@@ -577,7 +588,8 @@ void field_construction() /* c */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view c18 = {};
 
-    const std::string_view c19 = {{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    const std::string_view c19 = {{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view c19 = {};
   };
@@ -621,7 +633,8 @@ void field_construction() /* c */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view c28{};
 
-    std::string_view c29{{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    std::string_view c29{{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: constructing{{.*}}default
     // CHECK-FIXES: std::string_view c29{};
 
@@ -641,7 +654,8 @@ void field_construction() /* c */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view c33{};
 
-    const std::string_view c34{{}}; // Default `const CharT*`
+    // Default `const CharT*`
+    const std::string_view c34{{}};
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: constructing{{.*}}default
     // CHECK-FIXES: const std::string_view c34{};
   };
@@ -694,7 +708,8 @@ void field_construction() /* c */ {
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
           // CHECK-FIXES: c43(),
 
-          c44({}) { // Default `const CharT*`
+          // Default `const CharT*`
+          c44({}) {
       // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
       // CHECK-FIXES: c44() {
     }
@@ -754,7 +769,8 @@ void field_construction() /* c */ {
           // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
           // CHECK-FIXES: c53{},
 
-          c54{{}} { // Default `const CharT*`
+          // Default `const CharT*`
+          c54{{}} {
       // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: constructing{{.*}}default
       // CHECK-FIXES: c54{} {
     }
@@ -852,7 +868,8 @@ void default_argument_construction() /* d */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
     // CHECK-FIXES: void d13(std::string_view sv = {});
 
-    void d14(std::string_view sv = {{}}); // Default `const CharT*`
+    // Default `const CharT*`
+    void d14(std::string_view sv = {{}});
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: constructing{{.*}}default
     // CHECK-FIXES: void d14(std::string_view sv = {});
 
@@ -872,7 +889,8 @@ void default_argument_construction() /* d */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
     // CHECK-FIXES: void d18(const std::string_view sv = {});
 
-    void d19(const std::string_view sv = {{}}); // Default `const CharT*`
+    // Default `const CharT*`
+    void d19(const std::string_view sv = {{}});
     // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: constructing{{.*}}default
     // CHECK-FIXES: void d19(const std::string_view sv = {});
   }
@@ -920,7 +938,8 @@ void heap_construction() /* e */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new std::string_view()) /* e4 */;
 
-    (void)(new std::string_view({})) /* e5 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)(new std::string_view({})) /* e5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new std::string_view()) /* e5 */;
 
@@ -940,7 +959,8 @@ void heap_construction() /* e */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new const std::string_view()) /* e9 */;
 
-    (void)(new const std::string_view({})) /* e10 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)(new const std::string_view({})) /* e10 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new const std::string_view()) /* e10 */;
   }
@@ -986,7 +1006,8 @@ void heap_construction() /* e */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new std::string_view{}) /* e19 */;
 
-    (void)(new std::string_view{{}}) /* e20 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)(new std::string_view{{}}) /* e20 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new std::string_view{}) /* e20 */;
 
@@ -1006,7 +1027,8 @@ void heap_construction() /* e */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new const std::string_view{}) /* e24 */;
 
-    (void)(new const std::string_view{{}}) /* e25 */; // Default `const CharT*`
+    // Default `const CharT*`
+    (void)(new const std::string_view{{}}) /* e25 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: constructing{{.*}}default
     // CHECK-FIXES: (void)(new const std::string_view{}) /* e25 */;
   }
@@ -1054,7 +1076,8 @@ void function_argument_initialization() /* f */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing{{.*}}empty string
     // CHECK-FIXES: function("") /* f4 */;
 
-    function({{}}) /* f5 */; // Default `const CharT*`
+    // Default `const CharT*`
+    function({{}}) /* f5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: passing{{.*}}empty string
     // CHECK-FIXES: function("") /* f5 */;
   }
@@ -1102,7 +1125,8 @@ void assignment(std::string_view sv) /* g */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment{{.*}}default
     // CHECK-FIXES: sv = {} /* g4 */;
 
-    sv = {{}} /* g5 */; // Default `const CharT*`
+    // Default `const CharT*`
+    sv = {{}} /* g5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: assignment{{.*}}default
     // CHECK-FIXES: sv = {} /* g5 */;
   }
@@ -1150,7 +1174,8 @@ void pointer_assignment(std::string_view *sv_ptr) /* h */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
     // CHECK-FIXES: *sv_ptr = {} /* h4 */;
 
-    *sv_ptr = {{}} /* h5 */; // Default `const CharT*`
+    // Default `const CharT*`
+    *sv_ptr = {{}} /* h5 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: assignment{{.*}}default
     // CHECK-FIXES: *sv_ptr = {} /* h5 */;
   }
@@ -1566,7 +1591,8 @@ void return_statement() /* q */ {
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
     // CHECK-FIXES: []() -> SV { return {}; } /* q6 */;
 
-    []() -> SV { return {{}}; } /* q7 */; // Default `const CharT*`
+    // Default `const CharT*`
+    []() -> SV { return {{}}; } /* q7 */;
     // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: constructing{{.*}}default
     // CHECK-FIXES: []() -> SV { return {}; } /* q7 */;
   }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-string-compare.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-string-compare.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-suspicious-string-compare %t -- \
+// RUN: %check_clang_tidy %s bugprone-suspicious-string-compare %t -- \
 // RUN: -config='{CheckOptions: \
 // RUN:  {bugprone-suspicious-string-compare.WarnOnImplicitComparison: true, \
 // RUN:   bugprone-suspicious-string-compare.WarnOnLogicalNotComparison: true}}' \
@@ -117,187 +117,187 @@ int test_implicit_compare_with_functions() {
   if (memcmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'memcmp' is called without explicitly comparing result
-  // CHECK-FIXES: memcmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (memcmp(A, "a", 1) != 0)
 
   if (wmemcmp(W, L"a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'wmemcmp' is called without explicitly comparing result
-  // CHECK-FIXES: wmemcmp(W, L"a", 1) != 0)
+  // CHECK-FIXES: if (wmemcmp(W, L"a", 1) != 0)
 
   if (memicmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'memicmp' is called without explicitly comparing result
-  // CHECK-FIXES: memicmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (memicmp(A, "a", 1) != 0)
 
   if (_memicmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_memicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _memicmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (_memicmp(A, "a", 1) != 0)
 
   if (_memicmp_l(A, "a", 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_memicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _memicmp_l(A, "a", 1, locale) != 0)
+  // CHECK-FIXES: if (_memicmp_l(A, "a", 1, locale) != 0)
 
   if (strcmp(A, "a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'strcmp' is called without explicitly comparing result
-  // CHECK-FIXES: strcmp(A, "a") != 0)
+  // CHECK-FIXES: if (strcmp(A, "a") != 0)
 
   if (strncmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'strncmp' is called without explicitly comparing result
-  // CHECK-FIXES: strncmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (strncmp(A, "a", 1) != 0)
 
   if (strcasecmp(A, "a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'strcasecmp' is called without explicitly comparing result
-  // CHECK-FIXES: strcasecmp(A, "a") != 0)
+  // CHECK-FIXES: if (strcasecmp(A, "a") != 0)
 
   if (strncasecmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'strncasecmp' is called without explicitly comparing result
-  // CHECK-FIXES: strncasecmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (strncasecmp(A, "a", 1) != 0)
 
   if (stricmp(A, "a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'stricmp' is called without explicitly comparing result
-  // CHECK-FIXES: stricmp(A, "a") != 0)
+  // CHECK-FIXES: if (stricmp(A, "a") != 0)
 
   if (strcmpi(A, "a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'strcmpi' is called without explicitly comparing result
-  // CHECK-FIXES: strcmpi(A, "a") != 0)
+  // CHECK-FIXES: if (strcmpi(A, "a") != 0)
 
   if (_stricmp(A, "a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_stricmp' is called without explicitly comparing result
-  // CHECK-FIXES: _stricmp(A, "a") != 0)
+  // CHECK-FIXES: if (_stricmp(A, "a") != 0)
 
   if (strnicmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'strnicmp' is called without explicitly comparing result
-  // CHECK-FIXES: strnicmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (strnicmp(A, "a", 1) != 0)
 
   if (_strnicmp(A, "a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_strnicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _strnicmp(A, "a", 1) != 0)
+  // CHECK-FIXES: if (_strnicmp(A, "a", 1) != 0)
 
   if (_stricmp_l(A, "a", locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_stricmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _stricmp_l(A, "a", locale) != 0)
+  // CHECK-FIXES: if (_stricmp_l(A, "a", locale) != 0)
 
   if (_strnicmp_l(A, "a", 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_strnicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _strnicmp_l(A, "a", 1, locale) != 0)
+  // CHECK-FIXES: if (_strnicmp_l(A, "a", 1, locale) != 0)
 
   if (wcscmp(W, L"a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'wcscmp' is called without explicitly comparing result
-  // CHECK-FIXES: wcscmp(W, L"a") != 0)
+  // CHECK-FIXES: if (wcscmp(W, L"a") != 0)
 
   if (wcsncmp(W, L"a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'wcsncmp' is called without explicitly comparing result
-  // CHECK-FIXES: wcsncmp(W, L"a", 1) != 0)
+  // CHECK-FIXES: if (wcsncmp(W, L"a", 1) != 0)
 
   if (wcscasecmp(W, L"a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'wcscasecmp' is called without explicitly comparing result
-  // CHECK-FIXES: wcscasecmp(W, L"a") != 0)
+  // CHECK-FIXES: if (wcscasecmp(W, L"a") != 0)
 
   if (wcsicmp(W, L"a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'wcsicmp' is called without explicitly comparing result
-  // CHECK-FIXES: wcsicmp(W, L"a") != 0)
+  // CHECK-FIXES: if (wcsicmp(W, L"a") != 0)
 
   if (_wcsicmp(W, L"a"))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_wcsicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _wcsicmp(W, L"a") != 0)
+  // CHECK-FIXES: if (_wcsicmp(W, L"a") != 0)
 
   if (_wcsicmp_l(W, L"a", locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_wcsicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _wcsicmp_l(W, L"a", locale) != 0)
+  // CHECK-FIXES: if (_wcsicmp_l(W, L"a", locale) != 0)
 
   if (wcsnicmp(W, L"a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function 'wcsnicmp' is called without explicitly comparing result
-  // CHECK-FIXES: wcsnicmp(W, L"a", 1) != 0)
+  // CHECK-FIXES: if (wcsnicmp(W, L"a", 1) != 0)
 
   if (_wcsnicmp(W, L"a", 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_wcsnicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _wcsnicmp(W, L"a", 1) != 0)
+  // CHECK-FIXES: if (_wcsnicmp(W, L"a", 1) != 0)
 
   if (_wcsnicmp_l(W, L"a", 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_wcsnicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _wcsnicmp_l(W, L"a", 1, locale) != 0)
+  // CHECK-FIXES: if (_wcsnicmp_l(W, L"a", 1, locale) != 0)
 
   if (_mbscmp(U, V))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbscmp' is called without explicitly comparing result
-  // CHECK-FIXES: _mbscmp(U, V) != 0)
+  // CHECK-FIXES: if (_mbscmp(U, V) != 0)
 
   if (_mbsncmp(U, V, 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsncmp' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsncmp(U, V, 1) != 0)
+  // CHECK-FIXES: if (_mbsncmp(U, V, 1) != 0)
 
   if (_mbsnbcmp(U, V, 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsnbcmp' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsnbcmp(U, V, 1) != 0)
+  // CHECK-FIXES: if (_mbsnbcmp(U, V, 1) != 0)
 
   if (_mbsnbicmp(U, V, 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsnbicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsnbicmp(U, V, 1) != 0)
+  // CHECK-FIXES: if (_mbsnbicmp(U, V, 1) != 0)
 
   if (_mbsicmp(U, V))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsicmp(U, V) != 0)
+  // CHECK-FIXES: if (_mbsicmp(U, V) != 0)
 
   if (_mbsnicmp(U, V, 1))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsnicmp' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsnicmp(U, V, 1) != 0)
+  // CHECK-FIXES: if (_mbsnicmp(U, V, 1) != 0)
 
   if (_mbscmp_l(U, V, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbscmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _mbscmp_l(U, V, locale) != 0)
+  // CHECK-FIXES: if (_mbscmp_l(U, V, locale) != 0)
 
   if (_mbsncmp_l(U, V, 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsncmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsncmp_l(U, V, 1, locale) != 0)
+  // CHECK-FIXES: if (_mbsncmp_l(U, V, 1, locale) != 0)
 
   if (_mbsicmp_l(U, V, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsicmp_l(U, V, locale) != 0)
+  // CHECK-FIXES: if (_mbsicmp_l(U, V, locale) != 0)
 
   if (_mbsnicmp_l(U, V, 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsnicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsnicmp_l(U, V, 1, locale) != 0)
+  // CHECK-FIXES: if (_mbsnicmp_l(U, V, 1, locale) != 0)
 
   if (_mbsnbcmp_l(U, V, 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsnbcmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsnbcmp_l(U, V, 1, locale) != 0)
+  // CHECK-FIXES: if (_mbsnbcmp_l(U, V, 1, locale) != 0)
 
   if (_mbsnbicmp_l(U, V, 1, locale))
     return 0;
   // CHECK-MESSAGES: [[@LINE-2]]:7: warning: function '_mbsnbicmp_l' is called without explicitly comparing result
-  // CHECK-FIXES: _mbsnbicmp_l(U, V, 1, locale) != 0)
+  // CHECK-FIXES: if (_mbsnbicmp_l(U, V, 1, locale) != 0)
 
   return 1;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/swapped-arguments.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/swapped-arguments.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-swapped-arguments %t
+// RUN: %check_clang_tidy %s bugprone-swapped-arguments %t
 
 void F(int, double);
 
@@ -9,7 +9,7 @@ void G(T a, U b) {
   F(a, b); // no-warning
   F(2.0, 4);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: argument with implicit conversion from 'double' to 'int' followed by argument converted from 'int' to 'double', potentially swapped arguments.
-// CHECK-FIXES: F(4, 2.0)
+// CHECK-FIXES: F(4, 2.0);
 }
 
 void funShortFloat(short, float);
@@ -20,7 +20,7 @@ void funBoolFloat(bool, float);
 void foo() {
   F(1.0, 3);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: argument with implicit conversion from 'double' to 'int' followed by argument converted from 'int' to 'double', potentially swapped arguments.
-// CHECK-FIXES: F(3, 1.0)
+// CHECK-FIXES: F(3, 1.0);
 
 #define M(x, y) x##y()
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-prefer-member-initializer %t -- -- -fcxx-exceptions
+// RUN: %check_clang_tidy %s cppcoreguidelines-prefer-member-initializer %t -- -- -fcxx-exceptions
 
 extern void __assert_fail (__const char *__assertion, __const char *__file,
     unsigned int __line, __const char *__function)
@@ -398,7 +398,7 @@ public:
   }
 
   explicit Complex19(int) {
-    // CHECK-FIXES: Complex19(int) : n(12) {
+    // CHECK-FIXES: explicit Complex19(int) : n(12) {
     n = 12;
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'n' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
     // CHECK-FIXES: {{^\ *$}}

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-constant-array-index.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-constant-array-index.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-bounds-constant-array-index %t
+// RUN: %check_clang_tidy %s cppcoreguidelines-pro-bounds-constant-array-index %t
 
 typedef __SIZE_TYPE__ size_t;
 
@@ -151,7 +151,6 @@ void g() {
   for (int i = 0; i < 10; ++i) {
     a[i] = i;
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not use array subscript when the index is not an integer constant expression
-    // CHECK-FIXES: gsl::at(a, i) = i;
     gsl::at(a, i) = i; // OK, gsl::at() instead of []
   }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init-use-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init-use-assignment.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-type-member-init %t -- -config="{CheckOptions: {cppcoreguidelines-pro-type-member-init.UseAssignment: true}}" -- -fsigned-char
+// RUN: %check_clang_tidy %s cppcoreguidelines-pro-type-member-init %t -- -config="{CheckOptions: {cppcoreguidelines-pro-type-member-init.UseAssignment: true}}" -- -fsigned-char
 
 struct T {
   int i;
@@ -30,7 +30,7 @@ struct S {
   double d;
   // CHECK-FIXES: double d = 0.0;
   long double ld;
-  // CHECK-FIXES: double ld = 0.0L;
+  // CHECK-FIXES: long double ld = 0.0L;
   int *ptr;
   // CHECK-FIXES: int *ptr = nullptr;
   T t;

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++11,c++14,c++17 %s cppcoreguidelines-pro-type-member-init %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy -std=c++11,c++14,c++17 %s cppcoreguidelines-pro-type-member-init %t -- -- -fno-delayed-template-parsing
 // FIXME: Fix the checker to work in C++20 mode.
 
 struct PositiveFieldBeforeConstructor {
@@ -105,7 +105,7 @@ template <class T> class NegativeTemplateConstructor {
     int FIELD;                                   \
   };                                             \
 // Ensure FIELD is not initialized since fixes inside of macros are disabled.
-// CHECK-FIXES: int FIELD;
+// CHECK-FIXES: int FIELD; {{\\}}
 
 UNINITIALIZED_FIELD_IN_MACRO_BODY(F);
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: constructor does not initialize these fields: F
@@ -429,7 +429,7 @@ template struct PositiveTemplateVirtualDestructor<int>;
     virtual ~UninitializedFieldVirtual##FIELD() {}       \
   };                                                     \
 // Ensure FIELD is not initialized since fixes inside of macros are disabled.
-// CHECK-FIXES: int FIELD;
+// CHECK-FIXES: int FIELD; {{\\}}
 
 UNINITIALIZED_FIELD_IN_MACRO_BODY_VIRTUAL(F);
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: constructor does not initialize these fields: F

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/virtual-class-destructor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/virtual-class-destructor.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-virtual-class-destructor %t -- --fix-notes
+// RUN: %check_clang_tidy %s cppcoreguidelines-virtual-class-destructor %t -- --fix-notes
 
 // CHECK-MESSAGES: :[[@LINE+4]]:8: warning: destructor of 'PrivateVirtualBaseStruct' is private and prevents using the type [cppcoreguidelines-virtual-class-destructor]
 // CHECK-MESSAGES: :[[@LINE+3]]:8: note: make it public and virtual
@@ -163,7 +163,7 @@ protected:
 // CHECK-FIXES: class OverridingDerivedClass : ProtectedNonVirtualClass {
 // CHECK-FIXES-NEXT: public:
 // CHECK-FIXES-NEXT: virtual ~OverridingDerivedClass() = default;
-// CHECK-FIXES-NEXT: void f() override;
+// CHECK-FIXES-NEXT: void f() override; // is implicitly virtual
 // CHECK-FIXES-NEXT: };
 class OverridingDerivedClass : ProtectedNonVirtualClass {
 public:
@@ -186,7 +186,7 @@ class NonOverridingDerivedClass : ProtectedNonVirtualClass {
 // CHECK-MESSAGES: :[[@LINE+5]]:8: note: make it public and virtual
 // CHECK-FIXES: struct OverridingDerivedStruct : ProtectedNonVirtualBaseStruct {
 // CHECK-FIXES-NEXT: virtual ~OverridingDerivedStruct() = default;
-// CHECK-FIXES-NEXT: void f() override;
+// CHECK-FIXES-NEXT: void f() override; // is implicitly virtual
 // CHECK-FIXES-NEXT: };
 struct OverridingDerivedStruct : ProtectedNonVirtualBaseStruct {
   void f() override; // is implicitly virtual
@@ -289,26 +289,18 @@ protected:
   virtual CONCAT(~Foo, Bar2()); // FIXME: We should have a fixit for this.
 };
 
-// CHECK-MESSAGES: :[[@LINE+6]]:7: warning: destructor of 'FooBar3' is protected and virtual [cppcoreguidelines-virtual-class-destructor]
-// CHECK-MESSAGES: :[[@LINE+5]]:7: note: make it protected and non-virtual
-// CHECK-FIXES:      class FooBar3 {
-// CHECK-FIXES-NEXT: protected:
-// CHECK-FIXES-NEXT:   ~FooBar3();
-// CHECK-FIXES-NEXT: };
+// CHECK-MESSAGES: :[[@LINE+2]]:7: warning: destructor of 'FooBar3' is protected and virtual [cppcoreguidelines-virtual-class-destructor]
+// CHECK-MESSAGES: :[[@LINE+1]]:7: note: make it protected and non-virtual
 class FooBar3 {
 protected:
-  CONCAT(vir, tual) ~FooBar3();
+  CONCAT(vir, tual) ~FooBar3(); // FIXME: We should have a fixit for this.
 };
 
-// CHECK-MESSAGES: :[[@LINE+6]]:7: warning: destructor of 'FooBar4' is protected and virtual [cppcoreguidelines-virtual-class-destructor]
-// CHECK-MESSAGES: :[[@LINE+5]]:7: note: make it protected and non-virtual
-// CHECK-FIXES:      class FooBar4 {
-// CHECK-FIXES-NEXT: protected:
-// CHECK-FIXES-NEXT:   ~CONCAT(Foo, Bar4());
-// CHECK-FIXES-NEXT: };
+// CHECK-MESSAGES: :[[@LINE+2]]:7: warning: destructor of 'FooBar4' is protected and virtual [cppcoreguidelines-virtual-class-destructor]
+// CHECK-MESSAGES: :[[@LINE+1]]:7: note: make it protected and non-virtual
 class FooBar4 {
 protected:
-  CONCAT(vir, tual) ~CONCAT(Foo, Bar4());
+  CONCAT(vir, tual) ~CONCAT(Foo, Bar4()); // FIXME: We should have a fixit for this.
 };
 
 // CHECK-MESSAGES: :[[@LINE+3]]:7: warning: destructor of 'FooBar5' is protected and virtual [cppcoreguidelines-virtual-class-destructor]

--- a/clang-tools-extra/test/clang-tidy/checkers/google/build-explicit-make-pair.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/build-explicit-make-pair.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s google-build-explicit-make-pair %t
+// RUN: %check_clang_tidy %s google-build-explicit-make-pair %t
 
 namespace std {
 template <class T1, class T2>
@@ -17,7 +17,7 @@ void templ(T a, T b) {
   std::make_pair<T, unsigned>(a, b);
   std::make_pair<int, int>(1, 2);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: for C++11-compatibility, omit template arguments from make_pair
-// CHECK-FIXES: std::make_pair(1, 2)
+// CHECK-FIXES: std::make_pair(1, 2);
 }
 
 template <typename T>
@@ -26,15 +26,15 @@ int t();
 void test(int i) {
   std::make_pair<int, int>(i, i);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: for C++11-compatibility, omit template arguments from make_pair
-// CHECK-FIXES: std::make_pair(i, i)
+// CHECK-FIXES: std::make_pair(i, i);
 
   std::make_pair<unsigned, int>(i, i);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: for C++11-compatibility, use pair directly
-// CHECK-FIXES: std::pair<unsigned, int>(i, i)
+// CHECK-FIXES: std::pair<unsigned, int>(i, i);
 
   std::make_pair<int, unsigned>(i, i);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: for C++11-compatibility, use pair directly
-// CHECK-FIXES: std::pair<int, unsigned>(i, i)
+// CHECK-FIXES: std::pair<int, unsigned>(i, i);
 
 #define M std::make_pair<int, unsigned>(i, i);
 M

--- a/clang-tools-extra/test/clang-tidy/checkers/google/objc-avoid-nsobject-new.m
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/objc-avoid-nsobject-new.m
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s google-objc-avoid-nsobject-new %t
+// RUN: %check_clang_tidy %s google-objc-avoid-nsobject-new %t
 
 @interface NSObject
 + (instancetype)new;
@@ -25,18 +25,18 @@
 void CheckSpecificInitRecommendations(void) {
   NSObject *object = [NSObject new];
   // CHECK-MESSAGES: [[@LINE-1]]:22: warning: do not create objects with +new [google-objc-avoid-nsobject-new]
-  // CHECK-FIXES: [NSObject alloc] init];
+  // CHECK-FIXES: NSObject *object = {{[[][[]}}NSObject alloc] init];
 
   NSDate *correctDate = [NSDate date];
   NSDate *incorrectDate = [NSDate new];
   // CHECK-MESSAGES: [[@LINE-1]]:27: warning: do not create objects with +new [google-objc-avoid-nsobject-new]
-  // CHECK-FIXES: [NSDate date];
+  // CHECK-FIXES: NSDate *incorrectDate = [NSDate date];
 
   NSObject *macroCreated = ALLOCATE_OBJECT(NSObject);  // Shouldn't warn on macros.
 
   NSMutableDictionary *dict = [NSMutableDictionary<NSString *, NSString *> new];
   // CHECK-MESSAGES: [[@LINE-1]]:31: warning: do not create objects with +new [google-objc-avoid-nsobject-new]
-  // CHECK-FIXES: [NSMutableDictionary<NSString *, NSString *> alloc] init];
+  // CHECK-FIXES: NSMutableDictionary *dict = {{[[][[]}}NSMutableDictionary<NSString *, NSString *> alloc] init];
 }
 
 @interface Foo : NSObject

--- a/clang-tools-extra/test/clang-tidy/checkers/google/upgrade-googletest-case.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/upgrade-googletest-case.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s google-upgrade-googletest-case %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy %s google-upgrade-googletest-case %t -- -- -I%S/Inputs
 // RUN: %check_clang_tidy -check-suffix=NOSUITE %s google-upgrade-googletest-case %t -- -- -DNOSUITE -I%S/Inputs/gtest/nosuite
 
 #include "gtest/gtest.h"
@@ -89,12 +89,14 @@ public:
   // CHECK-FIXES: static void TearDownTestSuite();
 };
 
-template <typename T> void FooTypedTest<T>::SetUpTestCase() {}
-// CHECK-MESSAGES: [[@LINE-1]]:45: warning: Google Test APIs named with 'case'
+template <typename T>
+void FooTypedTest<T>::SetUpTestCase() {}
+// CHECK-MESSAGES: [[@LINE-1]]:23: warning: Google Test APIs named with 'case'
 // CHECK-FIXES: void FooTypedTest<T>::SetUpTestSuite() {}
 
-template <typename T> void FooTypedTest<T>::TearDownTestCase() {}
-// CHECK-MESSAGES: [[@LINE-1]]:45: warning: Google Test APIs named with 'case'
+template <typename T>
+void FooTypedTest<T>::TearDownTestCase() {}
+// CHECK-MESSAGES: [[@LINE-1]]:23: warning: Google Test APIs named with 'case'
 // CHECK-FIXES: void FooTypedTest<T>::TearDownTestSuite() {}
 
 class BarTest : public testing::Test {

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-isa-or-dyn-cast-in-conditionals.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-isa-or-dyn-cast-in-conditionals.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s llvm-prefer-isa-or-dyn-cast-in-conditionals %t
+// RUN: %check_clang_tidy %s llvm-prefer-isa-or-dyn-cast-in-conditionals %t
 
 struct X;
 struct Y;
@@ -79,7 +79,7 @@ bool foo(Y *y, Z *z) {
     break;
   } while (cast<X>(y));
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: cast<> in conditional
-  // CHECK-FIXES: while (isa<X>(y));
+  // CHECK-FIXES: } while (isa<X>(y));
 
   if (dyn_cast<X>(y))
     return true;
@@ -100,7 +100,7 @@ bool foo(Y *y, Z *z) {
     break;
   } while (dyn_cast<X>(y));
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: return value from dyn_cast<> not used
-  // CHECK-FIXES: while (isa<X>(y));
+  // CHECK-FIXES: } while (isa<X>(y));
 
   if (y && isa<X>(y))
     return true;

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s llvm-prefer-register-over-unsigned %t
+// RUN: %check_clang_tidy %s llvm-prefer-register-over-unsigned %t
 
 namespace llvm {
 class Register {
@@ -23,8 +23,8 @@ llvm::RegisterLike getRegLike();
 void apply_1() {
   unsigned Reg1 = getReg();
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'Reg1' declared as 'unsigned int'; use 'llvm::Register' instead [llvm-prefer-register-over-unsigned]
-  // CHECK-FIXES: apply_1()
-  // CHECK-FIXES-NEXT: llvm::Register Reg1 = getReg();
+  // CHECK-FIXES:      void apply_1() {
+  // CHECK-FIXES-NEXT:   llvm::Register Reg1 = getReg();
 }
 
 void apply_2() {
@@ -34,110 +34,110 @@ void apply_2() {
   //        DeclContext for the function so we can't elide the llvm:: in this
   //        case. Fortunately, it doesn't actually occur in the LLVM code base.
   // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: variable 'Reg2' declared as 'unsigned int'; use 'llvm::Register' instead [llvm-prefer-register-over-unsigned]
-  // CHECK-FIXES: apply_2()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: llvm::Register Reg2 = getReg();
+  // CHECK-FIXES:      void apply_2() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   llvm::Register Reg2 = getReg();
 }
 
 namespace llvm {
 void apply_3() {
   unsigned Reg3 = getReg();
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'Reg3' declared as 'unsigned int'; use 'Register' instead [llvm-prefer-register-over-unsigned]
-  // CHECK-FIXES: apply_3()
-  // CHECK-FIXES-NEXT: Register Reg3 = getReg();
+  // CHECK-FIXES:      void apply_3() {
+  // CHECK-FIXES-NEXT:   Register Reg3 = getReg();
 }
 } // end namespace llvm
 
 void done_1() {
   llvm::Register Reg1 = getReg();
-  // CHECK-FIXES: done_1()
-  // CHECK-FIXES-NEXT: llvm::Register Reg1 = getReg();
+  // CHECK-FIXES:      void done_1() {
+  // CHECK-FIXES-NEXT:   llvm::Register Reg1 = getReg();
 }
 
 void done_2() {
   using namespace llvm;
   Register Reg2 = getReg();
-  // CHECK-FIXES: done_2()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: Register Reg2 = getReg();
+  // CHECK-FIXES:      void done_2() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   Register Reg2 = getReg();
 }
 
 namespace llvm {
 void done_3() {
   Register Reg3 = getReg();
-  // CHECK-FIXES: done_3()
-  // CHECK-FIXES-NEXT: Register Reg3 = getReg();
+  // CHECK-FIXES:      void done_3() {
+  // CHECK-FIXES-NEXT:   Register Reg3 = getReg();
 }
 } // end namespace llvm
 
 void do_nothing_1() {
   unsigned Reg1 = getRegLike();
-  // CHECK-FIXES: do_nothing_1()
-  // CHECK-FIXES-NEXT: unsigned Reg1 = getRegLike();
+  // CHECK-FIXES:      void do_nothing_1() {
+  // CHECK-FIXES-NEXT:   unsigned Reg1 = getRegLike();
 }
 
 void do_nothing_2() {
   using namespace llvm;
   unsigned Reg2 = getRegLike();
-  // CHECK-FIXES: do_nothing_2()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: unsigned Reg2 = getRegLike();
+  // CHECK-FIXES:      void do_nothing_2() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   unsigned Reg2 = getRegLike();
 }
 
 namespace llvm {
 void do_nothing_3() {
   unsigned Reg3 = getRegLike();
-  // CHECK-FIXES: do_nothing_3()
-  // CHECK-FIXES-NEXT: unsigned Reg3 = getRegLike();
+  // CHECK-FIXES:      void do_nothing_3() {
+  // CHECK-FIXES-NEXT:   unsigned Reg3 = getRegLike();
 }
 } // end namespace llvm
 
 void fn1(llvm::Register R);
 void do_nothing_4() {
   fn1(getReg());
-  // CHECK-FIXES: do_nothing_4()
-  // CHECK-FIXES-NEXT: fn1(getReg());
+  // CHECK-FIXES:      void do_nothing_4() {
+  // CHECK-FIXES-NEXT:   fn1(getReg());
 }
 
 void fn2(unsigned R);
 void do_nothing_5() {
   fn2(getReg());
-  // CHECK-FIXES: do_nothing_5()
-  // CHECK-FIXES-NEXT: fn2(getReg());
+  // CHECK-FIXES:      void do_nothing_5() {
+  // CHECK-FIXES-NEXT:   fn2(getReg());
 }
 
 void do_nothing_6() {
   using namespace llvm;
   Register Reg6{getReg()};
-  // CHECK-FIXES: do_nothing_6()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: Register Reg6{getReg()};
+  // CHECK-FIXES:      void do_nothing_6() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   Register Reg6{getReg()};
 }
 
 void do_nothing_7() {
   using namespace llvm;
   Register Reg7;
   Reg7.Reg = getReg();
-  // CHECK-FIXES: do_nothing_7()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: Register Reg7;
-  // CHECK-FIXES-NEXT: Reg7.Reg = getReg();
+  // CHECK-FIXES:      void do_nothing_7() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   Register Reg7;
+  // CHECK-FIXES-NEXT:   Reg7.Reg = getReg();
 }
 
 void do_nothing_8() {
   using namespace llvm;
   RegisterLike Reg8{getReg()};
-  // CHECK-FIXES: do_nothing_8()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: RegisterLike Reg8{getReg()};
+  // CHECK-FIXES:      void do_nothing_8() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   RegisterLike Reg8{getReg()};
 }
 
 void do_nothing_9() {
   using namespace llvm;
   RegisterLike Reg9;
   Reg9.Reg = getReg();
-  // CHECK-FIXES: do_nothing_9()
-  // CHECK-FIXES-NEXT: using namespace llvm;
-  // CHECK-FIXES-NEXT: RegisterLike Reg9;
-  // CHECK-FIXES-NEXT: Reg9.Reg = getReg();
+  // CHECK-FIXES:      void do_nothing_9() {
+  // CHECK-FIXES-NEXT:   using namespace llvm;
+  // CHECK-FIXES-NEXT:   RegisterLike Reg9;
+  // CHECK-FIXES-NEXT:   Reg9.Reg = getReg();
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/twine-local.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/twine-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s llvm-twine-local %t
+// RUN: %check_clang_tidy %s llvm-twine-local %t
 
 namespace llvm {
 class Twine {
@@ -24,7 +24,7 @@ int main() {
   const Twine t = Twine("a") + "b" + Twine(42);
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t = (Twine("a") + "b" + Twine(42)).str();
+// CHECK-FIXES: const std::string t = (Twine("a") + "b" + Twine(42)).str();
   foo(Twine("a") + "b");
 
   Twine Prefix = false ? "__INT_FAST" : "__UINT_FAST";
@@ -35,31 +35,31 @@ int main() {
   const Twine t2 = Twine();
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t2 = (Twine()).str();
+// CHECK-FIXES: const std::string t2 = (Twine()).str();
   foo(Twine() + "b");
 
   const Twine t3 = Twine(42);
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t3 = (Twine(42)).str();
+// CHECK-FIXES: const std::string t3 = (Twine(42)).str();
 
   const Twine t4 = Twine(42) + "b";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t4 = (Twine(42) + "b").str();
+// CHECK-FIXES: const std::string t4 = (Twine(42) + "b").str();
 
   const Twine t5 = Twine() + "b";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t5 = (Twine() + "b").str();
+// CHECK-FIXES: const std::string t5 = (Twine() + "b").str();
 
   const Twine t6 = true ? Twine() : Twine(42);
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t6 = (true ? Twine() : Twine(42)).str();
+// CHECK-FIXES: const std::string t6 = (true ? Twine() : Twine(42)).str();
 
   const Twine t7 = false ? Twine() : Twine("b");
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: twine variables are prone to use-after-free bugs
 // CHECK-MESSAGES: note: FIX-IT applied suggested code changes
-// CHECK-FIXES: std::string t7 = (false ? Twine() : Twine("b")).str();
+// CHECK-FIXES: const std::string t7 = (false ? Twine() : Twine("b")).str();
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-new-mlir-op-builder.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-new-mlir-op-builder.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s llvm-use-new-mlir-op-builder %t
+// RUN: %check_clang_tidy %s llvm-use-new-mlir-op-builder %t
 
 namespace mlir {
 class Location {};
@@ -36,25 +36,24 @@ struct NamedOp {
 template <typename T>
 void g(mlir::OpBuilder &b) {
   // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]
-  // CHECK-FIXES: T::create(b, b.getUnknownLoc(), "gaz")
+  // CHECK-FIXES: T::create(b, b.getUnknownLoc(), "gaz");
   b.create<T>(b.getUnknownLoc(), "gaz");
 }
 
 void f() {
   mlir::OpBuilder builder;
   // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]
-  // CHECK-FIXES: mlir::  ModuleOp::create(builder, builder.getUnknownLoc())
+  // CHECK-FIXES: mlir::  ModuleOp::create(builder, builder.getUnknownLoc());
   builder.create<mlir::  ModuleOp>(builder.getUnknownLoc());
 
   using mlir::NamedOp;
   // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]
-  // CHECK-FIXES: NamedOp::create(builder, builder.getUnknownLoc(), "baz")
+  // CHECK-FIXES: NamedOp::create(builder, builder.getUnknownLoc(), "baz");
   builder.create<NamedOp>(builder.getUnknownLoc(), "baz");
 
-  // CHECK-MESSAGES: :[[@LINE+4]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]
-  // CHECK-FIXES: NamedOp::create(builder,
-  // CHECK-FIXES:   builder.getUnknownLoc(),
-  // CHECK-FIXES:   "caz")
+  // CHECK-MESSAGES: :[[@LINE+3]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]
+  // CHECK-FIXES: NamedOp::create(builder, builder.getUnknownLoc(),
+  // CHECK-FIXES:   "caz");
   builder.
    create<NamedOp>(
      builder.getUnknownLoc(),
@@ -67,7 +66,7 @@ void f() {
 
   mlir::ImplicitLocOpBuilder ib;
   // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]
-  // CHECK-FIXES: mlir::ModuleOp::create(ib)
+  // CHECK-FIXES: mlir::ModuleOp::create(ib);
   ib.create<mlir::ModuleOp>(   );
 
   // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use 'OpType::create(builder, ...)' instead of 'builder.create<OpType>(...)' [llvm-use-new-mlir-op-builder]

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-pointers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-pointers.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s misc-const-correctness %t \
+// RUN: %check_clang_tidy %s misc-const-correctness %t \
 // RUN: -config='{CheckOptions: {\
 // RUN:   misc-const-correctness.AnalyzeValues: false,\
 // RUN:   misc-const-correctness.AnalyzeReferences: false,\
@@ -14,7 +14,7 @@ void pointee_to_const() {
   int a[] = {1, 2};
   int *p_local0 = &a[0];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: pointee of variable 'p_local0' of type 'int *' can be declared 'const'
-  // CHECK-FIXES: int  const*p_local0
+  // CHECK-FIXES: int  const*p_local0 = &a[0];
   p_local0 = &a[1];
 }
 
@@ -22,7 +22,7 @@ void array_of_pointer_to_const() {
   int a[] = {1, 2};
   int *p_local0[1] = {&a[0]};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: pointee of variable 'p_local0' of type 'int *[1]' can be declared 'const'
-  // CHECK-FIXES: int  const*p_local0[1]
+  // CHECK-FIXES: int  const*p_local0[1] = {&a[0]};
   p_local0[0] = &a[1];
 }
 
@@ -31,7 +31,7 @@ void template_fn() {
   T a[] = {1, 2};
   T *p_local0 = &a[0];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: pointee of variable 'p_local0' of type 'char *' can be declared 'const'
-  // CHECK-FIXES: T  const*p_local0
+  // CHECK-FIXES: T  const*p_local0 = &a[0];
   p_local0 = &a[1];
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-values.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-values.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s misc-const-correctness %t \
+// RUN: %check_clang_tidy %s misc-const-correctness %t \
 // RUN: -config='{CheckOptions: \
 // RUN:  {misc-const-correctness.AnalyzeValues: true,\
 // RUN:   misc-const-correctness.WarnPointersAsValues: true,\
@@ -10,32 +10,31 @@ void potential_const_pointer() {
   double np_local0[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   double *p_local0 = &np_local0[1];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'double *' can be declared 'const'
-  // CHECK-FIXES: double *const p_local0
+  // CHECK-FIXES: double *const p_local0 = &np_local0[1];
 
   using doublePtr = double*;
   using doubleArray = double[15];
   doubleArray np_local1;
   doublePtr p_local1 = &np_local1[0];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'doublePtr' (aka 'double *') can be declared 'const'
-  // CHECK-FIXES: doublePtr const p_local1
+  // CHECK-FIXES: doublePtr const p_local1 = &np_local1[0];
 }
 
 void range_for() {
   int np_local0[2] = {1, 2};
   int *p_local0[2] = {&np_local0[0], &np_local0[1]};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int *[2]' can be declared 'const'
-  // CHECK-FIXES: int *const p_local0[2]
+  // CHECK-FIXES: int *const p_local0[2] = {&np_local0[0], &np_local0[1]};
   for (const int *p_local1 : p_local0) {
   // CHECK-MESSAGES: [[@LINE-1]]:8: warning: variable 'p_local1' of type 'const int *' can be declared 'const'
-  // CHECK-FIXES: for (const int *const p_local1 : p_local0)
+  // CHECK-FIXES: for (const int *const p_local1 : p_local0) {
   }
 
   int *p_local2[2] = {nullptr, nullptr};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local2' of type 'int *[2]' can be declared 'const'
-  // CHECK-FIXES: int *const p_local2[2]
+  // CHECK-FIXES: int *const p_local2[2] = {nullptr, nullptr};
   for (const auto *con_ptr : p_local2) {
   }
-
 }
 
 template <typename T>
@@ -59,7 +58,7 @@ void EmitProtocolMethodList(T &&Methods) {
   // some expressions are type-dependent.
   SmallVector<const int *> p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'SmallVector<const int *>' can be declared 'const'
-  // CHECK-FIXES: SmallVector<const int *> const p_local0
+  // CHECK-FIXES: SmallVector<const int *> const p_local0;
   SmallVector<const int *> np_local0;
   for (const auto *I : Methods) {
     if (I == nullptr)
@@ -70,6 +69,6 @@ void EmitProtocolMethodList(T &&Methods) {
 void instantiate() {
   int *p_local0[4] = {nullptr, nullptr, nullptr, nullptr};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int *[4]' can be declared 'const'
-  // CHECK-FIXES: int *const p_local0[4]
+  // CHECK-FIXES: int *const p_local0[4] = {nullptr, nullptr, nullptr, nullptr};
   EmitProtocolMethodList(p_local0);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s misc-const-correctness %t -- \
+// RUN: %check_clang_tidy %s misc-const-correctness %t -- \
 // RUN:   -config="{CheckOptions: {\
 // RUN:     misc-const-correctness.TransformValues: true, \
 // RUN:     misc-const-correctness.WarnPointersAsValues: false, \
@@ -38,7 +38,7 @@ void some_function(double, wchar_t);
 void some_function(double np_arg0, wchar_t np_arg1) {
   int p_local0 = 2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 2;
 
   int np_local0;
   const int np_local1 = 42;
@@ -60,7 +60,7 @@ void some_function(double np_arg0, wchar_t np_arg1) {
 int function_try_block() try {
   int p_local0 = 0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 0;
   return p_local0;
 } catch (...) {
   return 0;
@@ -69,13 +69,13 @@ int function_try_block() try {
 void nested_scopes() {
   int p_local0 = 2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 2;
   int np_local0 = 42;
 
   {
     int p_local1 = 42;
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: variable 'p_local1' of type 'int' can be declared 'const'
-    // CHECK-FIXES: int const p_local1
+    // CHECK-FIXES: int const p_local1 = 42;
     np_local0 *= 2;
   }
 }
@@ -89,7 +89,7 @@ void some_lambda_environment_capture_all_by_reference(double np_arg0) {
   int np_local0 = 0;
   int p_local0 = 1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 1;
 
   int np_local2;
   const int np_local3 = 2;
@@ -99,14 +99,14 @@ void some_lambda_environment_capture_all_by_reference(double np_arg0) {
 
   int p_local1 = 0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local1
+  // CHECK-FIXES: int const p_local1 = 0;
 }
 
 void some_lambda_environment_capture_all_by_value(double np_arg0) {
   int np_local0 = 0;
   int p_local0 = 1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 1;
 
   int np_local1;
   const int np_local2 = 2;
@@ -139,12 +139,12 @@ void some_pointer_taking(int *out) {
 
   int p_local1 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local1
+  // CHECK-FIXES: int const p_local1 = 42;
   const int *const p0_p_local1 = &p_local1;
 
   int p_local2 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local2' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local2
+  // CHECK-FIXES: int const p_local2 = 42;
   function_in_pointer(&p_local2);
 }
 
@@ -163,19 +163,19 @@ void some_reference_taking() {
 
   int p_local0 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 42;
   const int &r0_p_local0 = p_local0;
 
   int p_local1 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local1
+  // CHECK-FIXES: int const p_local1 = 42;
   function_in_ref(p_local1);
 }
 
 double *non_const_pointer_return() {
   double p_local0 = 0.0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local0
+  // CHECK-FIXES: double const p_local0 = 0.0;
   double np_local0 = 24.4;
 
   return &np_local0;
@@ -184,10 +184,10 @@ double *non_const_pointer_return() {
 const double *const_pointer_return() {
   double p_local0 = 0.0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local0
+  // CHECK-FIXES: double const p_local0 = 0.0;
   double p_local1 = 24.4;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local1
+  // CHECK-FIXES: double const p_local1 = 24.4;
   return &p_local1;
 }
 
@@ -195,10 +195,10 @@ const double *const_pointer_return() {
 const double &const_ref_return() {
   double p_local0 = 0.0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local0
+  // CHECK-FIXES: double const p_local0 = 0.0;
   double p_local1 = 24.4;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local1
+  // CHECK-FIXES: double const p_local1 = 24.4;
   return p_local1;
 }
 
@@ -237,7 +237,7 @@ void define_locals(T np_arg0, T &np_arg1, int np_arg2) {
   // non-template values are ok still.
   int p_local0 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 42;
   np_local4 += p_local0;
 }
 
@@ -306,19 +306,19 @@ void direct_class_access() {
 
   ConstNonConstClass p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'ConstNonConstClass' can be declared 'const'
-  // CHECK-FIXES: ConstNonConstClass const p_local0
+  // CHECK-FIXES: ConstNonConstClass const p_local0;
   p_local0.constMethod();
 
   ConstNonConstClass p_local1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'ConstNonConstClass' can be declared 'const'
-  // CHECK-FIXES: ConstNonConstClass const p_local1
+  // CHECK-FIXES: ConstNonConstClass const p_local1;
   double np_local1;
   p_local1.modifyingMethod(np_local1);
 
   double np_local2;
   ConstNonConstClass p_local2(np_local2);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local2' of type 'ConstNonConstClass' can be declared 'const'
-  // CHECK-FIXES: ConstNonConstClass const p_local2(np_local2)
+  // CHECK-FIXES: ConstNonConstClass const p_local2(np_local2);
 
   ConstNonConstClass np_local3;
   np_local3.NonConstMember = 42.;
@@ -328,14 +328,14 @@ void direct_class_access() {
 
   ConstNonConstClass p_local3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local3' of type 'ConstNonConstClass' can be declared 'const'
-  // CHECK-FIXES: ConstNonConstClass const p_local3
+  // CHECK-FIXES: ConstNonConstClass const p_local3;
   const double val0 = p_local3.NonConstMember;
   const double val1 = p_local3.NonConstMemberRef;
   const double val2 = *p_local3.NonConstMemberPtr;
 
   ConstNonConstClass p_local4;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local4' of type 'ConstNonConstClass' can be declared 'const'
-  // CHECK-FIXES: ConstNonConstClass const p_local4
+  // CHECK-FIXES: ConstNonConstClass const p_local4;
   *np_local4.NonConstMemberPtr = 42.;
 }
 
@@ -347,7 +347,7 @@ void class_access_array() {
 
   ConstNonConstClass p_local0[2];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'ConstNonConstClass[2]' can be declared 'const'
-  // CHECK-FIXES: ConstNonConstClass const p_local0[2]
+  // CHECK-FIXES: ConstNonConstClass const p_local0[2];
   p_local0[0].constMethod();
   np_local0[1].constMethod();
 }
@@ -367,10 +367,10 @@ void internal_operator_calls() {
   OperatorsAsConstAsPossible np_local1;
   OperatorsAsConstAsPossible p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'OperatorsAsConstAsPossible' can be declared 'const'
-  // CHECK-FIXES: OperatorsAsConstAsPossible const p_local0
+  // CHECK-FIXES: OperatorsAsConstAsPossible const p_local0;
   OperatorsAsConstAsPossible p_local1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'OperatorsAsConstAsPossible' can be declared 'const'
-  // CHECK-FIXES: OperatorsAsConstAsPossible const p_local1
+  // CHECK-FIXES: OperatorsAsConstAsPossible const p_local1;
 
   np_local0 += p_local0;
   np_local1 = p_local0 + p_local1;
@@ -383,10 +383,10 @@ void internal_operator_calls() {
 
   NonConstOperators p_local2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local2' of type 'NonConstOperators' can be declared 'const'
-  // CHECK-FIXES: NonConstOperators const p_local2
+  // CHECK-FIXES: NonConstOperators const p_local2;
   NonConstOperators p_local3 = p_local2 - p_local2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local3' of type 'NonConstOperators' can be declared 'const'
-  // CHECK-FIXES: NonConstOperators const p_local3
+  // CHECK-FIXES: NonConstOperators const p_local3 = p_local2 - p_local2;
 }
 
 struct MyVector {
@@ -411,17 +411,17 @@ void vector_usage() {
 
   double p_local0[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'double[10]' can be declared 'const'
-  // CHECK-FIXES: double const p_local0[10]
+  // CHECK-FIXES: double const p_local0[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   double p_local1 = p_local0[5];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local1
+  // CHECK-FIXES: double const p_local1 = p_local0[5];
 
-  // The following subscript calls suprisingly choose the non-const operator
+  // The following subscript calls surprisingly choose the non-const operator
   // version.
   MyVector np_local2;
   double p_local2 = np_local2[42];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local2' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local2
+  // CHECK-FIXES: double const p_local2 = np_local2[42];
 
   MyVector np_local3;
   const double np_local4 = np_local3[42];
@@ -430,7 +430,7 @@ void vector_usage() {
   const MyVector np_local5{};
   double p_local3 = np_local5[42];
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local3' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local3
+  // CHECK-FIXES: double const p_local3 = np_local5[42];
 }
 
 void const_handle(const double &np_local0);
@@ -460,27 +460,27 @@ void handle_from_array() {
   // Constant handles are ok
   double p_local1[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'double[10]' can be declared 'const'
-  // CHECK-FIXES: double const p_local1[10]
+  // CHECK-FIXES: double const p_local1[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   const double *p_local2 = &p_local1[2]; // Could be `const double *const`, but warning deactivated by default
 
   double p_local3[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local3' of type 'double[10]' can be declared 'const'
-  // CHECK-FIXES: double const p_local3[10]
+  // CHECK-FIXES: double const p_local3[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   const double &const_ref = p_local3[2];
 
   double p_local4[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local4' of type 'double[10]' can be declared 'const'
-  // CHECK-FIXES: double const p_local4[10]
+  // CHECK-FIXES: double const p_local4[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   const double *const_ptr;
   const_ptr = &p_local4[2];
 
   double p_local5[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local5' of type 'double[10]' can be declared 'const'
-  // CHECK-FIXES: double const p_local5[10]
+  // CHECK-FIXES: double const p_local5[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   const_handle(p_local5[2]);
   double p_local6[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local6' of type 'double[10]' can be declared 'const'
-  // CHECK-FIXES: double const p_local6[10]
+  // CHECK-FIXES: double const p_local6[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
   const_handle(&p_local6[2]);
 }
 
@@ -513,15 +513,15 @@ void range_for() {
 
   int p_local0[2] = {1, 2};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int[2]' can be declared 'const'
-  // CHECK-FIXES: int const p_local0[2]
+  // CHECK-FIXES: int const p_local0[2] = {1, 2};
   for (int value : p_local0) {
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: variable 'value' of type 'int' can be declared 'const'
-    // CHECK-FIXES: int const value
+    // CHECK-FIXES: for (int const value : p_local0) {
   }
 
   int p_local1[2] = {1, 2};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'int[2]' can be declared 'const'
-  // CHECK-FIXES: int const p_local1[2]
+  // CHECK-FIXES: int const p_local1[2] = {1, 2};
   for (const int &const_ref : p_local1) {
   }
 }
@@ -552,7 +552,7 @@ void conversion_operators() {
   ModifyingConversion np_local0;
   NonModifyingConversion p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'NonModifyingConversion' can be declared 'const'
-  // CHECK-FIXES: NonModifyingConversion const p_local0
+  // CHECK-FIXES: NonModifyingConversion const p_local0;
 
   int np_local1 = np_local0;
   np_local1 = p_local0;
@@ -561,16 +561,16 @@ void conversion_operators() {
 void casts() {
   decltype(sizeof(void *)) p_local0 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'decltype(sizeof(void *))'
-  // CHECK-FIXES: decltype(sizeof(void *)) const p_local0
+  // CHECK-FIXES: decltype(sizeof(void *)) const p_local0 = 42;
   auto np_local0 = reinterpret_cast<void *>(p_local0);
   np_local0 = nullptr;
 
   int p_local1 = 43;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local1
+  // CHECK-FIXES: int const p_local1 = 43;
   short p_local2 = static_cast<short>(p_local1);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local2' of type 'short' can be declared 'const'
-  // CHECK-FIXES: short const p_local2
+  // CHECK-FIXES: short const p_local2 = static_cast<short>(p_local1);
 
   int np_local1 = p_local2;
   int &np_local2 = static_cast<int &>(np_local1);
@@ -584,7 +584,7 @@ void ternary_operator() {
 
   int p_local0 = 3, np_local3 = 5;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-NOT-FIXES: int const p_local0 = 3
+  // CHECK-NOT-FIXES: int const p_local0 = 3, np_local3 = 5;
   const int &np_local4 = true ? p_local0 : ++np_local3;
 
   int np_local5[3] = {1, 2, 3};
@@ -636,13 +636,13 @@ struct TMPClass {
 void meta_type() {
   TMPClass<int> p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'TMPClass<int>' can be declared 'const'
-  // CHECK-FIXES: TMPClass<int> const p_local0
+  // CHECK-FIXES: TMPClass<int> const p_local0;
   p_local0.alwaysConst();
   p_local0.sometimesConst();
 
   TMPClass<double> p_local1;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'TMPClass<double>' can be declared 'const'
-  // CHECK-FIXES: TMPClass<double> const p_local1
+  // CHECK-FIXES: TMPClass<double> const p_local1;
   p_local1.alwaysConst();
 
   TMPClass<double> np_local0;
@@ -659,7 +659,7 @@ template <typename T>
 void placement_new_in_unique_ptr() {
   int p_local0 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 42;
   int np_local0 = p_local0;
   new to_construct<T>(np_local0);
 }
@@ -696,7 +696,7 @@ void TestRegisters() {
 
   HardwareRegister p_reg1{3, 22};
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_reg1' of type 'HardwareRegister' can be declared 'const'
-  // CHECK-FIXES: HardwareRegister const p_reg1
+  // CHECK-FIXES: HardwareRegister const p_reg1{3, 22};
   const unsigned p_val = p_reg1.another;
 }
 
@@ -745,7 +745,7 @@ struct A {
 void f() {
   int p_local0 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 42;
   int np_local0 = 42;
   f_signature action = my_alloc;
   action(np_local0);
@@ -795,7 +795,7 @@ void for_bad_iterators() {
   non_const_iterator np_local3;
   for (int p_local0 : np_local3)
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: variable 'p_local0' of type 'int' can be declared 'const'
-    // CHECK-FIXES: int const p_local0
+    // CHECK-FIXES: for (int const p_local0 : np_local3)
     ;
 
   // Horrible code constructs...
@@ -805,21 +805,21 @@ void for_bad_iterators() {
     non_const_iterator np_local5;
     for (int p_local1 : np_local4, np_local5)
       // CHECK-MESSAGES: [[@LINE-1]]:10: warning: variable 'p_local1' of type 'int' can be declared 'const'
-      // CHECK-FIXES: int const p_local1
+      // CHECK-FIXES: for (int const p_local1 : np_local4, np_local5)
       ;
 
     non_const_iterator np_local6;
     non_const_iterator np_local7;
     for (int p_local2 : 1 > 2 ? np_local6 : np_local7)
       // CHECK-MESSAGES: [[@LINE-1]]:10: warning: variable 'p_local2' of type 'int' can be declared 'const'
-      // CHECK-FIXES: int const p_local2
+      // CHECK-FIXES: for (int const p_local2 : 1 > 2 ? np_local6 : np_local7)
       ;
 
     non_const_iterator np_local8;
     non_const_iterator np_local9;
     for (int p_local3 : 2 > 1 ? np_local8 : (np_local8, np_local9))
       // CHECK-MESSAGES: [[@LINE-1]]:10: warning: variable 'p_local3' of type 'int' can be declared 'const'
-      // CHECK-FIXES: int const p_local3
+      // CHECK-FIXES: for (int const p_local3 : 2 > 1 ? np_local8 : (np_local8, np_local9))
       ;
   }
 }
@@ -836,23 +836,23 @@ struct good_iterator {
 void good_iterators() {
   good_iterator p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'good_iterator' can be declared 'const'
-  // CHECK-FIXES: good_iterator const p_local0
+  // CHECK-FIXES: good_iterator const p_local0;
   good_iterator &p_local1 = p_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local1' of type 'good_iterator &' can be declared 'const'
-  // CHECK-FIXES: good_iterator  const&p_local1
+  // CHECK-FIXES: good_iterator  const&p_local1 = p_local0;
 
   for (int p_local2 : p_local1) {
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: variable 'p_local2' of type 'int' can be declared 'const'
-    // CHECK-FIXES: int const p_local2
+    // CHECK-FIXES: for (int const p_local2 : p_local1) {
     (void)p_local2;
   }
 
   good_iterator p_local3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local3' of type 'good_iterator' can be declared 'const'
-  // CHECK-FIXES: good_iterator const p_local3
+  // CHECK-FIXES: good_iterator const p_local3;
   for (int p_local4 : p_local3)
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: variable 'p_local4' of type 'int' can be declared 'const'
-    // CHECK-FIXES: int const p_local4
+    // CHECK-FIXES: for (int const p_local4 : p_local3)
     ;
   good_iterator np_local1;
   for (int &np_local2 : np_local1)
@@ -871,11 +871,11 @@ void for_ok_iterators_array() {
   int np_local0[42];
   int(&p_local0)[42] = np_local0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int (&)[42]' can be declared 'const'
-  // CHECK-FIXES: int const(&p_local0)[42]
+  // CHECK-FIXES: int const(&p_local0)[42] = np_local0;
 
   for (int p_local1 : p_local0) {
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: variable 'p_local1' of type 'int' can be declared 'const'
-    // CHECK-FIXES: int const p_local1
+    // CHECK-FIXES: for (int const p_local1 : p_local0) {
     (void)p_local1;
   }
 }
@@ -891,7 +891,7 @@ void complex_usage() {
   int np_local0 = 42;
   int p_local0 = 42;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
+  // CHECK-FIXES: int const p_local0 = 42;
   int np_local1 = 42;
   (np_local0 == p_local0 ? np_local0 : (p_local0, np_local1))++;
 }
@@ -920,7 +920,7 @@ void create_false_positive() {
   int np_local0 = 42;
   list_init p_local0 = {np_local0};
   // CHECK-MESSAGES:[[@LINE-1]]:3: warning: variable 'p_local0' of type 'list_init' can be declared 'const'
-  // CHECK-FIXES: list_init const p_local0
+  // CHECK-FIXES: list_init const p_local0 = {np_local0};
 }
 struct list_init_derived {
   base &member;
@@ -929,7 +929,7 @@ void list_init_derived_func() {
   derived np_local0;
   list_init_derived p_local0 = {np_local0};
   // CHECK-MESSAGES:[[@LINE-1]]:3: warning: variable 'p_local0' of type 'list_init_derived' can be declared 'const'
-  // CHECK-FIXES: list_init_derived const p_local0
+  // CHECK-FIXES: list_init_derived const p_local0 = {np_local0};
 }
 template <typename L, typename R>
 struct ref_pair {
@@ -945,7 +945,7 @@ void cast_in_class_hierarchy() {
   derived np_local0;
   base p_local1 = static_cast<base &>(np_local0);
   // CHECK-MESSAGES:[[@LINE-1]]:3: warning: variable 'p_local1' of type 'base' can be declared 'const'
-  // CHECK-FIXES: base const p_local1
+  // CHECK-FIXES: base const p_local1 = static_cast<base &>(np_local0);
 }
 
 void function_ref_target(int);

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/definitions-in-headers.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/definitions-in-headers.hpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s misc-definitions-in-headers %t -- --fix-notes
+// RUN: %check_clang_tidy %s misc-definitions-in-headers %t -- --fix-notes
 
 int f() {
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: function 'f' defined in a header file; function definitions in header files can lead to ODR violations [misc-definitions-in-headers]
@@ -25,7 +25,7 @@ class CA {
 
 void CA::f2() { }
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: function 'f2' defined in a header file;
-// CHECK-FIXES: inline void CA::f2() {
+// CHECK-FIXES: inline void CA::f2() { }
 
 template <>
 int CA::f3() {

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -1,7 +1,7 @@
 // RUN: mkdir -p %t.dir
 // RUN: echo "static void staticFunctionHeader(int i) {;}" > %t.dir/header.h
 // RUN: echo "static void staticFunctionHeader(int  /*i*/) {;}" > %t.dir/header-fixed.h
-// RUN: %check_clang_tidy  --match-partial-fixes -std=c++11 %s misc-unused-parameters %t.dir/code -- -header-filter='.*' -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy -std=c++11 %s misc-unused-parameters %t.dir/code -- -header-filter='.*' -- -fno-delayed-template-parsing
 // RUN: diff %t.dir/header.h %t.dir/header-fixed.h
 // FIXME: Make the test work in all language modes.
 
@@ -67,41 +67,41 @@ static void staticFunctionA(int i);
 // CHECK-FIXES: static void staticFunctionA();
 static void staticFunctionA(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: static void staticFunctionA()
+// CHECK-FIXES: static void staticFunctionA() {;}
 
 static void staticFunctionB(int i, int j) { (void)i; }
 // CHECK-MESSAGES: :[[@LINE-1]]:40: warning
-// CHECK-FIXES: static void staticFunctionB(int i)
+// CHECK-FIXES: static void staticFunctionB(int i) { (void)i; }
 
 static void staticFunctionC(int i, int j) { (void)j; }
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: static void staticFunctionC(int j)
+// CHECK-FIXES: static void staticFunctionC(int j) { (void)j; }
 
 static void staticFunctionD(int i, int j, int k) { (void)i; (void)k; }
 // CHECK-MESSAGES: :[[@LINE-1]]:40: warning
-// CHECK-FIXES: static void staticFunctionD(int i, int k)
+// CHECK-FIXES: static void staticFunctionD(int i, int k) { (void)i; (void)k; }
 
 static void staticFunctionE(int i = 4) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: static void staticFunctionE()
+// CHECK-FIXES: static void staticFunctionE() {;}
 
 static void staticFunctionF(int i = 4);
 // CHECK-FIXES: static void staticFunctionF();
 static void staticFunctionF(int i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: static void staticFunctionF()
+// CHECK-FIXES: static void staticFunctionF() {;}
 
 static void staticFunctionG(int i[]);
 // CHECK-FIXES: static void staticFunctionG();
 static void staticFunctionG(int i[]) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning
-// CHECK-FIXES: static void staticFunctionG()
+// CHECK-FIXES: static void staticFunctionG() {;}
 
 static void staticFunctionH(void (*fn)());
 // CHECK-FIXES: static void staticFunctionH();
 static void staticFunctionH(void (*fn)()) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:36: warning
-// CHECK-FIXES: static void staticFunctionH()
+// CHECK-FIXES: static void staticFunctionH() {;}
 
 static void someCallSites() {
   staticFunctionA(1);
@@ -298,7 +298,7 @@ using fn = void(int);
 void f(fn *);
 void test() {
   // CHECK-MESSAGES: :[[@LINE+2]]:12: warning: parameter 'I' is unused
-  // CHECK-FIXES: f([](int  /*I*/) {
+  // CHECK-FIXES: f([](int  /*I*/) { return; });
   f([](int I) { return; });
 }
 } // namespace lambda

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-bind.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-bind.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s modernize-avoid-bind %t
+// RUN: %check_clang_tidy -std=c++14-or-later %s modernize-avoid-bind %t
 
 namespace std {
 inline namespace impl {
@@ -229,19 +229,19 @@ void testFunctionObjects() {
   D *e = nullptr;
   auto AAA = std::bind(d, 1, 2);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: prefer a lambda to std::bind
-  // CHECK-FIXES: auto AAA = [d] { d(1, 2); }
+  // CHECK-FIXES: auto AAA = [d] { d(1, 2); };
 
   auto BBB = std::bind(*e, 1, 2);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: prefer a lambda to std::bind
-  // CHECK-FIXES: auto BBB = [e] { (*e)(1, 2); }
+  // CHECK-FIXES: auto BBB = [e] { (*e)(1, 2); };
 
   auto CCC = std::bind(D{}, 1, 2);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: prefer a lambda to std::bind
-  // CHECK-FIXES: auto CCC = [] { D{}(1, 2); }
+  // CHECK-FIXES: auto CCC = [] { D{}(1, 2); };
 
   auto DDD = std::bind(D(), 1, 2);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: prefer a lambda to std::bind
-  // CHECK-FIXES: auto DDD = [] { D()(1, 2); }
+  // CHECK-FIXES: auto DDD = [] { D()(1, 2); };
 
   auto EEE = std::bind(*D::create(), 1, 2);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: prefer a lambda to std::bind
@@ -384,11 +384,11 @@ struct E {
 
     auto III = std::bind(&D::operator(), d, 1, 2);
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer a lambda to std::bind
-    // CHECK-FIXES: auto III = [d] { (*d)(1, 2); }
+    // CHECK-FIXES: auto III = [d] { (*d)(1, 2); };
 
     auto JJJ = std::bind(&D::operator(), &dd, 1, 2);
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer a lambda to std::bind
-    // CHECK-FIXES: auto JJJ = [ObjectPtr = &dd] { (*ObjectPtr)(1, 2); }
+    // CHECK-FIXES: auto JJJ = [ObjectPtr = &dd] { (*ObjectPtr)(1, 2); };
 
     auto KKK = std::bind(&D::operator(), _1, 1, 2);
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer a lambda to std::bind
@@ -396,11 +396,11 @@ struct E {
 
     auto LLL = std::bind(&D::operator bool, d);
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer a lambda to std::bind
-    // CHECK-FIXES: auto LLL = [d] { return d->operator bool(); }
+    // CHECK-FIXES: auto LLL = [d] { return d->operator bool(); };
 
     auto MMM = std::bind(&E::operator(), this, 1, 2);
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer a lambda to std::bind
-    // CHECK-FIXES: auto MMM = [this] { return (*this)(1, 2); }
+    // CHECK-FIXES: auto MMM = [this] { return (*this)(1, 2); };
   }
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/concat-nested-namespaces.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/concat-nested-namespaces.cpp
@@ -1,10 +1,10 @@
 // RUN: mkdir -p %t.dir
 // RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %t.dir/modernize-concat-nested-namespaces.h
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++17 -check-suffix=NORMAL %s modernize-concat-nested-namespaces %t.dir/code -- -header-filter=".*" -- -I %t.dir
+// RUN: %check_clang_tidy -std=c++17 -check-suffix=NORMAL %s modernize-concat-nested-namespaces %t.dir/code -- -header-filter=".*" -- -I %t.dir
 // RUN: FileCheck -input-file=%t.dir/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
 // Restore header file and re-run with c++20:
 // RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %t.dir/modernize-concat-nested-namespaces.h
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++20 -check-suffixes=NORMAL,CPP20 %s modernize-concat-nested-namespaces %t.dir/code -- -header-filter=".*" -- -I %t.dir
+// RUN: %check_clang_tidy -std=c++20 -check-suffixes=NORMAL,CPP20 %s modernize-concat-nested-namespaces %t.dir/code -- -header-filter=".*" -- -I %t.dir
 // RUN: FileCheck -input-file=%t.dir/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
 
 #include "modernize-concat-nested-namespaces.h"
@@ -38,16 +38,16 @@ void t();
 namespace n9 {
 namespace n10 {
 // CHECK-MESSAGES-NORMAL-DAG: :[[@LINE-2]]:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]
-// CHECK-FIXES-NORMAL: namespace n9::n10
+// CHECK-FIXES-NORMAL: namespace n9::n10 {
 void t();
 } // namespace n10
 } // namespace n9
-// CHECK-FIXES-NORMAL: }
+// CHECK-FIXES-NORMAL: } // namespace n9::n10
 
 namespace n11 {
 namespace n12 {
 // CHECK-MESSAGES-NORMAL-DAG: :[[@LINE-2]]:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]
-// CHECK-FIXES-NORMAL: namespace n11::n12
+// CHECK-FIXES-NORMAL: namespace n11::n12 {
 namespace n13 {
 void t();
 }
@@ -71,7 +71,7 @@ namespace n18 {
 namespace n19 {
 namespace n20 {
 // CHECK-MESSAGES-NORMAL-DAG: :[[@LINE-3]]:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]
-// CHECK-FIXES-NORMAL: namespace n18::n19::n20
+// CHECK-FIXES-NORMAL: namespace n18::n19::n20 {
 void t();
 } // namespace n20
 } // namespace n19
@@ -94,11 +94,11 @@ namespace {
 namespace n24 {
 namespace n25 {
 // CHECK-MESSAGES-NORMAL-DAG: :[[@LINE-2]]:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]
-// CHECK-FIXES-NORMAL: namespace n24::n25
+// CHECK-FIXES-NORMAL: namespace n24::n25 {
 void t();
 } // namespace n25
 } // namespace n24
-// CHECK-FIXES-NORMAL: }
+// CHECK-FIXES-NORMAL: } // namespace n24::n25
 } // namespace
 } // namespace n23
 
@@ -136,7 +136,7 @@ void t();
 namespace n39 {
 namespace n40 {
 // CHECK-MESSAGES-NORMAL-DAG: :[[@LINE-2]]:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]
-// CHECK-FIXES-NORMAL: namespace n39::n40
+// CHECK-FIXES-NORMAL: namespace n39::n40 {
 #ifdef IEXIST
 void t() {}
 #endif
@@ -147,7 +147,7 @@ void t() {}
 namespace n41 {
 namespace n42 {
 // CHECK-MESSAGES-NORMAL-DAG: :[[@LINE-2]]:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]
-// CHECK-FIXES-NORMAL: namespace n41::n42
+// CHECK-FIXES-NORMAL: namespace n41::n42 {
 #ifdef IDONTEXIST
 void t() {}
 #endif

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
+// RUN: %check_clang_tidy %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
 
 #include "structures.h"
 
@@ -18,7 +18,7 @@ void f() {
     int K;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: Sum += I;
   // CHECK-FIXES-NEXT: int K;
 
@@ -27,7 +27,7 @@ void f() {
     Sum += Arr[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -36,7 +36,7 @@ void f() {
     int Y = Arr[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: int X = I;
   // CHECK-FIXES-NEXT: int Y = I + 2;
 
@@ -45,7 +45,7 @@ void f() {
     X = Arr[I];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: int X = N;
   // CHECK-FIXES-NEXT: X = I;
 
@@ -53,7 +53,7 @@ void f() {
     Arr[I] += 1;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: I += 1;
 
   for (int I = 0; I < N; ++I) {
@@ -61,7 +61,7 @@ void f() {
     Arr[I]++;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: int X = I + 2;
   // CHECK-FIXES-NEXT: I++;
 
@@ -69,14 +69,14 @@ void f() {
     Arr[I] = 4 + Arr[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: I = 4 + I;
 
   for (int I = 0; I < NMinusOne + 1; ++I) {
     Sum += Arr[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: Sum += I;
 
   for (int I = 0; I < N; ++I) {
@@ -84,7 +84,7 @@ void f() {
     Sum += Arr[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number %d has address %p\n", I, &I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -96,7 +96,7 @@ void f() {
       size += sizeof((Matrix[I]));
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Matrix)
+  // CHECK-FIXES: for (auto & I : Matrix) {
   // CHECK-FIXES-NEXT: size += sizeof(I);
   // CHECK-FIXES-NEXT: size += sizeof I;
   // CHECK-FIXES-NEXT: size += sizeof(I);
@@ -106,7 +106,7 @@ void f() {
     Teas[I].g();
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Tea : Teas)
+  // CHECK-FIXES: for (auto & Tea : Teas) {
   // CHECK-FIXES-NEXT: Tea.g();
 
   for (int I = 0; N > I; ++I) {
@@ -114,7 +114,7 @@ void f() {
     Sum += Arr[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number %d has address %p\n", I, &I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -123,7 +123,7 @@ void f() {
     Sum += Arr[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number %d has address %p\n", I, &I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -132,7 +132,7 @@ void f() {
     Sum += Arr[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number %d has address %p\n", I, &I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 }
@@ -142,7 +142,7 @@ const int *constArray() {
     printf("2 * %d = %d\n", ConstArr[I], ConstArr[I] + ConstArr[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : ConstArr)
+  // CHECK-FIXES: for (int I : ConstArr) {
   // CHECK-FIXES-NEXT: printf("2 * %d = %d\n", I, I + I);
 
   const NonTriviallyCopyable NonCopy[N]{};
@@ -150,7 +150,7 @@ const int *constArray() {
     printf("2 * %d = %d\n", NonCopy[I].X, NonCopy[I].X + NonCopy[I].X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const auto & I : NonCopy)
+  // CHECK-FIXES: for (const auto & I : NonCopy) {
   // CHECK-FIXES-NEXT: printf("2 * %d = %d\n", I.X, I.X + I.X);
 
   const TriviallyCopyableButBig Big[N]{};
@@ -158,7 +158,7 @@ const int *constArray() {
     printf("2 * %d = %d\n", Big[I].X, Big[I].X + Big[I].X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const auto & I : Big)
+  // CHECK-FIXES: for (const auto & I : Big) {
   // CHECK-FIXES-NEXT: printf("2 * %d = %d\n", I.X, I.X + I.X);
 
   bool Something = false;
@@ -167,7 +167,7 @@ const int *constArray() {
       return &ConstArr[I];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const int & I : ConstArr)
+  // CHECK-FIXES: for (const int & I : ConstArr) {
   // CHECK-FIXES-NEXT: if (Something)
   // CHECK-FIXES-NEXT: return &I;
 
@@ -182,14 +182,14 @@ struct HasArr {
       printf("%d", Arr[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int I : Arr)
+    // CHECK-FIXES: for (int I : Arr) {
     // CHECK-FIXES-NEXT: printf("%d", I);
 
     for (int I = 0; I < N; ++I) {
       printf("%d", ValArr[I].X);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (auto & I : ValArr)
+    // CHECK-FIXES: for (auto & I : ValArr) {
     // CHECK-FIXES-NEXT: printf("%d", I.X);
   }
 
@@ -198,14 +198,14 @@ struct HasArr {
       printf("%d", this->Arr[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int I : this->Arr)
+    // CHECK-FIXES: for (int I : this->Arr) {
     // CHECK-FIXES-NEXT: printf("%d", I);
 
     for (int I = 0; I < N; ++I) {
       printf("%d", this->ValArr[I].X);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (auto & I : this->ValArr)
+    // CHECK-FIXES: for (auto & I : this->ValArr) {
     // CHECK-FIXES-NEXT: printf("%d", I.X);
   }
 };
@@ -217,14 +217,14 @@ struct HasIndirectArr {
       printf("%d", HA.Arr[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int I : HA.Arr)
+    // CHECK-FIXES: for (int I : HA.Arr) {
     // CHECK-FIXES-NEXT: printf("%d", I);
 
     for (int I = 0; I < N; ++I) {
       printf("%d", HA.ValArr[I].X);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (auto & I : HA.ValArr)
+    // CHECK-FIXES: for (auto & I : HA.ValArr) {
     // CHECK-FIXES-NEXT: printf("%d", I.X);
   }
 
@@ -233,14 +233,14 @@ struct HasIndirectArr {
       printf("%d", this->HA.Arr[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int I : this->HA.Arr)
+    // CHECK-FIXES: for (int I : this->HA.Arr) {
     // CHECK-FIXES-NEXT: printf("%d", I);
 
     for (int I = 0; I < N; ++I) {
       printf("%d", this->HA.ValArr[I].X);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (auto & I : this->HA.ValArr)
+    // CHECK-FIXES: for (auto & I : this->HA.ValArr) {
     // CHECK-FIXES-NEXT: printf("%d", I.X);
   }
 };
@@ -285,7 +285,7 @@ void f() {
     printf("I found %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Tt)
+  // CHECK-FIXES: for (int & It : Tt) {
   // CHECK-FIXES-NEXT: printf("I found %d\n", It);
 
   // Do not crash because of Qq.begin() converting. Q::iterator converts with a
@@ -295,7 +295,7 @@ void f() {
     printf("I found %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Qq)
+  // CHECK-FIXES: for (int & It : Qq) {
   // CHECK-FIXES-NEXT: printf("I found %d\n", It);
 
   T *Pt;
@@ -303,7 +303,7 @@ void f() {
     printf("I found %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : *Pt)
+  // CHECK-FIXES: for (int & It : *Pt) {
   // CHECK-FIXES-NEXT: printf("I found %d\n", It);
 
   S Ss;
@@ -311,7 +311,7 @@ void f() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   S *Ps;
@@ -319,42 +319,42 @@ void f() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & P : *Ps)
+  // CHECK-FIXES: for (auto & P : *Ps) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", P.X);
 
   for (S::const_iterator It = Ss.cbegin(), E = Ss.cend(); It != E; ++It) {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto It : Ss)
+  // CHECK-FIXES: for (auto It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   for (S::iterator It = Ss.begin(), E = Ss.end(); It != E; ++It) {
     printf("s has value %d\n", It->X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   for (S::iterator It = Ss.begin(), E = Ss.end(); It != E; ++It) {
     It->X = 3;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: It.X = 3;
 
   for (S::iterator It = Ss.begin(), E = Ss.end(); It != E; ++It) {
     (*It).X = 3;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: It.X = 3;
 
   for (S::iterator It = Ss.begin(), E = Ss.end(); It != E; ++It) {
     It->nonConstFun(4, 5);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: It.nonConstFun(4, 5);
 
   U Uu;
@@ -362,14 +362,14 @@ void f() {
     printf("s has value %d\n", It->X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Uu)
+  // CHECK-FIXES: for (auto & It : Uu) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   for (U::iterator It = Uu.begin(), E = Uu.end(); It != E; ++It) {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Uu)
+  // CHECK-FIXES: for (auto & It : Uu) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   for (U::iterator It = Uu.begin(), E = Uu.end(); It != E; ++It) {
@@ -389,7 +389,7 @@ void f() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : V)
+  // CHECK-FIXES: for (int & It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 
   for (dependent<int>::iterator It(V.begin()), E = V.end();
@@ -397,7 +397,7 @@ void f() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : V)
+  // CHECK-FIXES: for (int & It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 
   doublyDependent<int, int> Intmap;
@@ -406,7 +406,7 @@ void f() {
     printf("Intmap[%d] = %d", It->first, It->second);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Intmap)
+  // CHECK-FIXES: for (auto & It : Intmap) {
   // CHECK-FIXES: printf("Intmap[%d] = %d", It.first, It.second);
 
   // PtrSet's iterator dereferences by value so auto & can't be used.
@@ -418,7 +418,7 @@ void f() {
       (void) *I;
     }
     // CHECK-MESSAGES: :[[@LINE-5]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (auto Val_int_ptr : Val_int_ptrs)
+    // CHECK-FIXES: for (auto Val_int_ptr : Val_int_ptrs) {
   }
 
   // This container uses an iterator where the dereference type is a typedef of
@@ -432,7 +432,7 @@ void f() {
       (void) *I;
     }
     // CHECK-MESSAGES: :[[@LINE-5]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int & Int_ptr : Int_ptrs)
+    // CHECK-FIXES: for (int & Int_ptr : Int_ptrs) {
   }
 
   {
@@ -451,49 +451,49 @@ void f() {
     printf("%d\n", (**I).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Dpp)
+  // CHECK-FIXES: for (auto & I : Dpp) {
   // CHECK-FIXES-NEXT: printf("%d\n", (*I).X);
 
   for (dependent<Val *>::iterator I = Dpp.begin(), E = Dpp.end(); I != E; ++I) {
     printf("%d\n", (*I)->X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Dpp)
+  // CHECK-FIXES: for (auto & I : Dpp) {
   // CHECK-FIXES-NEXT: printf("%d\n", I->X);
 
   for (S::iterator It = begin(Ss), E = end(Ss); It != E; ++It) {
     printf("s0 has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: printf("s0 has value %d\n", It.X);
 
   for (S::iterator It = std::begin(Ss), E = std::end(Ss); It != E; ++It) {
     printf("s1 has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: printf("s1 has value %d\n", It.X);
 
   for (S::iterator It = begin(*Ps), E = end(*Ps); It != E; ++It) {
     printf("s2 has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : *Ps)
+  // CHECK-FIXES: for (auto & It : *Ps) {
   // CHECK-FIXES-NEXT: printf("s2 has value %d\n", It.X);
 
   for (S::iterator It = begin(*Ps); It != end(*Ps); ++It) {
     printf("s3 has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : *Ps)
+  // CHECK-FIXES: for (auto & It : *Ps) {
   // CHECK-FIXES-NEXT: printf("s3 has value %d\n", It.X);
 
   for (S::const_iterator It = cbegin(Ss), E = cend(Ss); It != E; ++It) {
     printf("s4 has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto It : Ss)
+  // CHECK-FIXES: for (auto It : Ss) {
   // CHECK-FIXES-NEXT: printf("s4 has value %d\n", It.X);
 }
 
@@ -507,7 +507,7 @@ void different_type() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto It : Ss)
+  // CHECK-FIXES: for (auto It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   S *Ps;
@@ -515,7 +515,7 @@ void different_type() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto P : *Ps)
+  // CHECK-FIXES: for (auto P : *Ps) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", P.X);
 
   dependent<int> V;
@@ -524,7 +524,7 @@ void different_type() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int It : V)
+  // CHECK-FIXES: for (int It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 
   for (dependent<int>::const_iterator It(V.begin()), E = V.end();
@@ -532,7 +532,7 @@ void different_type() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int It : V)
+  // CHECK-FIXES: for (int It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 }
 
@@ -634,7 +634,7 @@ void f() {
     Sum += V[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : V)
+  // CHECK-FIXES: for (int I : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -643,7 +643,7 @@ void f() {
     Sum += V.at(I) + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : V)
+  // CHECK-FIXES: for (int I : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -652,7 +652,7 @@ void f() {
     Sum += Pv->at(I) + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : *Pv)
+  // CHECK-FIXES: for (int I : *Pv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -665,7 +665,7 @@ void f() {
     Sum += (*Pv)[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : *Pv)
+  // CHECK-FIXES: for (int I : *Pv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -674,7 +674,7 @@ void f() {
     Sum += Cv->at(I) + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : *Cv)
+  // CHECK-FIXES: for (int I : *Cv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -683,7 +683,7 @@ void f() {
     Sum += V[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : V)
+  // CHECK-FIXES: for (int I : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -692,7 +692,7 @@ void f() {
     Sum += V[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : V)
+  // CHECK-FIXES: for (int I : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -701,7 +701,7 @@ void f() {
     Sum += V[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : V)
+  // CHECK-FIXES: for (int I : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -710,7 +710,7 @@ void f() {
     Sum += VD[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : VD)
+  // CHECK-FIXES: for (int I : VD) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -719,7 +719,7 @@ void f() {
     Sum += V[I] + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : V)
+  // CHECK-FIXES: for (int I : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2;
 
@@ -727,14 +727,14 @@ void f() {
     V[I] = 0;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : V)
+  // CHECK-FIXES: for (int & I : V) {
   // CHECK-FIXES-NEXT: I = 0;
 
   for (int I = 0, E = std::size(V); E != I; ++I) {
     V[I] = 0;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : V)
+  // CHECK-FIXES: for (int & I : V) {
   // CHECK-FIXES-NEXT: I = 0;
 
   // Although 'length' might be a valid free function, only size() is standardized
@@ -748,7 +748,7 @@ void f() {
     Sum += Vals[I].X;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Val : Vals)
+  // CHECK-FIXES: for (auto & Val : Vals) {
   // CHECK-FIXES-NEXT: Sum += Val.X;
 }
 
@@ -760,7 +760,7 @@ void constness() {
     Sum += Constv[I].X + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const auto & I : Constv)
+  // CHECK-FIXES: for (const auto & I : Constv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I.X);
   // CHECK-FIXES-NEXT: Sum += I.X + 2;
 
@@ -769,7 +769,7 @@ void constness() {
     Sum += Constv.at(I).X + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const auto & I : Constv)
+  // CHECK-FIXES: for (const auto & I : Constv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I.X);
   // CHECK-FIXES-NEXT: Sum += I.X + 2;
 
@@ -778,7 +778,7 @@ void constness() {
     Sum += Pconstv->at(I).X + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const auto & I : *Pconstv)
+  // CHECK-FIXES: for (const auto & I : *Pconstv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I.X);
   // CHECK-FIXES-NEXT: Sum += I.X + 2;
 
@@ -791,7 +791,7 @@ void constness() {
     Sum += (*Pconstv)[I].X + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (const auto & I : *Pconstv)
+  // CHECK-FIXES: for (const auto & I : *Pconstv) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I.X);
   // CHECK-FIXES-NEXT: Sum += I.X + 2;
 }
@@ -804,14 +804,14 @@ void constRef(const dependent<int>& ConstVRef) {
     sum += ConstVRef[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : ConstVRef)
+  // CHECK-FIXES: for (int I : ConstVRef) {
   // CHECK-FIXES-NEXT: sum += I;
 
   for (auto I = ConstVRef.begin(), E = ConstVRef.end(); I != E; ++I) {
     sum += *I;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : ConstVRef)
+  // CHECK-FIXES: for (int I : ConstVRef) {
   // CHECK-FIXES-NEXT: sum += I;
 }
 
@@ -889,7 +889,7 @@ void derefByValueTest() {
     printf("%d\n", DBV[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (unsigned int I : DBV)
+  // CHECK-FIXES: for (unsigned int I : DBV) {
   // CHECK-FIXES-NEXT: printf("%d\n", I);
 
   for (unsigned I = 0, E = DBV.size(); I < E; ++I) {
@@ -897,7 +897,7 @@ void derefByValueTest() {
     printf("%d\n", DBV[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (unsigned int I : DBV)
+  // CHECK-FIXES: for (unsigned int I : DBV) {
   // CHECK-FIXES-NEXT: auto f = [DBV, &I]() {};
   // CHECK-FIXES-NEXT: printf("%d\n", I);
 }
@@ -960,7 +960,7 @@ template <unsigned  p> void _dependenceArrayTest() {
     for (unsigned j = 0; j < 3; ++j)
       printf("%d", test[j][i]);
   // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: use range-based for loop instead
-  // CHECK-FIXES: (auto & j : test)
+  // CHECK-FIXES: for (auto & j : test)
   // CHECK-FIXES: printf("%d", j[i]);
 }
 void dependenceArrayTest() {
@@ -992,13 +992,13 @@ void test() {
     auto V = [T = Arr[I]]() {};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: auto V = [T = I]() {};
   for (int I = 0; I < N; ++I) {
     auto V = [T = 10 + Arr[I]]() {};
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: auto V = [T = 10 + I]() {};
 
   for (int I = 0; I < N; ++I) {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-const.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-const.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-loop-convert %t
+// RUN: %check_clang_tidy %s modernize-loop-convert %t
 
 struct Str {
   Str() = default;
@@ -43,7 +43,7 @@ void memberFunctionsAndOperators() {
     Array[I].constMember(0);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (auto I : Array)
+  // CHECK-FIXES: for (auto I : Array) {
   // CHECK-FIXES-NEXT: I.constMember(0);
 
   for (int I = 0; I < N; ++I) {
@@ -51,14 +51,14 @@ void memberFunctionsAndOperators() {
       foo();
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto I : Array)
+  // CHECK-FIXES: for (auto I : Array) {
   // CHECK-FIXES-NEXT: if (I < OtherStr)
   for (int I = 0; I < N; ++I) {
     if (Right[I] < OtherRight)
       foo();
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (const auto & I : Right)
+  // CHECK-FIXES: for (const auto & I : Right) {
   // CHECK-FIXES-NEXT: if (I < OtherRight)
 
   // Calling non-const member functions is not.
@@ -66,21 +66,21 @@ void memberFunctionsAndOperators() {
     Array[I].nonConstMember(0);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Array)
+  // CHECK-FIXES: for (auto & I : Array) {
   // CHECK-FIXES-NEXT: I.nonConstMember(0);
 
   for (int I = 0; I < N; ++I) {
     Array[I] = OtherStr;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Array)
+  // CHECK-FIXES: for (auto & I : Array) {
   // CHECK-FIXES-NEXT: I = OtherStr;
 
   for (int I = 0; I < N; ++I) {
     Right[I] = OtherRight;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Right)
+  // CHECK-FIXES: for (auto & I : Right) {
   // CHECK-FIXES-NEXT: I = OtherRight;
 }
 
@@ -90,14 +90,14 @@ void usedAsParameterToFunctionOrOperator() {
     copyArg(Array[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto I : Array)
+  // CHECK-FIXES: for (auto I : Array) {
   // CHECK-FIXES-NEXT: copyArg(I);
 
   for (int I = 0; I < N; ++I) {
     copyArg(Right[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Right)
+  // CHECK-FIXES: for (auto & I : Right) {
   // CHECK-FIXES-NEXT: copyArg(I);
 
   // Using as a const reference argument is allowed.
@@ -105,7 +105,7 @@ void usedAsParameterToFunctionOrOperator() {
     constRefArg(Array[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto I : Array)
+  // CHECK-FIXES: for (auto I : Array) {
   // CHECK-FIXES-NEXT: constRefArg(I);
 
   for (int I = 0; I < N; ++I) {
@@ -113,14 +113,14 @@ void usedAsParameterToFunctionOrOperator() {
       foo();
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto I : Array)
+  // CHECK-FIXES: for (auto I : Array) {
   // CHECK-FIXES-NEXT: if (OtherStr < I)
 
   for (int I = 0; I < N; ++I) {
     constRefArg(Right[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (const auto & I : Right)
+  // CHECK-FIXES: for (const auto & I : Right) {
   // CHECK-FIXES-NEXT: constRefArg(I);
 
   // Using as a non-const reference is not.
@@ -128,20 +128,20 @@ void usedAsParameterToFunctionOrOperator() {
     nonConstRefArg(Array[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Array)
+  // CHECK-FIXES: for (auto & I : Array) {
   // CHECK-FIXES-NEXT: nonConstRefArg(I);
   for (int I = 0; I < N; ++I) {
     nonConstRefArg(Right[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Right)
+  // CHECK-FIXES: for (auto & I : Right) {
   // CHECK-FIXES-NEXT: nonConstRefArg(I);
   for (int I = 0; I < N; ++I) {
     if (OtherRight < Right[I])
       foo();
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Right)
+  // CHECK-FIXES: for (auto & I : Right) {
   // CHECK-FIXES-NEXT: if (OtherRight < I)
 }
 
@@ -151,19 +151,19 @@ void primitiveTypes() {
     copyArg(Ints[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: copyArg(Int);
   for (int I = 0; I < N; ++I) {
     constRefArg(Ints[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: constRefArg(Int);
   for (int I = 0; I < N; ++I) {
     nonConstRefArg(Ints[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int & Int : Ints)
+  // CHECK-FIXES: for (int & Int : Ints) {
   // CHECK-FIXES-NEXT: nonConstRefArg(Int);
 
   // Builtin operators.
@@ -173,7 +173,7 @@ void primitiveTypes() {
       foo();
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: if (Int < N)
 
   for (int I = 0; I < N; ++I) {
@@ -181,7 +181,7 @@ void primitiveTypes() {
       foo();
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: if (N == Int)
 
   // Assignment.
@@ -189,21 +189,21 @@ void primitiveTypes() {
     Ints[I] = OtherInt;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int & Int : Ints)
+  // CHECK-FIXES: for (int & Int : Ints) {
   // CHECK-FIXES-NEXT: Int = OtherInt;
 
   for (int I = 0; I < N; ++I) {
     OtherInt = Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: OtherInt = Int;
 
   for (int I = 0; I < N; ++I) {
     OtherInt = Ints[I] = OtherInt;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int & Int : Ints)
+  // CHECK-FIXES: for (int & Int : Ints) {
   // CHECK-FIXES-NEXT: OtherInt = Int = OtherInt;
 
   // Arithmetic operations.
@@ -211,21 +211,21 @@ void primitiveTypes() {
     OtherInt += Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: OtherInt += Int;
 
   for (int I = 0; I < N; ++I) {
     Ints[I] += Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int & Int : Ints)
+  // CHECK-FIXES: for (int & Int : Ints) {
   // CHECK-FIXES-NEXT: Int += Int;
 
   for (int I = 0; I < N; ++I) {
     int Res = 5 * (Ints[I] + 1) - Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: int Res = 5 * (Int + 1) - Int;
 }
 
@@ -238,7 +238,7 @@ void takingReferences() {
     Str &K = Array[I];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & I : Array)
+  // CHECK-FIXES: for (auto & I : Array) {
   // CHECK-FIXES-NEXT: Str &J = I;
   // CHECK-FIXES-NEXT: Str &K = I;
   for (int I = 0; I < N; ++I) {
@@ -246,7 +246,7 @@ void takingReferences() {
     const Str &K = Array[I];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto I : Array)
+  // CHECK-FIXES: for (auto I : Array) {
   // CHECK-FIXES-NEXT: const Str &J = I;
   // CHECK-FIXES-NEXT: const Str &K = I;
 
@@ -256,7 +256,7 @@ void takingReferences() {
     int &K = Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int & Int : Ints)
+  // CHECK-FIXES: for (int & Int : Ints) {
   // CHECK-FIXES-NEXT: int &J = Int;
   // CHECK-FIXES-NEXT: int &K = Int;
   for (int I = 0; I < N; ++I) {
@@ -264,7 +264,7 @@ void takingReferences() {
     const int &K = Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: const int &J = Int;
   // CHECK-FIXES-NEXT: const int &K = Int;
 
@@ -274,27 +274,27 @@ void takingReferences() {
     (void)J;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto J : Array)
+  // CHECK-FIXES: for (auto J : Array) {
   for (int I = 0; I < N; ++I) {
     Str &J = Array[I];
     (void)J;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto & J : Array)
+  // CHECK-FIXES: for (auto & J : Array) {
 
   for (int I = 0; I < N; ++I) {
     const int &J = Ints[I];
     (void)J;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int J : Ints)
+  // CHECK-FIXES: for (int J : Ints) {
 
   for (int I = 0; I < N; ++I) {
     int &J = Ints[I];
     (void)J;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int & J : Ints)
+  // CHECK-FIXES: for (int & J : Ints) {
 }
 
 template <class T>
@@ -315,7 +315,7 @@ void testContainerOfConstIents() {
     OtherInt -= Ints[I];
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
 
   vector<const Str> Strs;
   for (int I = 0; I < Strs.size(); ++I) {
@@ -323,7 +323,7 @@ void testContainerOfConstIents() {
     constRefArg(Strs[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop
-  // CHECK-FIXES: for (auto Str : Strs)
+  // CHECK-FIXES: for (auto Str : Strs) {
 }
 
 // When we are inside a const-qualified member functions, all the data members
@@ -341,20 +341,20 @@ class TestInsideConstFunction {
         copyArg(Ints[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-4]]:5: warning: use range-based for loop
-    // CHECK-FIXES: for (int Int : Ints)
+    // CHECK-FIXES: for (int Int : Ints) {
 
     for (int I = 0; I < N; ++I) {
       Array[I].constMember(0);
       constRefArg(Array[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-4]]:5: warning: use range-based for loop
-    // CHECK-FIXES: for (auto I : Array)
+    // CHECK-FIXES: for (auto I : Array) {
 
     for (int I = 0; I < V.size(); ++I) {
       if (V[I])
         copyArg(V[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-4]]:5: warning: use range-based for loop
-    // CHECK-FIXES: for (int I : V)
+    // CHECK-FIXES: for (int I : V) {
   }
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-extra.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-extra.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
+// RUN: %check_clang_tidy %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
 
 #include "structures.h"
 
@@ -14,7 +14,7 @@ void f() {
     int B = Arr[I][A];
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Arr)
+  // CHECK-FIXES: for (auto & I : Arr) {
   // CHECK-FIXES-NEXT: int A = 0;
   // CHECK-FIXES-NEXT: int B = I[A];
 
@@ -51,7 +51,7 @@ void aliasing() {
     int Y = T.X;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & T : Arr)
+  // CHECK-FIXES: for (auto & T : Arr) {
   // CHECK-FIXES-NOT: Val &{{[a-z_]+}} =
   // CHECK-FIXES-NEXT: {}
   // CHECK-FIXES-NEXT: int Y = T.X;
@@ -64,7 +64,7 @@ void aliasing() {
     int Z = Arr[I].X + T.X;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Arr)
+  // CHECK-FIXES: for (auto & I : Arr) {
   // CHECK-FIXES-NEXT: Val &T = I;
   // CHECK-FIXES-NEXT: int Y = T.X;
   // CHECK-FIXES-NEXT: int Z = I.X + T.X;
@@ -75,7 +75,7 @@ void aliasing() {
     int Z = Arr[I].X + T.X;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Arr)
+  // CHECK-FIXES: for (auto & I : Arr) {
   // CHECK-FIXES-NEXT: Val T = I;
   // CHECK-FIXES-NEXT: int Y = T.X;
   // CHECK-FIXES-NEXT: int Z = I.X + T.X;
@@ -88,7 +88,7 @@ void aliasing() {
     int Y = T.X;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & T : V)
+  // CHECK-FIXES: for (auto & T : V) {
   // CHECK-FIXES-NEXT: {}
   // CHECK-FIXES-NEXT: int Y = T.X;
 
@@ -99,7 +99,7 @@ void aliasing() {
     int Y = T.X;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & T : *Pv)
+  // CHECK-FIXES: for (auto & T : *Pv) {
   // CHECK-FIXES-NEXT: {}
   // CHECK-FIXES-NEXT: int Y = T.X;
 
@@ -108,7 +108,7 @@ void aliasing() {
     int Y = T.X;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Arr)
+  // CHECK-FIXES: for (auto & I : Arr) {
   // CHECK-FIXES-NEXT: Val &T = func(I);
   // CHECK-FIXES-NEXT: int Y = T.X;
 
@@ -119,8 +119,8 @@ void aliasing() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Alias : IntArr)
-  // CHECK-FIXES-NEXT: if (Alias)
+  // CHECK-FIXES: for (int Alias : IntArr) {
+  // CHECK-FIXES-NEXT: if (Alias) {
 
   for (unsigned I = 0; I < N; ++I) {
     while (int Alias = IntArr[I]) {
@@ -128,8 +128,8 @@ void aliasing() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Alias : IntArr)
-  // CHECK-FIXES-NEXT: while (Alias)
+  // CHECK-FIXES: for (int Alias : IntArr) {
+  // CHECK-FIXES-NEXT: while (Alias) {
 
   for (unsigned I = 0; I < N; ++I) {
     switch (int Alias = IntArr[I]) {
@@ -138,8 +138,8 @@ void aliasing() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-6]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Alias : IntArr)
-  // CHECK-FIXES-NEXT: switch (Alias)
+  // CHECK-FIXES: for (int Alias : IntArr) {
+  // CHECK-FIXES-NEXT: switch (Alias) {
 
   for (unsigned I = 0; I < N; ++I) {
     for (int Alias = IntArr[I]; Alias < N; ++Alias) {
@@ -147,8 +147,8 @@ void aliasing() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Alias : IntArr)
-  // CHECK-FIXES-NEXT: for (; Alias < N; ++Alias)
+  // CHECK-FIXES: for (int Alias : IntArr) {
+  // CHECK-FIXES-NEXT: for (; Alias < N; ++Alias) {
 
   for (unsigned I = 0; I < N; ++I) {
     for (unsigned J = 0; int Alias = IntArr[I]; ++J) {
@@ -156,15 +156,15 @@ void aliasing() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Alias : IntArr)
-  // CHECK-FIXES-NEXT: for (unsigned J = 0; Alias; ++J)
+  // CHECK-FIXES: for (int Alias : IntArr) {
+  // CHECK-FIXES-NEXT: for (unsigned J = 0; Alias; ++J) {
 
   struct IntRef { IntRef(); IntRef(const int& i); operator int*(); };
   for (int I = 0; I < N; ++I) {
     IntRef Int(IntArr[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : IntArr)
+  // CHECK-FIXES: for (int I : IntArr) {
   // CHECK-FIXES-NEXT: IntRef Int(I);
 
   int *PtrArr[N];
@@ -173,7 +173,7 @@ void aliasing() {
     printf("%d\n", *P);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto P : PtrArr)
+  // CHECK-FIXES: for (auto P : PtrArr) {
   // CHECK-FIXES-NEXT: printf("%d\n", *P);
 
   IntRef Refs[N];
@@ -182,7 +182,7 @@ void aliasing() {
     printf("%d\n", *P);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Ref : Refs)
+  // CHECK-FIXES: for (auto & Ref : Refs) {
   // CHECK-FIXES-NEXT: int *P = Ref;
   // CHECK-FIXES-NEXT: printf("%d\n", *P);
 
@@ -212,7 +212,7 @@ void refs_and_vals() {
     Alias.X = 0;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto Alias : S_const)
+  // CHECK-FIXES: for (auto Alias : S_const) {
   // CHECK-FIXES-NOT: MutableVal {{[a-z_]+}} =
   // CHECK-FIXES-NEXT: {}
   // CHECK-FIXES-NEXT: Alias.X = 0;
@@ -223,7 +223,7 @@ void refs_and_vals() {
     Alias.X = 0;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto Alias : Ss)
+  // CHECK-FIXES: for (auto Alias : Ss) {
   // CHECK-FIXES-NOT: MutableVal {{[a-z_]+}} =
   // CHECK-FIXES-NEXT: {}
   // CHECK-FIXES-NEXT: Alias.X = 0;
@@ -234,7 +234,7 @@ void refs_and_vals() {
     Alias.X = 0;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Alias : Ss)
+  // CHECK-FIXES: for (auto & Alias : Ss) {
   // CHECK-FIXES-NOT: MutableVal &{{[a-z_]+}} =
   // CHECK-FIXES-NEXT: {}
   // CHECK-FIXES-NEXT: Alias.X = 0;
@@ -246,7 +246,7 @@ void refs_and_vals() {
     unsigned Othersize = Other.size();
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Dep)
+  // CHECK-FIXES: for (int & It : Dep) {
   // CHECK-FIXES-NEXT: printf("%d\n", It);
   // CHECK-FIXES-NEXT: const int& Idx = Other[0];
   // CHECK-FIXES-NEXT: unsigned Othersize = Other.size();
@@ -255,7 +255,7 @@ void refs_and_vals() {
     Other.at(i);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & i : Other)
+  // CHECK-FIXES: for (int & i : Other) {
   // CHECK-FIXES: i;
 
   for (int I = 0, E = Dep.size(); I != E; ++I) {
@@ -273,21 +273,21 @@ struct MemberNaming {
       printf("%d\n", Ints[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int Int : Ints)
+    // CHECK-FIXES: for (int Int : Ints) {
     // CHECK-FIXES-NEXT: printf("%d\n", Int);
 
     for (int I = 0; I < N; ++I) {
       printf("%d\n", Ints_[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int Int : Ints_)
+    // CHECK-FIXES: for (int Int : Ints_) {
     // CHECK-FIXES-NEXT: printf("%d\n", Int);
 
     for (int I = 0; I < DInts.size(); ++I) {
       printf("%d\n", DInts[I]);
     }
     // CHECK-MESSAGES: :[[@LINE-3]]:5: warning: use range-based for loop instead
-    // CHECK-FIXES: for (int DInt : DInts)
+    // CHECK-FIXES: for (int DInt : DInts) {
     // CHECK-FIXES-NEXT: printf("%d\n", DInt);
   }
 
@@ -298,14 +298,14 @@ void MemberNaming::outOfLine() {
     printf("%d\n", Ints[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Int : Ints)
+  // CHECK-FIXES: for (int Int : Ints) {
   // CHECK-FIXES-NEXT: printf("%d\n", Int);
 
   for (int I = 0; I < N; ++I) {
     printf("%d\n", Ints_[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Int : Ints_)
+  // CHECK-FIXES: for (int Int : Ints_) {
   // CHECK-FIXES-NEXT: printf("%d\n", Int);
 }
 
@@ -334,7 +334,7 @@ void sameNames() {
     (void)Nums[I];
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Nums)
+  // CHECK-FIXES: for (int & I : Nums) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2 + Num;
   // CHECK-FIXES-NEXT: (void)I;
@@ -346,7 +346,7 @@ void sameNames() {
     (void)Nums[I];
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Nums)
+  // CHECK-FIXES: for (int & I : Nums) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", I);
   // CHECK-FIXES-NEXT: Sum += I + 2 + Num + Elem;
   // CHECK-FIXES-NEXT: (void)I;
@@ -357,7 +357,7 @@ void oldIndexConflict() {
     printf("Num: %d\n", Nums[Num]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int Num : Nums)
+  // CHECK-FIXES: for (int Num : Nums) {
   // CHECK-FIXES-NEXT: printf("Num: %d\n", Num);
 
   S Things;
@@ -365,7 +365,7 @@ void oldIndexConflict() {
     printf("Thing: %d %d\n", Thing->X, (*Thing).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Thing : Things)
+  // CHECK-FIXES: for (auto & Thing : Things) {
   // CHECK-FIXES-NEXT: printf("Thing: %d %d\n", Thing.X, Thing.X);
 }
 
@@ -376,7 +376,7 @@ void macroConflict() {
     printf("Max of 3 and 5: %d\n", MAX(3, 5));
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : MAXs)
+  // CHECK-FIXES: for (auto & It : MAXs) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
   // CHECK-FIXES-NEXT: printf("Max of 3 and 5: %d\n", MAX(3, 5));
 
@@ -385,7 +385,7 @@ void macroConflict() {
     printf("Max of 3 and 5: %d\n", MAX(3, 5));
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto It : MAXs)
+  // CHECK-FIXES: for (auto It : MAXs) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
   // CHECK-FIXES-NEXT: printf("Max of 3 and 5: %d\n", MAX(3, 5));
 
@@ -396,8 +396,8 @@ void macroConflict() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : DEFs)
-  // CHECK-FIXES-NEXT: if (It == DEF)
+  // CHECK-FIXES: for (int & It : DEFs) {
+  // CHECK-FIXES-NEXT: if (It == DEF) {
   // CHECK-FIXES-NEXT: printf("I found %d\n", It);
 }
 
@@ -407,7 +407,7 @@ void keywordConflict() {
     *It = 5;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : ints)
+  // CHECK-FIXES: for (int & It : ints) {
   // CHECK-FIXES-NEXT: It = 5;
 
   U __FUNCTION__s;
@@ -416,7 +416,7 @@ void keywordConflict() {
     int __FUNCTION__s_It = (*It).X + 2;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : __FUNCTION__s)
+  // CHECK-FIXES: for (auto & It : __FUNCTION__s) {
   // CHECK-FIXES-NEXT: int __FUNCTION__s_It = It.X + 2;
 }
 
@@ -435,7 +435,7 @@ void typeConflict() {
     *It = sizeof(Val);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Vals)
+  // CHECK-FIXES: for (int & It : Vals) {
   // CHECK-FIXES-NEXT: It = sizeof(Val);
 
   typedef struct Val TD;
@@ -454,7 +454,7 @@ void typeConflict() {
     (void) *It;
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : TDs)
+  // CHECK-FIXES: for (auto & It : TDs) {
   // CHECK-FIXES-NEXT: TD V;
   // CHECK-FIXES-NEXT: V.X = 5;
 
@@ -464,7 +464,7 @@ void typeConflict() {
     *It = sizeof(St);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Sts)
+  // CHECK-FIXES: for (int & It : Sts) {
   // CHECK-FIXES-NEXT: It = sizeof(St);
 }
 
@@ -528,8 +528,8 @@ void f() {
   }
   // CHECK-MESSAGES: :[[@LINE-8]]:3: warning: use range-based for loop instead
   // CHECK-MESSAGES: :[[@LINE-8]]:5: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Arr)
-  // CHECK-FIXES-NEXT: for (auto & J : Arr)
+  // CHECK-FIXES: for (auto & I : Arr) {
+  // CHECK-FIXES-NEXT: for (auto & J : Arr) {
   // CHECK-FIXES-NEXT: int K = I.X + J.X;
   // CHECK-FIXES-NOT: int L = I.X + I.X;
 
@@ -542,8 +542,8 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Nest)
-  // CHECK-FIXES-NEXT: for (int J = 0; J < M; ++J)
+  // CHECK-FIXES: for (auto & I : Nest) {
+  // CHECK-FIXES-NEXT: for (int J = 0; J < M; ++J) {
   // CHECK-FIXES-NEXT: printf("Got item %d", I[J].X);
 
   // Note that the order of M and N are switched for this test.
@@ -554,8 +554,8 @@ void f() {
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:5: warning: use range-based for loop instead
   // CHECK-FIXES-NOT: for (auto & {{[a-zA-Z_]+}} : Nest[I])
-  // CHECK-FIXES: for (int J = 0; J < M; ++J)
-  // CHECK-FIXES-NEXT: for (auto & I : Nest)
+  // CHECK-FIXES: for (int J = 0; J < M; ++J) {
+  // CHECK-FIXES-NEXT: for (auto & I : Nest) {
   // CHECK-FIXES-NEXT: printf("Got item %d", I[J].X);
 
   // The inner loop is also convertible.
@@ -566,8 +566,8 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : NestT)
-  // CHECK-FIXES-NEXT: for (T::iterator TI = I.begin(), TE = I.end(); TI != TE; ++TI)
+  // CHECK-FIXES: for (auto & I : NestT) {
+  // CHECK-FIXES-NEXT: for (T::iterator TI = I.begin(), TE = I.end(); TI != TE; ++TI) {
   // CHECK-FIXES-NEXT: printf("%d", *TI);
 
   // The inner loop is also convertible.
@@ -578,8 +578,8 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto I : NestS)
-  // CHECK-FIXES-NEXT: for (S::const_iterator SI = I.begin(), SE = I.end(); SI != SE; ++SI)
+  // CHECK-FIXES: for (auto I : NestS) {
+  // CHECK-FIXES-NEXT: for (S::const_iterator SI = I.begin(), SE = I.end(); SI != SE; ++SI) {
   // CHECK-FIXES-NEXT: printf("%d", *SI);
 
   for (Nested<S>::const_iterator I = NestS.begin(), E = NestS.end(); I != E; ++I) {
@@ -590,7 +590,7 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-7]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto Ss : NestS)
+  // CHECK-FIXES: for (auto Ss : NestS) {
 
   for (Nested<S>::iterator I = NestS.begin(), E = NestS.end(); I != E; ++I) {
     S &Ss = *I;
@@ -600,7 +600,7 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-7]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Ss : NestS)
+  // CHECK-FIXES: for (auto & Ss : NestS) {
 
   Foo foo;
   for (Nested<S>::const_iterator I = NestS.begin(), E = NestS.end(); I != E; ++I) {
@@ -611,7 +611,7 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-7]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto Ss : NestS)
+  // CHECK-FIXES: for (auto Ss : NestS) {
 
   for (Nested<S>::iterator I = NestS.begin(), E = NestS.end(); I != E; ++I) {
     S &Ss = *I;
@@ -621,7 +621,7 @@ void f() {
     }
   }
   // CHECK-MESSAGES: :[[@LINE-7]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & Ss : NestS)
+  // CHECK-FIXES: for (auto & Ss : NestS) {
 
 }
 
@@ -638,7 +638,7 @@ void complexContainer() {
     MutableVal J = *I;
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & I : Exes[Index].getS())
+  // CHECK-FIXES: for (auto & I : Exes[Index].getS()) {
   // CHECK-FIXES-NEXT: MutableVal K = I;
   // CHECK-FIXES-NEXT: MutableVal J = I;
 }
@@ -650,7 +650,7 @@ void f() {
     printf("I found %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Tt)
+  // CHECK-FIXES: for (int & It : Tt) {
   // CHECK-FIXES-NEXT: printf("I found %d\n", It);
 
   T *Pt;
@@ -658,7 +658,7 @@ void f() {
     printf("I found %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : *Pt)
+  // CHECK-FIXES: for (int & It : *Pt) {
   // CHECK-FIXES-NEXT: printf("I found %d\n", It);
 
   S Ss;
@@ -666,7 +666,7 @@ void f() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   S *Ps;
@@ -674,35 +674,35 @@ void f() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & P : *Ps)
+  // CHECK-FIXES: for (auto & P : *Ps) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", P.X);
 
   for (S::iterator It = Ss.begin(); It != Ss.end(); ++It) {
     printf("s has value %d\n", It->X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   for (S::iterator It = Ss.begin(); It != Ss.end(); ++It) {
     It->X = 3;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: It.X = 3;
 
   for (S::iterator It = Ss.begin(); It != Ss.end(); ++It) {
     (*It).X = 3;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: It.X = 3;
 
   for (S::iterator It = Ss.begin(); It != Ss.end(); ++It) {
     It->nonConstFun(4, 5);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Ss)
+  // CHECK-FIXES: for (auto & It : Ss) {
   // CHECK-FIXES-NEXT: It.nonConstFun(4, 5);
 
   U Uu;
@@ -710,14 +710,14 @@ void f() {
     printf("s has value %d\n", It->X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Uu)
+  // CHECK-FIXES: for (auto & It : Uu) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   for (U::iterator It = Uu.begin(); It != Uu.end(); ++It) {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : Uu)
+  // CHECK-FIXES: for (auto & It : Uu) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   U::iterator A;
@@ -733,7 +733,7 @@ void f() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : V)
+  // CHECK-FIXES: for (int & It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 
   for (dependent<int>::iterator It(V.begin());
@@ -741,7 +741,7 @@ void f() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : V)
+  // CHECK-FIXES: for (int & It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 
   doublyDependent<int, int> intmap;
@@ -750,7 +750,7 @@ void f() {
     printf("intmap[%d] = %d", It->first, It->second);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto & It : intmap)
+  // CHECK-FIXES: for (auto & It : intmap) {
   // CHECK-FIXES-NEXT: printf("intmap[%d] = %d", It.first, It.second);
 }
 
@@ -765,7 +765,7 @@ void different_type() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto It : Ss)
+  // CHECK-FIXES: for (auto It : Ss) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", It.X);
 
   S *Ps;
@@ -773,7 +773,7 @@ void different_type() {
     printf("s has value %d\n", (*It).X);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (auto P : *Ps)
+  // CHECK-FIXES: for (auto P : *Ps) {
   // CHECK-FIXES-NEXT: printf("s has value %d\n", P.X);
 
   dependent<int> V;
@@ -781,14 +781,14 @@ void different_type() {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int It : V)
+  // CHECK-FIXES: for (int It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 
   for (dependent<int>::const_iterator It(V.begin()); It != V.end(); ++It) {
     printf("Fibonacci number is %d\n", *It);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int It : V)
+  // CHECK-FIXES: for (int It : V) {
   // CHECK-FIXES-NEXT: printf("Fibonacci number is %d\n", It);
 }
 
@@ -808,7 +808,7 @@ void messing_with_macros() {
     printf("Value: %d\n", Arr[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT:  printf("Value: %d\n", I);
 
   for (int I = 0; I < N; ++I) {
@@ -821,7 +821,7 @@ void messing_with_macros() {
     THREE_PARAM(Arr[I], Arr[I], Arr[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & I : Arr)
+  // CHECK-FIXES: for (int & I : Arr) {
   // CHECK-FIXES-NEXT: TWO_PARAM(I, I);
   // CHECK-FIXES-NEXT: THREE_PARAM(I, I, I);
 }
@@ -907,10 +907,11 @@ void capturesIndex() {
     F(Arr[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-6]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
-  // CHECK-FIXES-NEXT: auto F = [Arr, &I](int k)
-  // CHECK-FIXES-NEXT: printf("%d\n", I + k);
-  // CHECK-FIXES: F(I);
+  // CHECK-FIXES: for (int I : Arr) {
+  // CHECK-FIXES-NEXT: auto F = [Arr, &I](int k) {
+  // CHECK-FIXES-NEXT:   printf("%d\n", I + k);
+  // CHECK-FIXES-NEXT: };
+  // CHECK-FIXES-NEXT: F(I);
 }
 
 void implicitCapture() {
@@ -939,8 +940,8 @@ void implicitCapture() {
     };
   }
   // CHECK-MESSAGES: :[[@LINE-6]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
-  // CHECK-FIXES-NEXT: auto G3 = [&]()
+  // CHECK-FIXES: for (int I : Arr) {
+  // CHECK-FIXES-NEXT: auto G3 = [&]() {
   // CHECK-FIXES-NEXT: int R3 = I;
   // CHECK-FIXES-NEXT: int J3 = I + R3;
 
@@ -950,8 +951,8 @@ void implicitCapture() {
     };
   }
   // CHECK-MESSAGES: :[[@LINE-5]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
-  // CHECK-FIXES-NEXT: auto G4 = [=]()
+  // CHECK-FIXES: for (int I : Arr) {
+  // CHECK-FIXES-NEXT: auto G4 = [=]() {
   // CHECK-FIXES-NEXT: int R4 = I + 5;
 
   // Alias by value.
@@ -962,8 +963,8 @@ void implicitCapture() {
     };
   }
   // CHECK-MESSAGES: :[[@LINE-6]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int R5 : Arr)
-  // CHECK-FIXES-NEXT: auto G5 = [&]()
+  // CHECK-FIXES: for (int R5 : Arr) {
+  // CHECK-FIXES-NEXT: auto G5 = [&]() {
   // CHECK-FIXES-NEXT: int J5 = 8 + R5;
 
   // Alias by reference.
@@ -974,8 +975,8 @@ void implicitCapture() {
     };
   }
   // CHECK-MESSAGES: :[[@LINE-6]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & R6 : Arr)
-  // CHECK-FIXES-NEXT: auto G6 = [&]()
+  // CHECK-FIXES: for (int & R6 : Arr) {
+  // CHECK-FIXES-NEXT: auto G6 = [&]() {
   // CHECK-FIXES-NEXT: int J6 = -1 + R6;
 }
 
@@ -1029,14 +1030,14 @@ void captureByValue() {
     auto C1 = [&Arr, I]() { if (Arr[I] == 1); };
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Arr)
+  // CHECK-FIXES: for (int I : Arr) {
   // CHECK-FIXES-NEXT: auto C1 = [&Arr, &I]() { if (I == 1); };
 
   for (unsigned I = 0; I < Dep.size(); ++I) {
     auto C2 = [&Dep, I]() { if (Dep[I] == 2); };
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Dep)
+  // CHECK-FIXES: for (int I : Dep) {
   // CHECK-FIXES-NEXT: auto C2 = [&Dep, &I]() { if (I == 2); };
 }
 
@@ -1062,7 +1063,7 @@ void f() {
     E Ee{ { { g( { Array[I] } ) } } };
   }
   // CHECK-MESSAGES: :[[@LINE-7]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : Array)
+  // CHECK-FIXES: for (int I : Array) {
   // CHECK-FIXES-NEXT: int A{ I };
   // CHECK-FIXES-NEXT: int B{ g(I) };
   // CHECK-FIXES-NEXT: int C{ g( { I } ) };
@@ -1079,7 +1080,7 @@ void bug28341() {
       if (value > 127)
         ;
   // CHECK-MESSAGES: :[[@LINE-4]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for(unsigned char value : v)
+  // CHECK-FIXES: for(unsigned char value : v) {
   // CHECK-FIXES-NEXT: if (value > 127)
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/make-shared.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/make-shared.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-make-shared %t -- -- -I %S/Inputs/smart-ptr
+// RUN: %check_clang_tidy %s modernize-make-shared %t -- -- -I %S/Inputs/smart-ptr
 
 #include "shared_ptr.h"
 // CHECK-FIXES: #include <memory>
@@ -226,7 +226,7 @@ void initialization(int T, Base b) {
   // CHECK-FIXES: std::shared_ptr<APair> PAggr = std::make_shared<APair>(APair{T, 1});
   PAggr.reset(new APair{T, 1});
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use std::make_shared instead
-  // CHECK-FIXES: std::make_shared<APair>(APair{T, 1});
+  // CHECK-FIXES: PAggr = std::make_shared<APair>(APair{T, 1});
 
   // Test different kinds of initialization of the pointee, when the shared_ptr
   // is initialized with braces.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/make-unique.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/make-unique.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s modernize-make-unique %t -- -- -I %S/Inputs/smart-ptr
+// RUN: %check_clang_tidy -std=c++14-or-later %s modernize-make-unique %t -- -- -I %S/Inputs/smart-ptr
 
 #include "unique_ptr.h"
 #include "initializer_list.h"
@@ -271,7 +271,7 @@ void initialization(int T, Base b) {
   // CHECK-FIXES: std::unique_ptr<APair> PAggr = std::make_unique<APair>(APair{T, 1});
   PAggr.reset(new APair{T, 1});
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use std::make_unique instead
-  // CHECK-FIXES: std::make_unique<APair>(APair{T, 1});
+  // CHECK-FIXES: PAggr = std::make_unique<APair>(APair{T, 1});
 
   // Check aggregate init with intermediate temporaries.
   std::unique_ptr<APair> PAggrTemp = std::unique_ptr<APair>(new APair({T, 1}));
@@ -480,7 +480,7 @@ void initialization(int T, Base b) {
   std::unique_ptr<int[]> FI;
   FI.reset(new int[5]()); // value initialization.
   // CHECK-MESSAGES: :[[@LINE-1]]:6: warning:
-  // CHECK-FIXES: FI = std::make_unique<int[]>(5);
+  // CHECK-FIXES: FI = std::make_unique<int[]>(5); // value initialization.
 
   // The check doesn't give warnings and fixes for cases where the original new
   // expression does default initialization.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/min-max-use-initializer-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/min-max-use-initializer-list.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-min-max-use-initializer-list %t
+// RUN: %check_clang_tidy %s modernize-min-max-use-initializer-list %t
 
 // CHECK-FIXES: #include <algorithm>
 namespace utils {
@@ -206,7 +206,7 @@ int min7 = std::min(1, std::min(2, 3, fless_than), fgreater_than);
 // CHECK-FIXES: int min7 = std::min(1, std::min(2, 3, fless_than), fgreater_than);
 
 int max8 = std::max(1, std::max(2, 3, fless_than), less_than);
-// CHECK-FIXES: int max8 = std::max(1, std::max(2, 3, fless_than), less_than)
+// CHECK-FIXES: int max8 = std::max(1, std::max(2, 3, fless_than), less_than);
 
 int min8 = std::min(1, std::min(2, 3, fless_than), less_than);
 // CHECK-FIXES: int min8 = std::min(1, std::min(2, 3, fless_than), less_than);

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-pass-by-value %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy %s modernize-pass-by-value %t -- -- -fno-delayed-template-parsing
 
 namespace {
 // POD types are trivially move constructible.
@@ -92,7 +92,7 @@ struct H {
 using namespace ns_H;
 H::H(const HMovable &M) : M(M) {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: pass by value and use std::move
-// CHECK-FIXES: H(HMovable M) : M(std::move(M)) {}
+// CHECK-FIXES: H::H(HMovable M) : M(std::move(M)) {}
 
 // Try messing up with macros.
 #define MOVABLE_PARAM(Name) const Movable & Name

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-redundant-void-arg %t
+// RUN: %check_clang_tidy %s modernize-redundant-void-arg %t
 
 #define NULL 0
 
@@ -452,22 +452,22 @@ struct DefinitionWithNoBody {
 #define BODY {}
 #define LAMBDA1 [](void){}
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: redundant void argument list in lambda expression [modernize-redundant-void-arg]
-// CHECK-FIXES: LAMBDA1 [](){}
+// CHECK-FIXES: #define LAMBDA1 [](){}
 
 #define LAMBDA2 [](void)BODY
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: redundant void argument list in lambda expression [modernize-redundant-void-arg]
-// CHECK-FIXES: LAMBDA2 []()BODY
+// CHECK-FIXES: #define LAMBDA2 []()BODY
 
 #define LAMBDA3(captures, args, body) captures args body
 #define WRAP(...) __VA_ARGS__
 
 #define LAMBDA4 (void)LAMBDA3([],(void),BODY)
 // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: redundant void argument list in lambda expression [modernize-redundant-void-arg]
-// CHECK-FIXES: LAMBDA4 (void)LAMBDA3([],(),BODY)
+// CHECK-FIXES: #define LAMBDA4 (void)LAMBDA3([],(),BODY)
 
 #define LAMBDA5 []() -> void (*)(void) {return BODY;}
 // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: redundant void argument list in lambda expression [modernize-redundant-void-arg]
-// CHECK-FIXES: LAMBDA5 []() -> void (*)() {return BODY;}
+// CHECK-FIXES: #define LAMBDA5 []() -> void (*)() {return BODY;}
 void lambda_expression_with_macro_test(){
   (void)LAMBDA1;
   (void)LAMBDA2;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-auto-ptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-auto-ptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-replace-auto-ptr %t -- -- -I %S/Inputs/replace-auto-ptr
+// RUN: %check_clang_tidy %s modernize-replace-auto-ptr %t -- -- -I %S/Inputs/replace-auto-ptr
 
 // CHECK-FIXES: #include <utility>
 
@@ -15,7 +15,7 @@ std::auto_ptr<Derived> create_derived_ptr();
 // Test function return values (declaration)
 std::auto_ptr<char> f_5();
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: auto_ptr is deprecated
-// CHECK-FIXES: std::unique_ptr<char> f_5()
+// CHECK-FIXES: std::unique_ptr<char> f_5();
 
 
 // Test function parameters.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast-remove-stars.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast-remove-stars.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.RemoveStars: 'true' , modernize-use-auto.MinTypeNameLength: '0'}}" \
 // RUN:   -- -frtti
 
@@ -108,7 +108,7 @@ typedef unsigned char xmlChar;
   do {                           \
     xmlChar *s = (xmlChar *)(x); \
   } while (false);
-// CHECK-FIXES: xmlChar *s = (xmlChar *)(x);
+// CHECK-FIXES: xmlChar *s = (xmlChar *)(x); {{\\}}
 
 void f_cstyle_cast() {
   auto *a = new A();

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.MinTypeNameLength: '0'}}" \
 // RUN:   -- -I %S/Inputs/use-auto -frtti
 
@@ -108,7 +108,7 @@ typedef unsigned char xmlChar;
   do {                           \
     xmlChar *s = (xmlChar *)(x); \
   } while (false);
-// CHECK-FIXES: xmlChar *s = (xmlChar *)(x);
+// CHECK-FIXES: xmlChar *s = (xmlChar *)(x); {{\\}}
 
 void f_cstyle_cast() {
   auto *a = new A();

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-for-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-for-pointer.cpp
@@ -1,20 +1,20 @@
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=REMOVE %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy -check-suffix=REMOVE %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.RemoveStars: 'true', modernize-use-auto.MinTypeNameLength: '0'}}"
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.RemoveStars: 'false', modernize-use-auto.MinTypeNameLength: '0'}}"
 
 void pointerToFunction() {
   void (*(*(f1)))() = static_cast<void (**)()>(nullptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use auto when initializing
-  // CHECK-FIXES-REMOVE: auto f1 =
-  // CHECK-FIXES: auto *f1 =
+  // CHECK-FIXES-REMOVE: auto f1 = static_cast<void (**)()>(nullptr);
+  // CHECK-FIXES: auto *f1 = static_cast<void (**)()>(nullptr);
 }
 
 void pointerToArray() {
   int(*a1)[2] = new int[10][2];
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use auto when initializing
-  // CHECK-FIXES-REMOVE: auto a1 =
-  // CHECK-FIXES: auto *a1 =
+  // CHECK-FIXES-REMOVE: auto a1 = new int[10][2];
+  // CHECK-FIXES: auto *a1 = new int[10][2];
 }
 
 void memberFunctionPointer() {
@@ -23,7 +23,7 @@ void memberFunctionPointer() {
   };
   void(A::* a1)() = static_cast<void(A::*)()>(nullptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use auto when initializing
-  // CHECK-FIXES-REMOVE: auto a1 =
-  // CHECK-FIXES: auto *a1 =
+  // CHECK-FIXES-REMOVE: auto a1 = static_cast<void(A::*)()>(nullptr);
+  // CHECK-FIXES: auto *a1 = static_cast<void(A::*)()>(nullptr);
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-iterator.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-iterator.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++11,c++14 %s modernize-use-auto %t -- -- -I %S/Inputs/use-auto
+// RUN: %check_clang_tidy -std=c++11,c++14 %s modernize-use-auto %t -- -- -I %S/Inputs/use-auto
 // FIXME: Fix the checker to work in C++17 mode.
 
 #include "containers.h"
@@ -277,18 +277,18 @@ void pointer_to_iterator() {
 void loop() {
   for (std::vector<int>::iterator I = Vec.begin(); I != Vec.end(); ++I) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: use auto when declaring iterators
-    // CHECK-FIXES: for (auto I = Vec.begin(); I != Vec.end(); ++I)
+    // CHECK-FIXES: for (auto I = Vec.begin(); I != Vec.end(); ++I) {
   }
 
   for (int_iterator I = Vec.begin(), E = Vec.end(); I != E; ++I) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: use auto when declaring iterators
-    // CHECK-FIXES: for (auto I = Vec.begin(), E = Vec.end(); I != E; ++I)
+    // CHECK-FIXES: for (auto I = Vec.begin(), E = Vec.end(); I != E; ++I) {
   }
 
   std::vector<std::vector<int>::iterator> IterVec;
   for (std::vector<int>::iterator I : IterVec) {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: use auto when declaring iterators
-    // CHECK-FIXES: for (auto I : IterVec)
+    // CHECK-FIXES: for (auto I : IterVec) {
   }
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-min-type-name-length.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-min-type-name-length.cpp
@@ -1,7 +1,7 @@
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=0-0 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=0-8 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=1-0 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=1-8 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
+// RUN: %check_clang_tidy -check-suffix=0-0 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
+// RUN: %check_clang_tidy -check-suffix=0-8 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
+// RUN: %check_clang_tidy -check-suffix=1-0 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
+// RUN: %check_clang_tidy -check-suffix=1-8 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
 
 template <class T> extern T foo();
 template <class T> struct P {  explicit P(T t) : t_(t) {}  T t_;};
@@ -17,10 +17,10 @@ int bar() {
     // CHECK-FIXES-1-0: auto  i = {{.*}}
     // CHECK-FIXES-1-8: long i = {{.*}}
     const long ci = static_cast<long>(foo<const long>());
-    // CHECK-FIXES-0-0: auto ci = {{.*}}
-    // CHECK-FIXES-0-8: long ci = {{.*}}
-    // CHECK-FIXES-1-0: auto  ci = {{.*}}
-    // CHECK-FIXES-1-8: long ci = {{.*}}
+    // CHECK-FIXES-0-0: const auto ci = {{.*}}
+    // CHECK-FIXES-0-8: const long ci = {{.*}}
+    // CHECK-FIXES-1-0: const auto  ci = {{.*}}
+    // CHECK-FIXES-1-8: const long ci = {{.*}}
     long *pi = static_cast<long *>(foo<long *>());
     // CHECK-FIXES-0-0: auto *pi = {{.*}}
     // CHECK-FIXES-0-8: long *pi = {{.*}}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default-copy.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default-copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-equals-default %t -- \
+// RUN: %check_clang_tidy %s modernize-use-equals-default %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-equals-default.IgnoreMacros: false}}" \
 // RUN:   -- -fno-delayed-template-parsing -fexceptions -Wno-error=return-type
 
@@ -35,7 +35,7 @@ struct IL {
 // Skip unions.
 union NU {
   NU(const NU &Other) : Field(Other.Field) {}
-  // CHECK-FIXES: NU(const NU &Other) :
+  // CHECK-FIXES: NU(const NU &Other) : Field(Other.Field) {}
   NU &operator=(const NU &Other) {
     Field = Other.Field;
     return *this;
@@ -47,7 +47,7 @@ union NU {
 // Skip structs/classes containing anonymous unions.
 struct SU {
   SU(const SU &Other) : Field(Other.Field) {}
-  // CHECK-FIXES: SU(const SU &Other) :
+  // CHECK-FIXES: SU(const SU &Other) : Field(Other.Field) {}
   SU &operator=(const SU &Other) {
     Field = Other.Field;
     return *this;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-equals-default %t -- -- -fno-delayed-template-parsing -fexceptions
+// RUN: %check_clang_tidy %s modernize-use-equals-default %t -- -- -fno-delayed-template-parsing -fexceptions
 
 // Out of line definition.
 class OL {
@@ -145,7 +145,7 @@ struct ST {
   // CHECK-FIXES: ST() = default;
   ~ST() {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use '= default'
-  // CHECK-FIXES: ST() = default;
+  // CHECK-FIXES: ~ST() = default;
 };
 
 // Deleted constructor/destructor.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++17 %s modernize-use-integer-sign-comparison %t -- \
+// RUN: %check_clang_tidy -std=c++17 %s modernize-use-integer-sign-comparison %t -- \
 // RUN: -config="{CheckOptions: {modernize-use-integer-sign-comparison.EnableQtSupport: true}}"
 
 // CHECK-FIXES: #include <QtCore/q20utility.h>
@@ -92,7 +92,8 @@ int AllComparisons() {
     if (static_cast<unsigned int>(uArray[2]) < static_cast<int>(sArray[2]))
         return 0;
 // CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
-// CHECK-FIXES: if (q20::cmp_less(uArray[2],sArray[2]))
+// CHECK-FIXES: if (q20::cmp_less(uArray[2],sArray[2])))
+// FIXME: There should only be 2 closing braces. The fix-it inserts an unbalanced one.
 
     if ((unsigned int)uArray[3] < (int)sArray[3])
         return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++20 %s modernize-use-integer-sign-comparison %t
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-integer-sign-comparison %t
 
 // CHECK-FIXES: #include <utility>
 
@@ -91,7 +91,8 @@ int AllComparisons() {
     if (static_cast<unsigned int>(uArray[2]) < static_cast<int>(sArray[2]))
         return 0;
 // CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
-// CHECK-FIXES: if (std::cmp_less(uArray[2],sArray[2]))
+// CHECK-FIXES: if (std::cmp_less(uArray[2],sArray[2])))
+// FIXME: There should only be 2 closing braces. The fix-it inserts an unbalanced one.
 
     if ((unsigned int)uArray[3] < (int)sArray[3])
         return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-nullptr %t -- \
+// RUN: %check_clang_tidy %s modernize-use-nullptr %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-nullptr.NullMacros: 'MY_NULL,NULL'}}"
 
 #define NULL 0
@@ -91,7 +91,7 @@ template <typename T> struct pear {
   // it is often defined as __null and the check will catch it.)
   void f() { x = __null; }
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: use nullptr [modernize-use-nullptr]
-  // CHECK-FIXES: x = nullptr;
+  // CHECK-FIXES: void f() { x = nullptr; }
 
   // But if you say 0, we allow the possibility that T can be used with integral
   // and pointer types, and "0" is an acceptable initializer (even if "{}" might
@@ -118,11 +118,13 @@ void test_macro_args() {
   // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: use nullptr
   // CHECK-FIXES: IS_EQ(static_cast<int*>(nullptr), Ptr);
 
-  IS_EQ(0, Ptr);    // literal
+  // literal
+  IS_EQ(0, Ptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use nullptr
   // CHECK-FIXES: IS_EQ(nullptr, Ptr);
 
-  IS_EQ(NULL, Ptr); // macro
+  // macro
+  IS_EQ(NULL, Ptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use nullptr
   // CHECK-FIXES: IS_EQ(nullptr, Ptr);
 
@@ -205,7 +207,7 @@ void test_macro_args() {
   } a[2] = {ENTRY(0), {0}};
   // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: use nullptr
   // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: use nullptr
-  // CHECK-FIXES: a[2] = {ENTRY(nullptr), {nullptr}};
+  // CHECK-FIXES: } a[2] = {ENTRY(nullptr), {nullptr}};
 #undef ENTRY
 
 #define assert1(expr) (expr) ? 0 : 1

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-override,cppcoreguidelines-explicit-virtual-functions %t -- -- -fexceptions
+// RUN: %check_clang_tidy %s modernize-use-override,cppcoreguidelines-explicit-virtual-functions %t -- -- -fexceptions
 
 #define ABSTRACT = 0
 
@@ -96,7 +96,8 @@ public:
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer using
   // CHECK-FIXES: void j() const override;
 
-  virtual MustUseResultObject k();  // Has an implicit attribute.
+  // Has an implicit attribute.
+  virtual MustUseResultObject k();
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer using
   // CHECK-FIXES: MustUseResultObject k() override;
 
@@ -203,7 +204,8 @@ public:
   // CHECK-MESSAGES: :[[@LINE-2]]:16: warning: prefer using
   // CHECK-FIXES: void j() const override
 
-  virtual MustUseResultObject k();  // Has an implicit attribute.
+  // Has an implicit attribute.
+  virtual MustUseResultObject k();
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer using
   // CHECK-FIXES: MustUseResultObject k() override;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format.cpp
@@ -1,11 +1,11 @@
-// RUN: %check_clang_tidy --match-partial-fixes \
-// RUN:   -std=c++20 %s modernize-use-std-format %t -- \
+// RUN: %check_clang_tidy \
+// RUN:   -std=c++20-or-later %s modernize-use-std-format %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-format.StrictMode: true}}" \
 // RUN:   -- -isystem %clang_tidy_headers \
 // RUN:      -DPRI_CMDLINE_MACRO="\"s\"" \
 // RUN:      -D__PRI_CMDLINE_MACRO="\"s\""
-// RUN: %check_clang_tidy --match-partial-fixes \
-// RUN:   -std=c++20 %s modernize-use-std-format %t -- \
+// RUN: %check_clang_tidy \
+// RUN:   -std=c++20-or-later %s modernize-use-std-format %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-format.StrictMode: false}}" \
 // RUN:   -- -isystem %clang_tidy_headers \
 // RUN:      -DPRI_CMDLINE_MACRO="\"s\"" \
@@ -70,32 +70,32 @@ std::string StrFormat_strict_conversion() {
 std::string StrFormat_field_width_and_precision() {
   auto s1 = absl::StrFormat("width only:%*d width and precision:%*.*f precision only:%.*f", 3, 42, 4, 2, 3.14159265358979323846, 5, 2.718);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("width only:{:{}} width and precision:{:{}.{}f} precision only:{:.{}f}", 42, 3, 3.14159265358979323846, 4, 2, 2.718, 5);
+  // CHECK-FIXES: auto s1 = std::format("width only:{:{}} width and precision:{:{}.{}f} precision only:{:.{}f}", 42, 3, 3.14159265358979323846, 4, 2, 2.718, 5);
 
   auto s2 = absl::StrFormat("width and precision positional:%1$*2$.*3$f after", 3.14159265358979323846, 4, 2);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("width and precision positional:{0:{1}.{2}f} after", 3.14159265358979323846, 4, 2);
+  // CHECK-FIXES: auto s2 = std::format("width and precision positional:{0:{1}.{2}f} after", 3.14159265358979323846, 4, 2);
 
   const int width = 10, precision = 3;
   const unsigned int ui1 = 42, ui2 = 43, ui3 = 44;
   auto s3 = absl::StrFormat("casts width only:%*d width and precision:%*.*d precision only:%.*d\n", 3, ui1, 4, 2, ui2, 5, ui3);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES-NOTSTRICT: std::format("casts width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", ui1, 3, ui2, 4, 2, ui3, 5);
-  // CHECK-FIXES-STRICT: std::format("casts width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", static_cast<int>(ui1), 3, static_cast<int>(ui2), 4, 2, static_cast<int>(ui3), 5);
+  // CHECK-FIXES-NOTSTRICT: auto s3 = std::format("casts width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", ui1, 3, ui2, 4, 2, ui3, 5);
+  // CHECK-FIXES-STRICT: auto s3 = std::format("casts width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", static_cast<int>(ui1), 3, static_cast<int>(ui2), 4, 2, static_cast<int>(ui3), 5);
 
   auto s4 = absl::StrFormat("c_str removal width only:%*s width and precision:%*.*s precision only:%.*s", 3, s1.c_str(), 4, 2, s2.c_str(), 5, s3.c_str());
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("c_str removal width only:{:>{}} width and precision:{:>{}.{}} precision only:{:.{}}", s1, 3, s2, 4, 2, s3, 5);
+  // CHECK-FIXES: auto s4 = std::format("c_str removal width only:{:>{}} width and precision:{:>{}.{}} precision only:{:.{}}", s1, 3, s2, 4, 2, s3, 5);
 
   const std::string *ps1 = &s1, *ps2 = &s2, *ps3 = &s3;
   auto s5 = absl::StrFormat("c_str() removal pointer width only:%-*s width and precision:%-*.*s precision only:%-.*s", 3, ps1->c_str(), 4, 2, ps2->c_str(), 5, ps3->c_str());
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("c_str() removal pointer width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", *ps1, 3, *ps2, 4, 2, *ps3, 5);
+  // CHECK-FIXES: auto s5 = std::format("c_str() removal pointer width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", *ps1, 3, *ps2, 4, 2, *ps3, 5);
 
   iterator<std::string> is1, is2, is3;
   auto s6 = absl::StrFormat("c_str() removal iterator width only:%-*s width and precision:%-*.*s precision only:%-.*s", 3, is1->c_str(), 4, 2, is2->c_str(), 5, is3->c_str());
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("c_str() removal iterator width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", *is1, 3, *is2, 4, 2, *is3, 5);
+  // CHECK-FIXES: auto s6 = std::format("c_str() removal iterator width only:{:{}} width and precision:{:{}.{}} precision only:{:.{}}", *is1, 3, *is2, 4, 2, *is3, 5);
 
   return s1 + s2 + s3 + s4 + s5 + s6;
 }
@@ -105,7 +105,7 @@ void StrFormat_macros() {
 #define FORMAT absl::StrFormat
   auto s1 = FORMAT("Hello %d", 42);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("Hello {}", 42);
+  // CHECK-FIXES: auto s1 = std::format("Hello {}", 42);
 
   // Arguments that are macros aren't replaced with their value, even if they are rearranged.
 #define VALUE 3.14159265358979323846
@@ -113,7 +113,7 @@ void StrFormat_macros() {
 #define PRECISION 4
   auto s3 = absl::StrFormat("Hello %*.*f", WIDTH, PRECISION, VALUE);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("Hello {:{}.{}f}", VALUE, WIDTH, PRECISION);
+  // CHECK-FIXES: auto s3 = std::format("Hello {:{}.{}f}", VALUE, WIDTH, PRECISION);
 
   const uint64_t u64 = 42;
   const uint32_t u32 = 32;
@@ -121,11 +121,11 @@ void StrFormat_macros() {
 
   auto s4 = absl::StrFormat("Replaceable macro at end %" PRIu64, u64);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("Replaceable macro at end {}", u64);
+  // CHECK-FIXES: auto s4 = std::format("Replaceable macro at end {}", u64);
 
   auto s5 = absl::StrFormat("Replaceable macros in middle %" PRIu64 " %" PRIu32 "\n", u64, u32);
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: use 'std::format' instead of 'StrFormat' [modernize-use-std-format]
-  // CHECK-FIXES: std::format("Replaceable macros in middle {} {}\n", u64, u32);
+  // CHECK-FIXES: auto s5 = std::format("Replaceable macros in middle {} {}\n", u64, u32);
 
 // These need PRI and __PRI prefixes so that the check get as far as looking for
 // where the macro comes from.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print.cpp
@@ -1,11 +1,11 @@
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffixes=,STRICT \
-// RUN:   -std=c++23 %s modernize-use-std-print %t -- \
+// RUN: %check_clang_tidy -check-suffixes=,STRICT \
+// RUN:   -std=c++23-or-later %s modernize-use-std-print %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-print.StrictMode: true}}" \
 // RUN:   -- -isystem %clang_tidy_headers -fexceptions \
 // RUN:      -DPRI_CMDLINE_MACRO="\"s\"" \
 // RUN:      -D__PRI_CMDLINE_MACRO="\"s\""
-// RUN: %check_clang_tidy --match-partial-fixes -check-suffixes=,NOTSTRICT \
-// RUN:   -std=c++23 %s modernize-use-std-print %t -- \
+// RUN: %check_clang_tidy -check-suffixes=,NOTSTRICT \
+// RUN:   -std=c++23-or-later %s modernize-use-std-print %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-print.StrictMode: false}}" \
 // RUN:   -- -isystem %clang_tidy_headers -fexceptions \
 // RUN:      -DPRI_CMDLINE_MACRO="\"s\"" \
@@ -113,7 +113,7 @@ int printf_uses_return_value(int choice) {
 
   for (printf("for init statement %d\n", i);;)
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: use 'std::println' instead of 'printf' [modernize-use-std-print]
-    // CHECK-FIXES: std::println("for init statement {}", i);
+    // CHECK-FIXES: for (std::println("for init statement {}", i);;)
     ;;
 
   for (int j = printf("for init statement %d\n", i);;)
@@ -124,7 +124,7 @@ int printf_uses_return_value(int choice) {
 
   for (;; printf("for expression %d\n", i))
     // CHECK-MESSAGES: [[@LINE-1]]:11: warning: use 'std::println' instead of 'printf' [modernize-use-std-print]
-    // CHECK-FIXES: std::println("for expression {}", i)
+    // CHECK-FIXES: for (;; std::println("for expression {}", i))
     ;;
 
   for (auto C : "foo")
@@ -228,7 +228,7 @@ int fprintf_uses_return_value(int choice) {
 
   for (fprintf(stderr, "for init statement %d\n", i);;)
     // CHECK-MESSAGES: [[@LINE-1]]:8: warning: use 'std::println' instead of 'fprintf' [modernize-use-std-print]
-    // CHECK-FIXES: std::println(stderr, "for init statement {}", i);
+    // CHECK-FIXES: for (std::println(stderr, "for init statement {}", i);;)
     ;;
 
   for (int j = fprintf(stderr, "for init statement %d\n", i);;)
@@ -239,7 +239,7 @@ int fprintf_uses_return_value(int choice) {
 
   for (;; fprintf(stderr, "for expression %d\n", i))
     // CHECK-MESSAGES: [[@LINE-1]]:11: warning: use 'std::println' instead of 'fprintf' [modernize-use-std-print]
-    // CHECK-FIXES: std::println(stderr, "for expression {}", i)
+    // CHECK-FIXES: for (;; std::println(stderr, "for expression {}", i))
     ;;
 
   for (auto C : "foo")

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-fix.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-fix.cpp
@@ -1,33 +1,33 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s performance-noexcept-move-constructor %t -- -- -fexceptions
+// RUN: %check_clang_tidy %s performance-noexcept-move-constructor %t -- -- -fexceptions
 
 struct C_1 {
  ~C_1() {}
  C_1(int a) {}
  C_1(C_1&& a) :C_1(5) {}
- // CHECK-FIXES: ){{.*}}noexcept{{.*}}:
+ // CHECK-FIXES: C_1(C_1&& a)  noexcept :C_1(5) {}
  C_1& operator=(C_1&&) { return *this; }
- // CHECK-FIXES: ){{.*}}noexcept{{.*}} {
+ // CHECK-FIXES: C_1& operator=(C_1&&)  noexcept { return *this; }
 };
 
 struct C_2 {
  ~C_2() {}
  C_2(C_2&& a);
-// CHECK-FIXES: ){{.*}}noexcept{{.*}};
+// CHECK-FIXES: C_2(C_2&& a) noexcept ;
  C_2& operator=(C_2&&);
-// CHECK-FIXES: ){{.*}}noexcept{{.*}};
+// CHECK-FIXES: C_2& operator=(C_2&&) noexcept ;
 };
 
 C_2::C_2(C_2&& a) {}
-// CHECK-FIXES: ){{.*}}noexcept{{.*}} {}
+// CHECK-FIXES: C_2::C_2(C_2&& a)  noexcept {}
 C_2& C_2::operator=(C_2&&) { return *this; }
-// CHECK-FIXES: ){{.*}}noexcept{{.*}} {
+// CHECK-FIXES: C_2& C_2::operator=(C_2&&)  noexcept { return *this; }
 
 struct C_3 {
  ~C_3() {}
  C_3(C_3&& a);
-// CHECK-FIXES: ){{.*}}noexcept{{.*}};
+// CHECK-FIXES: C_3(C_3&& a) noexcept ;
  C_3& operator=(C_3&& a);
-// CHECK-FIXES: ){{.*}}noexcept{{.*}};
+// CHECK-FIXES: C_3& operator=(C_3&& a) noexcept ;
 };
 
 C_3::C_3(C_3&& a) = default;
@@ -36,7 +36,7 @@ C_3& C_3::operator=(C_3&& a) = default;
 template <class T>
 struct C_4 {
  C_4(C_4<T>&&) {}
-// CHECK-FIXES: ){{.*}}noexcept{{.*}} {}
+// CHECK-FIXES: C_4(C_4<T>&&)  noexcept {}
  ~C_4() {}
  C_4& operator=(C_4&& a) = default;
 };
@@ -44,7 +44,7 @@ struct C_4 {
 template <class T>
 struct C_5 {
  C_5(C_5<T>&&) {}
-// CHECK-FIXES:){{.*}}noexcept{{.*}} {}
+// CHECK-FIXES: C_5(C_5<T>&&)  noexcept {}
  ~C_5() {}
  auto operator=(C_5&& a)->C_5<T> = default;
 };
@@ -52,12 +52,12 @@ struct C_5 {
 template <class T>
 struct C_6 {
  C_6(C_6<T>&&) {}
-// CHECK-FIXES:){{.*}}noexcept{{.*}} {}
+// CHECK-FIXES: C_6(C_6<T>&&)  noexcept {}
  ~C_6() {}
  auto operator=(C_6&& a)->C_6<T>;
-// CHECK-FIXES:){{.*}}noexcept{{.*}};
+// CHECK-FIXES: auto operator=(C_6&& a) noexcept ->C_6<T>;
 };
 
 template <class T>
 auto C_6<T>::operator=(C_6<T>&& a) -> C_6<T> {}
-// CHECK-FIXES: ){{.*}}noexcept{{.*}} {}
+// CHECK-FIXES: auto C_6<T>::operator=(C_6<T>&& a)  noexcept -> C_6<T> {}

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-copy-initialization.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-copy-initialization.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++17-or-later %s performance-unnecessary-copy-initialization %t
+// RUN: %check_clang_tidy -std=c++17-or-later %s performance-unnecessary-copy-initialization %t
 
 template <typename T>
 struct Iterator {
@@ -469,7 +469,7 @@ struct NegativeConstructor {
     auto AssignedInMacro = T.reference();                                      \
   }                                                                            \
 // Ensure fix is not applied.
-// CHECK-FIXES: auto AssignedInMacro = T.reference();
+// CHECK-FIXES: auto AssignedInMacro = T.reference(); {{\\}}
 
 UNNECESSARY_COPY_INIT_IN_MACRO_BODY(ExpensiveToCopyType)
 // CHECK-MESSAGES: [[@LINE-1]]:1: warning: the variable 'AssignedInMacro' of type 'ExpensiveToCopyType' is copy-constructed
@@ -480,7 +480,7 @@ void PositiveMacroArgument(const ExpensiveToCopyType &Obj) {
   UNNECESSARY_COPY_INIT_IN_MACRO_ARGUMENT(auto CopyInMacroArg = Obj.reference());
   // CHECK-MESSAGES: [[@LINE-1]]:48: warning: the variable 'CopyInMacroArg' of type 'ExpensiveToCopyType' is copy-constructed
   // Ensure fix is not applied.
-  // CHECK-FIXES: auto CopyInMacroArg = Obj.reference()
+  // CHECK-FIXES: UNNECESSARY_COPY_INIT_IN_MACRO_ARGUMENT(auto CopyInMacroArg = Obj.reference());
   CopyInMacroArg.constMethod();
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-delayed.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-delayed.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s performance-unnecessary-value-param %t -- -- -fdelayed-template-parsing
+// RUN: %check_clang_tidy %s performance-unnecessary-value-param %t -- -- -fdelayed-template-parsing
 
 struct ExpensiveToCopyType {
   const ExpensiveToCopyType & constReference() const {
@@ -152,7 +152,7 @@ void NegativeTypedefParam(const Container<ExpensiveToCopyType>::const_reference 
   void inMacro(const ExpensiveToCopyType T) {           \
   }                                                     \
 // Ensure fix is not applied.
-// CHECK-FIXES: void inMacro(const ExpensiveToCopyType T) {
+// CHECK-FIXES: void inMacro(const ExpensiveToCopyType T) { {{\\}}
 
 UNNECESSARY_VALUE_PARAM_IN_MACRO_BODY()
 // CHECK-MESSAGES: [[@LINE-1]]:1: warning: the const qualified parameter 'T'
@@ -162,7 +162,7 @@ UNNECESSARY_VALUE_PARAM_IN_MACRO_BODY()
 
 UNNECESSARY_VALUE_PARAM_IN_MACRO_ARGUMENT(void inMacroArgument(const ExpensiveToCopyType InMacroArg) {})
 // CHECK-MESSAGES: [[@LINE-1]]:90: warning: the const qualified parameter 'InMacroArg'
-// CHECK-FIXES: void inMacroArgument(const ExpensiveToCopyType InMacroArg) {}
+// CHECK-FIXES: UNNECESSARY_VALUE_PARAM_IN_MACRO_ARGUMENT(void inMacroArgument(const ExpensiveToCopyType InMacroArg) {})
 
 struct VirtualMethod {
   virtual ~VirtualMethod() {}
@@ -171,7 +171,7 @@ struct VirtualMethod {
 
 struct NegativeOverriddenMethod : public VirtualMethod {
   void handle(ExpensiveToCopyType Overridden) const {
-    // CHECK-FIXES: handle(ExpensiveToCopyType Overridden) const {
+    // CHECK-FIXES: void handle(ExpensiveToCopyType Overridden) const {
   }
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s performance-unnecessary-value-param %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy %s performance-unnecessary-value-param %t -- -- -fno-delayed-template-parsing
 
 // CHECK-FIXES: #include <utility>
 
@@ -215,7 +215,7 @@ void NegativeTypedefParam(const Container<ExpensiveToCopyType>::const_reference 
   void inMacro(const ExpensiveToCopyType T) {           \
   }                                                     \
 // Ensure fix is not applied.
-// CHECK-FIXES: void inMacro(const ExpensiveToCopyType T) {
+// CHECK-FIXES: void inMacro(const ExpensiveToCopyType T) { {{\\}}
 
 UNNECESSARY_VALUE_PARAM_IN_MACRO_BODY()
 // CHECK-MESSAGES: [[@LINE-1]]:1: warning: the const qualified parameter 'T'
@@ -225,7 +225,7 @@ UNNECESSARY_VALUE_PARAM_IN_MACRO_BODY()
 
 UNNECESSARY_VALUE_PARAM_IN_MACRO_ARGUMENT(void inMacroArgument(const ExpensiveToCopyType InMacroArg) {})
 // CHECK-MESSAGES: [[@LINE-1]]:90: warning: the const qualified parameter 'InMacroArg'
-// CHECK-FIXES: void inMacroArgument(const ExpensiveToCopyType InMacroArg) {}
+// CHECK-FIXES: UNNECESSARY_VALUE_PARAM_IN_MACRO_ARGUMENT(void inMacroArgument(const ExpensiveToCopyType InMacroArg) {})
 
 struct VirtualMethod {
   virtual ~VirtualMethod() {}
@@ -234,7 +234,7 @@ struct VirtualMethod {
 
 struct NegativeOverriddenMethod : public VirtualMethod {
   void handle(ExpensiveToCopyType Overridden) const {
-    // CHECK-FIXES: handle(ExpensiveToCopyType Overridden) const {
+    // CHECK-FIXES: void handle(ExpensiveToCopyType Overridden) const {
   }
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/braces-around-statements.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/braces-around-statements.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s readability-braces-around-statements %t
+// RUN: %check_clang_tidy %s readability-braces-around-statements %t
 
 void do_something(const char *) {}
 
@@ -77,15 +77,16 @@ void test() {
   // CHECK-FIXES-NEXT: do_something("for");
   // CHECK-FIXES-NEXT: }
 
-  for (;;) {
-    do_something("for-ok");
-  }
   for (;;)
     ;
   // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: statement should be inside braces
   // CHECK-FIXES: for (;;) {
   // CHECK-FIXES-NEXT: ;
   // CHECK-FIXES-NEXT: }
+
+  for (;;) {
+    do_something("for-ok");
+  }
 
   int arr[4] = {1, 2, 3, 4};
   for (int a : arr)
@@ -378,7 +379,7 @@ int test_macros(bool b) {
 
   #define WRAP(X) { X; }
   // This is to ensure no other CHECK-FIXES matches the macro definition:
-  // CHECK-FIXES: WRAP
+  // CHECK-FIXES: #define WRAP(X) { X; }
 
   // Use-case: LLVM_DEBUG({ for(...) do_something(); });
   WRAP({

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/const-return-type.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/const-return-type.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s readability-const-return-type %t -- -- -Wno-error=return-type
+// RUN: %check_clang_tidy -std=c++14-or-later %s readability-const-return-type %t -- -- -Wno-error=return-type
 
 //  p# = positive test
 //  n# = negative test
@@ -66,7 +66,7 @@ class Clazz {
   const Klazz<const int>* const p5() const;
   // CHECK-FIXES: const Klazz<const int>* p5() const;
 
-  const Clazz operator++(int x) {  //  p12
+  const Clazz operator++(int x) {
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: return type 'const Clazz' is 'const
   // CHECK-FIXES: Clazz operator++(int x) {
   }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s readability-container-size-empty %t -- \
+// RUN: %check_clang_tidy -std=c++14-or-later %s readability-container-size-empty %t -- \
 // RUN: -config="{CheckOptions: {readability-container-size-empty.ExcludedComparisonTypes: '::std::array;::IgnoredDummyType'}}" \
 // RUN: -- -fno-delayed-template-parsing -isystem %clang_tidy_headers
 #include <string>
@@ -807,7 +807,7 @@ bool testStringLiterals(const std::string& s)
   using namespace std::string_literals;
   return s == ""s;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used
-  // CHECK-FIXES: return s.empty()
+  // CHECK-FIXES: return s.empty();
 }
 
 bool testNotEmptyStringLiterals(const std::string& s)
@@ -951,7 +951,7 @@ public:
   void doit() {
     if (!size()) {
       // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: the 'empty' method should be used to check for emptiness instead of 'size'
-      // CHECK-FIXES: if (empty())
+      // CHECK-FIXES: if (empty()) {
     }
   }
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c23-or-later --match-partial-fixes %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -std=c23-or-later %s readability-implicit-bool-conversion %t
 // RUN: %check_clang_tidy -std=c23-or-later -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
@@ -341,28 +341,28 @@ int implicitConversionReturnInt()
 {
     return true;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'bool' -> 'int'
-    // CHECK-FIXES: return 1
+    // CHECK-FIXES: return 1;
 }
 
 int implicitConversionReturnIntWithParens()
 {
     return (true);
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'bool' -> 'int'
-    // CHECK-FIXES: return 1
+    // CHECK-FIXES: return 1;
 }
 
 bool implicitConversionReturnBool()
 {
     return 1;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'int' -> 'bool'
-    // CHECK-FIXES: return true
+    // CHECK-FIXES: return true;
 }
 
 bool implicitConversionReturnBoolWithParens()
 {
     return (1);
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'int' -> 'bool'
-    // CHECK-FIXES: return true
+    // CHECK-FIXES: return true;
 }
 
 int keepCompactReturnInC_PR71848() {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t
 // RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
@@ -490,14 +490,14 @@ int implicitConversionReturnInt()
 {
     return true;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'bool' -> 'int'
-    // CHECK-FIXES: return 1
+    // CHECK-FIXES: return 1;
 }
 
 int implicitConversionReturnIntWithParens()
 {
     return (true);
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'bool' -> 'int'
-    // CHECK-FIXES: return 1
+    // CHECK-FIXES: return 1;
 }
 
 
@@ -505,14 +505,14 @@ bool implicitConversionReturnBool()
 {
     return 1;
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'int' -> 'bool'
-    // CHECK-FIXES: return true
+    // CHECK-FIXES: return true;
 }
 
 bool implicitConversionReturnBoolWithParens()
 {
     return (1);
     // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'int' -> 'bool'
-    // CHECK-FIXES: return true
+    // CHECK-FIXES: return true;
 }
 
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s readability-math-missing-parentheses %t
+// RUN: %check_clang_tidy %s readability-math-missing-parentheses %t
 
 #define MACRO_AND &
 #define MACRO_ADD +
@@ -123,7 +123,7 @@ void f(){
     //CHECK-MESSAGES: :[[@LINE+3]]:77: warning: '-' has higher precedence than '^'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
     //CHECK-MESSAGES: :[[@LINE+2]]:94: warning: '/' has higher precedence than '-'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
     //CHECK-FIXES: int q = (1 MACRO_ADD (2 MACRO_MULTIPLY 3)) MACRO_OR ((4 MACRO_AND 5) MACRO_XOR (6 MACRO_SUBTRACT (7 MACRO_DIVIDE 8)));
-    int q = 1 MACRO_ADD 2 MACRO_MULTIPLY 3 MACRO_OR 4 MACRO_AND 5 MACRO_XOR 6 MACRO_SUBTRACT 7 MACRO_DIVIDE 8; // No warning
+    int q = 1 MACRO_ADD 2 MACRO_MULTIPLY 3 MACRO_OR 4 MACRO_AND 5 MACRO_XOR 6 MACRO_SUBTRACT 7 MACRO_DIVIDE 8;
 
     //CHECK-MESSAGES: :[[@LINE+1]]:21: warning: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
     int r = FUN(0 + 1 * 2);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s readability-simplify-boolean-expr %t
+// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
 
 class A {
 public:
@@ -353,4 +353,4 @@ bool S::expr_with_cleanups() {
   return true;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: m_ar == (A)m_ar;
+// CHECK-FIXES: return m_ar == (A)m_ar;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s readability-simplify-boolean-expr %t
+// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
 
 bool a1 = false;
 
@@ -1019,7 +1019,7 @@ bool expr_with_cleanups(A &S) {
   return true;
 }
 // CHECK-MESSAGES: :[[@LINE-4]]:12: warning: {{.*}} in conditional return
-// CHECK-FIXES: S == (A)S;{{$}}
+// CHECK-FIXES: return S == (A)S;{{$}}
 
 template <bool B>
 void ignoreInstantiations() {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/uppercase-literal-suffix-integer-custom-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/uppercase-literal-suffix-integer-custom-list.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s readability-uppercase-literal-suffix %t -- -config="{CheckOptions: {readability-uppercase-literal-suffix.NewSuffixes: 'L;uL'}}" -- -I %clang_tidy_headers
+// RUN: %check_clang_tidy %s readability-uppercase-literal-suffix %t -- -config="{CheckOptions: {readability-uppercase-literal-suffix.NewSuffixes: 'L;uL'}}" -- -I %clang_tidy_headers
 
 #include "integral_constant.h"
 
@@ -53,7 +53,7 @@ void integer_suffix() {
   static_assert(is_same<decltype(v11), const unsigned long>::value, "");
   static_assert(v11 == 1, "");
 
-  static constexpr auto v12 = 1UL; // OK.
+  static constexpr auto v12 = 1UL;
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: integer literal has suffix 'UL', which is not uppercase
   // CHECK-FIXES: static constexpr auto v12 = 1uL;
   static_assert(is_same<decltype(v12), const unsigned long>::value, "");

--- a/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-conflicted-fixes-of-alias-checkers.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-conflicted-fixes-of-alias-checkers.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t -- \
+// RUN: %check_clang_tidy %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t -- \
 //// RUN:     -config='{CheckOptions: { \
 //// RUN:         cppcoreguidelines-pro-type-member-init.UseAssignment: true, \
 //// RUN:     }}'
@@ -19,5 +19,5 @@ public:
 private:
   int _num1;
   int _num2;
-  // CHECK-FIXES: _num2;
+  // CHECK-FIXES: int _num2;
 };

--- a/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-fixes-of-alias-checkers.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-fixes-of-alias-checkers.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t
+// RUN: %check_clang_tidy %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t
 
 namespace std {
 
@@ -28,7 +28,7 @@ public:
 private:
   int _num1;
   int _num2;
-  // CHECK-FIXES: _num2{};
+  // CHECK-FIXES: int _num2{};
 };
 
 void should_use_emplace(std::vector<Foo> &v) {


### PR DESCRIPTION
Follow up to #162293.

Now the question is: do we want to remove the `--match-partial-fixes` option entirely? It *could* break downstream users of `check_clang_tidy.py` and force them to migrate; is that a reason to keep it around though?

Most of the changes are mechanical, but see my comments on the interesting ones.