### PR TITLE
[DebugInfo][DwarfDebug][CodeView] Allow DISubprogram to be attached to multiple Functions

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -306,8 +306,8 @@ private:
 
   // The UDTs we have seen while processing types; each entry is a pair of type
   // index and type name.
-  std::vector<std::pair<std::string, const DIType *>> LocalUDTs;
-  std::vector<std::pair<std::string, const DIType *>> GlobalUDTs;
+  MapVector<const DIType *, std::string> LocalUDTs;
+  MapVector<const DIType *, std::string> GlobalUDTs;
 
   using FileToFilepathMapTy = std::map<const DIFile *, std::string>;
   FileToFilepathMapTy FileToFilepathMap;
@@ -352,8 +352,7 @@ private:
 
   void emitDebugInfoForRetainedTypes();
 
-  void emitDebugInfoForUDTs(
-      const std::vector<std::pair<std::string, const DIType *>> &UDTs);
+  template <typename Range> void emitDebugInfoForUDTs(Range &&UDTs);
 
   void collectDebugInfoForGlobals();
   void emitDebugInfoForGlobals();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -178,7 +178,7 @@ unsigned DwarfCompileUnit::getOrCreateSourceID(const DIFile *File) {
 DIE *DwarfCompileUnit::getOrCreateGlobalVariableDIE(
     const DIGlobalVariable *GV, ArrayRef<GlobalExpr> GlobalExprs) {
   // Check for pre-existence.
-  if (DIE *Die = getDIE(GV))
+  if (DIE *Die = getDIEs(GV).getVariableDIE(GV))
     return Die;
 
   assert(GV);
@@ -795,7 +795,9 @@ DIE *DwarfCompileUnit::constructLexicalScopeDIE(LexicalScope *Scope) {
 
 DIE *DwarfCompileUnit::constructVariableDIE(DbgVariable &DV, bool Abstract) {
   auto *VariableDie = DIE::get(DIEValueAllocator, DV.getTag());
-  insertDIE(DV.getVariable(), VariableDie);
+  getDIEs(DV.getVariable())
+      .getLVs()
+      .insertDIE(DV.getVariable(), &DV, VariableDie, Abstract);
   DV.setDIE(*VariableDie);
   // Abstract variables don't get common attributes later, so apply them now.
   if (Abstract) {
@@ -1010,7 +1012,9 @@ DIE *DwarfCompileUnit::constructVariableDIE(DbgVariable &DV,
 DIE *DwarfCompileUnit::constructLabelDIE(DbgLabel &DL,
                                          const LexicalScope &Scope) {
   auto LabelDie = DIE::get(DIEValueAllocator, DL.getTag());
-  insertDIE(DL.getLabel(), LabelDie);
+  getDIEs(DL.getLabel())
+      .getLabels()
+      .insertDIE(DL.getLabel(), &DL, LabelDie, Scope.isAbstractScope());
   DL.setDIE(*LabelDie);
 
   if (Scope.isAbstractScope())

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -1839,14 +1839,16 @@ DIE *DwarfCompileUnit::getOrCreateSubprogramDIE(const DISubprogram *SP,
                                                 const Function *F,
                                                 bool Minimal) {
   if (!F && SP->isDefinition()) {
-    F = DD->getLexicalScopes().getFunction(SP);
+    const auto *Fs = DD->getLexicalScopes().getFunctions(SP);
 
-    if (!F) {
+    if (!Fs || Fs->size() != 1) {
       // SP may belong to another CU. Determine the CU similarly
       // to DwarfDebug::constructAbstractSubprogramScopeDIE.
       return &DD->getOrCreateAbstractSubprogramCU(SP, *this)
                   .getOrCreateAbstractSubprogramDIE(SP);
     }
+
+    F = *Fs->begin();
   }
 
   return DwarfUnit::getOrCreateSubprogramDIE(SP, F, Minimal);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -1476,8 +1476,9 @@ DIE *DwarfCompileUnit::getOrCreateImportedEntityDIE(
   return IMDie;
 }
 
-void DwarfCompileUnit::finishSubprogramDefinition(const DISubprogram *SP) {
-  DIE *D = getDIE(SP);
+void DwarfCompileUnit::finishSubprogramDefinition(const DISubprogram *SP,
+                                                  const Function *F) {
+  DIE *D = getDIEs(SP).getLocalScopes().getConcreteDIE(SP, F);
   if (DIE *AbsSPDIE = getAbstractScopeDIEs().lookup(SP)) {
     if (D)
       // If this subprogram has an abstract definition, reference that

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.h
@@ -79,15 +79,9 @@ class DwarfCompileUnit final : public DwarfUnit {
   // List of concrete lexical block scopes belong to subprograms within this CU.
   DenseMap<const DILocalScope *, DIE *> LexicalBlockDIEs;
 
-  // List of abstract local scopes (either DISubprogram or DILexicalBlock).
-  DenseMap<const DILocalScope *, DIE *> AbstractLocalScopeDIEs;
-  SmallPtrSet<const DISubprogram *, 8> FinalizedAbstractSubprograms;
-
   // List of inlined lexical block scopes that belong to subprograms within this
   // CU.
   DenseMap<const DILocalScope *, SmallVector<DIE *, 2>> InlinedLocalScopeDIEs;
-
-  DenseMap<const DINode *, std::unique_ptr<DbgEntity>> AbstractEntities;
 
   /// DWO ID for correlating skeleton and split units.
   uint64_t DWOId = 0;
@@ -126,22 +120,20 @@ class DwarfCompileUnit final : public DwarfUnit {
 
   bool isDwoUnit() const override;
 
+  DwarfInfoHolder &getDIEs(const DINode *N) { return DwarfUnit::getDIEs(N); }
+
+  DwarfInfoHolder &getDIEs() { return getDIEs(nullptr); }
+
   DenseMap<const DILocalScope *, DIE *> &getAbstractScopeDIEs() {
-    if (isDwoUnit() && !DD->shareAcrossDWOCUs())
-      return AbstractLocalScopeDIEs;
-    return DU->getAbstractScopeDIEs();
+    return getDIEs().getAbstractScopeDIEs();
   }
 
   DenseMap<const DINode *, std::unique_ptr<DbgEntity>> &getAbstractEntities() {
-    if (isDwoUnit() && !DD->shareAcrossDWOCUs())
-      return AbstractEntities;
-    return DU->getAbstractEntities();
+    return getDIEs().getAbstractEntities();
   }
 
   auto &getFinalizedAbstractSubprograms() {
-    if (isDwoUnit() && !DD->shareAcrossDWOCUs())
-      return FinalizedAbstractSubprograms;
-    return DU->getFinalizedAbstractSubprograms();
+    return getDIEs().getFinalizedAbstractSubprograms();
   }
 
   void finishNonUnitTypeDIE(DIE& D, const DICompositeType *CTy) override;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.h
@@ -124,8 +124,8 @@ class DwarfCompileUnit final : public DwarfUnit {
 
   DwarfInfoHolder &getDIEs() { return getDIEs(nullptr); }
 
-  DenseMap<const DILocalScope *, DIE *> &getAbstractScopeDIEs() {
-    return getDIEs().getAbstractScopeDIEs();
+  DwarfInfoHolder::AbstractScopeMapT &getAbstractScopeDIEs() {
+    return getDIEs().getLocalScopes().getAbstractDIEs();
   }
 
   DenseMap<const DINode *, std::unique_ptr<DbgEntity>> &getAbstractEntities() {
@@ -319,7 +319,7 @@ public:
   DIE *getOrCreateImportedEntityDIE(const DIImportedEntity *IE);
   DIE *constructImportedEntityDIE(const DIImportedEntity *IE);
 
-  void finishSubprogramDefinition(const DISubprogram *SP);
+  void finishSubprogramDefinition(const DISubprogram *SP, const Function *F);
   void finishEntityDefinition(const DbgEntity *Entity);
   void attachLexicalScopesAbstractOrigins();
 

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -502,7 +502,8 @@ void DwarfDebug::addSubprogramNames(
   // well into the name table. Only do that if we are going to actually emit
   // that name.
   if (LinkageName != "" && SP->getName() != LinkageName &&
-      (useAllLinkageNames() || InfoHolder.getAbstractScopeDIEs().lookup(SP)))
+      (useAllLinkageNames() ||
+       InfoHolder.getDIEs().getAbstractScopeDIEs().lookup(SP)))
     addAccelName(Unit, NameTableKind, LinkageName, Die);
 
   // If this is an Objective-C selector name add it to the ObjC accelerator

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2750,7 +2750,7 @@ void DwarfDebug::endFunctionImpl(const MachineFunction *MF) {
   // is still needed as we need its source location.
   if (!TheCU.getCUNode()->getDebugInfoForProfiling() &&
       TheCU.getCUNode()->getEmissionKind() == DICompileUnit::LineTablesOnly &&
-      LScopes.getAbstractScopesList().empty() && !IsDarwin) {
+      !LScopes.currentFunctionHasInlinedScopes() && !IsDarwin) {
     for (const auto &R : Asm->MBBSectionRanges)
       addArangeLabel(SymbolCU(&TheCU, R.second.BeginLabel));
 
@@ -2791,7 +2791,7 @@ void DwarfDebug::endFunctionImpl(const MachineFunction *MF) {
   DIE &ScopeDIE =
       TheCU.constructSubprogramScopeDIE(SP, F, FnScope, FunctionLineTableLabel);
   if (auto *SkelCU = TheCU.getSkeleton())
-    if (!LScopes.getAbstractScopesList().empty() &&
+    if (LScopes.currentFunctionHasInlinedScopes() &&
         TheCU.getCUNode()->getSplitDebugInlining())
       SkelCU->constructSubprogramScopeDIE(SP, F, FnScope,
                                           FunctionLineTableLabel);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -373,7 +373,8 @@ class DwarfDebug : public DebugHandlerBase {
 
   /// This is a collection of subprogram MDNodes that are processed to
   /// create DIEs.
-  SmallSetVector<const DISubprogram *, 16> ProcessedSPNodes;
+  SmallSetVector<std::pair<const DISubprogram *, const Function *>, 16>
+      ProcessedSPNodes;
 
   /// Map function-local imported entities to their parent local scope
   /// (either DILexicalBlock or DISubprogram) for a processed function

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -61,7 +61,7 @@ protected:
 
   /// Tracks the mapping of unit level debug information variables to debug
   /// information entries.
-  DenseMap<const MDNode *, DIE *> MDNodeToDieMap;
+  DwarfInfoHolder InfoHolder;
 
   /// A list of all the DIEBlocks in use.
   std::vector<DIEBlock *> DIEBlocks;
@@ -139,7 +139,7 @@ public:
   /// We delegate the request to DwarfDebug when the MDNode can be part of the
   /// type system, since DIEs for the type system can be shared across CUs and
   /// the mappings are kept in DwarfDebug.
-  DIE *getDIE(const DINode *D) const;
+  DIE *getDIE(const DINode *D) const { return getDIEs(D).getDIE(D); }
 
   /// Returns a fresh newly allocated DIELoc.
   DIELoc *getDIELoc() { return new (DIEValueAllocator) DIELoc; }
@@ -152,6 +152,18 @@ public:
   void insertDIE(const DINode *Desc, DIE *D);
 
   void insertDIE(DIE *D);
+
+  const DwarfInfoHolder &getDIEs(const DINode *N) const {
+    if (isShareableAcrossCUs(N))
+      return DU->getDIEs();
+
+    return InfoHolder;
+  }
+
+  DwarfInfoHolder &getDIEs(const DINode *N) {
+    return const_cast<DwarfInfoHolder &>(
+        const_cast<const DwarfUnit *>(this)->getDIEs(N));
+  }
 
   /// Add a flag that is true to the DIE.
   void addFlag(DIE &Die, dwarf::Attribute Attribute);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -298,6 +298,8 @@ public:
   /// Create a DIE with the given Tag, add the DIE to its parent, and
   /// call insertDIE if MD is not null.
   DIE &createAndAddDIE(dwarf::Tag Tag, DIE &Parent, const DINode *N = nullptr);
+  DIE &createAndAddSubprogramDIE(DIE &Parent, const DISubprogram *SP,
+                                 const Function *F);
 
   bool useSegmentedStringOffsetsTable() const {
     return DD->useSegmentedStringOffsetsTable();
@@ -398,6 +400,9 @@ private:
                                          const DITemplateTypeParameter *TP);
   void constructTemplateValueParameterDIE(DIE &Buffer,
                                           const DITemplateValueParameter *TVP);
+
+  DIE *getExistingSubprogramDIE(const DISubprogram *SP,
+                                const Function *FnHint) const;
 
   /// Return the default lower bound for an array.
   ///

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -336,9 +336,6 @@ class Verifier : public InstVisitor<Verifier>, VerifierSupport {
   /// Keep track of the metadata nodes that have been checked already.
   SmallPtrSet<const Metadata *, 32> MDNodes;
 
-  /// Keep track which DISubprogram is attached to which function.
-  DenseMap<const DISubprogram *, const Function *> DISubprogramAttachments;
-
   /// Track all DICompileUnits visited.
   SmallPtrSet<const Metadata *, 2> CUVisited;
 
@@ -485,7 +482,6 @@ public:
     verifyCompileUnits();
 
     verifyDeoptimizeCallingConvs();
-    DISubprogramAttachments.clear();
     return !Broken;
   }
 
@@ -3145,11 +3141,6 @@ void Verifier::visitFunction(const Function &F) {
                 "function definition may only have a distinct !dbg attachment",
                 &F);
 
-        auto *SP = cast<DISubprogram>(I.second);
-        const Function *&AttachedTo = DISubprogramAttachments[SP];
-        CheckDI(!AttachedTo || AttachedTo == &F,
-                "DISubprogram attached to more than one function", SP, &F);
-        AttachedTo = &F;
         AllowLocs = AreDebugLocsAllowed::Yes;
         break;
       }

--- a/llvm/test/DebugInfo/COFF/shared-sp.ll
+++ b/llvm/test/DebugInfo/COFF/shared-sp.ll
@@ -1,0 +1,129 @@
+; RUN: llc -filetype=obj < %s -o - 2>&1 | llvm-readobj - --codeview | FileCheck %s
+
+; Check that when DISubprogram is attached to two functions, CodeView is
+; produced correctly.
+
+; CHECK:  Subsection [
+; CHECK:    GlobalProcIdSym {
+; CHECK:      Kind: S_GPROC32_ID (0x1147)
+; CHECK:      FunctionType: foo (0x1002)
+; CHECK:      CodeOffset: foo+0x0
+; CHECK:      Flags [ (0x80)
+; CHECK:        HasOptimizedDebugInfo (0x80)
+; CHECK:      ]
+; CHECK:      DisplayName: foo
+; CHECK:      LinkageName: foo
+; CHECK:    }
+; CHECK:    LocalSym {
+; CHECK:      Kind: S_LOCAL (0x113E)
+; CHECK:      Type: int (0x74)
+; CHECK:      Flags [ (0x0)
+; CHECK:      ]
+; CHECK:      VarName: a
+; CHECK:    }
+; CHECK:    LocalSym {
+; CHECK:      Kind: S_LOCAL (0x113E)
+; CHECK:      Type: foo::bar (0x1005)
+; CHECK:      Flags [ (0x0)
+; CHECK:      ]
+; CHECK:      VarName: c
+; CHECK:    }
+; CHECK:    UDTSym {
+; CHECK:      Kind: S_UDT (0x1108)
+; CHECK:      Type: foo::bar (0x1005)
+; CHECK:      UDTName: foo::bar
+; CHECK:    }
+; CHECK:  ]
+; CHECK:  Subsection [
+; CHECK:    GlobalProcIdSym {
+; CHECK:      Kind: S_GPROC32_ID (0x1147)
+; CHECK:      FunctionType: foo (0x1002)
+; CHECK:      CodeOffset: foo_clone+0x0
+; CHECK:      Flags [ (0x80)
+; CHECK:        HasOptimizedDebugInfo (0x80)
+; CHECK:      ]
+; CHECK:      DisplayName: foo
+; CHECK:      LinkageName: foo_clone
+; CHECK:    }
+; CHECK:    LocalSym {
+; CHECK:      Kind: S_LOCAL (0x113E)
+; CHECK:      Type: int (0x74)
+; CHECK:      Flags [ (0x0)
+; CHECK:      ]
+; CHECK:      VarName: a
+; CHECK:    }
+; CHECK:    LocalSym {
+; CHECK:      Kind: S_LOCAL (0x113E)
+; CHECK:      Type: foo::bar (0x1005)
+; CHECK:      Flags [ (0x0)
+; CHECK:      ]
+; CHECK:      VarName: c
+; CHECK:    }
+; CHECK:    UDTSym {
+; CHECK:      Kind: S_UDT (0x1108)
+; CHECK:      Type: foo::bar (0x1005)
+; CHECK:      UDTName: foo::bar
+; CHECK:    }
+; CHECK:  ]
+
+; ModuleID = 'shared-sp.ll'
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc19.29.30133"
+
+!0 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !2, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !4, retainedNodes: !{})
+!1 = !DIFile(filename: "example.c", directory: "/")
+!2 = !DISubroutineType(types: !3)
+!3 = !{!5}
+!4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, emissionKind: FullDebug)
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+
+; Local variable.
+!10 = !DILocalVariable(name: "a", scope: !0, file: !1, line: 2, type: !5)
+
+; DICompositeType local to foo.
+!11 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !0, file: !1, line: 2, size: 32, elements: !12)
+!12 = !{!13}
+!13 = !DIDerivedType(tag: DW_TAG_member, name: "m", scope: !11, file: !1, line: 2, baseType: !5, size: 32)
+
+; Local variable of type struct bar, local to foo.
+!14 = !DILocalVariable(name: "c", scope: !0, file: !1, line: 2, type: !11)
+
+!101 = !DILocation(line: 2, column: 5, scope: !0)
+!102 = !DILocation(line: 3, column: 1, scope: !0)
+!103 = !DILocation(line: 2, column: 12, scope: !0)
+
+!llvm.dbg.cu = !{!4}
+!llvm.module.flags = !{!29, !30}
+
+!29 = !{i32 2, !"CodeView", i32 1}
+!30 = !{i32 2, !"Debug Info Version", i32 3}
+
+define i32 @foo() !dbg !0 {
+entry:
+  ; Local variable 'a' debug info.
+  %a.addr = alloca i32, align 4, !dbg !101
+    #dbg_declare(ptr %a.addr, !10, !DIExpression(), !101)
+  store i32 42, ptr %a.addr, align 4, !dbg !101
+
+  ; Local variable 'c' (struct bar) debug info.
+  %c.addr = alloca %struct.bar, align 4, !dbg !103
+    #dbg_declare(ptr %c.addr, !14, !DIExpression(), !103)
+
+  ret i32 42, !dbg !102
+}
+
+define i32 @foo_clone() !dbg !0 {
+entry:
+  ; Local variable 'a' debug info.
+  %a.addr = alloca i32, align 4, !dbg !101
+    #dbg_declare(ptr %a.addr, !10, !DIExpression(), !101)
+  store i32 42, ptr %a.addr, align 4, !dbg !101
+
+  ; Local variable 'c' (struct bar) debug info.
+  %c.addr = alloca %struct.bar, align 4, !dbg !103
+    #dbg_declare(ptr %c.addr, !14, !DIExpression(), !103)
+
+  ret i32 42, !dbg !102
+}
+
+%struct.bar = type { i32 }

--- a/llvm/test/DebugInfo/COFF/udts-complete.ll
+++ b/llvm/test/DebugInfo/COFF/udts-complete.ll
@@ -33,9 +33,9 @@
 ; CHECK:   Mod 0000 | `.debug$S`:
 ; CHECK:        0 | S_GDATA32 [size = 20] `gv`
 ; CHECK:            type = 0x1002 (Foo), addr = 0000:0000
-; CHECK:        0 | S_UDT [size = 12] `Bar`
-; CHECK:            original type = 0x1002
 ; CHECK:        0 | S_UDT [size = 12] `Baz`
+; CHECK:            original type = 0x1002
+; CHECK:        0 | S_UDT [size = 12] `Bar`
 ; CHECK:            original type = 0x1002
 ; CHECK:        0 | S_UDT [size = 12] `Foo`
 ; CHECK:            original type = 0x1002

--- a/llvm/test/DebugInfo/COFF/udts-fixpoint.ll
+++ b/llvm/test/DebugInfo/COFF/udts-fixpoint.ll
@@ -16,11 +16,11 @@
 ; Check that there are only two typedefs, a and c.
 ; CHECK:        .short  4360        # Record kind: S_UDT
 ; CHECK:        .long   {{.*}}      # Type
-; CHECK:        .asciz  "a"
+; CHECK:        .asciz  "c"
 ; CHECK:        .p2align        2
 ; CHECK:        .short  4360        # Record kind: S_UDT
 ; CHECK:        .long   {{.*}}      # Type
-; CHECK:        .asciz  "c"
+; CHECK:        .asciz  "a"
 ; CHECK:        .p2align        2
 ;   No other S_UDTs.
 ; CHECK-NOT: S_UDT

--- a/llvm/test/DebugInfo/X86/namelist1.ll
+++ b/llvm/test/DebugInfo/X86/namelist1.ll
@@ -2,7 +2,10 @@
 ; DW_TAG_namelist_item attributes are emitted correctly.
 ;
 ; RUN: llc -O0 -mtriple=x86_64-unknown-linux-gnu %s -filetype=obj -o %t.o
-; RUN: llvm-dwarfdump %t.o | FileCheck %s
+; RUN: llvm-dwarfdump %t.o | FileCheck %s --implicit-check-not=DW_TAG_subprogram
+;
+; Ensure that a single DW_TAG_subprogram is produced.
+; CHECK:                    DW_TAG_subprogram
 ;
 ; CHECK: [[ITEM1:0x.+]]:       DW_TAG_variable
 ; CHECK:                          DW_AT_name  ("a")

--- a/llvm/test/DebugInfo/X86/shared-empty-sp.ll
+++ b/llvm/test/DebugInfo/X86/shared-empty-sp.ll
@@ -1,0 +1,48 @@
+; RUN: llc -filetype=obj < %s -o %t 2>&1 | FileCheck --allow-empty --implicit-check-not='warning:' %s
+; RUN: llvm-dwarfdump -verify %t
+; RUN: llvm-dwarfdump %t | FileCheck %s --check-prefix=DWARF --implicit-check-not=DW_TAG
+
+; DWARF:      DW_TAG_compile_unit
+
+; Abstract subprogram.
+; DWARF: [[FOO:.*]]:   DW_TAG_subprogram
+; DWARF:               DW_AT_name ("foo"
+; DWARF:               DW_AT_inline (DW_INL_inlined)
+
+; Concrete subprogram.
+; DWARF:               DW_TAG_subprogram
+; DWARF:                 DW_AT_abstract_origin ([[FOO]]
+
+; Concrete subprogram.
+; DWARF:               DW_TAG_subprogram
+; DWARF:                 DW_AT_abstract_origin ([[FOO]]
+
+; Check that when DISubprogram is attached to two empty functions (with no lexical scopes),
+; they get different DW_TAG_subprograms.
+
+; ModuleID = 'example'
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+!0 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !2, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !{})
+!1 = !DIFile(filename: "example.c", directory: "/")
+!2 = !DISubroutineType(types: !4)
+!4 = !{}
+
+!3 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, emissionKind: FullDebug)
+
+!llvm.dbg.cu = !{!3}
+!llvm.module.flags = !{!30}
+
+!30 = !{i32 1, !"Debug Info Version", i32 3}
+
+define void @foo() !dbg !0 {
+entry:
+  ret void
+}
+
+define void @foo_clone() !dbg !0 {
+entry:
+  ret void
+}

--- a/llvm/test/DebugInfo/X86/shared-sp.ll
+++ b/llvm/test/DebugInfo/X86/shared-sp.ll
@@ -1,0 +1,98 @@
+; RUN: llc -filetype=obj < %s -o %t 2>&1 | FileCheck --allow-empty --implicit-check-not='warning:' %s
+; RUN: llvm-dwarfdump -verify %t
+; RUN: llvm-dwarfdump %t | FileCheck %s --check-prefix=DWARF --implicit-check-not=DW_TAG
+
+; Check that when DISubprogram is attached to two functions, DWARF is produced
+; correctly.
+
+; DWARF:      DW_TAG_compile_unit
+
+; Abstract subprogram.
+; DWARF: [[FOO:.*]]:   DW_TAG_subprogram
+; DWARF:               DW_AT_name ("foo"
+; DWARF:               DW_AT_inline (DW_INL_inlined)
+; DWARF: [[A:.*]]:       DW_TAG_variable
+; DWARF:                   DW_AT_name ("a"
+; DWARF:                 DW_TAG_structure_type
+; DWARF:                   DW_TAG_member
+; DWARF: [[C:.*]]:       DW_TAG_variable
+; DWARF:                   DW_AT_name ("c"
+
+; DWARF:               DW_TAG_base_type
+
+; Concrete subprogram.
+; DWARF:               DW_TAG_subprogram
+; DWARF:                 DW_AT_abstract_origin ([[FOO]]
+; DWARF:                 DW_TAG_variable
+; DWARF:                   DW_AT_abstract_origin ([[A]]
+; DWARF:                 DW_TAG_variable
+; DWARF:                   DW_AT_abstract_origin ([[C]]
+
+; Concrete subprogram.
+; DWARF:               DW_TAG_subprogram
+; DWARF:                 DW_AT_abstract_origin ([[FOO]]
+; DWARF:                 DW_TAG_variable
+; DWARF:                   DW_AT_abstract_origin ([[A]]
+; DWARF:                 DW_TAG_variable
+; DWARF:                   DW_AT_abstract_origin ([[C]]
+
+; ModuleID = 'shared-sp.ll'
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+!0 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !2, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !4, retainedNodes: !{})
+!1 = !DIFile(filename: "example.c", directory: "/")
+!2 = !DISubroutineType(types: !3)
+!3 = !{!5}
+!4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, emissionKind: FullDebug)
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+
+; Local variable.
+!10 = !DILocalVariable(name: "a", scope: !0, file: !1, line: 2, type: !5)
+
+; DICompositeType local to foo.
+!11 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !0, file: !1, line: 2, size: 32, elements: !12)
+!12 = !{!13}
+!13 = !DIDerivedType(tag: DW_TAG_member, name: "m", scope: !11, file: !1, line: 2, baseType: !5, size: 32)
+
+; Local variable of type struct bar, local to foo.
+!14 = !DILocalVariable(name: "c", scope: !0, file: !1, line: 2, type: !11)
+
+!101 = !DILocation(line: 2, column: 5, scope: !0)
+!102 = !DILocation(line: 3, column: 1, scope: !0)
+!103 = !DILocation(line: 2, column: 12, scope: !0)
+
+!llvm.dbg.cu = !{!4}
+!llvm.module.flags = !{!30}
+
+!30 = !{i32 2, !"Debug Info Version", i32 3}
+
+define i32 @foo() !dbg !0 {
+entry:
+  ; Local variable 'a' debug info.
+  %a.addr = alloca i32, align 4, !dbg !101
+    #dbg_declare(ptr %a.addr, !10, !DIExpression(), !101)
+  store i32 42, ptr %a.addr, align 4, !dbg !101
+
+  ; Local variable 'c' (struct bar) debug info.
+  %c.addr = alloca %struct.bar, align 4, !dbg !103
+    #dbg_declare(ptr %c.addr, !14, !DIExpression(), !103)
+
+  ret i32 42, !dbg !102
+}
+
+define i32 @foo_clone() !dbg !0 {
+entry:
+  ; Local variable 'a' debug info.
+  %a.addr = alloca i32, align 4, !dbg !101
+    #dbg_declare(ptr %a.addr, !10, !DIExpression(), !101)
+  store i32 42, ptr %a.addr, align 4, !dbg !101
+
+  ; Local variable 'c' (struct bar) debug info.
+  %c.addr = alloca %struct.bar, align 4, !dbg !103
+    #dbg_declare(ptr %c.addr, !14, !DIExpression(), !103)
+
+  ret i32 42, !dbg !102
+}
+
+%struct.bar = type { i32 }

--- a/llvm/test/Verifier/metadata-function-dbg.ll
+++ b/llvm/test/Verifier/metadata-function-dbg.ll
@@ -11,16 +11,6 @@ define void @f2() !dbg !4 !dbg !4 {
   unreachable
 }
 
-; CHECK:      DISubprogram attached to more than one function
-define void @f3() !dbg !4 {
-  unreachable
-}
-
-; CHECK:      DISubprogram attached to more than one function
-define void @f4() !dbg !4 {
-  unreachable
-}
-
 ; CHECK-NOT:  !dbg
 ; CHECK:      function !dbg attachment must be a subprogram
 ; CHECK-NEXT: ptr @bar


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/152680
* https://github.com/llvm/llvm-project/pull/162852

In https://github.com/llvm/llvm-project/pull/75385 (and the following tries), an attempt was made, to support attaching local types to DILocalScopes, and to store function local types in DISubprogram's `retainedNodes:` field.

That patch failed to land due to issues arising during LTO process. If two definition DISubprograms from different compile units represent, essentially, the same source code function, and have common local DICompositeType, and if this DICompositeType is uniqued (due to ODRUniquingDebugTypes feature), the subprograms end up having wrong retainedNodes list/scoping relationship.

To tackle this issue, in https://github.com/llvm/llvm-project/pull/142166, it was proposed to force-unique all DISubporgrams even if they don't contain odr-uniqued types (https://github.com/llvm/llvm-project/pull/142166#issuecomment-2981729002). It should establish one-to-one-to-many relationship between DISubprograms, abstract DIEs and function clones (from different CUs, in case of LTO).

To implement that, AsmPrinter should support correct emission of debug info for DISubprograms attached to multiple functions. This is the goal of this commit.

Here, LexicalScope's function map is replaced with multimap between DISubprogram and (possibly multiple) functions attached to it. LexicalScope is modified to create an abstract scope for a DISubprogram having multiple llvm::Function attachments. `DwarfCompileUnit::getOrCreateSubprogramDIE` can recognize the case of DISubprogram attached to multiple Functions, and return abstract DIE when needed.

CodeViewDebug is adopted as well. UDTs are ensured to be emmited properly in the cases that are addressed here. Please let me know if more changes to CodeView needed, as I'm not very familiar with the format.