### PR TITLE
[clang-tidy][NFC] Remove stale comment in test

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-constant-array-index-c++03.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-constant-array-index-c++03.cpp
@@ -1,7 +1,5 @@
 // RUN: %check_clang_tidy -std=c++98-or-later %s cppcoreguidelines-pro-bounds-constant-array-index %t
 
-// Note: this test expects no diagnostics, but FileCheck cannot handle that,
-// hence the use of | count 0.
 template <int index> struct B {
   int get() {
     // The next line used to crash the check (in C++03 mode only).


### PR DESCRIPTION
Commit cb18647 removed the `| count 0` in this file but left behind this stale comment.