### PR TITLE
[AMDGPU][NFC] Fix clang frontend<->sema layering issue

### DIFF
--- a/clang/lib/Sema/SemaAMDGPU.cpp
+++ b/clang/lib/Sema/SemaAMDGPU.cpp
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Sema/SemaAMDGPU.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/TargetBuiltins.h"
-#include "clang/Frontend/FrontendDiagnostic.h"
 #include "clang/Sema/Ownership.h"
 #include "clang/Sema/Sema.h"
 #include "llvm/Support/AMDGPUAddrSpace.h"


### PR DESCRIPTION
#140210 added `#include "clang/Frontend/FrontendDiagnostic.h"` to clang/lib/Sema/SemaAMDGPU.cpp, but Frontend itself has a dependency on Sema. This creates a layering issue as described in https://llvm.org/docs/CodingStandards.html#library-layering.

Fortunately, d076608d58d1ec55016eb747a995511e3a3f72aa made this easy to fix, as clang/Frontend/FrontendDiagnostic.h just forwards to clang/Basic/DiagnosticFrontend.h, so it's trivial to make this depend on basic instead of frontend.