### PR TITLE
[mlir][amdgpu] Add Inliner interface

### DIFF
--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -40,6 +41,15 @@ using namespace mlir::amdgpu;
 
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.cpp.inc"
 
+namespace {
+struct AMDGPUInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
 void AMDGPUDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
@@ -49,6 +59,7 @@ void AMDGPUDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUAttributes.cpp.inc"
       >();
+  addInterfaces<AMDGPUInlinerInterface>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -42,7 +42,7 @@ using namespace mlir::amdgpu;
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.cpp.inc"
 
 namespace {
-struct AMDGPUInlinerInterface : public DialectInlinerInterface {
+struct AMDGPUInlinerInterface final : DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
   bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
     return true;

--- a/mlir/test/Dialect/AMDGPU/inlining.mlir
+++ b/mlir/test/Dialect/AMDGPU/inlining.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-opt %s --inline | FileCheck %s
+
+func.func @calee(%arg0 : f32) -> f32 {
+  %0 = amdgpu.permlane_swap %arg0 32 : f32
+  func.return %0 : f32
+}
+
+// CHECK-LABEL: func @caller
+func.func @caller(%arg0 : f32) -> f32 {
+  // CHECK-NOT: call
+  //     CHECK: amdgpu.permlane_swap
+  %0 = call @calee(%arg0) : (f32) -> f32
+  func.return %0 : f32
+}


### PR DESCRIPTION
All the `amdgpu` dialect ops can be inlined.