### PR TITLE
[C2y] Implement WG14 N3622 static used in an inline

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -180,6 +180,9 @@ C Language Changes
 
 C2y Feature Support
 ^^^^^^^^^^^^^^^^^^^
+- No longer triggering ``-Wstatic-in-inline`` in C2y mode; use of a static
+  function or variable within an extern inline function is no longer a
+  constraint per `WG14 N3622 <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3622.txt>`_.
 - Clang now supports `N3355 <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3355.htm>`_ Named Loops.
 
 C23 Feature Support

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1400,7 +1400,7 @@ def C23 : DiagGroup<"c23-extensions", [VariadicMacroArgumentsOmitted]>;
 def : DiagGroup<"c2x-extensions", [C23]>;
 
 // A warning group for warnings about using C2y features as extensions.
-def C2y : DiagGroup<"c2y-extensions">;
+def C2y : DiagGroup<"c2y-extensions", [StaticInInline]>;
 
 // Previously supported warning group which is no longer pertinent as binary
 // literals are a C++14 and C23 extension now instead of a GNU extension.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6326,11 +6326,14 @@ def warn_internal_linkage_local_storage : Warning<
   InGroup<IgnoredAttributes>;
 
 def ext_internal_in_extern_inline : ExtWarn<
-  "static %select{function|variable}0 %1 is used in an inline function with "
-  "external linkage">, InGroup<StaticInInline>;
+  "using static %select{function|variable}0 %1 in an inline function with "
+  "external linkage is a C2y extension">, InGroup<StaticInInline>;
 def ext_internal_in_extern_inline_quiet : Extension<
-  "static %select{function|variable}0 %1 is used in an inline function with "
-  "external linkage">, InGroup<StaticInInline>;
+  ext_internal_in_extern_inline.Summary>, InGroup<StaticInInline>;
+def warn_c2y_compat_internal_in_extern_inline : Warning<
+  "using static %select{function|variable}0 %1 in an inline function with "
+  "external linkage is incompatible with standards before C2y">,
+  InGroup<CPre2yCompat>, DefaultIgnore;
 def warn_static_local_in_extern_inline : Warning<
   "non-constant static local variable in inline function may be different "
   "in different files">, InGroup<StaticLocalInInline>;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -167,10 +167,11 @@ static void diagnoseUseOfInternalDeclInInlineFunction(Sema &S,
   // contexts where the warning is a false positive, or where it is technically
   // correct but benign.
   //
-  // This is also disabled in C2y because of WG14 N3622 which removed the
-  // constraint entirely. It is left enabled in earlier language modes because
-  // this is a constraint in those language modes.
-  if (S.getLangOpts().CPlusPlus || S.getLangOpts().C2y)
+  // WG14 N3622 which removed the constraint entirely in C2y. It is left
+  // enabled in earlier language modes because this is a constraint in those
+  // language modes. But in C2y mode, we still want to issue the "incompatible
+  // with previous standards" diagnostic, too.
+  if (S.getLangOpts().CPlusPlus)
     return;
 
   // Check if this is an inlined function or method.
@@ -194,16 +195,17 @@ static void diagnoseUseOfInternalDeclInInlineFunction(Sema &S,
   // This last can give us false negatives, but it's better than warning on
   // wrappers for simple C library functions.
   const FunctionDecl *UsedFn = dyn_cast<FunctionDecl>(D);
-  bool DowngradeWarning = S.getSourceManager().isInMainFile(Loc);
-  if (!DowngradeWarning && UsedFn)
-    DowngradeWarning = UsedFn->isInlined() || UsedFn->hasAttr<ConstAttr>();
+  unsigned DiagID;
+  if (S.getLangOpts().C2y)
+    DiagID = diag::warn_c2y_compat_internal_in_extern_inline;
+  else if ((UsedFn && (UsedFn->isInlined() || UsedFn->hasAttr<ConstAttr>())) ||
+           S.getSourceManager().isInMainFile(Loc))
+    DiagID = diag::ext_internal_in_extern_inline_quiet;
+  else
+    DiagID = diag::ext_internal_in_extern_inline;
 
-  S.Diag(Loc, DowngradeWarning ? diag::ext_internal_in_extern_inline_quiet
-                               : diag::ext_internal_in_extern_inline)
-    << /*IsVar=*/!UsedFn << D;
-
+  S.Diag(Loc, DiagID) << /*IsVar=*/!UsedFn << D;
   S.MaybeSuggestAddingStaticToDecl(Current);
-
   S.Diag(D->getCanonicalDecl()->getLocation(), diag::note_entity_declared_at)
       << D;
 }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -166,7 +166,11 @@ static void diagnoseUseOfInternalDeclInInlineFunction(Sema &S,
   // This is disabled under C++; there are too many ways for this to fire in
   // contexts where the warning is a false positive, or where it is technically
   // correct but benign.
-  if (S.getLangOpts().CPlusPlus)
+  //
+  // This is also disabled in C2y because of WG14 N3622 which removed the
+  // constraint entirely. It is left enabled in earlier language modes because
+  // this is a constraint in those language modes.
+  if (S.getLangOpts().CPlusPlus || S.getLangOpts().C2y)
     return;
 
   // Check if this is an inlined function or method.

--- a/clang/test/C/C2y/n3622.c
+++ b/clang/test/C/C2y/n3622.c
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -verify=good -pedantic -Wall -std=c2y %s
-// RUN: %clang_cc1 -verify -pedantic -Wall -std=c23 %s
-// RUN: %clang_cc1 -verify -pedantic -Wall -std=c17 %s
+// RUN: %clang_cc1 -verify=compat,expected -pedantic -Wall -Wpre-c2y-compat -std=c2y %s
+// RUN: %clang_cc1 -verify=ped,expected -pedantic -Wall -std=c23 %s
+// RUN: %clang_cc1 -verify=ped,expected -pedantic -Wall -std=c17 %s
 // good-no-diagnostics
 
 /* WG14 N3622: Clang 22
@@ -15,6 +16,10 @@ static void static_func(void) {} // expected-note {{declared here}}
 static int static_var;           // expected-note {{declared here}}
 
 extern inline void test(void) {
-  static_func();   // expected-warning {{static function 'static_func' is used in an inline function with external linkage}}
-  static_var = 12; // expected-warning {{static variable 'static_var' is used in an inline function with external linkage}}
+  static_func();   /* ped-warning {{using static function 'static_func' in an inline function with external linkage is a C2y extension}}
+                      compat-warning {{using static function 'static_func' in an inline function with external linkage is incompatible with standards before C2y}}
+                    */
+  static_var = 12; /* ped-warning {{using static variable 'static_var' in an inline function with external linkage is a C2y extension}}
+                      compat-warning {{using static variable 'static_var' in an inline function with external linkage is incompatible with standards before C2y}}
+                    */
 }

--- a/clang/test/C/C2y/n3622.c
+++ b/clang/test/C/C2y/n3622.c
@@ -7,7 +7,7 @@
  * Allow calling static inline within extern inline
  *
  * This verifies that a constraint from previous standards is no longer
- * triggered in C2y mode. The constraint is with calling a statric function
+ * triggered in C2y mode. The constraint is with calling a static function
  * or using a static variable from an inline function with external linkage.
  */
 

--- a/clang/test/C/C2y/n3622.c
+++ b/clang/test/C/C2y/n3622.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -verify=good -pedantic -Wall -std=c2y %s
+// RUN: %clang_cc1 -verify -pedantic -Wall -std=c23 %s
+// RUN: %clang_cc1 -verify -pedantic -Wall -std=c17 %s
+// good-no-diagnostics
+
+/* WG14 N3622: Clang 22
+ * Allow calling static inline within extern inline
+ *
+ * This verifies that a constraint from previous standards is no longer
+ * triggered in C2y mode. The constraint is with calling a statric function
+ * or using a static variable from an inline function with external linkage.
+ */
+
+static void static_func(void) {} // expected-note {{declared here}}
+static int static_var;           // expected-note {{declared here}}
+
+extern inline void test(void) {
+  static_func();   // expected-warning {{static function 'static_func' is used in an inline function with external linkage}}
+  static_var = 12; // expected-warning {{static variable 'static_var' is used in an inline function with external linkage}}
+}

--- a/clang/test/Sema/inline.c
+++ b/clang/test/Sema/inline.c
@@ -11,14 +11,14 @@ static int staticFunction(void); // expected-note + {{'staticFunction' declared 
 static struct { int x; } staticStruct; // expected-note + {{'staticStruct' declared here}}
 
 inline int useStatic (void) { // expected-note 3 {{use 'static' to give inline function 'useStatic' internal linkage}}
-  staticFunction(); // expected-warning{{static function 'staticFunction' is used in an inline function with external linkage}}
-  (void)staticStruct.x; // expected-warning{{static variable 'staticStruct' is used in an inline function with external linkage}}
-  return staticVar; // expected-warning{{static variable 'staticVar' is used in an inline function with external linkage}}
+  staticFunction(); // expected-warning{{using static function 'staticFunction' in an inline function with external linkage is a C2y extension}}
+  (void)staticStruct.x; // expected-warning{{using static variable 'staticStruct' in an inline function with external linkage is a C2y extension}}
+  return staticVar; // expected-warning{{using static variable 'staticVar' in an inline function with external linkage is a C2y extension}}
 }
 
 extern inline int useStaticFromExtern (void) { // no suggestions
-  staticFunction(); // expected-warning{{static function 'staticFunction' is used in an inline function with external linkage}}
-  return staticVar; // expected-warning{{static variable 'staticVar' is used in an inline function with external linkage}}
+  staticFunction(); // expected-warning{{using static function 'staticFunction' in an inline function with external linkage is a C2y extension}}
+  return staticVar; // expected-warning{{using static variable 'staticVar' in an inline function with external linkage is a C2y extension}}
 }
 
 static inline int useStaticFromStatic (void) {
@@ -67,8 +67,8 @@ inline int useStaticMainFile (void) {
 #pragma clang diagnostic warning "-Wstatic-in-inline"
 
 inline int useStaticAgain (void) { // expected-note 2 {{use 'static' to give inline function 'useStaticAgain' internal linkage}}
-  staticFunction(); // expected-warning{{static function 'staticFunction' is used in an inline function with external linkage}}
-  return staticVar; // expected-warning{{static variable 'staticVar' is used in an inline function with external linkage}}
+  staticFunction(); // expected-warning{{using static function 'staticFunction' in an inline function with external linkage is a C2y extension}}
+  return staticVar; // expected-warning{{using static variable 'staticVar' in an inline function with external linkage is a C2y extension}}
 }
 
 #pragma clang diagnostic pop
@@ -86,8 +86,8 @@ extern inline void defineStaticVarInExtern(void) {
 // Check behavior of line markers.
 # 1 "XXX.h" 1
 inline int useStaticMainFileInLineMarker(void) { // expected-note 2 {{use 'static' to give inline function 'useStaticMainFileInLineMarker' internal linkage}}
-  staticFunction(); // expected-warning{{static function 'staticFunction' is used in an inline function with external linkage}}
-  return staticVar; // expected-warning{{static variable 'staticVar' is used in an inline function with external linkage}}
+  staticFunction(); // expected-warning{{using static function 'staticFunction' in an inline function with external linkage is a C2y extension}}
+  return staticVar; // expected-warning{{using static variable 'staticVar' in an inline function with external linkage is a C2y extension}}
 }
 # 100 "inline.c" 2
 

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -349,7 +349,7 @@ conformance.</p>
     <tr>
       <td>Allow calling static inline within extern inline</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3622.txt">N3622</a></td>
-      <td class="unknown" align="center">Unknown</td>
+      <td class="unreleased" align="center">Clang 22</td>
 	</tr>
     <tr>
       <td>Generic replacement (v. 2 of quasi-literals)</td>


### PR DESCRIPTION
This paper removes the constraint that a static variable or function cannot be used within an extern inline function. The diagnostic is still being produced in earlier language modes for conformance reasons but has always been accepted as an extension.