### PR TITLE
[libclang/python]  Add isFunctionInlined support 

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2365,7 +2365,7 @@ class Cursor(Structure):
     @cursor_null_guard
     def is_function_inlined(self) -> bool:
         """
-        Check if the function is inlined
+        Check if the function is inlined.
         """
         assert self.kind == TypeKind.FUNCTIONPROTO
         return conf.lib.clang_Cursor_isFunctionInlined(self)  # type: ignore [no-any-return]

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2362,6 +2362,7 @@ class Cursor(Structure):
         """
         return conf.lib.clang_getFieldDeclBitWidth(self)  # type: ignore [no-any-return]
 
+    @cursor_null_guard
     def is_function_inlined(self) -> bool:
         """
         Check if the function is inlined

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2368,7 +2368,7 @@ class Cursor(Structure):
         Check if the function is inlined
         """
         assert self.kind == TypeKind.FUNCTIONPROTO
-        return bool(conf.lib.clang_Cursor_isFunctionInlined(self))  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_isFunctionInlined(self)  # type: ignore [no-any-return]
 
     @cursor_null_guard
     def has_attrs(self) -> bool:
@@ -4316,7 +4316,7 @@ FUNCTION_LIST: list[LibFunc] = [
     ("clang_Cursor_isAnonymous", [Cursor], bool),
     ("clang_Cursor_isAnonymousRecordDecl", [Cursor], bool),
     ("clang_Cursor_isBitField", [Cursor], bool),
-    ("clang_Cursor_isFunctionInlined", [Cursor], c_uint),
+    ("clang_Cursor_isFunctionInlined", [Cursor], bool),
     ("clang_Location_isInSystemHeader", [SourceLocation], bool),
     ("clang_PrintingPolicy_dispose", [PrintingPolicy]),
     ("clang_PrintingPolicy_getProperty", [PrintingPolicy, c_int], c_uint),

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2362,6 +2362,13 @@ class Cursor(Structure):
         """
         return conf.lib.clang_getFieldDeclBitWidth(self)  # type: ignore [no-any-return]
 
+    def is_function_inlined(self) -> bool:
+        """
+        Check if the function is inlined
+        """
+        assert self.kind == TypeKind.FUNCTIONPROTO
+        return bool(conf.lib.clang_Cursor_isFunctionInlined(self))  # type: ignore [no-any-return]
+
     @cursor_null_guard
     def has_attrs(self) -> bool:
         """
@@ -4308,6 +4315,7 @@ FUNCTION_LIST: list[LibFunc] = [
     ("clang_Cursor_isAnonymous", [Cursor], bool),
     ("clang_Cursor_isAnonymousRecordDecl", [Cursor], bool),
     ("clang_Cursor_isBitField", [Cursor], bool),
+    ("clang_Cursor_isFunctionInlined", [Cursor], c_uint),
     ("clang_Location_isInSystemHeader", [SourceLocation], bool),
     ("clang_PrintingPolicy_dispose", [PrintingPolicy]),
     ("clang_PrintingPolicy_getProperty", [PrintingPolicy, c_int], c_uint),

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -4315,7 +4315,7 @@ FUNCTION_LIST: list[LibFunc] = [
     ("clang_Cursor_isAnonymous", [Cursor], bool),
     ("clang_Cursor_isAnonymousRecordDecl", [Cursor], bool),
     ("clang_Cursor_isBitField", [Cursor], bool),
-    ("clang_Cursor_isFunctionInlined", [Cursor], bool),
+    ("clang_Cursor_isFunctionInlined", [Cursor], c_uint),
     ("clang_Location_isInSystemHeader", [SourceLocation], bool),
     ("clang_PrintingPolicy_dispose", [PrintingPolicy]),
     ("clang_PrintingPolicy_getProperty", [PrintingPolicy, c_int], c_uint),

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2367,7 +2367,7 @@ class Cursor(Structure):
         """
         Check if the function is inlined.
         """
-        return conf.lib.clang_Cursor_isFunctionInlined(self)  # type: ignore [no-any-return]
+        return bool(conf.lib.clang_Cursor_isFunctionInlined(self))
 
     @cursor_null_guard
     def has_attrs(self) -> bool:

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2367,7 +2367,6 @@ class Cursor(Structure):
         """
         Check if the function is inlined.
         """
-        assert self.kind == TypeKind.FUNCTIONPROTO
         return conf.lib.clang_Cursor_isFunctionInlined(self)  # type: ignore [no-any-return]
 
     @cursor_null_guard

--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -784,6 +784,11 @@ int count(int a, int b){
         cursor = get_cursor(tu, "reg")
         self.assertEqual(cursor.storage_class, StorageClass.REGISTER)
 
+    def test_function_inlined(self):
+        tu = get_tu("inline void foo(void);")
+        cursor = get_cursor(tu, "foo")
+        self.assertEqual(cursor.is_function_inlined(), True)
+
     def test_availability(self):
         tu = get_tu("class A { A(A const&) = delete; };", lang="cpp")
 

--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -785,9 +785,19 @@ int count(int a, int b){
         self.assertEqual(cursor.storage_class, StorageClass.REGISTER)
 
     def test_function_inlined(self):
-        tu = get_tu("inline void foo(void);")
-        cursor = get_cursor(tu, "foo")
+        tu = get_tu(
+            """
+inline void f_inline(void);
+void f_noninline(void);
+int d_noninline;
+"""
+        )
+        cursor = get_cursor(tu, "f_inline")
         self.assertEqual(cursor.is_function_inlined(), True)
+        cursor = get_cursor(tu, "f_noninline")
+        self.assertEqual(cursor.is_function_inlined(), False)
+        cursor = get_cursor(tu, "d_noninline")
+        self.assertEqual(cursor.is_function_inlined(), False)
 
     def test_availability(self):
         tu = get_tu("class A { A(A const&) = delete; };", lang="cpp")

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -615,6 +615,7 @@ Sanitizers
 
 Python Binding Changes
 ----------------------
+- Exposed ``clang_Cursor_is_function_inlined``.
 - Exposed ``clang_getCursorLanguage`` via ``Cursor.language``.
 - Add all missing ``CursorKind``s, ``TypeKind``s and
   ``ExceptionSpecificationKind``s from ``Index.h``

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -615,7 +615,7 @@ Sanitizers
 
 Python Binding Changes
 ----------------------
-- Exposed ``clang_Cursor_is_function_inlined``.
+- Exposed ``clang_Cursor_isFunctionInlined``.
 - Exposed ``clang_getCursorLanguage`` via ``Cursor.language``.
 - Add all missing ``CursorKind``s, ``TypeKind``s and
   ``ExceptionSpecificationKind``s from ``Index.h``


### PR DESCRIPTION
`cindex.py` was missing support for [isFunctionInlined](https://clang.llvm.org/doxygen/group__CINDEX__TYPES.html#ga963097b9aecabf5dce7554dff18b061d), this PR add it.