### PR TITLE
[clang-doc] simplify filename selection for namespaces

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -582,11 +582,10 @@ static SmallString<16> determineFileName(Info *I, SmallString<128> &Path) {
   if (I->IT == InfoType::IT_record) {
     auto *RecordSymbolInfo = static_cast<SymbolInfo *>(I);
     FileName = RecordSymbolInfo->MangledName;
-  } else if (I->IT == InfoType::IT_namespace && I->Name != "")
-    // Serialize the global namespace as index.json
-    FileName = I->Name;
+  } else if (I->USR == GlobalNamespaceID)
+    FileName = "index";
   else
-    FileName = I->getFileBaseName();
+    FileName = I->Name;
   sys::path::append(Path, FileName + ".json");
   return FileName;
 }

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -30,6 +30,9 @@ namespace doc {
 // SHA1'd hash of a USR.
 using SymbolID = std::array<uint8_t, 20>;
 
+constexpr SymbolID GlobalNamespaceID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 struct BaseRecordInfo;
 struct EnumInfo;
 struct FunctionInfo;


### PR DESCRIPTION
determineFileName was confusing regarding namespaces. The comment and
conditional were both misleading. Now, we just check against a static
global namespace USR to make a file use "index", or just use the name.