### PR TITLE
[MLIR][Vector] Fix test following vector.splat removal

### DIFF
--- a/mlir/test/Integration/Dialect/Vector/CPU/0-d-vectors.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/0-d-vectors.mlir
@@ -140,7 +140,6 @@ func.func @entry() {
 
   // Warning: these must be called in their textual order of definition in the
   // file to not mess up FileCheck.
-  call  @splat_0d(%4) : (f32) -> ()
   call  @broadcast_0d(%4) : (f32) -> ()
   call  @bitcast_0d() : () -> ()
   call  @constant_mask_0d() : () -> ()


### PR DESCRIPTION
This is a fix for the failing integration test (see https://lab.llvm.org/buildbot/#/builders/177/builds/22398) reported in https://github.com/llvm/llvm-project/pull/162167. 