### PR TITLE
[flang] Fix build breakage with FLANG_ENABLE_WERROR on (NFC)

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3383,7 +3383,8 @@ static void genOMPDispatch(lower::AbstractConverter &converter,
     }
   }
 
-  switch (llvm::omp::Directive dir = item->id) {
+  llvm::omp::Directive dir = item->id;
+  switch (dir) {
   case llvm::omp::Directive::OMPD_barrier:
     newOp = genBarrierOp(converter, symTable, semaCtx, eval, loc, queue, item);
     break;


### PR DESCRIPTION
Fix the compile error:
```
llvm-project/flang/lib/Lower/OpenMP/OpenMP.cpp:3386:32: error: variable 'dir' set but not used [-Werror,-Wunused-but-set-variable]
 3386 |   switch (llvm::omp::Directive dir = item->id) {
      |                                ^
1 error generated.
```