### PR TITLE
[NFC][LLVM] Code cleanup in bugpoint

### DIFF
--- a/llvm/tools/bugpoint/BugDriver.cpp
+++ b/llvm/tools/bugpoint/BugDriver.cpp
@@ -27,9 +27,7 @@
 #include <memory>
 using namespace llvm;
 
-namespace llvm {
-Triple TargetTriple;
-}
+Triple llvm::TargetTriple;
 
 DiscardTemp::~DiscardTemp() {
   if (SaveTemps) {
@@ -41,18 +39,14 @@ DiscardTemp::~DiscardTemp() {
     errs() << "Failed to delete temp file " << toString(std::move(E)) << '\n';
 }
 
-// Anonymous namespace to define command line options for debugging.
-//
-namespace {
 // Output - The user can specify a file containing the expected output of the
 // program.  If this filename is set, it is used as the reference diff source,
 // otherwise the raw input run through an interpreter is used as the reference
 // source.
 //
-cl::opt<std::string> OutputFile("output",
-                                cl::desc("Specify a reference program output "
-                                         "(for miscompilation detection)"));
-}
+static cl::opt<std::string>
+    OutputFile("output", cl::desc("Specify a reference program output "
+                                  "(for miscompilation detection)"));
 
 /// If we reduce or update the program somehow, call this method to update
 /// bugdriver with it.  This deletes the old module and sets the specified one
@@ -238,7 +232,7 @@ Error BugDriver::run() {
   return Error::success();
 }
 
-void llvm::PrintFunctionList(const std::vector<Function *> &Funcs) {
+void llvm::printFunctionList(const std::vector<Function *> &Funcs) {
   unsigned NumPrint = Funcs.size();
   if (NumPrint > 10)
     NumPrint = 10;
@@ -249,7 +243,7 @@ void llvm::PrintFunctionList(const std::vector<Function *> &Funcs) {
   outs().flush();
 }
 
-void llvm::PrintGlobalVariableList(const std::vector<GlobalVariable *> &GVs) {
+void llvm::printGlobalVariableList(const std::vector<GlobalVariable *> &GVs) {
   unsigned NumPrint = GVs.size();
   if (NumPrint > 10)
     NumPrint = 10;

--- a/llvm/tools/bugpoint/BugDriver.h
+++ b/llvm/tools/bugpoint/BugDriver.h
@@ -57,7 +57,6 @@ class BugDriver {
 
   // FIXME: sort out public/private distinctions...
   friend class ReducePassList;
-  friend class ReduceMisCodegenFunctions;
 
 public:
   BugDriver(const char *toolname, bool find_bugs, unsigned timeout,
@@ -76,7 +75,7 @@ public:
   void setPassesToRun(const std::vector<std::string> &PTR) {
     PassesToRun = PTR;
   }
-  const std::vector<std::string> &getPassesToRun() const { return PassesToRun; }
+  ArrayRef<std::string> getPassesToRun() const { return PassesToRun; }
 
   /// run - The top level method that is invoked after all of the instance
   /// variables are set up from command line arguments. The \p as_child argument
@@ -111,7 +110,6 @@ public:
   Error debugCodeGenerator();
 
   /// isExecutingJIT - Returns true if bugpoint is currently testing the JIT
-  ///
   bool isExecutingJIT();
 
   Module &getProgram() const { return *Program; }
@@ -167,7 +165,7 @@ public:
                              bool RemoveBitcode = false) const;
 
   /// This function is used to output M to a file named "bugpoint-ID.bc".
-  void EmitProgressBitcode(const Module &M, const std::string &ID,
+  void emitProgressBitcode(const Module &M, const std::string &ID,
                            bool NoFlyer = false) const;
 
   /// This method clones the current Program and deletes the specified
@@ -214,7 +212,6 @@ public:
   /// outs() a single line message indicating whether compilation was successful
   /// or failed, unless Quiet is set.  ExtraArgs specifies additional arguments
   /// to pass to the child bugpoint instance.
-  ///
   bool runPasses(Module &Program, const std::vector<std::string> &PassesToRun,
                  std::string &OutputFilename, bool DeleteOutput = false,
                  bool Quiet = false,
@@ -223,7 +220,6 @@ public:
   /// runPasses - Just like the method above, but this just returns true or
   /// false indicating whether or not the optimizer crashed on the specified
   /// input (true = crashed).  Does not produce any output.
-  ///
   bool runPasses(Module &M, const std::vector<std::string> &PassesToRun) const {
     std::string Filename;
     return runPasses(M, PassesToRun, Filename, true);
@@ -247,7 +243,6 @@ public:
 private:
   /// initializeExecutionEnvironment - This method is used to set up the
   /// environment for executing LLVM programs.
-  ///
   Error initializeExecutionEnvironment();
 };
 
@@ -258,37 +253,31 @@ struct DiscardTemp {
 
 ///  Given a bitcode or assembly input filename, parse and return it, or return
 ///  null if not possible.
-///
 std::unique_ptr<Module> parseInputFile(StringRef InputFilename,
                                        LLVMContext &ctxt);
 
 /// getPassesString - Turn a list of passes into a string which indicates the
 /// command line options that must be passed to add the passes.
-///
 std::string getPassesString(const std::vector<std::string> &Passes);
 
-/// PrintFunctionList - prints out list of problematic functions
-///
-void PrintFunctionList(const std::vector<Function *> &Funcs);
+/// Prints out list of problematic functions
+void printFunctionList(const std::vector<Function *> &Funcs);
 
-/// PrintGlobalVariableList - prints out list of problematic global variables
-///
-void PrintGlobalVariableList(const std::vector<GlobalVariable *> &GVs);
+/// Prints out list of problematic global variables
+void printGlobalVariableList(const std::vector<GlobalVariable *> &GVs);
 
-// DeleteGlobalInitializer - "Remove" the global variable by deleting its
-// initializer, making it external.
-//
-void DeleteGlobalInitializer(GlobalVariable *GV);
+/// "Remove" the global variable by deleting its initializer, making it
+/// external.
+void deleteGlobalInitializer(GlobalVariable *GV);
 
-// DeleteFunctionBody - "Remove" the function by deleting all of it's basic
-// blocks, making it external.
-//
-void DeleteFunctionBody(Function *F);
+/// "Remove" the function by deleting all of it's basic blocks, making it
+/// external.
+void deleteFunctionBody(Function *F);
 
 /// Given a module and a list of functions in the module, split the functions
 /// OUT of the specified module, and place them in the new module.
 std::unique_ptr<Module>
-SplitFunctionsOutOfModule(Module *M, const std::vector<Function *> &F,
+splitFunctionsOutOfModule(Module *M, const std::vector<Function *> &F,
                           ValueToValueMapTy &VMap);
 
 } // End llvm namespace

--- a/llvm/tools/bugpoint/ExecutionDriver.cpp
+++ b/llvm/tools/bugpoint/ExecutionDriver.cpp
@@ -36,15 +36,16 @@ enum OutputType {
   CompileCustom,
   Custom
 };
+} // namespace
 
-cl::opt<double> AbsTolerance("abs-tolerance",
-                             cl::desc("Absolute error tolerated"),
-                             cl::init(0.0));
-cl::opt<double> RelTolerance("rel-tolerance",
-                             cl::desc("Relative error tolerated"),
-                             cl::init(0.0));
+static cl::opt<double> AbsTolerance("abs-tolerance",
+                                    cl::desc("Absolute error tolerated"),
+                                    cl::init(0.0));
+static cl::opt<double> RelTolerance("rel-tolerance",
+                                    cl::desc("Relative error tolerated"),
+                                    cl::init(0.0));
 
-cl::opt<OutputType> InterpreterSel(
+static cl::opt<OutputType> InterpreterSel(
     cl::desc("Specify the \"test\" i.e. suspect back-end:"),
     cl::values(clEnumValN(AutoPick, "auto", "Use best guess"),
                clEnumValN(RunLLI, "run-int", "Execute with the interpreter"),
@@ -60,7 +61,7 @@ cl::opt<OutputType> InterpreterSel(
                           "the bitcode. Useful for cross-compilation.")),
     cl::init(AutoPick));
 
-cl::opt<OutputType> SafeInterpreterSel(
+static cl::opt<OutputType> SafeInterpreterSel(
     cl::desc("Specify \"safe\" i.e. known-good backend:"),
     cl::values(clEnumValN(AutoPick, "safe-auto", "Use best guess"),
                clEnumValN(RunLLC, "safe-run-llc", "Compile with LLC"),
@@ -69,16 +70,16 @@ cl::opt<OutputType> SafeInterpreterSel(
                           "the bitcode. Useful for cross-compilation.")),
     cl::init(AutoPick));
 
-cl::opt<std::string> SafeInterpreterPath(
+static cl::opt<std::string> SafeInterpreterPath(
     "safe-path", cl::desc("Specify the path to the \"safe\" backend program"),
     cl::init(""));
 
-cl::opt<bool> AppendProgramExitCode(
+static cl::opt<bool> AppendProgramExitCode(
     "append-exit-code",
     cl::desc("Append the exit code to the output so it gets diff'd too"),
     cl::init(false));
 
-cl::opt<std::string>
+static cl::opt<std::string>
     InputFile("input", cl::init("/dev/null"),
               cl::desc("Filename to pipe in as stdin (default: /dev/null)"));
 
@@ -89,20 +90,19 @@ static cl::list<std::string>
 static cl::list<std::string> AdditionalLinkerArgs(
     "Xlinker", cl::desc("Additional arguments to pass to the linker"));
 
-cl::opt<std::string> CustomCompileCommand(
+static cl::opt<std::string> CustomCompileCommand(
     "compile-command", cl::init("llc"),
     cl::desc("Command to compile the bitcode (use with -compile-custom) "
              "(default: llc)"));
 
-cl::opt<std::string> CustomExecCommand(
+static cl::opt<std::string> CustomExecCommand(
     "exec-command", cl::init("simulate"),
     cl::desc("Command to execute the bitcode (use with -run-custom) "
              "(default: simulate)"));
-}
 
-namespace llvm {
 // Anything specified after the --args option are taken as arguments to the
 // program being debugged.
+namespace llvm {
 cl::list<std::string> InputArgv("args", cl::Positional,
                                 cl::desc("<program arguments>..."),
                                 cl::PositionalEatsArgs);
@@ -110,25 +110,22 @@ cl::list<std::string> InputArgv("args", cl::Positional,
 cl::opt<std::string>
     OutputPrefix("output-prefix", cl::init("bugpoint"),
                  cl::desc("Prefix to use for outputs (default: 'bugpoint')"));
-}
+} // namespace llvm
 
-namespace {
-cl::list<std::string> ToolArgv("tool-args", cl::Positional,
-                               cl::desc("<tool arguments>..."),
-                               cl::PositionalEatsArgs);
+static cl::list<std::string> ToolArgv("tool-args", cl::Positional,
+                                      cl::desc("<tool arguments>..."),
+                                      cl::PositionalEatsArgs);
 
-cl::list<std::string> SafeToolArgv("safe-tool-args", cl::Positional,
-                                   cl::desc("<safe-tool arguments>..."),
-                                   cl::PositionalEatsArgs);
+static cl::list<std::string> SafeToolArgv("safe-tool-args", cl::Positional,
+                                          cl::desc("<safe-tool arguments>..."),
+                                          cl::PositionalEatsArgs);
 
-cl::opt<std::string> CCBinary("gcc", cl::init(""),
-                              cl::desc("The gcc binary to use."));
+static cl::opt<std::string> CCBinary("gcc", cl::init(""),
+                                     cl::desc("The gcc binary to use."));
 
-cl::list<std::string> CCToolArgv("gcc-tool-args", cl::Positional,
-                                 cl::desc("<gcc-tool arguments>..."),
-                                 cl::PositionalEatsArgs);
-}
-
+static cl::list<std::string> CCToolArgv("gcc-tool-args", cl::Positional,
+                                        cl::desc("<gcc-tool arguments>..."),
+                                        cl::PositionalEatsArgs);
 //===----------------------------------------------------------------------===//
 // BugDriver method implementation
 //

--- a/llvm/tools/bugpoint/Miscompilation.cpp
+++ b/llvm/tools/bugpoint/Miscompilation.cpp
@@ -33,16 +33,16 @@ extern cl::opt<std::string> OutputPrefix;
 extern cl::list<std::string> InputArgv;
 } // end namespace llvm
 
-namespace {
-static llvm::cl::opt<bool> DisableLoopExtraction(
+static cl::opt<bool> DisableLoopExtraction(
     "disable-loop-extraction",
     cl::desc("Don't extract loops when searching for miscompilations"),
     cl::init(false));
-static llvm::cl::opt<bool> DisableBlockExtraction(
+static cl::opt<bool> DisableBlockExtraction(
     "disable-block-extraction",
     cl::desc("Don't extract blocks when searching for miscompilations"),
     cl::init(false));
 
+namespace {
 class ReduceMiscompilingPasses : public ListReducer<std::string> {
   BugDriver &BD;
 
@@ -71,7 +71,7 @@ ReduceMiscompilingPasses::doTest(std::vector<std::string> &Prefix,
     errs() << " Error running this sequence of passes"
            << " on the input program!\n";
     BD.setPassesToRun(Suffix);
-    BD.EmitProgressBitcode(BD.getProgram(), "pass-error", false);
+    BD.emitProgressBitcode(BD.getProgram(), "pass-error", false);
     // TODO: This should propagate the error instead of exiting.
     if (Error E = BD.debugOptimizerCrash())
       exit(1);
@@ -113,7 +113,7 @@ ReduceMiscompilingPasses::doTest(std::vector<std::string> &Prefix,
     errs() << " Error running this sequence of passes"
            << " on the input program!\n";
     BD.setPassesToRun(Prefix);
-    BD.EmitProgressBitcode(BD.getProgram(), "pass-error", false);
+    BD.emitProgressBitcode(BD.getProgram(), "pass-error", false);
     // TODO: This should propagate the error instead of exiting.
     if (Error E = BD.debugOptimizerCrash())
       exit(1);
@@ -158,7 +158,7 @@ ReduceMiscompilingPasses::doTest(std::vector<std::string> &Prefix,
     errs() << " Error running this sequence of passes"
            << " on the input program!\n";
     BD.setPassesToRun(Suffix);
-    BD.EmitProgressBitcode(BD.getProgram(), "pass-error", false);
+    BD.emitProgressBitcode(BD.getProgram(), "pass-error", false);
     // TODO: This should propagate the error instead of exiting.
     if (Error E = BD.debugOptimizerCrash())
       exit(1);
@@ -253,7 +253,7 @@ ReduceMiscompilingFunctions::TestFuncs(const std::vector<Function *> &Funcs) {
          << (Funcs.size() == 1 ? "this function is" : "these functions are")
          << " run through the pass"
          << (BD.getPassesToRun().size() == 1 ? "" : "es") << ":";
-  PrintFunctionList(Funcs);
+  printFunctionList(Funcs);
   outs() << '\n';
 
   // Create a clone for two reasons:
@@ -277,7 +277,7 @@ ReduceMiscompilingFunctions::TestFuncs(const std::vector<Function *> &Funcs) {
   VMap.clear();
   std::unique_ptr<Module> ToNotOptimize = CloneModule(BD.getProgram(), VMap);
   std::unique_ptr<Module> ToOptimize =
-      SplitFunctionsOutOfModule(ToNotOptimize.get(), FuncsOnClone, VMap);
+      splitFunctionsOutOfModule(ToNotOptimize.get(), FuncsOnClone, VMap);
 
   Expected<bool> Broken =
       TestFn(BD, std::move(ToOptimize), std::move(ToNotOptimize));
@@ -314,7 +314,7 @@ ExtractLoops(BugDriver &BD,
 
     ValueToValueMapTy VMap;
     std::unique_ptr<Module> ToNotOptimize = CloneModule(BD.getProgram(), VMap);
-    std::unique_ptr<Module> ToOptimize = SplitFunctionsOutOfModule(
+    std::unique_ptr<Module> ToOptimize = splitFunctionsOutOfModule(
         ToNotOptimize.get(), MiscompiledFunctions, VMap);
     std::unique_ptr<Module> ToOptimizeLoopExtracted =
         BD.extractLoop(ToOptimize.get());
@@ -517,7 +517,7 @@ ReduceMiscompiledBlocks::TestFuncs(const std::vector<BasicBlock *> &BBs) {
 
   std::unique_ptr<Module> ToNotOptimize = CloneModule(BD.getProgram(), VMap);
   std::unique_ptr<Module> ToOptimize =
-      SplitFunctionsOutOfModule(ToNotOptimize.get(), FuncsOnClone, VMap);
+      splitFunctionsOutOfModule(ToNotOptimize.get(), FuncsOnClone, VMap);
 
   // Try the extraction.  If it doesn't work, then the block extractor crashed
   // or something, in which case bugpoint can't chase down this possibility.
@@ -572,7 +572,7 @@ ExtractBlocks(BugDriver &BD,
   ValueToValueMapTy VMap;
   std::unique_ptr<Module> ProgClone = CloneModule(BD.getProgram(), VMap);
   std::unique_ptr<Module> ToExtract =
-      SplitFunctionsOutOfModule(ProgClone.get(), MiscompiledFunctions, VMap);
+      splitFunctionsOutOfModule(ProgClone.get(), MiscompiledFunctions, VMap);
   std::unique_ptr<Module> Extracted =
       BD.extractMappedBlocksFromModule(Blocks, ToExtract.get());
   if (!Extracted) {
@@ -638,7 +638,7 @@ static Expected<std::vector<Function *>> DebugAMiscompilation(
   outs() << "\n*** The following function"
          << (MiscompiledFunctions.size() == 1 ? " is" : "s are")
          << " being miscompiled: ";
-  PrintFunctionList(MiscompiledFunctions);
+  printFunctionList(MiscompiledFunctions);
   outs() << '\n';
 
   // See if we can rip any loops out of the miscompiled functions and still
@@ -663,7 +663,7 @@ static Expected<std::vector<Function *>> DebugAMiscompilation(
       outs() << "\n*** The following function"
              << (MiscompiledFunctions.size() == 1 ? " is" : "s are")
              << " being miscompiled: ";
-      PrintFunctionList(MiscompiledFunctions);
+      printFunctionList(MiscompiledFunctions);
       outs() << '\n';
     }
   }
@@ -686,7 +686,7 @@ static Expected<std::vector<Function *>> DebugAMiscompilation(
       outs() << "\n*** The following function"
              << (MiscompiledFunctions.size() == 1 ? " is" : "s are")
              << " being miscompiled: ";
-      PrintFunctionList(MiscompiledFunctions);
+      printFunctionList(MiscompiledFunctions);
       outs() << '\n';
     }
   }
@@ -708,7 +708,7 @@ static Expected<bool> TestOptimizer(BugDriver &BD, std::unique_ptr<Module> Test,
   if (!Optimized) {
     errs() << " Error running this sequence of passes"
            << " on the input program!\n";
-    BD.EmitProgressBitcode(*Test, "pass-error", false);
+    BD.emitProgressBitcode(*Test, "pass-error", false);
     BD.setNewProgram(std::move(Test));
     if (Error E = BD.debugOptimizerCrash())
       return std::move(E);
@@ -750,7 +750,7 @@ Error BugDriver::debugMiscompilation() {
   outs() << "\n*** Found miscompiling pass"
          << (getPassesToRun().size() == 1 ? "" : "es") << ": "
          << getPassesString(getPassesToRun()) << '\n';
-  EmitProgressBitcode(*Program, "passinput");
+  emitProgressBitcode(*Program, "passinput");
 
   Expected<std::vector<Function *>> MiscompiledFunctions =
       DebugAMiscompilation(*this, TestOptimizer);
@@ -762,15 +762,15 @@ Error BugDriver::debugMiscompilation() {
   ValueToValueMapTy VMap;
   Module *ToNotOptimize = CloneModule(getProgram(), VMap).release();
   Module *ToOptimize =
-      SplitFunctionsOutOfModule(ToNotOptimize, *MiscompiledFunctions, VMap)
+      splitFunctionsOutOfModule(ToNotOptimize, *MiscompiledFunctions, VMap)
           .release();
 
   outs() << "  Non-optimized portion: ";
-  EmitProgressBitcode(*ToNotOptimize, "tonotoptimize", true);
+  emitProgressBitcode(*ToNotOptimize, "tonotoptimize", true);
   delete ToNotOptimize; // Delete hacked module.
 
   outs() << "  Portion that is input to optimizer: ";
-  EmitProgressBitcode(*ToOptimize, "tooptimize");
+  emitProgressBitcode(*ToOptimize, "tooptimize");
   delete ToOptimize; // Delete hacked module.
 
   return Error::success();
@@ -1028,7 +1028,7 @@ Error BugDriver::debugCodeGenerator() {
   ValueToValueMapTy VMap;
   std::unique_ptr<Module> ToNotCodeGen = CloneModule(getProgram(), VMap);
   std::unique_ptr<Module> ToCodeGen =
-      SplitFunctionsOutOfModule(ToNotCodeGen.get(), *Funcs, VMap);
+      splitFunctionsOutOfModule(ToNotCodeGen.get(), *Funcs, VMap);
 
   // Condition the modules
   ToCodeGen =

--- a/llvm/tools/bugpoint/OptimizerDriver.cpp
+++ b/llvm/tools/bugpoint/OptimizerDriver.cpp
@@ -87,7 +87,7 @@ bool BugDriver::writeProgramToFile(const std::string &Filename,
 
 /// This function is used to output the current Program to a file named
 /// "bugpoint-ID.bc".
-void BugDriver::EmitProgressBitcode(const Module &M, const std::string &ID,
+void BugDriver::emitProgressBitcode(const Module &M, const std::string &ID,
                                     bool NoFlyer) const {
   // Output the input to the current pass to a bitcode file, emit a message
   // telling the user how to reproduce it: opt -foo blah.bc

--- a/llvm/tools/bugpoint/ToolRunner.cpp
+++ b/llvm/tools/bugpoint/ToolRunner.cpp
@@ -25,29 +25,25 @@ using namespace llvm;
 
 #define DEBUG_TYPE "toolrunner"
 
-namespace llvm {
-cl::opt<bool> SaveTemps("save-temps", cl::init(false),
-                        cl::desc("Save temporary files"));
-}
+cl::opt<bool> llvm::SaveTemps("save-temps", cl::init(false),
+                              cl::desc("Save temporary files"));
 
-namespace {
-cl::opt<std::string>
+static cl::opt<std::string>
     RemoteClient("remote-client",
                  cl::desc("Remote execution client (rsh/ssh)"));
 
-cl::opt<std::string> RemoteHost("remote-host",
-                                cl::desc("Remote execution (rsh/ssh) host"));
+static cl::opt<std::string>
+    RemoteHost("remote-host", cl::desc("Remote execution (rsh/ssh) host"));
 
-cl::opt<std::string> RemotePort("remote-port",
-                                cl::desc("Remote execution (rsh/ssh) port"));
+static cl::opt<std::string>
+    RemotePort("remote-port", cl::desc("Remote execution (rsh/ssh) port"));
 
-cl::opt<std::string> RemoteUser("remote-user",
-                                cl::desc("Remote execution (rsh/ssh) user id"));
+static cl::opt<std::string>
+    RemoteUser("remote-user", cl::desc("Remote execution (rsh/ssh) user id"));
 
-cl::opt<std::string>
+static cl::opt<std::string>
     RemoteExtra("remote-extra-options",
                 cl::desc("Remote execution (rsh/ssh) extra options"));
-}
 
 /// RunProgramWithTimeout - This function provides an alternate interface
 /// to the sys::Program::ExecuteAndWait interface.
@@ -160,7 +156,7 @@ public:
       const std::vector<std::string> &SharedLibs = std::vector<std::string>(),
       unsigned Timeout = 0, unsigned MemoryLimit = 0) override;
 };
-}
+} // namespace
 
 Expected<int> LLI::ExecuteProgram(const std::string &Bitcode,
                                   const std::vector<std::string> &Args,
@@ -258,7 +254,7 @@ public:
         inconvertibleErrorCode());
   }
 };
-}
+} // namespace
 
 Error CustomCompiler::compileProgram(const std::string &Bitcode,
                                      unsigned Timeout, unsigned MemoryLimit) {
@@ -301,7 +297,7 @@ public:
       const std::vector<std::string> &SharedLibs = std::vector<std::string>(),
       unsigned Timeout = 0, unsigned MemoryLimit = 0) override;
 };
-}
+} // namespace
 
 Expected<int> CustomExecutor::ExecuteProgram(
     const std::string &Bitcode, const std::vector<std::string> &Args,
@@ -541,7 +537,7 @@ public:
       const std::vector<std::string> &SharedLibs = std::vector<std::string>(),
       unsigned Timeout = 0, unsigned MemoryLimit = 0) override;
 };
-}
+} // namespace
 
 Expected<int> JIT::ExecuteProgram(const std::string &Bitcode,
                                   const std::vector<std::string> &Args,

--- a/llvm/tools/bugpoint/bugpoint.cpp
+++ b/llvm/tools/bugpoint/bugpoint.cpp
@@ -90,7 +90,7 @@ public:
     D.addPass(std::string(PI->getPassArgument()));
   }
 };
-}
+} // namespace
 
 #define HANDLE_EXTENSION(Ext)                                                  \
   llvm::PassPluginLibraryInfo get##Ext##PluginInfo();


### PR DESCRIPTION
- Move file local variables and functions out of anonymous namespace and mark them static.
- Change a few function names to conform to LLVM coding standard (camelCase).
- Add end of namespace comments for anonymous namespaces.
