### PR TITLE
[clang][perf-training] Fix training when path to cmake has spaces in it

### DIFF
--- a/clang/utils/perf-training/lit.site.cfg.in
+++ b/clang/utils/perf-training/lit.site.cfg.in
@@ -1,6 +1,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
 import sys
+import shlex
 
 config.clang_tools_dir = lit_config.substitute("@CURRENT_TOOLS_DIR@")
 config.perf_helper_dir = "@CMAKE_CURRENT_SOURCE_DIR@"
@@ -8,7 +9,7 @@ config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.test_source_root = "@CLANG_PGO_TRAINING_DATA@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_exe = "@Python3_EXECUTABLE@"
-config.cmake_exe = "@CMAKE_COMMAND@"
+config.cmake_exe =  shlex.quote("@CMAKE_COMMAND@")
 config.llvm_src_dir ="@CMAKE_SOURCE_DIR@"
 config.cmake_generator ="@CMAKE_GENERATOR@"
 config.use_llvm_build = @CLANG_PGO_TRAINING_USE_LLVM_BUILD@


### PR DESCRIPTION
I uncovered this problem while trying to build release binaries on Windows with PGO.