### PR TITLE
Adding first version for which clang-tidy checks and their options are available

### DIFF
--- a/clang-tools-extra/docs/_static/clang-tools-extra-styles.css
+++ b/clang-tools-extra/docs/_static/clang-tools-extra-styles.css
@@ -21,3 +21,6 @@ details summary:hover {
   background-color: rgba(50, 150, 220, 0.2);
   cursor: pointer;
 }
+.strike {
+  text-decoration: line-through;
+}

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/string-find-startswith.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/string-find-startswith.rst
@@ -31,18 +31,18 @@ becomes
 Options
 -------
 
-.. option:: StringLikeClasses
+.. option:: StringLikeClasses (added in 15.0.0)
 
    Semicolon-separated list of names of string-like classes. By default both
    ``std::basic_string`` and ``std::basic_string_view`` are considered. The list
    of methods to be considered is fixed.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: AbseilStringsMatchHeader
+.. option:: AbseilStringsMatchHeader (added in 15.0.0)
 
    The location of Abseil's ``strings/match.h``. Defaults to
    ``absl/strings/match.h``.

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/string-find-str-contains.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/string-find-str-contains.rst
@@ -35,18 +35,18 @@ becomes
 Options
 -------
 
-.. option:: StringLikeClasses
+.. option:: StringLikeClasses (added in 15.0.0)
 
    Semicolon-separated list of names of string-like classes. By default includes
    ``::std::basic_string``, ``::std::basic_string_view``, and
    ``::absl::string_view``.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: AbseilStringsMatchHeader
+.. option:: AbseilStringsMatchHeader (added in 15.0.0)
 
    The location of Abseil's ``strings/match.h``. Defaults to
    ``absl/strings/match.h``.

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/single-work-item-barrier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/single-work-item-barrier.rst
@@ -52,7 +52,7 @@ Examples:
 Options
 -------
 
-.. option:: AOCVersion
+.. option:: AOCVersion (added in 15.0.0)
 
    Defines the version of the Altera Offline Compiler. Defaults to ``1600``
    (corresponding to version 16.00).

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/unroll-loops.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/unroll-loops.rst
@@ -96,7 +96,7 @@ Based on the `Altera SDK for OpenCL: Best Practices Guide
 Options
 -------
 
-.. option:: MaxLoopIterations
+.. option:: MaxLoopIterations (added in 15.0.0)
 
    Defines the maximum number of loop iterations that a fully unrolled loop
    can have. By default, it is set to `100`.

--- a/clang-tools-extra/docs/clang-tidy/checks/android/comparison-in-temp-failure-retry.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/comparison-in-temp-failure-retry.rst
@@ -38,7 +38,7 @@ If you encounter this, the fix is simple: lift the comparison out of the
 Options
 -------
 
-.. option:: RetryMacros
+.. option:: RetryMacros (added in 15.0.0)
 
    A comma-separated list of the names of retry macros to be checked.
    Default is `TEMP_FAILURE_RETRY`.

--- a/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
@@ -160,18 +160,18 @@ Transforms to:
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 19.1.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: IncludeBoostSystem
+.. option:: IncludeBoostSystem (added in 19.1.0)
    
    If `true` (default value) the boost headers are included as system headers
    with angle brackets (`#include <boost.hpp>`), otherwise quotes are used
    (`#include "boost.hpp"`).
 
-.. option:: UseReversePipe
+.. option:: UseReversePipe (added in 19.1.0)
 
   When `true` (default `false`), fixes which involve reverse ranges will use the
   pipe adaptor syntax instead of the function syntax.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/argument-comment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/argument-comment.rst
@@ -22,17 +22,17 @@ The check tries to detect typos and suggest automated fixes for them.
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 15.0.0)
 
    When `false`, the check will ignore leading and trailing
    underscores and case when comparing names -- otherwise they are taken into
    account. Default is `false`.
 
-.. option:: IgnoreSingleArgument
+.. option:: IgnoreSingleArgument (added in 15.0.0)
 
    When `true`, the check will ignore the single argument. Default is `false`.
 
-.. option:: CommentBoolLiterals
+.. option:: CommentBoolLiterals (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the boolean literal argument.
@@ -54,7 +54,7 @@ After:
 
   foo(/*TurnKey=*/true, /*PressButton=*/false);
 
-.. option:: CommentIntegerLiterals
+.. option:: CommentIntegerLiterals (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the integer literal argument.
@@ -76,7 +76,7 @@ After:
 
   foo(/*MeaningOfLife=*/42);
 
-.. option:: CommentFloatLiterals
+.. option:: CommentFloatLiterals (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the float/double literal argument.
@@ -98,7 +98,7 @@ After:
 
   foo(/*Pi=*/3.14159);
 
-.. option:: CommentStringLiterals
+.. option:: CommentStringLiterals (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the string literal argument.
@@ -124,7 +124,7 @@ After:
   foo(/*String=*/"Hello World");
   foo(/*WideString=*/L"Hello World");
 
-.. option:: CommentCharacterLiterals
+.. option:: CommentCharacterLiterals (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the character literal argument.
@@ -146,7 +146,7 @@ After:
 
   foo(/*Character=*/'A');
 
-.. option:: CommentUserDefinedLiterals
+.. option:: CommentUserDefinedLiterals (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the user defined literal argument.
@@ -172,7 +172,7 @@ After:
 
   foo(/*Distance=*/402.0_km);
 
-.. option:: CommentNullPtrs
+.. option:: CommentNullPtrs (added in 15.0.0)
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the nullptr literal argument.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assert-side-effect.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assert-side-effect.rst
@@ -12,18 +12,18 @@ builds.
 Options
 -------
 
-.. option:: AssertMacros
+.. option:: AssertMacros (added in 15.0.0)
 
    A comma-separated list of the names of assert macros to be checked.
    Default is `assert,NSAssert,NSCAssert`.
 
-.. option:: CheckFunctionCalls
+.. option:: CheckFunctionCalls (added in 15.0.0)
 
    Whether to treat non-const member and non-member functions as they produce
    side effects. Disabled by default because it can increase the number of false
    positive warnings.
 
-.. option:: IgnoredFunctions
+.. option:: IgnoredFunctions (added in 15.0.0)
 
    A semicolon-separated list of the names of functions or methods to be
    considered as not having side-effects. Regular expressions are accepted,

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/capturing-this-in-member-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/capturing-this-in-member-variable.rst
@@ -35,13 +35,13 @@ Possible fixes:
 Options
 -------
 
-.. option:: FunctionWrapperTypes
+.. option:: FunctionWrapperTypes (added in 21.1.0)
 
   A semicolon-separated list of names of types. Used to specify function
   wrapper that can hold lambda expressions.
   Default is `::std::function;::std::move_only_function;::boost::function`.
 
-.. option:: BindFunctions
+.. option:: BindFunctions (added in 21.1.0)
 
   A semicolon-separated list of fully qualified names of functions that can
   capture ``this`` pointer.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/dangling-handle.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/dangling-handle.rst
@@ -38,7 +38,7 @@ Examples:
 Options
 -------
 
-.. option:: HandleClasses
+.. option:: HandleClasses (added in 15.0.0)
 
    A semicolon-separated list of class names that should be treated as handles.
    By default only ``std::basic_string_view``,

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/easily-swappable-parameters.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/easily-swappable-parameters.rst
@@ -43,7 +43,7 @@ way of mixing at call sites the most.
 These options are expected to make the check report for more functions, and
 report longer mixable ranges.
 
-.. option:: QualifiersMix
+.. option:: QualifiersMix (added in 15.0.0)
 
     Whether to consider parameters of some *cvr-qualified* ``T`` and a
     differently *cvr-qualified* ``T`` (i.e. ``T`` and ``const T``, ``const T``
@@ -59,7 +59,7 @@ report longer mixable ranges.
 
         void *memcpy(const void *Destination, void *Source, std::size_t N) { /* ... */ }
 
-.. option:: ModelImplicitConversions
+.. option:: ModelImplicitConversions (added in 15.0.0)
 
     Whether to consider parameters of type ``T`` and ``U`` mixable if there
     exists an implicit conversion from ``T`` to ``U`` and ``U`` to ``T``.
@@ -99,7 +99,7 @@ Filtering options can be used to lessen the size of the diagnostics emitted by
 the checker, whether the aim is to ignore certain constructs or dampen the
 noisiness.
 
-.. option:: MinimumLength
+.. option:: MinimumLength (added in 15.0.0)
 
     The minimum length required from an adjacent parameter sequence to be
     diagnosed.
@@ -109,7 +109,7 @@ noisiness.
 
     For example, if `3` is specified, the examples above will not be matched.
 
-.. option:: IgnoredParameterNames
+.. option:: IgnoredParameterNames (added in 15.0.0)
 
     The list of parameter **names** that should never be considered part of a
     swappable adjacent parameter sequence.
@@ -123,7 +123,7 @@ noisiness.
     `""` (unnamed parameters), `iterator`, `begin`, `end`, `first`, `last`,
     `lhs`, `rhs`.
 
-.. option:: IgnoredParameterTypeSuffixes
+.. option:: IgnoredParameterTypeSuffixes (added in 15.0.0)
 
     The list of parameter **type name suffixes** that should never be
     considered part of a swappable adjacent parameter sequence.
@@ -140,7 +140,7 @@ noisiness.
     `ConstIterator`, `const_reverse_iterator`, `ConstReverseIterator`.
     In addition, `_Bool` (but not `_bool`) is also part of the default value.
 
-.. option:: SuppressParametersUsedTogether
+.. option:: SuppressParametersUsedTogether (added in 15.0.0)
 
     Suppresses diagnostics about parameters that are used together or in a
     similar fashion inside the function's body.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/empty-catch.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/empty-catch.rst
@@ -126,7 +126,7 @@ and maintainable.
 Options
 -------
 
-.. option:: IgnoreCatchWithKeywords
+.. option:: IgnoreCatchWithKeywords (added in 17.0.1)
 
   This option can be used to ignore specific catch statements containing
   certain keywords. If a ``catch`` statement body contains (case-insensitive)
@@ -134,7 +134,7 @@ Options
   catch will be ignored, and no warning will be raised.
   Default value: `@TODO;@FIXME`.
 
-.. option:: AllowEmptyCatchForExceptions
+.. option:: AllowEmptyCatchForExceptions (added in 17.0.1)
 
   This option can be used to ignore empty catch statements for specific
   exception types. By default, the check will raise a warning if an empty

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/exception-escape.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/exception-escape.rst
@@ -35,14 +35,14 @@ WARNING! This check may be expensive on large source files.
 Options
 -------
 
-.. option:: FunctionsThatShouldNotThrow
+.. option:: FunctionsThatShouldNotThrow (added in 15.0.0)
 
    Comma separated list containing function names which should not throw. An
    example value for this parameter can be ``WinMain`` which adds function
    ``WinMain()`` in the Windows API to the list of the functions which should
    not throw. Default value is an empty string.
 
-.. option:: IgnoredExceptions
+.. option:: IgnoredExceptions (added in 15.0.0)
 
    Comma separated list containing type names which are not counted as thrown
    exceptions in the check. Default value is an empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
@@ -34,18 +34,18 @@ where for that to happen you "only" need a ~269MPix image.
 Options
 -------
 
-.. option:: UseCXXStaticCastsInCppSources
+.. option:: UseCXXStaticCastsInCppSources (added in 15.0.0)
 
    When suggesting fix-its for C++ code, should C++-style ``static_cast<>()``'s
    be suggested, or C-style casts. Defaults to `true`.
 
-.. option:: UseCXXHeadersInCppSources
+.. option:: UseCXXHeadersInCppSources (added in 15.0.0)
 
    When suggesting to include the appropriate header in C++ code,
    should ``<cstddef>`` header be suggested, or ``<stddef.h>``.
    Defaults to `true`.
 
-.. option:: IgnoreConstantIntExpr
+.. option:: IgnoreConstantIntExpr (added in 19.1.0)
 
    If the multiplication operands are compile-time constants (like literals or
    are ``constexpr``) and fit within the source expression type, do not emit a

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/lambda-function-name.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/lambda-function-name.rst
@@ -29,7 +29,7 @@ Likely intended output::
 Options
 -------
 
-.. option::  IgnoreMacros
+.. option::  IgnoreMacros (added in 18.1.0)
 
   The value `true` specifies that attempting to get the name of a function from
   within a macro should not be diagnosed. The default value is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/misplaced-widening-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/misplaced-widening-cast.rst
@@ -60,6 +60,6 @@ written for this code:
 Options
 -------
 
-.. option:: CheckImplicitCasts
+.. option:: CheckImplicitCasts (added in 15.0.0)
 
    If `true`, enables detection of implicit casts. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.rst
@@ -46,7 +46,7 @@ improving the overall reliability and maintainability of the code.
 Options
 -------
 
-.. option:: EnableInC
+.. option:: EnableInC (added in 21.1.0)
 
    If `true`, enables the check in C code (it is always enabled in C++ code).
    Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/narrowing-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/narrowing-conversions.rst
@@ -62,33 +62,33 @@ This check diagnoses more instances of narrowing than the compiler warning
 Options
 -------
 
-.. option:: WarnOnIntegerNarrowingConversion
+.. option:: WarnOnIntegerNarrowingConversion (added in 20.1.0)
 
     When `true`, the check will warn on narrowing integer conversion
     (e.g. ``int`` to ``size_t``). `true` by default.
 
-.. option:: WarnOnIntegerToFloatingPointNarrowingConversion
+.. option:: WarnOnIntegerToFloatingPointNarrowingConversion (added in 20.1.0)
 
     When `true`, the check will warn on narrowing integer to floating-point
     conversion (e.g. ``size_t`` to ``double``). `true` by default.
 
-.. option:: WarnOnFloatingPointNarrowingConversion
+.. option:: WarnOnFloatingPointNarrowingConversion (added in 20.1.0)
 
     When `true`, the check will warn on narrowing floating point conversion
     (e.g. ``double`` to ``float``). `true` by default.
 
-.. option:: WarnWithinTemplateInstantiation
+.. option:: WarnWithinTemplateInstantiation (added in 20.1.0)
 
     When `true`, the check will warn on narrowing conversions within template
     instantiations. `false` by default.
 
-.. option:: WarnOnEquivalentBitWidth
+.. option:: WarnOnEquivalentBitWidth (added in 20.1.0)
 
     When `true`, the check will warn on narrowing conversions that arise from
     casting between types of equivalent bit width. (e.g.
     `int n = uint(0);` or `long long n = double(0);`) `true` by default.
 
-.. option:: IgnoreConversionFromTypes
+.. option:: IgnoreConversionFromTypes (added in 20.1.0)
 
    Narrowing conversions from any type in this semicolon-separated list will be
    ignored. This may be useful to weed out commonly occurring, but less commonly
@@ -97,7 +97,7 @@ Options
    suggested list for a legacy codebase would be
    `size_t;ptrdiff_t;size_type;difference_type`.
 
-.. option:: PedanticMode
+.. option:: PedanticMode (added in 20.1.0)
 
     When `true`, the check will warn on assigning a floating point constant
     to an integer value even if the floating point value is exactly

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion.rst
@@ -44,7 +44,7 @@ Example
 Options
 -------
 
-.. option:: EnumIgnoreList
+.. option:: EnumIgnoreList (added in 17.0.1)
 
   Option is used to ignore certain enum types when checking for
   implicit/explicit casts to bool. It accepts a semicolon-separated list of

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/not-null-terminated-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/not-null-terminated-result.rst
@@ -125,7 +125,7 @@ The given length is incremented by one.
 Options
 -------
 
-.. option::  WantToUseSafeFunctions
+.. option::  WantToUseSafeFunctions (added in 15.0.0)
 
    The value `true` specifies that the target environment is considered to
    implement '_s' suffixed memory and string handler functions which are safer

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/optional-value-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/optional-value-conversion.rst
@@ -63,13 +63,13 @@ The support for non-standard optional types such as ``boost::optional`` or
 Options:
 --------
 
-.. option:: OptionalTypes
+.. option:: OptionalTypes (added in 18.1.0)
 
     Semicolon-separated list of (fully qualified) optional type names or regular
     expressions that match the optional types.
     Default value is `::std::optional;::absl::optional;::boost::optional`.
 
-.. option:: ValueMethods
+.. option:: ValueMethods (added in 18.1.0)
 
     Semicolon-separated list of (fully qualified) method names or regular
     expressions that match the methods.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.rst
@@ -46,7 +46,7 @@ Example:
 Options
 -------
 
-.. option:: IgnoreInheritedVirtualFunctions
+.. option:: IgnoreInheritedVirtualFunctions (added in 19.1.0)
 
   When `true`, objects that only inherit a virtual function are not checked.
   Classes that do not declare a new virtual function are excluded

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/reserved-identifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/reserved-identifier.rst
@@ -46,12 +46,12 @@ identifier
 Options
 -------
 
-.. option:: Invert
+.. option:: Invert (added in 15.0.0)
 
    If `true`, inverts the check, i.e. flags names that are not reserved.
    Default is `false`.
 
-.. option:: AllowedIdentifiers
+.. option:: AllowedIdentifiers (added in 15.0.0)
 
    Semicolon-separated list of regular expressions that the check ignores. Default is an
    empty list.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
@@ -40,7 +40,7 @@ It has the alias names ``cert-sig30-c`` and ``cert-msc54-cpp``.
 Options
 -------
 
-.. option:: AsyncSafeFunctionSet
+.. option:: AsyncSafeFunctionSet (added in 15.0.0)
 
   Selects which set of functions is considered as asynchronous-safe
   (and therefore allowed in signal handlers). It can be set to the following values:

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
@@ -115,7 +115,7 @@ Options
   ``sal_Int8`` or ``int8_t``. In this case, human misinterpretation is not
   an issue. Default is an empty string.
 
-.. option:: DiagnoseSignedUnsignedCharComparisons
+.. option:: DiagnoseSignedUnsignedCharComparisons (added in 15.0.0)
 
   When `true`, the check will warn on ``signed char``/``unsigned char`` comparisons,
   otherwise these comparisons are ignored. By default, this option is set to `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -276,28 +276,28 @@ importantly, ``char``) are excluded.
 Options
 -------
 
-.. option:: WarnOnSizeOfConstant
+.. option:: WarnOnSizeOfConstant (added in 15.0.0)
 
    When `true`, the check will warn on an expression like
    ``sizeof(CONSTANT)``. Default is `true`.
 
-.. option:: WarnOnSizeOfIntegerExpression
+.. option:: WarnOnSizeOfIntegerExpression (added in 15.0.0)
 
    When `true`, the check will warn on an expression like ``sizeof(expr)``
    where the expression results in an integer. Default is `false`.
 
-.. option:: WarnOnSizeOfThis
+.. option:: WarnOnSizeOfThis (added in 15.0.0)
 
    When `true`, the check will warn on an expression like ``sizeof(this)``.
    Default is `true`.
 
-.. option:: WarnOnSizeOfCompareToConstant
+.. option:: WarnOnSizeOfCompareToConstant (added in 15.0.0)
 
    When `true`, the check will warn on an expression like
    ``sizeof(expr) <= k`` for a suspicious constant `k` while `k` is `0` or
    greater than `0x8000`. Default is `true`.
 
-.. option:: WarnOnSizeOfPointerToAggregate
+.. option:: WarnOnSizeOfPointerToAggregate (added in 16.0.0)
 
    When `true`, the check will warn when the argument of ``sizeof`` is either a
    pointer-to-aggregate type, an expression returning a pointer-to-aggregate
@@ -305,20 +305,20 @@ Options
    conversion (that may be implicit or explicit, for example ``array + 2`` or
    ``(int *)array``). Default is `true`.
 
-.. option:: WarnOnSizeOfPointer
+.. option:: WarnOnSizeOfPointer (added in 19.1.0)
 
    When `true`, the check will report all expressions where the argument of
    ``sizeof`` is an expression that produces a pointer (except for a few
    idiomatic expressions that are probably intentional and correct).
    This detects occurrences of CWE 467. Default is `false`.
 
-.. option:: WarnOnOffsetDividedBySizeOf
+.. option:: WarnOnOffsetDividedBySizeOf (added in 20.1.0)
 
    When `true`, the check will warn on pointer arithmetic where the
    element count is obtained from a division with ``sizeof(...)``,
    e.g., ``Ptr + Bytes / sizeof(*T)``. Default is `true`.
 
-.. option:: WarnOnSizeOfInLoopTermination
+.. option:: WarnOnSizeOfInLoopTermination (added in 21.1.0)
 
    When `true`, the check will warn about incorrect use of sizeof expression
    in loop termination condition. The warning triggers if the ``sizeof``

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/string-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/string-constructor.rst
@@ -48,16 +48,16 @@ Examples:
 Options
 -------
 
-.. option::  WarnOnLargeLength
+.. option::  WarnOnLargeLength (added in 15.0.0)
 
    When `true`, the check will warn on a string with a length greater than
    :option:`LargeLengthThreshold`. Default is `true`.
 
-.. option::  LargeLengthThreshold
+.. option::  LargeLengthThreshold (added in 15.0.0)
 
    An integer specifying the large length threshold. Default is `0x800000`.
 
-.. option:: StringNames
+.. option:: StringNames (added in 15.0.0)
 
     Default is `::std::basic_string;::std::basic_string_view`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-enum-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-enum-usage.rst
@@ -72,7 +72,7 @@ Examples:
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 15.0.0)
 
    Default value: 0.
    When non-null the suspicious bitmask usage will be investigated additionally

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-missing-comma.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-missing-comma.rst
@@ -43,17 +43,17 @@ This check may warn incorrectly on cases like:
 Options
 -------
 
-.. option::  SizeThreshold
+.. option::  SizeThreshold (added in 15.0.0)
 
    An unsigned integer specifying the minimum size of a string literal to be
    considered by the check. Default is ``5U``.
 
-.. option::  RatioThreshold
+.. option::  RatioThreshold (added in 15.0.0)
 
    A string specifying the maximum threshold ratio [0, 1.0] of suspicious string
    literals to be considered. Default is ``".2"``.
 
-.. option::  MaxConcatenatedTokens
+.. option::  MaxConcatenatedTokens (added in 15.0.0)
 
    An unsigned integer specifying the maximum number of concatenated tokens.
    Default is ``5U``.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-string-compare.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-string-compare.rst
@@ -40,15 +40,15 @@ a wrong context.
 Options
 -------
 
-.. option:: WarnOnImplicitComparison
+.. option:: WarnOnImplicitComparison (added in 15.0.0)
 
    When `true`, the check will warn on implicit comparison. `true` by default.
 
-.. option:: WarnOnLogicalNotComparison
+.. option:: WarnOnLogicalNotComparison (added in 15.0.0)
 
    When `true`, the check will warn on logical not comparison. `false` by default.
 
-.. option:: StringCompareLikeFunctions
+.. option:: StringCompareLikeFunctions (added in 15.0.0)
 
    A string specifying the comma-separated names of the extra string comparison
    functions. Default is an empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.rst
@@ -46,14 +46,14 @@ compilation error, albeit introducing potential hazards as discussed.
 Options
 -------
 
-.. option:: StringViewTypes
+.. option:: StringViewTypes (added in 19.1.0)
 
   Option allows users to specify custom string view-like types for analysis. It
   accepts a semicolon-separated list of type names or regular expressions
   matching these types. Default value is:
   `::std::basic_string_view;::llvm::StringRef`.
 
-.. option:: AllowedCallees
+.. option:: AllowedCallees (added in 19.1.0)
 
   Specifies methods, functions, or classes where the result of ``.data()`` is
   passed to. Allows to exclude such calls from the analysis. Accepts a

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/tagged-union-member-count.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/tagged-union-member-count.rst
@@ -118,7 +118,7 @@ Example counts:
 Options
 -------
 
-.. option:: EnableCountingEnumHeuristic
+.. option:: EnableCountingEnumHeuristic (added in 20.1.0)
 
 This option enables or disables the counting enum heuristic.
 It uses the prefixes and suffixes specified in the options
@@ -169,11 +169,11 @@ When :option:`EnableCountingEnumHeuristic` is `true`:
     } Data;
   };
 
-.. option:: CountingEnumPrefixes
+.. option:: CountingEnumPrefixes (added in 20.1.0)
 
 See :option:`CountingEnumSuffixes` below.
 
-.. option:: CountingEnumSuffixes
+.. option:: CountingEnumSuffixes (added in 20.1.0)
 
 CountingEnumPrefixes and CountingEnumSuffixes are lists of semicolon
 separated strings that are used to search for possible counting enum constants.
@@ -261,7 +261,7 @@ When :option:`EnableCountingEnumHeuristic` is `true` and :option:`CountingEnumPr
     } Data;
   };
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 20.1.0)
 
 When enabled, the check will also give a warning, when the number of tags
 is greater than the number of union data members.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
@@ -35,7 +35,7 @@ inspect compile-time constant loop boundaries to avoid overlaps with the warning
 Options
 -------
 
-.. option:: MagnitudeBitsUpperLimit
+.. option:: MagnitudeBitsUpperLimit (added in 15.0.0)
 
   Upper limit for the magnitude bits of the loop variable. If it's set the check
   filters out those catches in which the loop variable's type has more magnitude

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unhandled-self-assignment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unhandled-self-assignment.rst
@@ -121,7 +121,7 @@ temporary object into ``this`` (needs a move assignment operator):
 Options
 -------
 
-.. option:: WarnOnlyIfThisHasSuspiciousField
+.. option:: WarnOnlyIfThisHasSuspiciousField (added in 15.0.0)
 
   When `true`, the check will warn only if the container class of the copy
   assignment operator has any suspicious fields (pointer, C array and C++ smart

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
@@ -42,7 +42,7 @@ Or cast to char to explicitly indicate that output should be a character.
 Options
 -------
 
-.. option:: AllowedTypes
+.. option:: AllowedTypes (added in 21.1.0)
 
   A semicolon-separated list of type names that will be treated like the ``char``
   type: the check will not report variables declared with with these types or
@@ -52,7 +52,7 @@ Options
   ``typedef`` alias for ``unsigned char``.
   Default is `unsigned char;signed char`.
 
-.. option:: CastTypeName
+.. option:: CastTypeName (added in 21.1.0)
 
   When `CastTypeName` is specified, the fix-it will use `CastTypeName` as the
   cast target type. Otherwise, fix-it will automatically infer the type.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unsafe-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unsafe-functions.rst
@@ -128,7 +128,7 @@ fully qualified name (``::std::original``).
 Options
 -------
 
-.. option:: ReportMoreUnsafeFunctions
+.. option:: ReportMoreUnsafeFunctions (added in 17.0.1)
 
    When `true`, additional functions from widely used APIs (such as POSIX) are
    added to the list of reported functions.
@@ -136,14 +136,14 @@ Options
    this option enables.
    Default is `true`.
 
-.. option:: ReportDefaultFunctions
+.. option:: ReportDefaultFunctions (added in 20.1.0)
 
     When `true`, the check reports the default set of functions.
     Consider changing the setting to false if you only want to see custom
     functions matched via :ref:`custom functions<CustomFunctions>`.
     Default is `true`.
 
-.. option:: CustomFunctions
+.. option:: CustomFunctions (added in 20.1.0)
 
     A semicolon-separated list of custom functions to be matched. A matched
     function contains a regular expression, an optional name of the replacement

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-local-non-trivial-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-local-non-trivial-variable.rst
@@ -37,7 +37,7 @@ In the next example, `future2` would generate a warning that it is unused.
 Options
 -------
 
-.. option:: IncludeTypes
+.. option:: IncludeTypes (added in 18.1.0)
 
    Semicolon-separated list of regular expressions matching types of variables
    to check. By default the following types are checked:
@@ -51,7 +51,7 @@ Options
    * `::std::bitset`
    * `::std::filesystem::path`
 
-.. option:: ExcludeTypes
+.. option:: ExcludeTypes (added in 18.1.0)
 
    A semicolon-separated list of regular expressions matching types that are
    excluded from the `IncludeTypes` matches. By default it is an empty list.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
@@ -10,7 +10,7 @@ Operator overloading with assignment semantics are ignored.
 Options
 -------
 
-.. option:: CheckedFunctions
+.. option:: CheckedFunctions (added in 15.0.0)
 
    Semicolon-separated list of functions to check.
    This parameter supports regexp. The function is checked if the name
@@ -53,14 +53,14 @@ Options
      return value often indicates that the programmer confused the function with
      ``clear()``.
 
-.. option:: CheckedReturnTypes
+.. option:: CheckedReturnTypes (added in 17.0.1)
 
    Semicolon-separated list of function return types to check.
    By default the following function return types are checked:
    `^::std::error_code$`, `^::std::error_condition$`, `^::std::errc$`,
    `^::std::expected$`, `^::boost::system::error_code$`
 
-.. option:: AllowCastToVoid
+.. option:: AllowCastToVoid (added in 18.1.0)
 
    Controls whether casting return values to ``void`` is permitted. Default: `false`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
@@ -34,7 +34,7 @@ Examples:
 Options
 -------
 
-.. option:: DisallowedSeedTypes
+.. option:: DisallowedSeedTypes (added in 15.0.0)
 
    A comma-separated list of the type names which are disallowed.
    Default value is `time_t,std::time_t`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.rst
@@ -9,7 +9,7 @@ cert-oop57-cpp
 Options
 -------
 
-.. option:: MemSetNames
+.. option:: MemSetNames (added in 15.0.0)
 
    Specify extra functions to flag that act similarly to ``memset``.
    Specify names in a semicolon delimited list.
@@ -17,7 +17,7 @@ Options
    The check will detect the following functions:
    `memset`, `std::memset`.
 
-.. option:: MemCpyNames
+.. option:: MemCpyNames (added in 15.0.0)
 
    Specify extra functions to flag that act similarly to ``memcpy``.
    Specify names in a semicolon delimited list.
@@ -26,7 +26,7 @@ Options
    `std::memcpy`, `memcpy`, `std::memmove`, `memmove`, `std::strcpy`,
    `strcpy`, `memccpy`, `stpncpy`, `strncpy`.
 
-.. option:: MemCmpNames
+.. option:: MemCmpNames (added in 15.0.0)
 
    Specify extra functions to flag that act similarly to ``memcmp``.
    Specify names in a semicolon delimited list.

--- a/clang-tools-extra/docs/clang-tidy/checks/concurrency/mt-unsafe.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/concurrency/mt-unsafe.rst
@@ -35,7 +35,7 @@ Examples:
 Options
 -------
 
-.. option:: FunctionSet
+.. option:: FunctionSet (added in 15.0.0)
 
   Specifies which functions in libc should be considered thread-safe,
   possible values are `posix`, `glibc`, or `any`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-do-while.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-do-while.rst
@@ -24,7 +24,7 @@ Examples:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 16.0.0)
 
   Ignore the check when analyzing macros. This is useful for safely defining function-like macros:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-goto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-goto.rst
@@ -55,7 +55,7 @@ All other uses of ``goto`` are diagnosed in `C++`.
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 21.1.0)
 
    If set to `true`, the check will not warn if a ``goto`` statement is
    expanded from a macro. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.rst
@@ -45,7 +45,7 @@ or both.
 Options
 -------
 
-.. option:: AllowInternalLinkage
+.. option:: AllowInternalLinkage (added in 19.1.0)
 
    When set to `true`, static non-const variables and variables in anonymous
    namespaces will not generate a warning. The default value is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/init-variables.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/init-variables.rst
@@ -60,12 +60,12 @@ It warns for the uninitialized enum case, but without a FixIt:
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: MathHeader
+.. option:: MathHeader (added in 15.0.0)
 
    A string specifying the header to include to get the definition of `NAN`.
    Default is `<math.h>`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-usage.rst
@@ -44,19 +44,19 @@ results in the following warnings::
 Options
 -------
 
-.. option:: AllowedRegexp
+.. option:: AllowedRegexp (added in 15.0.0)
 
     A regular expression to filter allowed macros. For example
     `DEBUG*|LIBTORRENT*|TORRENT*|UNI*` could be applied to filter `libtorrent`.
     Default value is `^DEBUG_*`.
 
-.. option:: CheckCapsOnly
+.. option:: CheckCapsOnly (added in 15.0.0)
 
     Boolean flag to warn on all macros except those with CAPS_ONLY names.
     This option is intended to ease introduction of this check into older
     code bases. Default value is `false`.
 
-.. option:: IgnoreCommandLineMacros
+.. option:: IgnoreCommandLineMacros (added in 15.0.0)
 
     Boolean flag to toggle ignoring command-line-defined macros.
     Default value is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
@@ -38,7 +38,7 @@ Example:
 Options
 -------
 
-.. option:: ForwardFunction
+.. option:: ForwardFunction (added in 21.1.0)
 
    Specify the function used for forwarding. Default is `::std::forward`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-malloc.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-malloc.rst
@@ -32,17 +32,17 @@ management isn't easily transformed automatically into RAII.
 Options
 -------
 
-.. option:: Allocations
+.. option:: Allocations (added in 15.0.0)
 
    Semicolon-separated list of fully qualified names of memory allocation functions.
    Defaults to `::malloc;::calloc`.
 
-.. option:: Deallocations
+.. option:: Deallocations (added in 15.0.0)
 
    Semicolon-separated list of fully qualified names of memory allocation functions.
    Defaults to `::free`.
 
-.. option:: Reallocations
+.. option:: Reallocations (added in 15.0.0)
 
    Semicolon-separated list of fully qualified names of memory allocation functions.
    Defaults to `::realloc`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/owning-memory.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/owning-memory.rst
@@ -91,14 +91,14 @@ argument get called with either a ``gsl::owner<T*>`` or a newly created resource
 Options
 -------
 
-.. option:: LegacyResourceProducers
+.. option:: LegacyResourceProducers (added in 15.0.0)
 
    Semicolon-separated list of fully qualified names of legacy functions that create
    resources but cannot introduce ``gsl::owner<>``.
    Defaults to `::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile`.
 
 
-.. option:: LegacyResourceConsumers
+.. option:: LegacyResourceConsumers (added in 15.0.0)
 
    Semicolon-separated list of fully qualified names of legacy functions expecting
    resource owners as pointer arguments but cannot introduce ``gsl::owner<>``.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.rst
@@ -17,13 +17,13 @@ Optionally, this check can generate fixes using ``gsl::at`` for indexing.
 Options
 -------
 
-.. option:: GslHeader
+.. option:: GslHeader (added in 15.0.0)
 
    The check can generate fixes after this option has been set to the name of
    the include file that contains ``gsl::at()``, e.g. `"gsl/gsl.h"`.
    Default is an empty string.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.rst
@@ -30,7 +30,7 @@ rule from the C++ Core Guidelines.
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 18.1.0)
 
   When this setting is set to `true`, it means that any usage of ``const_cast``
   is not allowed. On the other hand, when it's set to `false`, it permits

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
@@ -27,13 +27,13 @@ fix is to zero initialize the variable via ``{}`` for C++11 and beyond or ``=
 Options
 -------
 
-.. option:: IgnoreArrays
+.. option:: IgnoreArrays (added in 15.0.0)
 
    If set to `true`, the check will not warn about array members that are not
    zero-initialized during construction. For performance critical code, it may
    be important to not initialize fixed-size array members. Default is `false`.
 
-.. option:: UseAssignment
+.. option:: UseAssignment (added in 15.0.0)
 
    If set to `true`, the check will provide fix-its with literal initializers
    \( ``int i = 0;`` \) instead of curly braces \( ``int i{};`` \).

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.rst
@@ -18,7 +18,7 @@ profile from the C++ Core Guidelines.
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 18.1.0)
 
   When set to `false`, no warnings are emitted for casts on non-polymorphic
   types. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved.rst
@@ -31,7 +31,7 @@ Example:
 Options
 -------
 
-.. option:: AllowPartialMove
+.. option:: AllowPartialMove (added in 17.0.1)
 
    If set to `true`, the check accepts ``std::move`` calls containing any
    subexpression containing the parameter. CppCoreGuideline F.18 officially
@@ -51,12 +51,12 @@ Options
       pair<Obj, Obj> other = std::move(p);
     }
 
-.. option:: IgnoreUnnamedParams
+.. option:: IgnoreUnnamedParams (added in 17.0.1)
 
    If set to `true`, the check ignores unnamed rvalue reference parameters.
    Default is `false`.
 
-.. option:: IgnoreNonDeducedTemplateTypes
+.. option:: IgnoreNonDeducedTemplateTypes (added in 17.0.1)
 
    If set to `true`, the check ignores non-deduced template type rvalue
    reference parameters. Default is `false`.
@@ -79,7 +79,7 @@ Options
       T other = std::forward<T>(t);
     }
 
-.. option:: MoveFunction
+.. option:: MoveFunction (added in 21.1.0)
 
    Specify the function used for moving. Default is `::std::move`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/special-member-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/special-member-functions.rst
@@ -22,7 +22,7 @@ from the C++ Core Guidelines.
 Options
 -------
 
-.. option:: AllowSoleDefaultDtor
+.. option:: AllowSoleDefaultDtor (added in 15.0.0)
 
    When set to `true` (default is `false`), this check will only trigger on
    destructors if they are defined and not defaulted.
@@ -43,7 +43,7 @@ Options
        ~C();
      };
 
-.. option:: AllowMissingMoveFunctions
+.. option:: AllowMissingMoveFunctions (added in 15.0.0)
 
    When set to `true` (default is `false`), this check doesn't flag classes
    which define no move operations at all. It still flags classes which define
@@ -58,7 +58,7 @@ Options
        ~A();
      };
 
-.. option:: AllowMissingMoveFunctionsWhenCopyIsDeleted
+.. option:: AllowMissingMoveFunctionsWhenCopyIsDeleted (added in 15.0.0)
 
    When set to `true` (default is `false`), this check doesn't flag classes
    which define deleted copy operations but don't define move operations. This
@@ -74,7 +74,7 @@ Options
        ~A();
      };
 
-.. option:: AllowImplicitlyDeletedCopyOrMove
+.. option:: AllowImplicitlyDeletedCopyOrMove (added in 19.1.0)
 
    When set to `true` (default is `false`), this check doesn't flag classes
    which implicitly delete copy or move operations.
@@ -86,7 +86,7 @@ Options
         ~A() { std::cout << "dtor\n"; }
       };
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 21.1.0)
 
    If set to `true`, the check will not give warnings for classes defined
    inside macros. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
@@ -29,7 +29,7 @@ Example:
 Options
 -------
 
-.. option:: IgnoreUnscopedEnumsInClasses
+.. option:: IgnoreUnscopedEnumsInClasses (added in 21.1.0)
 
    When `true`, ignores unscoped ``enum`` declarations in classes.
    Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-int.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-int.rst
@@ -14,14 +14,14 @@ Corresponding cpplint.py check: `runtime/int`.
 Options
 -------
 
-.. option:: UnsignedTypePrefix
+.. option:: UnsignedTypePrefix (added in 15.0.0)
 
    A string specifying the unsigned type prefix. Default is `uint`.
 
-.. option:: SignedTypePrefix
+.. option:: SignedTypePrefix (added in 15.0.0)
 
    A string specifying the signed type prefix. Default is `int`.
 
-.. option:: TypeSuffix
+.. option:: TypeSuffix (added in 15.0.0)
 
    A string specifying the type suffix. Default is an empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -19,6 +19,6 @@ and depending on used options it can be superfluous to enable both checks.
 Options
 -------
 
-.. option:: AllowCastToVoid
+.. option:: AllowCastToVoid (added in 18.1.0)
 
    Controls whether casting return values to ``void`` is permitted. Default: `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/multiway-paths-covered.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/multiway-paths-covered.rst
@@ -90,7 +90,7 @@ Degenerated ``switch`` statements without any labels are caught as well.
 Options
 -------
 
-.. option:: WarnOnMissingElse
+.. option:: WarnOnMissingElse (added in 15.0.0)
 
   Boolean flag that activates a warning for missing ``else`` branches.
   Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/signed-bitwise.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/signed-bitwise.rst
@@ -11,7 +11,7 @@ The according rule is defined in the `High Integrity C++ Standard, Section 5.6.1
 Options
 -------
 
-.. option:: IgnorePositiveIntegerLiterals
+.. option:: IgnorePositiveIntegerLiterals (added in 15.0.0)
 
    If this option is set to `true`, the check will not warn on bitwise operations with positive integer literals, e.g. `~0`, `2 << 1`, etc.
    Default value is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -33,8 +33,8 @@ Clang-Tidy Checks
    readability/*
    zircon/*
 
-.. csv-table::
-   :header: "Name", "Offers fixes"
+.. role:: strike
+   :class: strike
 
 .. csv-table::
    :header: "Name", "Offers fixes", "Added in", "Removed in"
@@ -176,6 +176,7 @@ Clang-Tidy Checks
    :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,, "7.1.0",
    :doc:`bugprone-use-after-move <bugprone/use-after-move>`,, "7.1.0",
    :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes", "7.1.0",
+   :strike:cert-dcl21-cpp,, "7.1.0", "19.1.0"
    :doc:`cert-dcl58-cpp <cert/dcl58-cpp>`,, "7.1.0",
    :doc:`cert-err33-c <cert/err33-c>`,, "14.0.0",
    :doc:`cert-err60-cpp <cert/err60-cpp>`,, "7.1.0",
@@ -185,7 +186,19 @@ Clang-Tidy Checks
    :doc:`cert-msc51-cpp <cert/msc51-cpp>`,, "7.1.0",
    :doc:`cert-oop57-cpp <cert/oop57-cpp>`,, "11.0.0",
    :doc:`cert-oop58-cpp <cert/oop58-cpp>`,, "10.0.0",
-   :doc:`clang-analyzer-security.insecureAPI.decodeValueOfObjCType <clang-analyzer/security.insecureAPI.decodeValueOfObjCType>`, Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType,, "10.0.0",
+   :strike:clang-analyzer-apiModeling.StdCLibraryFunctions,, "8.0.1", "17.0.1"
+   :strike:clang-analyzer-core.CallAndMessageModeling,, "11.0.0", "22.0.0"
+   :strike:clang-analyzer-core.DereferenceModeling,, "20.1.0", "22.0.0"
+   :strike:clang-analyzer-core.StackAddrEscapeBase,, "9.0.1", "22.0.0"
+   :strike:clang-analyzer-cplusplus.SmartPtr,, "9.0.1", "11.0.0"
+   :strike:clang-analyzer-cplusplus.VirtualCallModeling,, "10.0.0", "21.1.0"
+   :strike:clang-analyzer-llvm.Conventions,, "7.1.0", "8.0.1"
+   :strike:clang-analyzer-nullability.NullabilityBase,, "9.0.1", "21.1.0"
+   :strike:clang-analyzer-osx.NSOrCFErrorDerefChecker,, "9.0.1", "22.0.0"
+   :strike:clang-analyzer-valist.CopyToSelf,, "7.1.0", "22.0.0"
+   :strike:clang-analyzer-valist.Uninitialized,, "7.1.0", "22.0.0"
+   :strike:clang-analyzer-valist.Unterminated,, "7.1.0", "22.0.0"
+   :strike:clang-analyzer-valist.ValistBase,, "9.0.1", "22.0.0"
    :doc:`concurrency-mt-unsafe <concurrency/mt-unsafe>`,, "12.0.0",
    :doc:`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>`,, "13.0.0",
    :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines <cppcoreguidelines/avoid-capturing-lambda-coroutines>`,, "17.0.1",
@@ -221,10 +234,12 @@ Clang-Tidy Checks
    :doc:`cppcoreguidelines-virtual-class-destructor <cppcoreguidelines/virtual-class-destructor>`, "Yes", "14.0.0",
    :doc:`darwin-avoid-spinlock <darwin/avoid-spinlock>`,, "10.0.0",
    :doc:`darwin-dispatch-once-nonstatic <darwin/dispatch-once-nonstatic>`, "Yes", "10.0.0",
+   :strike:fuchsia-default-arguments,, "7.1.0", "9.0.1"
    :doc:`fuchsia-default-arguments-calls <fuchsia/default-arguments-calls>`,, "9.0.1",
    :doc:`fuchsia-default-arguments-declarations <fuchsia/default-arguments-declarations>`, "Yes", "9.0.1",
    :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`,, "7.1.0",
    :doc:`fuchsia-overloaded-operator <fuchsia/overloaded-operator>`,, "7.1.0",
+   :strike:fuchsia-restrict-system-includes,, "7.1.0", "11.0.0"
    :doc:`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>`,, "7.1.0",
    :doc:`fuchsia-temporary-objects <fuchsia/temporary-objects>`,, "22.0.0",
    :doc:`fuchsia-trailing-return <fuchsia/trailing-return>`,, "7.1.0",
@@ -245,6 +260,7 @@ Clang-Tidy Checks
    :doc:`google-runtime-float <google/runtime-float>`,, "22.0.0",
    :doc:`google-runtime-int <google/runtime-int>`,, "7.1.0",
    :doc:`google-runtime-operator <google/runtime-operator>`,, "7.1.0",
+   :strike:google-runtime-references,, "7.1.0", "12.0.0"
    :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes", "10.0.0",
    :doc:`hicpp-exception-baseclass <hicpp/exception-baseclass>`,, "7.1.0",
    :doc:`hicpp-ignored-remove-result <hicpp/ignored-remove-result>`,, "18.1.0",
@@ -338,6 +354,7 @@ Clang-Tidy Checks
    :doc:`mpi-type-mismatch <mpi/type-mismatch>`, "Yes", "7.1.0",
    :doc:`objc-assert-equals <objc/assert-equals>`, "Yes", "14.0.0",
    :doc:`objc-avoid-nserror-init <objc/avoid-nserror-init>`,, "7.1.0",
+   :strike:objc-avoid-spinlock,, "7.1.0", "10.0.0"
    :doc:`objc-dealloc-in-category <objc/dealloc-in-category>`,, "11.0.0",
    :doc:`objc-forbidden-subclassing <objc/forbidden-subclassing>`,, "7.1.0",
    :doc:`objc-missing-hash <objc/missing-hash>`,, "10.0.0",
@@ -383,6 +400,7 @@ Clang-Tidy Checks
    :doc:`readability-container-size-empty <readability/container-size-empty>`, "Yes", "7.1.0",
    :doc:`readability-convert-member-functions-to-static <readability/convert-member-functions-to-static>`, "Yes", "9.0.1",
    :doc:`readability-delete-null-pointer <readability/delete-null-pointer>`, "Yes", "7.1.0",
+   :strike:readability-deleted-default,, "7.1.0", "13.0.0"
    :doc:`readability-duplicate-include <readability/duplicate-include>`, "Yes", "14.0.0",
    :doc:`readability-else-after-return <readability/else-after-return>`, "Yes", "7.1.0",
    :doc:`readability-enum-initial-value <readability/enum-initial-value>`, "Yes", "19.1.0",

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -36,396 +36,397 @@ Clang-Tidy Checks
 .. csv-table::
    :header: "Name", "Offers fixes"
 
-   :doc:`abseil-cleanup-ctad <abseil/cleanup-ctad>`, "Yes"
-   :doc:`abseil-duration-addition <abseil/duration-addition>`, "Yes"
-   :doc:`abseil-duration-comparison <abseil/duration-comparison>`, "Yes"
-   :doc:`abseil-duration-conversion-cast <abseil/duration-conversion-cast>`, "Yes"
-   :doc:`abseil-duration-division <abseil/duration-division>`, "Yes"
-   :doc:`abseil-duration-factory-float <abseil/duration-factory-float>`, "Yes"
-   :doc:`abseil-duration-factory-scale <abseil/duration-factory-scale>`, "Yes"
-   :doc:`abseil-duration-subtraction <abseil/duration-subtraction>`, "Yes"
-   :doc:`abseil-duration-unnecessary-conversion <abseil/duration-unnecessary-conversion>`, "Yes"
-   :doc:`abseil-faster-strsplit-delimiter <abseil/faster-strsplit-delimiter>`, "Yes"
-   :doc:`abseil-no-internal-dependencies <abseil/no-internal-dependencies>`,
-   :doc:`abseil-no-namespace <abseil/no-namespace>`,
-   :doc:`abseil-redundant-strcat-calls <abseil/redundant-strcat-calls>`, "Yes"
-   :doc:`abseil-str-cat-append <abseil/str-cat-append>`, "Yes"
-   :doc:`abseil-string-find-startswith <abseil/string-find-startswith>`, "Yes"
-   :doc:`abseil-string-find-str-contains <abseil/string-find-str-contains>`, "Yes"
-   :doc:`abseil-time-comparison <abseil/time-comparison>`, "Yes"
-   :doc:`abseil-time-subtraction <abseil/time-subtraction>`, "Yes"
-   :doc:`abseil-upgrade-duration-conversions <abseil/upgrade-duration-conversions>`, "Yes"
-   :doc:`altera-id-dependent-backward-branch <altera/id-dependent-backward-branch>`,
-   :doc:`altera-kernel-name-restriction <altera/kernel-name-restriction>`,
-   :doc:`altera-single-work-item-barrier <altera/single-work-item-barrier>`,
-   :doc:`altera-struct-pack-align <altera/struct-pack-align>`, "Yes"
-   :doc:`altera-unroll-loops <altera/unroll-loops>`,
-   :doc:`android-cloexec-accept <android/cloexec-accept>`, "Yes"
-   :doc:`android-cloexec-accept4 <android/cloexec-accept4>`, "Yes"
-   :doc:`android-cloexec-creat <android/cloexec-creat>`, "Yes"
-   :doc:`android-cloexec-dup <android/cloexec-dup>`, "Yes"
-   :doc:`android-cloexec-epoll-create <android/cloexec-epoll-create>`, "Yes"
-   :doc:`android-cloexec-epoll-create1 <android/cloexec-epoll-create1>`, "Yes"
-   :doc:`android-cloexec-fopen <android/cloexec-fopen>`, "Yes"
-   :doc:`android-cloexec-inotify-init <android/cloexec-inotify-init>`, "Yes"
-   :doc:`android-cloexec-inotify-init1 <android/cloexec-inotify-init1>`, "Yes"
-   :doc:`android-cloexec-memfd-create <android/cloexec-memfd-create>`, "Yes"
-   :doc:`android-cloexec-open <android/cloexec-open>`, "Yes"
-   :doc:`android-cloexec-pipe <android/cloexec-pipe>`, "Yes"
-   :doc:`android-cloexec-pipe2 <android/cloexec-pipe2>`, "Yes"
-   :doc:`android-cloexec-socket <android/cloexec-socket>`, "Yes"
-   :doc:`android-comparison-in-temp-failure-retry <android/comparison-in-temp-failure-retry>`,
-   :doc:`boost-use-ranges <boost/use-ranges>`, "Yes"
-   :doc:`boost-use-to-string <boost/use-to-string>`, "Yes"
-   :doc:`bugprone-argument-comment <bugprone/argument-comment>`, "Yes"
-   :doc:`bugprone-assert-side-effect <bugprone/assert-side-effect>`,
-   :doc:`bugprone-assignment-in-if-condition <bugprone/assignment-in-if-condition>`,
-   :doc:`bugprone-bad-signal-to-kill-thread <bugprone/bad-signal-to-kill-thread>`,
-   :doc:`bugprone-bitwise-pointer-cast <bugprone/bitwise-pointer-cast>`,
-   :doc:`bugprone-bool-pointer-implicit-conversion <bugprone/bool-pointer-implicit-conversion>`, "Yes"
-   :doc:`bugprone-branch-clone <bugprone/branch-clone>`,
-   :doc:`bugprone-capturing-this-in-member-variable <bugprone/capturing-this-in-member-variable>`,
-   :doc:`bugprone-casting-through-void <bugprone/casting-through-void>`,
-   :doc:`bugprone-chained-comparison <bugprone/chained-comparison>`,
-   :doc:`bugprone-command-processor <bugprone/command-processor>`,
-   :doc:`bugprone-compare-pointer-to-member-virtual-function <bugprone/compare-pointer-to-member-virtual-function>`,
-   :doc:`bugprone-copy-constructor-init <bugprone/copy-constructor-init>`, "Yes"
-   :doc:`bugprone-crtp-constructor-accessibility <bugprone/crtp-constructor-accessibility>`, "Yes"
-   :doc:`bugprone-dangling-handle <bugprone/dangling-handle>`,
-   :doc:`bugprone-derived-method-shadowing-base-method <bugprone/derived-method-shadowing-base-method>`,
-   :doc:`bugprone-dynamic-static-initializers <bugprone/dynamic-static-initializers>`,
-   :doc:`bugprone-easily-swappable-parameters <bugprone/easily-swappable-parameters>`,
-   :doc:`bugprone-empty-catch <bugprone/empty-catch>`,
-   :doc:`bugprone-exception-escape <bugprone/exception-escape>`,
-   :doc:`bugprone-fold-init-type <bugprone/fold-init-type>`,
-   :doc:`bugprone-forward-declaration-namespace <bugprone/forward-declaration-namespace>`,
-   :doc:`bugprone-forwarding-reference-overload <bugprone/forwarding-reference-overload>`,
-   :doc:`bugprone-implicit-widening-of-multiplication-result <bugprone/implicit-widening-of-multiplication-result>`, "Yes"
-   :doc:`bugprone-inaccurate-erase <bugprone/inaccurate-erase>`, "Yes"
-   :doc:`bugprone-inc-dec-in-conditions <bugprone/inc-dec-in-conditions>`,
-   :doc:`bugprone-incorrect-enable-if <bugprone/incorrect-enable-if>`, "Yes"
-   :doc:`bugprone-incorrect-enable-shared-from-this <bugprone/incorrect-enable-shared-from-this>`, "Yes"
-   :doc:`bugprone-incorrect-roundings <bugprone/incorrect-roundings>`,
-   :doc:`bugprone-infinite-loop <bugprone/infinite-loop>`,
-   :doc:`bugprone-integer-division <bugprone/integer-division>`,
-   :doc:`bugprone-invalid-enum-default-initialization <bugprone/invalid-enum-default-initialization>`,
-   :doc:`bugprone-lambda-function-name <bugprone/lambda-function-name>`,
-   :doc:`bugprone-macro-parentheses <bugprone/macro-parentheses>`, "Yes"
-   :doc:`bugprone-macro-repeated-side-effects <bugprone/macro-repeated-side-effects>`,
-   :doc:`bugprone-misleading-setter-of-reference <bugprone/misleading-setter-of-reference>`,
-   :doc:`bugprone-misplaced-operator-in-strlen-in-alloc <bugprone/misplaced-operator-in-strlen-in-alloc>`, "Yes"
-   :doc:`bugprone-misplaced-pointer-arithmetic-in-alloc <bugprone/misplaced-pointer-arithmetic-in-alloc>`, "Yes"
-   :doc:`bugprone-misplaced-widening-cast <bugprone/misplaced-widening-cast>`,
-   :doc:`bugprone-move-forwarding-reference <bugprone/move-forwarding-reference>`, "Yes"
-   :doc:`bugprone-multi-level-implicit-pointer-conversion <bugprone/multi-level-implicit-pointer-conversion>`,
-   :doc:`bugprone-multiple-new-in-one-expression <bugprone/multiple-new-in-one-expression>`,
-   :doc:`bugprone-multiple-statement-macro <bugprone/multiple-statement-macro>`,
-   :doc:`bugprone-narrowing-conversions <bugprone/narrowing-conversions>`,
-   :doc:`bugprone-no-escape <bugprone/no-escape>`,
-   :doc:`bugprone-non-zero-enum-to-bool-conversion <bugprone/non-zero-enum-to-bool-conversion>`,
-   :doc:`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>`,
-   :doc:`bugprone-not-null-terminated-result <bugprone/not-null-terminated-result>`, "Yes"
-   :doc:`bugprone-optional-value-conversion <bugprone/optional-value-conversion>`, "Yes"
-   :doc:`bugprone-parent-virtual-call <bugprone/parent-virtual-call>`, "Yes"
-   :doc:`bugprone-pointer-arithmetic-on-polymorphic-object <bugprone/pointer-arithmetic-on-polymorphic-object>`,
-   :doc:`bugprone-posix-return <bugprone/posix-return>`, "Yes"
-   :doc:`bugprone-redundant-branch-condition <bugprone/redundant-branch-condition>`, "Yes"
-   :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
-   :doc:`bugprone-return-const-ref-from-parameter <bugprone/return-const-ref-from-parameter>`,
-   :doc:`bugprone-shared-ptr-array-mismatch <bugprone/shared-ptr-array-mismatch>`, "Yes"
-   :doc:`bugprone-signal-handler <bugprone/signal-handler>`,
-   :doc:`bugprone-signed-char-misuse <bugprone/signed-char-misuse>`,
-   :doc:`bugprone-sizeof-container <bugprone/sizeof-container>`,
-   :doc:`bugprone-sizeof-expression <bugprone/sizeof-expression>`,
-   :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,
-   :doc:`bugprone-standalone-empty <bugprone/standalone-empty>`, "Yes"
-   :doc:`bugprone-string-constructor <bugprone/string-constructor>`, "Yes"
-   :doc:`bugprone-string-integer-assignment <bugprone/string-integer-assignment>`, "Yes"
-   :doc:`bugprone-string-literal-with-embedded-nul <bugprone/string-literal-with-embedded-nul>`,
-   :doc:`bugprone-stringview-nullptr <bugprone/stringview-nullptr>`, "Yes"
-   :doc:`bugprone-suspicious-enum-usage <bugprone/suspicious-enum-usage>`,
-   :doc:`bugprone-suspicious-include <bugprone/suspicious-include>`,
-   :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,
-   :doc:`bugprone-suspicious-memset-usage <bugprone/suspicious-memset-usage>`, "Yes"
-   :doc:`bugprone-suspicious-missing-comma <bugprone/suspicious-missing-comma>`,
-   :doc:`bugprone-suspicious-realloc-usage <bugprone/suspicious-realloc-usage>`,
-   :doc:`bugprone-suspicious-semicolon <bugprone/suspicious-semicolon>`, "Yes"
-   :doc:`bugprone-suspicious-string-compare <bugprone/suspicious-string-compare>`, "Yes"
-   :doc:`bugprone-suspicious-stringview-data-usage <bugprone/suspicious-stringview-data-usage>`,
-   :doc:`bugprone-swapped-arguments <bugprone/swapped-arguments>`, "Yes"
-   :doc:`bugprone-switch-missing-default-case <bugprone/switch-missing-default-case>`,
-   :doc:`bugprone-tagged-union-member-count <bugprone/tagged-union-member-count>`,
-   :doc:`bugprone-terminating-continue <bugprone/terminating-continue>`, "Yes"
-   :doc:`bugprone-throw-keyword-missing <bugprone/throw-keyword-missing>`,
-   :doc:`bugprone-throwing-static-initialization <bugprone/throwing-static-initialization>`,
-   :doc:`bugprone-too-small-loop-variable <bugprone/too-small-loop-variable>`,
-   :doc:`bugprone-unchecked-optional-access <bugprone/unchecked-optional-access>`,
-   :doc:`bugprone-unchecked-string-to-number-conversion <bugprone/unchecked-string-to-number-conversion>`,
-   :doc:`bugprone-undefined-memory-manipulation <bugprone/undefined-memory-manipulation>`,
-   :doc:`bugprone-undelegated-constructor <bugprone/undelegated-constructor>`,
-   :doc:`bugprone-unhandled-exception-at-new <bugprone/unhandled-exception-at-new>`,
-   :doc:`bugprone-unhandled-self-assignment <bugprone/unhandled-self-assignment>`,
-   :doc:`bugprone-unintended-char-ostream-output <bugprone/unintended-char-ostream-output>`, "Yes"
-   :doc:`bugprone-unique-ptr-array-mismatch <bugprone/unique-ptr-array-mismatch>`, "Yes"
-   :doc:`bugprone-unsafe-functions <bugprone/unsafe-functions>`,
-   :doc:`bugprone-unused-local-non-trivial-variable <bugprone/unused-local-non-trivial-variable>`,
-   :doc:`bugprone-unused-raii <bugprone/unused-raii>`, "Yes"
-   :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,
-   :doc:`bugprone-use-after-move <bugprone/use-after-move>`,
-   :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes"
-   :doc:`cert-dcl58-cpp <cert/dcl58-cpp>`,
-   :doc:`cert-err33-c <cert/err33-c>`,
-   :doc:`cert-err60-cpp <cert/err60-cpp>`,
-   :doc:`cert-flp30-c <cert/flp30-c>`,
-   :doc:`cert-mem57-cpp <cert/mem57-cpp>`,
-   :doc:`cert-msc50-cpp <cert/msc50-cpp>`,
-   :doc:`cert-msc51-cpp <cert/msc51-cpp>`,
-   :doc:`cert-oop57-cpp <cert/oop57-cpp>`,
-   :doc:`cert-oop58-cpp <cert/oop58-cpp>`,
-   :doc:`concurrency-mt-unsafe <concurrency/mt-unsafe>`,
-   :doc:`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>`,
-   :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines <cppcoreguidelines/avoid-capturing-lambda-coroutines>`,
-   :doc:`cppcoreguidelines-avoid-const-or-ref-data-members <cppcoreguidelines/avoid-const-or-ref-data-members>`,
-   :doc:`cppcoreguidelines-avoid-do-while <cppcoreguidelines/avoid-do-while>`,
-   :doc:`cppcoreguidelines-avoid-goto <cppcoreguidelines/avoid-goto>`,
-   :doc:`cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines/avoid-non-const-global-variables>`,
-   :doc:`cppcoreguidelines-avoid-reference-coroutine-parameters <cppcoreguidelines/avoid-reference-coroutine-parameters>`,
-   :doc:`cppcoreguidelines-init-variables <cppcoreguidelines/init-variables>`, "Yes"
-   :doc:`cppcoreguidelines-interfaces-global-init <cppcoreguidelines/interfaces-global-init>`,
-   :doc:`cppcoreguidelines-macro-usage <cppcoreguidelines/macro-usage>`,
-   :doc:`cppcoreguidelines-misleading-capture-default-by-value <cppcoreguidelines/misleading-capture-default-by-value>`, "Yes"
-   :doc:`cppcoreguidelines-missing-std-forward <cppcoreguidelines/missing-std-forward>`,
-   :doc:`cppcoreguidelines-no-malloc <cppcoreguidelines/no-malloc>`,
-   :doc:`cppcoreguidelines-no-suspend-with-lock <cppcoreguidelines/no-suspend-with-lock>`,
-   :doc:`cppcoreguidelines-owning-memory <cppcoreguidelines/owning-memory>`,
-   :doc:`cppcoreguidelines-prefer-member-initializer <cppcoreguidelines/prefer-member-initializer>`, "Yes"
-   :doc:`cppcoreguidelines-pro-bounds-array-to-pointer-decay <cppcoreguidelines/pro-bounds-array-to-pointer-decay>`,
-   :doc:`cppcoreguidelines-pro-bounds-avoid-unchecked-container-access <cppcoreguidelines/pro-bounds-avoid-unchecked-container-access>`, "Yes"
-   :doc:`cppcoreguidelines-pro-bounds-constant-array-index <cppcoreguidelines/pro-bounds-constant-array-index>`, "Yes"
-   :doc:`cppcoreguidelines-pro-bounds-pointer-arithmetic <cppcoreguidelines/pro-bounds-pointer-arithmetic>`,
-   :doc:`cppcoreguidelines-pro-type-const-cast <cppcoreguidelines/pro-type-const-cast>`,
-   :doc:`cppcoreguidelines-pro-type-cstyle-cast <cppcoreguidelines/pro-type-cstyle-cast>`, "Yes"
-   :doc:`cppcoreguidelines-pro-type-member-init <cppcoreguidelines/pro-type-member-init>`, "Yes"
-   :doc:`cppcoreguidelines-pro-type-reinterpret-cast <cppcoreguidelines/pro-type-reinterpret-cast>`,
-   :doc:`cppcoreguidelines-pro-type-static-cast-downcast <cppcoreguidelines/pro-type-static-cast-downcast>`, "Yes"
-   :doc:`cppcoreguidelines-pro-type-union-access <cppcoreguidelines/pro-type-union-access>`,
-   :doc:`cppcoreguidelines-pro-type-vararg <cppcoreguidelines/pro-type-vararg>`,
-   :doc:`cppcoreguidelines-rvalue-reference-param-not-moved <cppcoreguidelines/rvalue-reference-param-not-moved>`,
-   :doc:`cppcoreguidelines-slicing <cppcoreguidelines/slicing>`,
-   :doc:`cppcoreguidelines-special-member-functions <cppcoreguidelines/special-member-functions>`,
-   :doc:`cppcoreguidelines-use-enum-class <cppcoreguidelines/use-enum-class>`,
-   :doc:`cppcoreguidelines-virtual-class-destructor <cppcoreguidelines/virtual-class-destructor>`, "Yes"
-   :doc:`darwin-avoid-spinlock <darwin/avoid-spinlock>`,
-   :doc:`darwin-dispatch-once-nonstatic <darwin/dispatch-once-nonstatic>`, "Yes"
-   :doc:`fuchsia-default-arguments-calls <fuchsia/default-arguments-calls>`,
-   :doc:`fuchsia-default-arguments-declarations <fuchsia/default-arguments-declarations>`, "Yes"
-   :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`,
-   :doc:`fuchsia-overloaded-operator <fuchsia/overloaded-operator>`,
-   :doc:`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>`,
-   :doc:`fuchsia-temporary-objects <fuchsia/temporary-objects>`,
-   :doc:`fuchsia-trailing-return <fuchsia/trailing-return>`,
-   :doc:`fuchsia-virtual-inheritance <fuchsia/virtual-inheritance>`,
-   :doc:`google-build-explicit-make-pair <google/build-explicit-make-pair>`,
-   :doc:`google-build-namespaces <google/build-namespaces>`,
-   :doc:`google-build-using-namespace <google/build-using-namespace>`,
-   :doc:`google-default-arguments <google/default-arguments>`,
-   :doc:`google-explicit-constructor <google/explicit-constructor>`, "Yes"
-   :doc:`google-global-names-in-headers <google/global-names-in-headers>`,
-   :doc:`google-objc-avoid-nsobject-new <google/objc-avoid-nsobject-new>`,
-   :doc:`google-objc-avoid-throwing-exception <google/objc-avoid-throwing-exception>`,
-   :doc:`google-objc-function-naming <google/objc-function-naming>`,
-   :doc:`google-objc-global-variable-declaration <google/objc-global-variable-declaration>`,
-   :doc:`google-readability-avoid-underscore-in-googletest-name <google/readability-avoid-underscore-in-googletest-name>`,
-   :doc:`google-readability-casting <google/readability-casting>`,
-   :doc:`google-readability-todo <google/readability-todo>`,
-   :doc:`google-runtime-float <google/runtime-float>`,
-   :doc:`google-runtime-int <google/runtime-int>`,
-   :doc:`google-runtime-operator <google/runtime-operator>`,
-   :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes"
-   :doc:`hicpp-exception-baseclass <hicpp/exception-baseclass>`,
-   :doc:`hicpp-ignored-remove-result <hicpp/ignored-remove-result>`,
-   :doc:`hicpp-multiway-paths-covered <hicpp/multiway-paths-covered>`,
-   :doc:`hicpp-no-assembler <hicpp/no-assembler>`,
-   :doc:`hicpp-signed-bitwise <hicpp/signed-bitwise>`,
-   :doc:`linuxkernel-must-check-errs <linuxkernel/must-check-errs>`,
-   :doc:`llvm-header-guard <llvm/header-guard>`,
-   :doc:`llvm-include-order <llvm/include-order>`, "Yes"
-   :doc:`llvm-namespace-comment <llvm/namespace-comment>`,
-   :doc:`llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm/prefer-isa-or-dyn-cast-in-conditionals>`, "Yes"
-   :doc:`llvm-prefer-register-over-unsigned <llvm/prefer-register-over-unsigned>`, "Yes"
-   :doc:`llvm-prefer-static-over-anonymous-namespace <llvm/prefer-static-over-anonymous-namespace>`,
-   :doc:`llvm-twine-local <llvm/twine-local>`, "Yes"
-   :doc:`llvm-use-new-mlir-op-builder <llvm/use-new-mlir-op-builder>`, "Yes"
-   :doc:`llvm-use-ranges <llvm/use-ranges>`, "Yes"
-   :doc:`llvmlibc-callee-namespace <llvmlibc/callee-namespace>`,
-   :doc:`llvmlibc-implementation-in-namespace <llvmlibc/implementation-in-namespace>`,
-   :doc:`llvmlibc-inline-function-decl <llvmlibc/inline-function-decl>`, "Yes"
-   :doc:`llvmlibc-restrict-system-libc-headers <llvmlibc/restrict-system-libc-headers>`, "Yes"
-   :doc:`misc-confusable-identifiers <misc/confusable-identifiers>`,
-   :doc:`misc-const-correctness <misc/const-correctness>`, "Yes"
-   :doc:`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>`,
-   :doc:`misc-definitions-in-headers <misc/definitions-in-headers>`, "Yes"
-   :doc:`misc-header-include-cycle <misc/header-include-cycle>`,
-   :doc:`misc-include-cleaner <misc/include-cleaner>`, "Yes"
-   :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,
-   :doc:`misc-misleading-identifier <misc/misleading-identifier>`,
-   :doc:`misc-misplaced-const <misc/misplaced-const>`,
-   :doc:`misc-new-delete-overloads <misc/new-delete-overloads>`,
-   :doc:`misc-no-recursion <misc/no-recursion>`,
-   :doc:`misc-non-copyable-objects <misc/non-copyable-objects>`,
-   :doc:`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>`,
-   :doc:`misc-override-with-different-visibility <misc/override-with-different-visibility>`,
-   :doc:`misc-redundant-expression <misc/redundant-expression>`, "Yes"
-   :doc:`misc-static-assert <misc/static-assert>`, "Yes"
-   :doc:`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>`,
-   :doc:`misc-unconventional-assign-operator <misc/unconventional-assign-operator>`,
-   :doc:`misc-uniqueptr-reset-release <misc/uniqueptr-reset-release>`, "Yes"
-   :doc:`misc-unused-alias-decls <misc/unused-alias-decls>`, "Yes"
-   :doc:`misc-unused-parameters <misc/unused-parameters>`, "Yes"
-   :doc:`misc-unused-using-decls <misc/unused-using-decls>`, "Yes"
-   :doc:`misc-use-anonymous-namespace <misc/use-anonymous-namespace>`,
-   :doc:`misc-use-internal-linkage <misc/use-internal-linkage>`, "Yes"
-   :doc:`modernize-avoid-bind <modernize/avoid-bind>`, "Yes"
-   :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,
-   :doc:`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>`,
-   :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,
-   :doc:`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>`, "Yes"
-   :doc:`modernize-deprecated-headers <modernize/deprecated-headers>`, "Yes"
-   :doc:`modernize-deprecated-ios-base-aliases <modernize/deprecated-ios-base-aliases>`, "Yes"
-   :doc:`modernize-loop-convert <modernize/loop-convert>`, "Yes"
-   :doc:`modernize-macro-to-enum <modernize/macro-to-enum>`, "Yes"
-   :doc:`modernize-make-shared <modernize/make-shared>`, "Yes"
-   :doc:`modernize-make-unique <modernize/make-unique>`, "Yes"
-   :doc:`modernize-min-max-use-initializer-list <modernize/min-max-use-initializer-list>`, "Yes"
-   :doc:`modernize-pass-by-value <modernize/pass-by-value>`, "Yes"
-   :doc:`modernize-raw-string-literal <modernize/raw-string-literal>`, "Yes"
-   :doc:`modernize-redundant-void-arg <modernize/redundant-void-arg>`, "Yes"
-   :doc:`modernize-replace-auto-ptr <modernize/replace-auto-ptr>`, "Yes"
-   :doc:`modernize-replace-disallow-copy-and-assign-macro <modernize/replace-disallow-copy-and-assign-macro>`, "Yes"
-   :doc:`modernize-replace-random-shuffle <modernize/replace-random-shuffle>`, "Yes"
-   :doc:`modernize-return-braced-init-list <modernize/return-braced-init-list>`, "Yes"
-   :doc:`modernize-shrink-to-fit <modernize/shrink-to-fit>`, "Yes"
-   :doc:`modernize-type-traits <modernize/type-traits>`, "Yes"
-   :doc:`modernize-unary-static-assert <modernize/unary-static-assert>`, "Yes"
-   :doc:`modernize-use-auto <modernize/use-auto>`, "Yes"
-   :doc:`modernize-use-bool-literals <modernize/use-bool-literals>`, "Yes"
-   :doc:`modernize-use-constraints <modernize/use-constraints>`, "Yes"
-   :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes"
-   :doc:`modernize-use-designated-initializers <modernize/use-designated-initializers>`, "Yes"
-   :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes"
-   :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes"
-   :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes"
-   :doc:`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>`, "Yes"
-   :doc:`modernize-use-nodiscard <modernize/use-nodiscard>`, "Yes"
-   :doc:`modernize-use-noexcept <modernize/use-noexcept>`, "Yes"
-   :doc:`modernize-use-nullptr <modernize/use-nullptr>`, "Yes"
-   :doc:`modernize-use-override <modernize/use-override>`, "Yes"
-   :doc:`modernize-use-ranges <modernize/use-ranges>`, "Yes"
-   :doc:`modernize-use-scoped-lock <modernize/use-scoped-lock>`, "Yes"
-   :doc:`modernize-use-starts-ends-with <modernize/use-starts-ends-with>`, "Yes"
-   :doc:`modernize-use-std-format <modernize/use-std-format>`, "Yes"
-   :doc:`modernize-use-std-numbers <modernize/use-std-numbers>`, "Yes"
-   :doc:`modernize-use-std-print <modernize/use-std-print>`, "Yes"
-   :doc:`modernize-use-trailing-return-type <modernize/use-trailing-return-type>`, "Yes"
-   :doc:`modernize-use-transparent-functors <modernize/use-transparent-functors>`, "Yes"
-   :doc:`modernize-use-uncaught-exceptions <modernize/use-uncaught-exceptions>`, "Yes"
-   :doc:`modernize-use-using <modernize/use-using>`, "Yes"
-   :doc:`mpi-buffer-deref <mpi/buffer-deref>`, "Yes"
-   :doc:`mpi-type-mismatch <mpi/type-mismatch>`, "Yes"
-   :doc:`objc-assert-equals <objc/assert-equals>`, "Yes"
-   :doc:`objc-avoid-nserror-init <objc/avoid-nserror-init>`,
-   :doc:`objc-dealloc-in-category <objc/dealloc-in-category>`,
-   :doc:`objc-forbidden-subclassing <objc/forbidden-subclassing>`,
-   :doc:`objc-missing-hash <objc/missing-hash>`,
-   :doc:`objc-nsdate-formatter <objc/nsdate-formatter>`,
-   :doc:`objc-nsinvocation-argument-lifetime <objc/nsinvocation-argument-lifetime>`, "Yes"
-   :doc:`objc-property-declaration <objc/property-declaration>`, "Yes"
-   :doc:`objc-super-self <objc/super-self>`, "Yes"
-   :doc:`openmp-exception-escape <openmp/exception-escape>`,
-   :doc:`openmp-use-default-none <openmp/use-default-none>`,
-   :doc:`performance-avoid-endl <performance/avoid-endl>`, "Yes"
-   :doc:`performance-enum-size <performance/enum-size>`,
-   :doc:`performance-faster-string-find <performance/faster-string-find>`, "Yes"
-   :doc:`performance-for-range-copy <performance/for-range-copy>`, "Yes"
-   :doc:`performance-implicit-conversion-in-loop <performance/implicit-conversion-in-loop>`,
-   :doc:`performance-inefficient-algorithm <performance/inefficient-algorithm>`, "Yes"
-   :doc:`performance-inefficient-string-concatenation <performance/inefficient-string-concatenation>`,
-   :doc:`performance-inefficient-vector-operation <performance/inefficient-vector-operation>`, "Yes"
-   :doc:`performance-move-const-arg <performance/move-const-arg>`, "Yes"
-   :doc:`performance-move-constructor-init <performance/move-constructor-init>`,
-   :doc:`performance-no-automatic-move <performance/no-automatic-move>`,
-   :doc:`performance-no-int-to-ptr <performance/no-int-to-ptr>`,
-   :doc:`performance-noexcept-destructor <performance/noexcept-destructor>`, "Yes"
-   :doc:`performance-noexcept-move-constructor <performance/noexcept-move-constructor>`, "Yes"
-   :doc:`performance-noexcept-swap <performance/noexcept-swap>`, "Yes"
-   :doc:`performance-trivially-destructible <performance/trivially-destructible>`, "Yes"
-   :doc:`performance-type-promotion-in-math-fn <performance/type-promotion-in-math-fn>`, "Yes"
-   :doc:`performance-unnecessary-copy-initialization <performance/unnecessary-copy-initialization>`, "Yes"
-   :doc:`performance-unnecessary-value-param <performance/unnecessary-value-param>`, "Yes"
-   :doc:`portability-avoid-pragma-once <portability/avoid-pragma-once>`,
-   :doc:`portability-restrict-system-includes <portability/restrict-system-includes>`, "Yes"
-   :doc:`portability-simd-intrinsics <portability/simd-intrinsics>`,
-   :doc:`portability-std-allocator-const <portability/std-allocator-const>`,
-   :doc:`portability-template-virtual-member-function <portability/template-virtual-member-function>`,
-   :doc:`readability-ambiguous-smartptr-reset-call <readability/ambiguous-smartptr-reset-call>`, "Yes"
-   :doc:`readability-avoid-const-params-in-decls <readability/avoid-const-params-in-decls>`, "Yes"
-   :doc:`readability-avoid-nested-conditional-operator <readability/avoid-nested-conditional-operator>`,
-   :doc:`readability-avoid-return-with-void-value <readability/avoid-return-with-void-value>`, "Yes"
-   :doc:`readability-avoid-unconditional-preprocessor-if <readability/avoid-unconditional-preprocessor-if>`,
-   :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes"
-   :doc:`readability-const-return-type <readability/const-return-type>`, "Yes"
-   :doc:`readability-container-contains <readability/container-contains>`, "Yes"
-   :doc:`readability-container-data-pointer <readability/container-data-pointer>`, "Yes"
-   :doc:`readability-container-size-empty <readability/container-size-empty>`, "Yes"
-   :doc:`readability-convert-member-functions-to-static <readability/convert-member-functions-to-static>`, "Yes"
-   :doc:`readability-delete-null-pointer <readability/delete-null-pointer>`, "Yes"
-   :doc:`readability-duplicate-include <readability/duplicate-include>`, "Yes"
-   :doc:`readability-else-after-return <readability/else-after-return>`, "Yes"
-   :doc:`readability-enum-initial-value <readability/enum-initial-value>`, "Yes"
-   :doc:`readability-function-cognitive-complexity <readability/function-cognitive-complexity>`,
-   :doc:`readability-function-size <readability/function-size>`,
-   :doc:`readability-identifier-length <readability/identifier-length>`,
-   :doc:`readability-identifier-naming <readability/identifier-naming>`, "Yes"
-   :doc:`readability-implicit-bool-conversion <readability/implicit-bool-conversion>`, "Yes"
-   :doc:`readability-inconsistent-declaration-parameter-name <readability/inconsistent-declaration-parameter-name>`, "Yes"
-   :doc:`readability-isolate-declaration <readability/isolate-declaration>`, "Yes"
-   :doc:`readability-magic-numbers <readability/magic-numbers>`,
-   :doc:`readability-make-member-function-const <readability/make-member-function-const>`, "Yes"
-   :doc:`readability-math-missing-parentheses <readability/math-missing-parentheses>`, "Yes"
-   :doc:`readability-misleading-indentation <readability/misleading-indentation>`,
-   :doc:`readability-misplaced-array-index <readability/misplaced-array-index>`, "Yes"
-   :doc:`readability-named-parameter <readability/named-parameter>`, "Yes"
-   :doc:`readability-non-const-parameter <readability/non-const-parameter>`, "Yes"
-   :doc:`readability-operators-representation <readability/operators-representation>`, "Yes"
-   :doc:`readability-qualified-auto <readability/qualified-auto>`, "Yes"
-   :doc:`readability-redundant-access-specifiers <readability/redundant-access-specifiers>`, "Yes"
-   :doc:`readability-redundant-casting <readability/redundant-casting>`, "Yes"
-   :doc:`readability-redundant-control-flow <readability/redundant-control-flow>`, "Yes"
-   :doc:`readability-redundant-declaration <readability/redundant-declaration>`, "Yes"
-   :doc:`readability-redundant-function-ptr-dereference <readability/redundant-function-ptr-dereference>`, "Yes"
-   :doc:`readability-redundant-inline-specifier <readability/redundant-inline-specifier>`, "Yes"
-   :doc:`readability-redundant-member-init <readability/redundant-member-init>`, "Yes"
-   :doc:`readability-redundant-parentheses <readability/redundant-parentheses>`, "Yes"
-   :doc:`readability-redundant-preprocessor <readability/redundant-preprocessor>`,
-   :doc:`readability-redundant-smartptr-get <readability/redundant-smartptr-get>`, "Yes"
-   :doc:`readability-redundant-string-cstr <readability/redundant-string-cstr>`, "Yes"
-   :doc:`readability-redundant-string-init <readability/redundant-string-init>`, "Yes"
-   :doc:`readability-reference-to-constructed-temporary <readability/reference-to-constructed-temporary>`,
-   :doc:`readability-simplify-boolean-expr <readability/simplify-boolean-expr>`, "Yes"
-   :doc:`readability-simplify-subscript-expr <readability/simplify-subscript-expr>`, "Yes"
-   :doc:`readability-static-accessed-through-instance <readability/static-accessed-through-instance>`, "Yes"
-   :doc:`readability-static-definition-in-anonymous-namespace <readability/static-definition-in-anonymous-namespace>`, "Yes"
-   :doc:`readability-string-compare <readability/string-compare>`, "Yes"
-   :doc:`readability-suspicious-call-argument <readability/suspicious-call-argument>`,
-   :doc:`readability-uniqueptr-delete-release <readability/uniqueptr-delete-release>`, "Yes"
-   :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes"
-   :doc:`readability-use-anyofallof <readability/use-anyofallof>`,
-   :doc:`readability-use-concise-preprocessor-directives <readability/use-concise-preprocessor-directives>`, "Yes"
-   :doc:`readability-use-std-min-max <readability/use-std-min-max>`, "Yes"
-   :doc:`zircon-temporary-objects <zircon/temporary-objects>`,
+.. csv-table::
+   :header: "Name", "Offers fixes", "Added in", "Removed in"
 
-Check aliases
--------------
+   :doc:`abseil-cleanup-ctad <abseil/cleanup-ctad>`, "Yes", "14.0.0",
+   :doc:`abseil-duration-addition <abseil/duration-addition>`, "Yes", "9.0.1",
+   :doc:`abseil-duration-comparison <abseil/duration-comparison>`, "Yes", "8.0.1",
+   :doc:`abseil-duration-conversion-cast <abseil/duration-conversion-cast>`, "Yes", "9.0.1",
+   :doc:`abseil-duration-division <abseil/duration-division>`, "Yes", "8.0.1",
+   :doc:`abseil-duration-factory-float <abseil/duration-factory-float>`, "Yes", "8.0.1",
+   :doc:`abseil-duration-factory-scale <abseil/duration-factory-scale>`, "Yes", "8.0.1",
+   :doc:`abseil-duration-subtraction <abseil/duration-subtraction>`, "Yes", "8.0.1",
+   :doc:`abseil-duration-unnecessary-conversion <abseil/duration-unnecessary-conversion>`, "Yes", "9.0.1",
+   :doc:`abseil-faster-strsplit-delimiter <abseil/faster-strsplit-delimiter>`, "Yes", "8.0.1",
+   :doc:`abseil-no-internal-dependencies <abseil/no-internal-dependencies>`,, "8.0.1",
+   :doc:`abseil-no-namespace <abseil/no-namespace>`,, "8.0.1",
+   :doc:`abseil-redundant-strcat-calls <abseil/redundant-strcat-calls>`, "Yes", "8.0.1",
+   :doc:`abseil-str-cat-append <abseil/str-cat-append>`, "Yes", "8.0.1",
+   :doc:`abseil-string-find-startswith <abseil/string-find-startswith>`, "Yes", "7.1.0",
+   :doc:`abseil-string-find-str-contains <abseil/string-find-str-contains>`, "Yes", "11.0.0",
+   :doc:`abseil-time-comparison <abseil/time-comparison>`, "Yes", "9.0.1",
+   :doc:`abseil-time-subtraction <abseil/time-subtraction>`, "Yes", "9.0.1",
+   :doc:`abseil-upgrade-duration-conversions <abseil/upgrade-duration-conversions>`, "Yes", "8.0.1",
+   :doc:`altera-id-dependent-backward-branch <altera/id-dependent-backward-branch>`,, "13.0.0",
+   :doc:`altera-kernel-name-restriction <altera/kernel-name-restriction>`,, "12.0.0",
+   :doc:`altera-single-work-item-barrier <altera/single-work-item-barrier>`,, "12.0.0",
+   :doc:`altera-struct-pack-align <altera/struct-pack-align>`, "Yes", "12.0.0",
+   :doc:`altera-unroll-loops <altera/unroll-loops>`,, "13.0.0",
+   :doc:`android-cloexec-accept <android/cloexec-accept>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-accept4 <android/cloexec-accept4>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-creat <android/cloexec-creat>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-dup <android/cloexec-dup>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-epoll-create <android/cloexec-epoll-create>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-epoll-create1 <android/cloexec-epoll-create1>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-fopen <android/cloexec-fopen>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-inotify-init <android/cloexec-inotify-init>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-inotify-init1 <android/cloexec-inotify-init1>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-memfd-create <android/cloexec-memfd-create>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-open <android/cloexec-open>`, "Yes", "7.1.0",
+   :doc:`android-cloexec-pipe <android/cloexec-pipe>`, "Yes", "9.0.1",
+   :doc:`android-cloexec-pipe2 <android/cloexec-pipe2>`, "Yes", "9.0.1",
+   :doc:`android-cloexec-socket <android/cloexec-socket>`, "Yes", "7.1.0",
+   :doc:`android-comparison-in-temp-failure-retry <android/comparison-in-temp-failure-retry>`,, "7.1.0",
+   :doc:`boost-use-ranges <boost/use-ranges>`, "Yes", "19.1.0",
+   :doc:`boost-use-to-string <boost/use-to-string>`, "Yes", "7.1.0",
+   :doc:`bugprone-argument-comment <bugprone/argument-comment>`, "Yes", "7.1.0",
+   :doc:`bugprone-assert-side-effect <bugprone/assert-side-effect>`,, "7.1.0",
+   :doc:`bugprone-assignment-in-if-condition <bugprone/assignment-in-if-condition>`,, "15.0.0",
+   :doc:`bugprone-bad-signal-to-kill-thread <bugprone/bad-signal-to-kill-thread>`,, "10.0.0",
+   :doc:`bugprone-bitwise-pointer-cast <bugprone/bitwise-pointer-cast>`,, "20.1.0",
+   :doc:`bugprone-bool-pointer-implicit-conversion <bugprone/bool-pointer-implicit-conversion>`, "Yes", "7.1.0",
+   :doc:`bugprone-branch-clone <bugprone/branch-clone>`,, "9.0.1",
+   :doc:`bugprone-capturing-this-in-member-variable <bugprone/capturing-this-in-member-variable>`,, "21.1.0",
+   :doc:`bugprone-casting-through-void <bugprone/casting-through-void>`,, "18.1.0",
+   :doc:`bugprone-chained-comparison <bugprone/chained-comparison>`,, "18.1.0",
+   :doc:`bugprone-command-processor <bugprone/command-processor>`,, "22.0.0",
+   :doc:`bugprone-compare-pointer-to-member-virtual-function <bugprone/compare-pointer-to-member-virtual-function>`,, "18.1.0",
+   :doc:`bugprone-copy-constructor-init <bugprone/copy-constructor-init>`, "Yes", "7.1.0",
+   :doc:`bugprone-crtp-constructor-accessibility <bugprone/crtp-constructor-accessibility>`, "Yes", "19.1.0",
+   :doc:`bugprone-dangling-handle <bugprone/dangling-handle>`,, "7.1.0",
+   :doc:`bugprone-derived-method-shadowing-base-method <bugprone/derived-method-shadowing-base-method>`,, "22.0.0",
+   :doc:`bugprone-dynamic-static-initializers <bugprone/dynamic-static-initializers>`,, "10.0.0",
+   :doc:`bugprone-easily-swappable-parameters <bugprone/easily-swappable-parameters>`,, "13.0.0",
+   :doc:`bugprone-empty-catch <bugprone/empty-catch>`,, "17.0.1",
+   :doc:`bugprone-exception-escape <bugprone/exception-escape>`,, "7.1.0",
+   :doc:`bugprone-fold-init-type <bugprone/fold-init-type>`,, "7.1.0",
+   :doc:`bugprone-forward-declaration-namespace <bugprone/forward-declaration-namespace>`,, "7.1.0",
+   :doc:`bugprone-forwarding-reference-overload <bugprone/forwarding-reference-overload>`,, "7.1.0",
+   :doc:`bugprone-implicit-widening-of-multiplication-result <bugprone/implicit-widening-of-multiplication-result>`, "Yes", "13.0.0",
+   :doc:`bugprone-inaccurate-erase <bugprone/inaccurate-erase>`, "Yes", "7.1.0",
+   :doc:`bugprone-inc-dec-in-conditions <bugprone/inc-dec-in-conditions>`,, "18.1.0",
+   :doc:`bugprone-incorrect-enable-if <bugprone/incorrect-enable-if>`, "Yes", "18.1.0",
+   :doc:`bugprone-incorrect-enable-shared-from-this <bugprone/incorrect-enable-shared-from-this>`, "Yes", "20.1.0",
+   :doc:`bugprone-incorrect-roundings <bugprone/incorrect-roundings>`,, "7.1.0",
+   :doc:`bugprone-infinite-loop <bugprone/infinite-loop>`,, "10.0.0",
+   :doc:`bugprone-integer-division <bugprone/integer-division>`,, "7.1.0",
+   :doc:`bugprone-invalid-enum-default-initialization <bugprone/invalid-enum-default-initialization>`,, "22.0.0",
+   :doc:`bugprone-lambda-function-name <bugprone/lambda-function-name>`,, "7.1.0",
+   :doc:`bugprone-macro-parentheses <bugprone/macro-parentheses>`, "Yes", "7.1.0",
+   :doc:`bugprone-macro-repeated-side-effects <bugprone/macro-repeated-side-effects>`,, "7.1.0",
+   :doc:`bugprone-misleading-setter-of-reference <bugprone/misleading-setter-of-reference>`,, "21.1.0",
+   :doc:`bugprone-misplaced-operator-in-strlen-in-alloc <bugprone/misplaced-operator-in-strlen-in-alloc>`, "Yes", "7.1.0",
+   :doc:`bugprone-misplaced-pointer-arithmetic-in-alloc <bugprone/misplaced-pointer-arithmetic-in-alloc>`, "Yes", "11.0.0",
+   :doc:`bugprone-misplaced-widening-cast <bugprone/misplaced-widening-cast>`,, "7.1.0",
+   :doc:`bugprone-move-forwarding-reference <bugprone/move-forwarding-reference>`, "Yes", "7.1.0",
+   :doc:`bugprone-multi-level-implicit-pointer-conversion <bugprone/multi-level-implicit-pointer-conversion>`,, "18.1.0",
+   :doc:`bugprone-multiple-new-in-one-expression <bugprone/multiple-new-in-one-expression>`,, "17.0.1",
+   :doc:`bugprone-multiple-statement-macro <bugprone/multiple-statement-macro>`,, "7.1.0",
+   :doc:`bugprone-narrowing-conversions <bugprone/narrowing-conversions>`,, "7.1.0",
+   :doc:`bugprone-no-escape <bugprone/no-escape>`,, "11.0.0",
+   :doc:`bugprone-non-zero-enum-to-bool-conversion <bugprone/non-zero-enum-to-bool-conversion>`,, "17.0.1",
+   :doc:`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>`,, "20.1.0",
+   :doc:`bugprone-not-null-terminated-result <bugprone/not-null-terminated-result>`, "Yes", "10.0.0",
+   :doc:`bugprone-optional-value-conversion <bugprone/optional-value-conversion>`, "Yes", "18.1.0",
+   :doc:`bugprone-parent-virtual-call <bugprone/parent-virtual-call>`, "Yes", "7.1.0",
+   :doc:`bugprone-pointer-arithmetic-on-polymorphic-object <bugprone/pointer-arithmetic-on-polymorphic-object>`,, "19.1.0",
+   :doc:`bugprone-posix-return <bugprone/posix-return>`, "Yes", "9.0.1",
+   :doc:`bugprone-redundant-branch-condition <bugprone/redundant-branch-condition>`, "Yes", "12.0.0",
+   :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes", "11.0.0",
+   :doc:`bugprone-return-const-ref-from-parameter <bugprone/return-const-ref-from-parameter>`,, "19.1.0",
+   :doc:`bugprone-shared-ptr-array-mismatch <bugprone/shared-ptr-array-mismatch>`, "Yes", "15.0.0",
+   :doc:`bugprone-signal-handler <bugprone/signal-handler>`,, "12.0.0",
+   :doc:`bugprone-signed-char-misuse <bugprone/signed-char-misuse>`,, "10.0.0",
+   :doc:`bugprone-sizeof-container <bugprone/sizeof-container>`,, "7.1.0",
+   :doc:`bugprone-sizeof-expression <bugprone/sizeof-expression>`,, "7.1.0",
+   :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,, "11.0.0",
+   :doc:`bugprone-standalone-empty <bugprone/standalone-empty>`, "Yes", "16.0.0",
+   :doc:`bugprone-string-constructor <bugprone/string-constructor>`, "Yes", "7.1.0",
+   :doc:`bugprone-string-integer-assignment <bugprone/string-integer-assignment>`, "Yes", "7.1.0",
+   :doc:`bugprone-string-literal-with-embedded-nul <bugprone/string-literal-with-embedded-nul>`,, "7.1.0",
+   :doc:`bugprone-stringview-nullptr <bugprone/stringview-nullptr>`, "Yes", "14.0.0",
+   :doc:`bugprone-suspicious-enum-usage <bugprone/suspicious-enum-usage>`,, "7.1.0",
+   :doc:`bugprone-suspicious-include <bugprone/suspicious-include>`,, "11.0.0",
+   :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,, "14.0.0",
+   :doc:`bugprone-suspicious-memset-usage <bugprone/suspicious-memset-usage>`, "Yes", "7.1.0",
+   :doc:`bugprone-suspicious-missing-comma <bugprone/suspicious-missing-comma>`,, "7.1.0",
+   :doc:`bugprone-suspicious-realloc-usage <bugprone/suspicious-realloc-usage>`,, "16.0.0",
+   :doc:`bugprone-suspicious-semicolon <bugprone/suspicious-semicolon>`, "Yes", "7.1.0",
+   :doc:`bugprone-suspicious-string-compare <bugprone/suspicious-string-compare>`, "Yes", "7.1.0",
+   :doc:`bugprone-suspicious-stringview-data-usage <bugprone/suspicious-stringview-data-usage>`,, "19.1.0",
+   :doc:`bugprone-swapped-arguments <bugprone/swapped-arguments>`, "Yes", "7.1.0",
+   :doc:`bugprone-switch-missing-default-case <bugprone/switch-missing-default-case>`,, "17.0.1",
+   :doc:`bugprone-tagged-union-member-count <bugprone/tagged-union-member-count>`,, "20.1.0",
+   :doc:`bugprone-terminating-continue <bugprone/terminating-continue>`, "Yes", "7.1.0",
+   :doc:`bugprone-throw-keyword-missing <bugprone/throw-keyword-missing>`,, "7.1.0",
+   :doc:`bugprone-throwing-static-initialization <bugprone/throwing-static-initialization>`,, "22.0.0",
+   :doc:`bugprone-too-small-loop-variable <bugprone/too-small-loop-variable>`,, "8.0.1",
+   :doc:`bugprone-unchecked-optional-access <bugprone/unchecked-optional-access>`,, "15.0.0",
+   :doc:`bugprone-unchecked-string-to-number-conversion <bugprone/unchecked-string-to-number-conversion>`,, "22.0.0",
+   :doc:`bugprone-undefined-memory-manipulation <bugprone/undefined-memory-manipulation>`,, "7.1.0",
+   :doc:`bugprone-undelegated-constructor <bugprone/undelegated-constructor>`,, "7.1.0",
+   :doc:`bugprone-unhandled-exception-at-new <bugprone/unhandled-exception-at-new>`,, "13.0.0",
+   :doc:`bugprone-unhandled-self-assignment <bugprone/unhandled-self-assignment>`,, "9.0.1",
+   :doc:`bugprone-unintended-char-ostream-output <bugprone/unintended-char-ostream-output>`, "Yes", "21.1.0",
+   :doc:`bugprone-unique-ptr-array-mismatch <bugprone/unique-ptr-array-mismatch>`, "Yes", "17.0.1",
+   :doc:`bugprone-unsafe-functions <bugprone/unsafe-functions>`,, "17.0.1",
+   :doc:`bugprone-unused-local-non-trivial-variable <bugprone/unused-local-non-trivial-variable>`,, "18.1.0",
+   :doc:`bugprone-unused-raii <bugprone/unused-raii>`, "Yes", "7.1.0",
+   :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,, "7.1.0",
+   :doc:`bugprone-use-after-move <bugprone/use-after-move>`,, "7.1.0",
+   :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes", "7.1.0",
+   :doc:`cert-dcl58-cpp <cert/dcl58-cpp>`,, "7.1.0",
+   :doc:`cert-err33-c <cert/err33-c>`,, "14.0.0",
+   :doc:`cert-err60-cpp <cert/err60-cpp>`,, "7.1.0",
+   :doc:`cert-flp30-c <cert/flp30-c>`,, "7.1.0",
+   :doc:`cert-mem57-cpp <cert/mem57-cpp>`,, "10.0.0",
+   :doc:`cert-msc50-cpp <cert/msc50-cpp>`,, "7.1.0",
+   :doc:`cert-msc51-cpp <cert/msc51-cpp>`,, "7.1.0",
+   :doc:`cert-oop57-cpp <cert/oop57-cpp>`,, "11.0.0",
+   :doc:`cert-oop58-cpp <cert/oop58-cpp>`,, "10.0.0",
+   :doc:`clang-analyzer-security.insecureAPI.decodeValueOfObjCType <clang-analyzer/security.insecureAPI.decodeValueOfObjCType>`, Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType,, "10.0.0",
+   :doc:`concurrency-mt-unsafe <concurrency/mt-unsafe>`,, "12.0.0",
+   :doc:`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>`,, "13.0.0",
+   :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines <cppcoreguidelines/avoid-capturing-lambda-coroutines>`,, "17.0.1",
+   :doc:`cppcoreguidelines-avoid-const-or-ref-data-members <cppcoreguidelines/avoid-const-or-ref-data-members>`,, "16.0.0",
+   :doc:`cppcoreguidelines-avoid-do-while <cppcoreguidelines/avoid-do-while>`,, "16.0.0",
+   :doc:`cppcoreguidelines-avoid-goto <cppcoreguidelines/avoid-goto>`,, "7.1.0",
+   :doc:`cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines/avoid-non-const-global-variables>`,, "11.0.0",
+   :doc:`cppcoreguidelines-avoid-reference-coroutine-parameters <cppcoreguidelines/avoid-reference-coroutine-parameters>`,, "16.0.0",
+   :doc:`cppcoreguidelines-init-variables <cppcoreguidelines/init-variables>`, "Yes", "10.0.0",
+   :doc:`cppcoreguidelines-interfaces-global-init <cppcoreguidelines/interfaces-global-init>`,, "7.1.0",
+   :doc:`cppcoreguidelines-macro-usage <cppcoreguidelines/macro-usage>`,, "8.0.1",
+   :doc:`cppcoreguidelines-misleading-capture-default-by-value <cppcoreguidelines/misleading-capture-default-by-value>`, "Yes", "17.0.1",
+   :doc:`cppcoreguidelines-missing-std-forward <cppcoreguidelines/missing-std-forward>`,, "17.0.1",
+   :doc:`cppcoreguidelines-no-malloc <cppcoreguidelines/no-malloc>`,, "7.1.0",
+   :doc:`cppcoreguidelines-no-suspend-with-lock <cppcoreguidelines/no-suspend-with-lock>`,, "18.1.0",
+   :doc:`cppcoreguidelines-owning-memory <cppcoreguidelines/owning-memory>`,, "7.1.0",
+   :doc:`cppcoreguidelines-prefer-member-initializer <cppcoreguidelines/prefer-member-initializer>`, "Yes", "13.0.0",
+   :doc:`cppcoreguidelines-pro-bounds-array-to-pointer-decay <cppcoreguidelines/pro-bounds-array-to-pointer-decay>`,, "7.1.0",
+   :doc:`cppcoreguidelines-pro-bounds-avoid-unchecked-container-access <cppcoreguidelines/pro-bounds-avoid-unchecked-container-access>`, "Yes", "22.0.0",
+   :doc:`cppcoreguidelines-pro-bounds-constant-array-index <cppcoreguidelines/pro-bounds-constant-array-index>`, "Yes", "7.1.0",
+   :doc:`cppcoreguidelines-pro-bounds-pointer-arithmetic <cppcoreguidelines/pro-bounds-pointer-arithmetic>`,, "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-const-cast <cppcoreguidelines/pro-type-const-cast>`,, "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-cstyle-cast <cppcoreguidelines/pro-type-cstyle-cast>`, "Yes", "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-member-init <cppcoreguidelines/pro-type-member-init>`, "Yes", "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-reinterpret-cast <cppcoreguidelines/pro-type-reinterpret-cast>`,, "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-static-cast-downcast <cppcoreguidelines/pro-type-static-cast-downcast>`, "Yes", "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-union-access <cppcoreguidelines/pro-type-union-access>`,, "7.1.0",
+   :doc:`cppcoreguidelines-pro-type-vararg <cppcoreguidelines/pro-type-vararg>`,, "7.1.0",
+   :doc:`cppcoreguidelines-rvalue-reference-param-not-moved <cppcoreguidelines/rvalue-reference-param-not-moved>`,, "17.0.1",
+   :doc:`cppcoreguidelines-slicing <cppcoreguidelines/slicing>`,, "7.1.0",
+   :doc:`cppcoreguidelines-special-member-functions <cppcoreguidelines/special-member-functions>`,, "7.1.0",
+   :doc:`cppcoreguidelines-use-enum-class <cppcoreguidelines/use-enum-class>`,, "21.1.0",
+   :doc:`cppcoreguidelines-virtual-class-destructor <cppcoreguidelines/virtual-class-destructor>`, "Yes", "14.0.0",
+   :doc:`darwin-avoid-spinlock <darwin/avoid-spinlock>`,, "10.0.0",
+   :doc:`darwin-dispatch-once-nonstatic <darwin/dispatch-once-nonstatic>`, "Yes", "10.0.0",
+   :doc:`fuchsia-default-arguments-calls <fuchsia/default-arguments-calls>`,, "9.0.1",
+   :doc:`fuchsia-default-arguments-declarations <fuchsia/default-arguments-declarations>`, "Yes", "9.0.1",
+   :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`,, "7.1.0",
+   :doc:`fuchsia-overloaded-operator <fuchsia/overloaded-operator>`,, "7.1.0",
+   :doc:`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>`,, "7.1.0",
+   :doc:`fuchsia-temporary-objects <fuchsia/temporary-objects>`,, "22.0.0",
+   :doc:`fuchsia-trailing-return <fuchsia/trailing-return>`,, "7.1.0",
+   :doc:`fuchsia-virtual-inheritance <fuchsia/virtual-inheritance>`,, "7.1.0",
+   :doc:`google-build-explicit-make-pair <google/build-explicit-make-pair>`,, "7.1.0",
+   :doc:`google-build-namespaces <google/build-namespaces>`,, "7.1.0",
+   :doc:`google-build-using-namespace <google/build-using-namespace>`,, "7.1.0",
+   :doc:`google-default-arguments <google/default-arguments>`,, "7.1.0",
+   :doc:`google-explicit-constructor <google/explicit-constructor>`, "Yes", "7.1.0",
+   :doc:`google-global-names-in-headers <google/global-names-in-headers>`,, "7.1.0",
+   :doc:`google-objc-avoid-nsobject-new <google/objc-avoid-nsobject-new>`,, "9.0.1",
+   :doc:`google-objc-avoid-throwing-exception <google/objc-avoid-throwing-exception>`,, "7.1.0",
+   :doc:`google-objc-function-naming <google/objc-function-naming>`,, "8.0.1",
+   :doc:`google-objc-global-variable-declaration <google/objc-global-variable-declaration>`,, "7.1.0",
+   :doc:`google-readability-avoid-underscore-in-googletest-name <google/readability-avoid-underscore-in-googletest-name>`,, "9.0.1",
+   :doc:`google-readability-casting <google/readability-casting>`,, "7.1.0",
+   :doc:`google-readability-todo <google/readability-todo>`,, "7.1.0",
+   :doc:`google-runtime-float <google/runtime-float>`,, "22.0.0",
+   :doc:`google-runtime-int <google/runtime-int>`,, "7.1.0",
+   :doc:`google-runtime-operator <google/runtime-operator>`,, "7.1.0",
+   :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes", "10.0.0",
+   :doc:`hicpp-exception-baseclass <hicpp/exception-baseclass>`,, "7.1.0",
+   :doc:`hicpp-ignored-remove-result <hicpp/ignored-remove-result>`,, "18.1.0",
+   :doc:`hicpp-multiway-paths-covered <hicpp/multiway-paths-covered>`,, "7.1.0",
+   :doc:`hicpp-no-assembler <hicpp/no-assembler>`,, "7.1.0",
+   :doc:`hicpp-signed-bitwise <hicpp/signed-bitwise>`,, "7.1.0",
+   :doc:`linuxkernel-must-check-errs <linuxkernel/must-check-errs>`,, "10.0.0",
+   :doc:`llvm-header-guard <llvm/header-guard>`,, "7.1.0",
+   :doc:`llvm-include-order <llvm/include-order>`, "Yes", "7.1.0",
+   :doc:`llvm-namespace-comment <llvm/namespace-comment>`,, "7.1.0",
+   :doc:`llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm/prefer-isa-or-dyn-cast-in-conditionals>`, "Yes", "9.0.1",
+   :doc:`llvm-prefer-register-over-unsigned <llvm/prefer-register-over-unsigned>`, "Yes", "10.0.0",
+   :doc:`llvm-prefer-static-over-anonymous-namespace <llvm/prefer-static-over-anonymous-namespace>`,, "21.1.0",
+   :doc:`llvm-twine-local <llvm/twine-local>`, "Yes", "7.1.0",
+   :doc:`llvm-use-new-mlir-op-builder <llvm/use-new-mlir-op-builder>`, "Yes", "22.0.0",
+   :doc:`llvm-use-ranges <llvm/use-ranges>`, "Yes", "22.0.0",
+   :doc:`llvmlibc-callee-namespace <llvmlibc/callee-namespace>`,, "11.0.0",
+   :doc:`llvmlibc-implementation-in-namespace <llvmlibc/implementation-in-namespace>`,, "11.0.0",
+   :doc:`llvmlibc-inline-function-decl <llvmlibc/inline-function-decl>`, "Yes", "17.0.1",
+   :doc:`llvmlibc-restrict-system-libc-headers <llvmlibc/restrict-system-libc-headers>`, "Yes", "11.0.0",
+   :doc:`misc-confusable-identifiers <misc/confusable-identifiers>`,, "15.0.0",
+   :doc:`misc-const-correctness <misc/const-correctness>`, "Yes", "15.0.0",
+   :doc:`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>`,, "18.1.0",
+   :doc:`misc-definitions-in-headers <misc/definitions-in-headers>`, "Yes", "7.1.0",
+   :doc:`misc-header-include-cycle <misc/header-include-cycle>`,, "17.0.1",
+   :doc:`misc-include-cleaner <misc/include-cleaner>`, "Yes", "17.0.1",
+   :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,, "14.0.0",
+   :doc:`misc-misleading-identifier <misc/misleading-identifier>`,, "14.0.0",
+   :doc:`misc-misplaced-const <misc/misplaced-const>`,, "7.1.0",
+   :doc:`misc-new-delete-overloads <misc/new-delete-overloads>`,, "7.1.0",
+   :doc:`misc-no-recursion <misc/no-recursion>`,, "11.0.0",
+   :doc:`misc-non-copyable-objects <misc/non-copyable-objects>`,, "7.1.0",
+   :doc:`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>`,, "8.0.1",
+   :doc:`misc-override-with-different-visibility <misc/override-with-different-visibility>`,, "22.0.0",
+   :doc:`misc-redundant-expression <misc/redundant-expression>`, "Yes", "7.1.0",
+   :doc:`misc-static-assert <misc/static-assert>`, "Yes", "7.1.0",
+   :doc:`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>`,, "7.1.0",
+   :doc:`misc-unconventional-assign-operator <misc/unconventional-assign-operator>`,, "7.1.0",
+   :doc:`misc-uniqueptr-reset-release <misc/uniqueptr-reset-release>`, "Yes", "7.1.0",
+   :doc:`misc-unused-alias-decls <misc/unused-alias-decls>`, "Yes", "7.1.0",
+   :doc:`misc-unused-parameters <misc/unused-parameters>`, "Yes", "7.1.0",
+   :doc:`misc-unused-using-decls <misc/unused-using-decls>`, "Yes", "7.1.0",
+   :doc:`misc-use-anonymous-namespace <misc/use-anonymous-namespace>`,, "16.0.0",
+   :doc:`misc-use-internal-linkage <misc/use-internal-linkage>`, "Yes", "19.1.0",
+   :doc:`modernize-avoid-bind <modernize/avoid-bind>`, "Yes", "7.1.0",
+   :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,, "8.0.1",
+   :doc:`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>`,, "22.0.0",
+   :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,, "22.0.0",
+   :doc:`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>`, "Yes", "8.0.1",
+   :doc:`modernize-deprecated-headers <modernize/deprecated-headers>`, "Yes", "7.1.0",
+   :doc:`modernize-deprecated-ios-base-aliases <modernize/deprecated-ios-base-aliases>`, "Yes", "8.0.1",
+   :doc:`modernize-loop-convert <modernize/loop-convert>`, "Yes", "7.1.0",
+   :doc:`modernize-macro-to-enum <modernize/macro-to-enum>`, "Yes", "15.0.0",
+   :doc:`modernize-make-shared <modernize/make-shared>`, "Yes", "7.1.0",
+   :doc:`modernize-make-unique <modernize/make-unique>`, "Yes", "7.1.0",
+   :doc:`modernize-min-max-use-initializer-list <modernize/min-max-use-initializer-list>`, "Yes", "19.1.0",
+   :doc:`modernize-pass-by-value <modernize/pass-by-value>`, "Yes", "7.1.0",
+   :doc:`modernize-raw-string-literal <modernize/raw-string-literal>`, "Yes", "7.1.0",
+   :doc:`modernize-redundant-void-arg <modernize/redundant-void-arg>`, "Yes", "7.1.0",
+   :doc:`modernize-replace-auto-ptr <modernize/replace-auto-ptr>`, "Yes", "7.1.0",
+   :doc:`modernize-replace-disallow-copy-and-assign-macro <modernize/replace-disallow-copy-and-assign-macro>`, "Yes", "11.0.0",
+   :doc:`modernize-replace-random-shuffle <modernize/replace-random-shuffle>`, "Yes", "7.1.0",
+   :doc:`modernize-return-braced-init-list <modernize/return-braced-init-list>`, "Yes", "7.1.0",
+   :doc:`modernize-shrink-to-fit <modernize/shrink-to-fit>`, "Yes", "7.1.0",
+   :doc:`modernize-type-traits <modernize/type-traits>`, "Yes", "17.0.1",
+   :doc:`modernize-unary-static-assert <modernize/unary-static-assert>`, "Yes", "7.1.0",
+   :doc:`modernize-use-auto <modernize/use-auto>`, "Yes", "7.1.0",
+   :doc:`modernize-use-bool-literals <modernize/use-bool-literals>`, "Yes", "7.1.0",
+   :doc:`modernize-use-constraints <modernize/use-constraints>`, "Yes", "18.1.0",
+   :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes", "7.1.0",
+   :doc:`modernize-use-designated-initializers <modernize/use-designated-initializers>`, "Yes", "19.1.0",
+   :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes", "7.1.0",
+   :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes", "7.1.0",
+   :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes", "7.1.0",
+   :doc:`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>`, "Yes", "20.1.0",
+   :doc:`modernize-use-nodiscard <modernize/use-nodiscard>`, "Yes", "8.0.1",
+   :doc:`modernize-use-noexcept <modernize/use-noexcept>`, "Yes", "7.1.0",
+   :doc:`modernize-use-nullptr <modernize/use-nullptr>`, "Yes", "7.1.0",
+   :doc:`modernize-use-override <modernize/use-override>`, "Yes", "7.1.0",
+   :doc:`modernize-use-ranges <modernize/use-ranges>`, "Yes", "19.1.0",
+   :doc:`modernize-use-scoped-lock <modernize/use-scoped-lock>`, "Yes", "21.1.0",
+   :doc:`modernize-use-starts-ends-with <modernize/use-starts-ends-with>`, "Yes", "18.1.0",
+   :doc:`modernize-use-std-format <modernize/use-std-format>`, "Yes", "19.1.0",
+   :doc:`modernize-use-std-numbers <modernize/use-std-numbers>`, "Yes", "18.1.0",
+   :doc:`modernize-use-std-print <modernize/use-std-print>`, "Yes", "17.0.1",
+   :doc:`modernize-use-trailing-return-type <modernize/use-trailing-return-type>`, "Yes", "9.0.1",
+   :doc:`modernize-use-transparent-functors <modernize/use-transparent-functors>`, "Yes", "7.1.0",
+   :doc:`modernize-use-uncaught-exceptions <modernize/use-uncaught-exceptions>`, "Yes", "7.1.0",
+   :doc:`modernize-use-using <modernize/use-using>`, "Yes", "7.1.0",
+   :doc:`mpi-buffer-deref <mpi/buffer-deref>`, "Yes", "7.1.0",
+   :doc:`mpi-type-mismatch <mpi/type-mismatch>`, "Yes", "7.1.0",
+   :doc:`objc-assert-equals <objc/assert-equals>`, "Yes", "14.0.0",
+   :doc:`objc-avoid-nserror-init <objc/avoid-nserror-init>`,, "7.1.0",
+   :doc:`objc-dealloc-in-category <objc/dealloc-in-category>`,, "11.0.0",
+   :doc:`objc-forbidden-subclassing <objc/forbidden-subclassing>`,, "7.1.0",
+   :doc:`objc-missing-hash <objc/missing-hash>`,, "10.0.0",
+   :doc:`objc-nsdate-formatter <objc/nsdate-formatter>`,, "16.0.0",
+   :doc:`objc-nsinvocation-argument-lifetime <objc/nsinvocation-argument-lifetime>`, "Yes", "11.0.0",
+   :doc:`objc-property-declaration <objc/property-declaration>`, "Yes", "7.1.0",
+   :doc:`objc-super-self <objc/super-self>`, "Yes", "9.0.1",
+   :doc:`openmp-exception-escape <openmp/exception-escape>`,, "9.0.1",
+   :doc:`openmp-use-default-none <openmp/use-default-none>`,, "9.0.1",
+   :doc:`performance-avoid-endl <performance/avoid-endl>`, "Yes", "17.0.1",
+   :doc:`performance-enum-size <performance/enum-size>`,, "18.1.0",
+   :doc:`performance-faster-string-find <performance/faster-string-find>`, "Yes", "7.1.0",
+   :doc:`performance-for-range-copy <performance/for-range-copy>`, "Yes", "7.1.0",
+   :doc:`performance-implicit-conversion-in-loop <performance/implicit-conversion-in-loop>`,, "7.1.0",
+   :doc:`performance-inefficient-algorithm <performance/inefficient-algorithm>`, "Yes", "7.1.0",
+   :doc:`performance-inefficient-string-concatenation <performance/inefficient-string-concatenation>`,, "7.1.0",
+   :doc:`performance-inefficient-vector-operation <performance/inefficient-vector-operation>`, "Yes", "7.1.0",
+   :doc:`performance-move-const-arg <performance/move-const-arg>`, "Yes", "7.1.0",
+   :doc:`performance-move-constructor-init <performance/move-constructor-init>`,, "7.1.0",
+   :doc:`performance-no-automatic-move <performance/no-automatic-move>`,, "10.0.0",
+   :doc:`performance-no-int-to-ptr <performance/no-int-to-ptr>`,, "12.0.0",
+   :doc:`performance-noexcept-destructor <performance/noexcept-destructor>`, "Yes", "17.0.1",
+   :doc:`performance-noexcept-move-constructor <performance/noexcept-move-constructor>`, "Yes", "7.1.0",
+   :doc:`performance-noexcept-swap <performance/noexcept-swap>`, "Yes", "17.0.1",
+   :doc:`performance-trivially-destructible <performance/trivially-destructible>`, "Yes", "10.0.0",
+   :doc:`performance-type-promotion-in-math-fn <performance/type-promotion-in-math-fn>`, "Yes", "7.1.0",
+   :doc:`performance-unnecessary-copy-initialization <performance/unnecessary-copy-initialization>`, "Yes", "7.1.0",
+   :doc:`performance-unnecessary-value-param <performance/unnecessary-value-param>`, "Yes", "7.1.0",
+   :doc:`portability-avoid-pragma-once <portability/avoid-pragma-once>`,, "21.1.0",
+   :doc:`portability-restrict-system-includes <portability/restrict-system-includes>`, "Yes", "11.0.0",
+   :doc:`portability-simd-intrinsics <portability/simd-intrinsics>`,, "7.1.0",
+   :doc:`portability-std-allocator-const <portability/std-allocator-const>`,, "15.0.0",
+   :doc:`portability-template-virtual-member-function <portability/template-virtual-member-function>`,, "20.1.0",
+   :doc:`readability-ambiguous-smartptr-reset-call <readability/ambiguous-smartptr-reset-call>`, "Yes", "21.1.0",
+   :doc:`readability-avoid-const-params-in-decls <readability/avoid-const-params-in-decls>`, "Yes", "7.1.0",
+   :doc:`readability-avoid-nested-conditional-operator <readability/avoid-nested-conditional-operator>`,, "18.1.0",
+   :doc:`readability-avoid-return-with-void-value <readability/avoid-return-with-void-value>`, "Yes", "18.1.0",
+   :doc:`readability-avoid-unconditional-preprocessor-if <readability/avoid-unconditional-preprocessor-if>`,, "17.0.1",
+   :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes", "7.1.0",
+   :doc:`readability-const-return-type <readability/const-return-type>`, "Yes", "8.0.1",
+   :doc:`readability-container-contains <readability/container-contains>`, "Yes", "14.0.0",
+   :doc:`readability-container-data-pointer <readability/container-data-pointer>`, "Yes", "14.0.0",
+   :doc:`readability-container-size-empty <readability/container-size-empty>`, "Yes", "7.1.0",
+   :doc:`readability-convert-member-functions-to-static <readability/convert-member-functions-to-static>`, "Yes", "9.0.1",
+   :doc:`readability-delete-null-pointer <readability/delete-null-pointer>`, "Yes", "7.1.0",
+   :doc:`readability-duplicate-include <readability/duplicate-include>`, "Yes", "14.0.0",
+   :doc:`readability-else-after-return <readability/else-after-return>`, "Yes", "7.1.0",
+   :doc:`readability-enum-initial-value <readability/enum-initial-value>`, "Yes", "19.1.0",
+   :doc:`readability-function-cognitive-complexity <readability/function-cognitive-complexity>`,, "12.0.0",
+   :doc:`readability-function-size <readability/function-size>`,, "7.1.0",
+   :doc:`readability-identifier-length <readability/identifier-length>`,, "14.0.0",
+   :doc:`readability-identifier-naming <readability/identifier-naming>`, "Yes", "7.1.0",
+   :doc:`readability-implicit-bool-conversion <readability/implicit-bool-conversion>`, "Yes", "7.1.0",
+   :doc:`readability-inconsistent-declaration-parameter-name <readability/inconsistent-declaration-parameter-name>`, "Yes", "7.1.0",
+   :doc:`readability-isolate-declaration <readability/isolate-declaration>`, "Yes", "8.0.1",
+   :doc:`readability-magic-numbers <readability/magic-numbers>`,, "8.0.1",
+   :doc:`readability-make-member-function-const <readability/make-member-function-const>`, "Yes", "10.0.0",
+   :doc:`readability-math-missing-parentheses <readability/math-missing-parentheses>`, "Yes", "19.1.0",
+   :doc:`readability-misleading-indentation <readability/misleading-indentation>`,, "7.1.0",
+   :doc:`readability-misplaced-array-index <readability/misplaced-array-index>`, "Yes", "7.1.0",
+   :doc:`readability-named-parameter <readability/named-parameter>`, "Yes", "7.1.0",
+   :doc:`readability-non-const-parameter <readability/non-const-parameter>`, "Yes", "7.1.0",
+   :doc:`readability-operators-representation <readability/operators-representation>`, "Yes", "17.0.1",
+   :doc:`readability-qualified-auto <readability/qualified-auto>`, "Yes", "10.0.0",
+   :doc:`readability-redundant-access-specifiers <readability/redundant-access-specifiers>`, "Yes", "10.0.0",
+   :doc:`readability-redundant-casting <readability/redundant-casting>`, "Yes", "18.1.0",
+   :doc:`readability-redundant-control-flow <readability/redundant-control-flow>`, "Yes", "7.1.0",
+   :doc:`readability-redundant-declaration <readability/redundant-declaration>`, "Yes", "7.1.0",
+   :doc:`readability-redundant-function-ptr-dereference <readability/redundant-function-ptr-dereference>`, "Yes", "7.1.0",
+   :doc:`readability-redundant-inline-specifier <readability/redundant-inline-specifier>`, "Yes", "18.1.0",
+   :doc:`readability-redundant-member-init <readability/redundant-member-init>`, "Yes", "7.1.0",
+   :doc:`readability-redundant-parentheses <readability/redundant-parentheses>`, "Yes", "22.0.0",
+   :doc:`readability-redundant-preprocessor <readability/redundant-preprocessor>`,, "8.0.1",
+   :doc:`readability-redundant-smartptr-get <readability/redundant-smartptr-get>`, "Yes", "7.1.0",
+   :doc:`readability-redundant-string-cstr <readability/redundant-string-cstr>`, "Yes", "7.1.0",
+   :doc:`readability-redundant-string-init <readability/redundant-string-init>`, "Yes", "7.1.0",
+   :doc:`readability-reference-to-constructed-temporary <readability/reference-to-constructed-temporary>`,, "18.1.0",
+   :doc:`readability-simplify-boolean-expr <readability/simplify-boolean-expr>`, "Yes", "7.1.0",
+   :doc:`readability-simplify-subscript-expr <readability/simplify-subscript-expr>`, "Yes", "7.1.0",
+   :doc:`readability-static-accessed-through-instance <readability/static-accessed-through-instance>`, "Yes", "7.1.0",
+   :doc:`readability-static-definition-in-anonymous-namespace <readability/static-definition-in-anonymous-namespace>`, "Yes", "7.1.0",
+   :doc:`readability-string-compare <readability/string-compare>`, "Yes", "7.1.0",
+   :doc:`readability-suspicious-call-argument <readability/suspicious-call-argument>`,, "13.0.0",
+   :doc:`readability-uniqueptr-delete-release <readability/uniqueptr-delete-release>`, "Yes", "7.1.0",
+   :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes", "8.0.1",
+   :doc:`readability-use-anyofallof <readability/use-anyofallof>`,, "11.0.0",
+   :doc:`readability-use-concise-preprocessor-directives <readability/use-concise-preprocessor-directives>`, "Yes", "21.1.0",
+   :doc:`readability-use-std-min-max <readability/use-std-min-max>`, "Yes", "19.1.0",
+   :doc:`zircon-temporary-objects <zircon/temporary-objects>`,, "7.1.0",
 
 .. csv-table::
    :header: "Name", "Redirect", "Offers fixes"

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/namespace-comment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/namespace-comment.rst
@@ -28,19 +28,19 @@ https://google.github.io/styleguide/cppguide.html#Namespaces
 Options
 -------
 
-.. option:: ShortNamespaceLines
+.. option:: ShortNamespaceLines (added in 15.0.0)
 
    Requires the closing brace of the namespace definition to be followed by a
    closing comment if the body of the namespace has more than
    `ShortNamespaceLines` lines of code. The value is an unsigned integer that
    defaults to `1U`.
 
-.. option:: SpacesBeforeComments
+.. option:: SpacesBeforeComments (added in 15.0.0)
 
    An unsigned integer specifying the number of spaces before the comment
    closing a namespace definition. Default is `1U`.
 
-.. option:: AllowOmittingNamespaceComments
+.. option:: AllowOmittingNamespaceComments (added in 21.1.0)
 
    When `true`, the check will accept if no namespace comment is present.
    The check will only fail if the specified namespace comment is different

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-static-over-anonymous-namespace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-static-over-anonymous-namespace.rst
@@ -62,12 +62,12 @@ Should become:
 Options
 -------
 
-.. option:: AllowVariableDeclarations
+.. option:: AllowVariableDeclarations (added in 21.1.0)
 
   When `true`, allow variable declarations to be in anonymous namespace.
   Default value is `true`.
 
-.. option:: AllowMemberFunctionsInClass
+.. option:: AllowMemberFunctionsInClass (added in 21.1.0)
 
   When `true`, only methods defined in anonymous namespace outside of the
   corresponding class will be warned. Default value is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/restrict-system-libc-headers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/restrict-system-libc-headers.rst
@@ -22,7 +22,7 @@ because they are ABI incompatible.
 Options
 -------
 
-.. option:: Includes
+.. option:: Includes (added in 15.0.0)
 
    A string containing a comma separated glob list of allowed include
    filenames. Similar to the -checks glob list for running clang-tidy itself,

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
@@ -66,7 +66,7 @@ an independent translation unit.
 Options
 -------
 
-.. option:: AnalyzeValues
+.. option:: AnalyzeValues (added in 21.1.0)
 
   Enable or disable the analysis of ordinary value variables, like
   ``int i = 42;``. Default is `true`.
@@ -83,7 +83,7 @@ Options
     // No warning
     int const a[] = {42, 42, 42};
 
-.. option:: AnalyzeReferences
+.. option:: AnalyzeReferences (added in 21.1.0)
 
   Enable or disable the analysis of reference variables, like
   ``int &ref = i;``. Default is `true`.
@@ -96,14 +96,14 @@ Options
     // No warning
     int const& ref = i;
 
-.. option:: AnalyzePointers
+.. option:: AnalyzePointers (added in 21.1.0)
 
   Enable or disable the analysis of pointers variables, like
   ``int *ptr = &i;``. For specific checks, see 
   :option:`WarnPointersAsValues` and :option:`WarnPointersAsPointers`.
   Default is `true`.
 
-.. option:: WarnPointersAsValues
+.. option:: WarnPointersAsValues (added in 21.1.0)
 
   This option enables the suggestion for ``const`` of the pointer itself.
   Pointer values have two possibilities to be ``const``, the pointer
@@ -118,7 +118,7 @@ Options
     // No warning
     const int *const pointer_variable = &value;
 
-.. option:: WarnPointersAsPointers
+.. option:: WarnPointersAsPointers (added in 21.1.0)
 
   This option enables the suggestion for ``const`` of the value pointing to.
   Default is `true`.
@@ -134,7 +134,7 @@ Options
     // Warning
     int *const pointer_variable = &value;
 
-.. option:: TransformValues
+.. option:: TransformValues (added in 21.1.0)
 
   Provides fixit-hints for value types that automatically add ``const`` if
   its a single declaration. Default is `true`.
@@ -155,7 +155,7 @@ Options
     int result = value * 3;
     result -= 10;
 
-.. option:: TransformReferences
+.. option:: TransformReferences (added in 21.1.0)
 
   Provides fixit-hints for reference types that automatically add ``const`` if
   its a single declaration. Default is `true`.
@@ -175,7 +175,7 @@ Options
     int result = ref_value * 3;
     result -= 10;
 
-.. option:: TransformPointersAsValues
+.. option:: TransformPointersAsValues (added in 21.1.0)
 
   Provides fixit-hints for pointers if their pointee is not changed. This does
   not analyze if the value-pointed-to is unchanged! Default is `false`.
@@ -209,7 +209,7 @@ Options
     int *changing_pointee = &value;
     changing_pointee = &result;
 
-.. option:: TransformPointersAsPointers
+.. option:: TransformPointersAsPointers (added in 21.1.0)
 
   Provides fix-it hints for pointers if the value it pointing to is not changed.
   Default is `false`.
@@ -230,7 +230,7 @@ Options
     // After
     const int * a[] = {&value, &value};
 
-.. option:: AllowedTypes
+.. option:: AllowedTypes (added in 21.1.0)
 
   A semicolon-separated list of names of types that will be excluded from
   const-correctness checking. Regular expressions are accepted, e.g.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
@@ -41,14 +41,14 @@ Following types are considered as hostile:
 Options
 -------
 
-.. option:: RAIITypesList
+.. option:: RAIITypesList (added in 18.1.0)
 
     A semicolon-separated list of qualified types which should not be allowed to
     persist across suspension points.
     Eg: `my::lockable;a::b;::my::other::lockable`
     The default value of this option is `std::lock_guard;std::scoped_lock`.
 
-.. option:: AllowedAwaitablesList
+.. option:: AllowedAwaitablesList (added in 18.1.0)
 
     A semicolon-separated list of qualified types of awaitables types which can
     be safely awaited while having hostile RAII objects in scope.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/header-include-cycle.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/header-include-cycle.rst
@@ -63,7 +63,7 @@ when making adjustments.
 Options
 -------
 
-.. option:: IgnoredFilesList
+.. option:: IgnoredFilesList (added in 17.0.1)
 
     Provides a way to exclude specific files/headers from the warnings raised by
     a check. This can be achieved by specifying a semicolon-separated list of

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
@@ -27,24 +27,24 @@ Example:
 Options
 -------
 
-.. option:: IgnoreHeaders
+.. option:: IgnoreHeaders (added in 17.0.1)
 
    A semicolon-separated list of regexes to disable insertion/removal of header
    files that match this regex as a suffix.  E.g., `foo/.*` disables
    insertion/removal for all headers under the directory `foo`. Default is an
    empty string, no headers will be ignored.
 
-.. option:: DeduplicateFindings
+.. option:: DeduplicateFindings (added in 18.1.0)
 
    A boolean that controls whether the check should deduplicate findings for the
    same symbol. Defaults to `true`.
 
-.. option:: UnusedIncludes
+.. option:: UnusedIncludes (added in 21.1.0)
 
    A boolean that controls whether the check should report unused includes
    (includes that are not used directly). Defaults to `true`.
 
-.. option:: MissingIncludes
+.. option:: MissingIncludes (added in 21.1.0)
 
    A boolean that controls whether the check should report missing includes
    (header files from which symbols are used but which are not directly included).

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.rst
@@ -15,13 +15,13 @@ classes or class consumers.
 Options
 -------
 
-.. option:: IgnoreClassesWithAllMemberVariablesBeingPublic
+.. option:: IgnoreClassesWithAllMemberVariablesBeingPublic (added in 15.0.0)
 
    When `true`, allows to completely ignore classes if **all** the member
    variables in that class declared with a ``public`` access specifier.
    Default is `false`.
 
-.. option:: IgnorePublicMemberVariables
+.. option:: IgnorePublicMemberVariables (added in 15.0.0)
 
    When `true`, allows to ignore (not diagnose) **all** the member variables
    declared with a ``public`` access specifier. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/throw-by-value-catch-by-reference.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/throw-by-value-catch-by-reference.rst
@@ -29,13 +29,13 @@ Exceptions:
 Options
 -------
 
-.. option:: CheckThrowTemporaries
+.. option:: CheckThrowTemporaries (added in 15.0.0)
 
    Triggers detection of violations of the CERT recommendation ERR09-CPP. Throw
    anonymous temporaries.
    Default is `true`.
 
-.. option:: WarnOnLargeObject
+.. option:: WarnOnLargeObject (added in 15.0.0)
 
    Also warns for any large, trivial object caught by value. Catching a large
    object by value is not dangerous but affects the performance negatively. The
@@ -43,7 +43,7 @@ Options
    using the `MaxSize` option.
    Default is `false`.
 
-.. option:: MaxSize
+.. option:: MaxSize (added in 15.0.0)
 
    Determines the maximum size of an object allowed to be caught without
    warning. Only applicable if :option:`WarnOnLargeObject` is set to `true`. If

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/uniqueptr-reset-release.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/uniqueptr-reset-release.rst
@@ -18,7 +18,7 @@ also be ``std::unique_ptr<Foo>*``.
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-parameters.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-parameters.rst
@@ -33,7 +33,7 @@ is more permissive (see :option:`StrictMode`).
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 15.0.0)
 
   When `false` (default value), the check will ignore trivially unused parameters,
   i.e. when the corresponding function has an empty body (and in case of
@@ -41,7 +41,7 @@ Options
   an unused parameter is unlikely to be unnoticed by a human reader, and
   there's basically no place for a bug to hide.
 
-.. option:: IgnoreVirtual
+.. option:: IgnoreVirtual (added in 17.0.1)
 
   Determines whether virtual method parameters should be inspected.
   Set to `true` to ignore them. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
@@ -37,7 +37,7 @@ Example:
 Options
 -------
 
-.. option:: FixMode
+.. option:: FixMode (added in 19.1.0)
 
   Selects what kind of a fix the check should provide. The default is `UseStatic`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-bind.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-bind.rst
@@ -44,7 +44,7 @@ lambdas.
 Options
 -------
 
-.. option:: PermissiveParameterList
+.. option:: PermissiveParameterList (added in 15.0.0)
 
   If the option is set to `true`, the check will append ``auto&&...`` to the end
   of every placeholder parameter list. Without this, it is possible for a fix-it

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-c-arrays.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-c-arrays.rst
@@ -65,7 +65,7 @@ can be either ``char* argv[]`` or ``char** argv``, but cannot be
 Options
 -------
 
-.. option:: AllowStringArrays
+.. option:: AllowStringArrays (added in 19.1.0)
 
   When set to `true` (default is `false`), variables of character array type
   with deduced length, initialized directly from string literals, will be ignored.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/deprecated-headers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/deprecated-headers.rst
@@ -73,7 +73,7 @@ since a library might want to expose some API for C and C++ libraries.
 Options
 -------
 
-.. option:: CheckHeaderFile
+.. option:: CheckHeaderFile (added in 15.0.0)
 
    `clang-tidy` cannot know if the header file included by the currently
    analyzed C++ source file is not included by any other C source files.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
@@ -143,13 +143,13 @@ lives.
 Options
 -------
 
-.. option:: UseCxx20ReverseRanges
+.. option:: UseCxx20ReverseRanges (added in 15.0.0)
 
    When set to true convert loops when in C++20 or later mode using
    ``std::ranges::reverse_view``.
    Default value is `true`.
 
-.. option:: MakeReverseRangeFunction
+.. option:: MakeReverseRangeFunction (added in 15.0.0)
 
    Specify the function used to reverse an iterator pair, the function should
    accept a class with ``rbegin`` and ``rend`` methods and return a
@@ -158,7 +158,7 @@ Options
    and ``llvm::reverse``.
    Default value is an empty string.
 
-.. option:: MakeReverseRangeHeader
+.. option:: MakeReverseRangeHeader (added in 15.0.0)
 
    Specifies the header file where :option:`MakeReverseRangeFunction` is
    declared. For the previous examples this option would be set to
@@ -170,7 +170,7 @@ Options
    system include.
    Default value is an empty string.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
@@ -29,27 +29,27 @@ expression, and replaces it with a call to ``std::make_shared``.
 Options
 -------
 
-.. option:: MakeSmartPtrFunction
+.. option:: MakeSmartPtrFunction (added in 15.0.0)
 
    A string specifying the name of make-shared-ptr function. Default is
    `std::make_shared`.
 
-.. option:: MakeSmartPtrFunctionHeader
+.. option:: MakeSmartPtrFunctionHeader (added in 15.0.0)
 
    A string specifying the corresponding header of make-shared-ptr function.
    Default is `<memory>`.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.
 
-.. option:: IgnoreDefaultInitialization
+.. option:: IgnoreDefaultInitialization (added in 15.0.0)
 
    If set to `false`, the check does not suggest edits that will transform
    default initialization into value initialization, as this can cause

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst
@@ -29,27 +29,27 @@ expression, and replaces it with a call to ``std::make_unique``.
 Options
 -------
 
-.. option:: MakeSmartPtrFunction
+.. option:: MakeSmartPtrFunction (added in 15.0.0)
 
    A string specifying the name of make-unique-ptr function. Default is
    `std::make_unique`.
 
-.. option:: MakeSmartPtrFunctionHeader
+.. option:: MakeSmartPtrFunctionHeader (added in 15.0.0)
 
    A string specifying the corresponding header of make-unique-ptr function.
    Default is `<memory>`.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.
 
-.. option:: IgnoreDefaultInitialization
+.. option:: IgnoreDefaultInitialization (added in 15.0.0)
 
    If set to `false`, the check does not suggest edits that will transform
    default initialization into value initialization, as this can cause

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/min-max-use-initializer-list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/min-max-use-initializer-list.rst
@@ -35,16 +35,16 @@ non-trivial types:
 Options
 =======
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 19.1.0)
 
   A string specifying which include-style is used, `llvm` or `google`. Default
   is `llvm`.
 
-.. option:: IgnoreNonTrivialTypes
+.. option:: IgnoreNonTrivialTypes (added in 19.1.0)
 
   A boolean specifying whether to ignore non-trivial types. Default is `true`.
 
-.. option:: IgnoreTrivialTypesOfSizeAbove
+.. option:: IgnoreTrivialTypesOfSizeAbove (added in 19.1.0)
 
   An integer specifying the size (in bytes) above which trivial types are
   ignored. Default is `32`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/pass-by-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/pass-by-value.rst
@@ -155,12 +155,12 @@ Example:
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: ValuesOnly
+.. option:: ValuesOnly (added in 15.0.0)
 
    When `true`, the check only warns about copied parameters that are already
    passed by value. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/raw-string-literal.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/raw-string-literal.rst
@@ -48,13 +48,13 @@ vertical tab in source code is not visually obvious.
 Options
 -------
 
-.. option:: DelimiterStem
+.. option:: DelimiterStem (added in 17.0.1)
 
   Custom delimiter to escape characters in raw string literals. It is used in
   the following construction: ``R"stem_delimiter(contents)stem_delimiter"``.
   The default value is `lit`.
 
-.. option:: ReplaceShorterLiterals
+.. option:: ReplaceShorterLiterals (added in 17.0.1)
 
   Controls replacing shorter non-raw string literals with longer raw string
   literals. Setting this option to `true` enables the replacement.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/replace-auto-ptr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/replace-auto-ptr.rst
@@ -75,7 +75,7 @@ Limitations
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/replace-disallow-copy-and-assign-macro.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/replace-disallow-copy-and-assign-macro.rst
@@ -45,7 +45,7 @@ Limitations
 Options
 -------
 
-.. option:: MacroName
+.. option:: MacroName (added in 15.0.0)
 
    A string specifying the macro name whose expansion will be replaced.
    Default is `DISALLOW_COPY_AND_ASSIGN`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/type-traits.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/type-traits.rst
@@ -27,7 +27,7 @@ Would be converted into:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 17.0.1)
 
   If `true` don't diagnose traits defined in macros.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-auto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-auto.rst
@@ -178,7 +178,7 @@ Limitations
 Options
 -------
 
-.. option:: MinTypeNameLength
+.. option:: MinTypeNameLength (added in 15.0.0)
 
    If the option is set to non-zero (default `5`), the check will ignore type
    names having a length less than the option value. The option affects
@@ -215,7 +215,7 @@ Options
   unsigned c = static_cast<unsigned>(foo());       // ---> auto c = ...
   long int d = static_cast<long int>(foo());       // ---> auto d = ...
 
-.. option:: RemoveStars
+.. option:: RemoveStars (added in 15.0.0)
 
    If the option is set to `true` (default is `false`), the check will remove
    stars from the non-typedef pointer types when replacing type names with

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-bool-literals.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-bool-literals.rst
@@ -22,7 +22,7 @@ Finds integer literals which are cast to ``bool``.
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default-member-init.rst
@@ -34,7 +34,7 @@ use of '= default'.
 Options
 -------
 
-.. option:: UseAssignment
+.. option:: UseAssignment (added in 15.0.0)
 
    If this option is set to `true` (default is `false`), the check will initialize
    members with an assignment. For example:
@@ -48,7 +48,7 @@ Options
     double j = 10.0;
   };
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If this option is set to `true` (default is `true`), the check will not warn
    about members declared inside macros.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-designated-initializers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-designated-initializers.rst
@@ -45,12 +45,12 @@ language modes.
 Options
 -------
 
-.. option::  IgnoreMacros
+.. option::  IgnoreMacros (added in 19.1.0)
 
   The value `false` specifies that components of initializer lists expanded from
   macros are not checked. The default value is `true`.
 
-.. option:: IgnoreSingleElementAggregates
+.. option:: IgnoreSingleElementAggregates (added in 19.1.0)
 
     The value `false` specifies that even initializers for aggregate types with
     only a single element should be checked. The default value is `true`.
@@ -58,18 +58,18 @@ Options
     standard library abstraction and not intended to be initialized with
     designated initializers.
 
-.. option:: RestrictToPODTypes
+.. option:: RestrictToPODTypes (added in 19.1.0)
 
     The value `true` specifies that only Plain Old Data (POD) types shall be
     checked. This makes the check applicable to even older C++ standards. The
     default value is `false`.
 
-.. option:: StrictCStandardCompliance
+.. option:: StrictCStandardCompliance (added in 19.1.0)
 
    When set to `false`, the check will not restrict itself to C99 and above.
    The default value is `true`.
 
-.. option:: StrictCppStandardCompliance
+.. option:: StrictCppStandardCompliance (added in 19.1.0)
 
    When set to `false`, the check will not restrict itself to C++20 and above.
    The default value is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-emplace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-emplace.rst
@@ -117,22 +117,22 @@ This check requires C++11 or higher to run.
 Options
 -------
 
-.. option:: ContainersWithPushBack
+.. option:: ContainersWithPushBack (added in 15.0.0)
 
    Semicolon-separated list of class names of custom containers that support
    ``push_back``.
 
-.. option:: ContainersWithPush
+.. option:: ContainersWithPush (added in 16.0.0)
 
    Semicolon-separated list of class names of custom containers that support
    ``push``.
 
-.. option:: ContainersWithPushFront
+.. option:: ContainersWithPushFront (added in 16.0.0)
 
    Semicolon-separated list of class names of custom containers that support
    ``push_front``.
 
-.. option:: IgnoreImplicitConstructors
+.. option:: IgnoreImplicitConstructors (added in 15.0.0)
 
     When `true`, the check will ignore implicitly constructed arguments of
     ``push_back``, e.g.
@@ -144,21 +144,21 @@ Options
 
     Default is `false`.
 
-.. option:: SmartPointers
+.. option:: SmartPointers (added in 15.0.0)
 
    Semicolon-separated list of class names of custom smart pointers.
 
-.. option:: TupleTypes
+.. option:: TupleTypes (added in 15.0.0)
 
     Semicolon-separated list of ``std::tuple``-like class names.
 
-.. option:: TupleMakeFunctions
+.. option:: TupleMakeFunctions (added in 15.0.0)
 
     Semicolon-separated list of ``std::make_tuple``-like function names. Those
     function calls will be removed from ``push_back`` calls and turned into
     ``emplace_back``.
 
-.. option:: EmplacyFunctions
+.. option:: EmplacyFunctions (added in 15.0.0)
 
     Semicolon-separated list of containers without their template parameters
     and some ``emplace``-like method of the container. Example:

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-default.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-default.rst
@@ -30,7 +30,7 @@ defaulted functions as trivial.
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will not give warnings inside macros and will
    ignore special members with bodies contain macros or preprocessor directives.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -39,7 +39,7 @@ for manually relocating functions to the ``public`` section.
   };
 
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If this option is set to `true` (default is `true`), the check will not warn
    about functions declared inside macros.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
@@ -30,12 +30,12 @@ becomes
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 20.1.0)
 
   A string specifying which include-style is used, `llvm` or `google`.
   Default is `llvm`.
 
-.. option:: EnableQtSupport
+.. option:: EnableQtSupport (added in 20.1.0)
 
   Makes C++17 ``q20::cmp_*`` alternative available for Qt-based
   applications. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-nodiscard.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-nodiscard.rst
@@ -47,7 +47,7 @@ transforms to:
 Options
 -------
 
-.. option:: ReplacementString
+.. option:: ReplacementString (added in 15.0.0)
 
     Specifies a macro to use instead of ``[[nodiscard]]``. This is useful when
     maintaining source code that needs to compile with a pre-C++17 compiler.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-noexcept.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-noexcept.rst
@@ -27,7 +27,7 @@ transforms to:
 Options
 -------
 
-.. option:: ReplacementString
+.. option:: ReplacementString (added in 15.0.0)
 
   Users can use :option:`ReplacementString` to specify a macro to use
   instead of ``noexcept``. This is useful when maintaining source code
@@ -52,7 +52,7 @@ transforms to:
 
 if the :option:`ReplacementString` option is set to `NOEXCEPT`.
 
-.. option:: UseNoexceptFalse
+.. option:: UseNoexceptFalse (added in 15.0.0)
 
 Enabled by default, disabling will generate fix-it hints that remove
 throwing dynamic exception specs, e.g., ``throw(<something>)``,

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-nullptr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-nullptr.rst
@@ -39,13 +39,13 @@ transforms to:
 Options
 -------
 
-.. option:: IgnoredTypes
+.. option:: IgnoredTypes (added in 18.1.0)
 
   Semicolon-separated list of regular expressions to match pointer types for
   which implicit casts will be ignored. Default value:
   `std::_CmpUnspecifiedParam::;^std::__cmp_cat::__unspec`.
 
-.. option:: NullMacros
+.. option:: NullMacros (added in 15.0.0)
 
    Comma-separated list of macro names that will be transformed along with
    ``NULL``. By default this check will only replace the ``NULL`` macro and will

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-override.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-override.rst
@@ -23,16 +23,16 @@ This can be useful as compilers can generate a compile time error when:
 Options
 -------
 
-.. option:: IgnoreDestructors
+.. option:: IgnoreDestructors (added in 15.0.0)
 
    If set to `true`, this check will not diagnose destructors. Default is `false`.
 
-.. option:: IgnoreTemplateInstantiations
+.. option:: IgnoreTemplateInstantiations (added in 17.0.1)
 
    If set to `true`, instructs this check to ignore virtual function overrides
    that are part of template instantiations. Default is `false`.
 
-.. option:: AllowOverrideAndFinal
+.. option:: AllowOverrideAndFinal (added in 15.0.0)
 
    If set to `true`, this check will not diagnose ``override`` as redundant
    with ``final``. This is useful when code will be compiled by a compiler with
@@ -40,13 +40,13 @@ Options
    members, such as ``gcc -Wsuggest-override``/``gcc -Werror=suggest-override``.
    Default is `false`.
 
-.. option:: OverrideSpelling
+.. option:: OverrideSpelling (added in 15.0.0)
 
    Specifies a macro to use instead of ``override``. This is useful when
    maintaining source code that also needs to compile with a pre-C++11
    compiler.
 
-.. option:: FinalSpelling
+.. option:: FinalSpelling (added in 15.0.0)
 
    Specifies a macro to use instead of ``final``. This is useful when
    maintaining source code that also needs to compile with a pre-C++11

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
@@ -128,12 +128,12 @@ Transforms to:
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 19.1.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: UseReversePipe
+.. option:: UseReversePipe (added in 19.1.0)
 
   When `true` (default `false`), fixes which involve reverse ranges will use the
   pipe adaptor syntax instead of the function syntax.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-scoped-lock.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-scoped-lock.rst
@@ -77,14 +77,14 @@ The check will not emit warnings if ``std::lock_guard`` is used implicitly via
 Options
 -------
 
-.. option:: WarnOnSingleLocks
+.. option:: WarnOnSingleLocks (added in 21.1.0)
 
   When `true`, the check will warn on single ``std::lock_guard`` declarations.
   Set this option to `false` if you want to get warnings only on multiple
   ``std::lock_guard`` declarations that can be replaced with a single
   ``std::scoped_lock``. Default is `true`.
 
-.. option:: WarnOnUsingAndTypedef
+.. option:: WarnOnUsingAndTypedef (added in 21.1.0)
 
   When `true`, the check will emit warnings if ``std::lock_guard`` is used
   in ``using`` or ``typedef`` context. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
@@ -29,7 +29,7 @@ documentation for that check.
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 19.1.0)
 
    When `true`, the check will add casts when converting from variadic
    functions and printing signed or unsigned integer types (including
@@ -60,7 +60,7 @@ Options
   `StrFormatLikeFunctions` since ``absl::StrFormat`` takes a function
   parameter pack and is not a variadic function.
 
-.. option:: StrFormatLikeFunctions
+.. option:: StrFormatLikeFunctions (added in 19.1.0)
 
    A semicolon-separated list of (fully qualified) function names to
    replace, with the requirement that the first parameter contains the
@@ -69,7 +69,7 @@ Options
    but the replacement function name must be unqualified. The default value
    for this option is `absl::StrFormat`.
 
-.. option:: ReplacementFormatFunction
+.. option:: ReplacementFormatFunction (added in 19.1.0)
 
    The function that will be used to replace the function set by the
    `StrFormatLikeFunctions` option rather than the default
@@ -77,7 +77,7 @@ Options
    that is compatible with ``std::format``. A suitable candidate would be
    `fmt::format`.
 
-.. option:: FormatHeader
+.. option:: FormatHeader (added in 19.1.0)
 
    The header that must be included for the declaration of
    `ReplacementFormatFunction` so that a ``#include`` directive can be added if

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -61,14 +61,14 @@ appropriate.
 Options
 -------
 
-.. option:: DiffThreshold
+.. option:: DiffThreshold (added in 18.1.0)
 
     A floating point value that sets the detection threshold for when literals
     match a constant. A literal matches a constant if
     ``abs(literal - constant) < DiffThreshold`` evaluates to ``true``. Default
     is `0.001`.
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 18.1.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -93,7 +93,7 @@ If the call is deemed suitable for conversion then:
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 17.0.1)
 
    When `true`, the check will add casts when converting from variadic
    functions like ``printf`` and printing signed or unsigned integer types
@@ -120,7 +120,7 @@ Options
   `4294967254` and `-1` respectively.) When `false` (which is the default),
   these casts will not be added which may cause a change in the output.
 
-.. option:: PrintfLikeFunctions
+.. option:: PrintfLikeFunctions (added in 17.0.1)
 
    A semicolon-separated list of (fully qualified) function names to
    replace, with the requirement that the first parameter contains the
@@ -131,7 +131,7 @@ Options
    this option is `printf; absl::PrintF`, otherwise it is empty.
 
 
-.. option:: FprintfLikeFunctions
+.. option:: FprintfLikeFunctions (added in 17.0.1)
 
    A semicolon-separated list of (fully qualified) function names to
    replace, with the requirement that the first parameter is retained, the
@@ -142,7 +142,7 @@ Options
    are set then the default value for this option is `fprintf;
    absl::FPrintF`, otherwise it is empty.
 
-.. option:: ReplacementPrintFunction
+.. option:: ReplacementPrintFunction (added in 17.0.1)
 
    The function that will be used to replace ``printf``, ``fprintf`` etc.
    during conversion rather than the default ``std::print`` when the
@@ -150,7 +150,7 @@ Options
    function provides an interface that is compatible with ``std::print``. A
    suitable candidate would be ``fmt::print``.
 
-.. option:: ReplacementPrintlnFunction
+.. option:: ReplacementPrintlnFunction (added in 17.0.1)
 
    The function that will be used to replace ``printf``, ``fprintf`` etc.
    during conversion rather than the default ``std::println`` when the
@@ -158,7 +158,7 @@ Options
    function provides an interface that is compatible with ``std::println``.
    A suitable candidate would be ``fmt::println``.
 
-.. option:: PrintHeader
+.. option:: PrintHeader (added in 17.0.1)
 
    The header that must be included for the declaration of
    `ReplacementPrintFunction` so that a ``#include`` directive can be

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-trailing-return-type.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-trailing-return-type.rst
@@ -73,12 +73,12 @@ The check can currently only detect and avoid a clash with a function parameter 
 Options
 -------
 
-.. option:: TransformFunctions
+.. option:: TransformFunctions (added in 21.1.0)
 
   When set to `true`, function declarations will be transformed to use trailing
   return. Default is `true`.
 
-.. option:: TransformLambdas
+.. option:: TransformLambdas (added in 21.1.0)
 
   Controls how lambda expressions are transformed to use trailing
   return type. Possible values are:

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-transparent-functors.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-transparent-functors.rst
@@ -30,7 +30,7 @@ untouched to preserve the semantics.
 Options
 -------
 
-.. option:: SafeMode
+.. option:: SafeMode (added in 15.0.0)
 
   If the option is set to `true`, the check will not diagnose cases where
   using a transparent functor cannot be guaranteed to produce identical results

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-using.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-using.rst
@@ -41,12 +41,12 @@ This check requires using C++11 or higher to run.
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.
 
-.. option:: IgnoreExternC
+.. option:: IgnoreExternC (added in 18.1.0)
 
    If set to `true`, the check will not give warning inside `extern "C"`scope.
    Default is `false`

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.rst
@@ -20,7 +20,7 @@ as not supporting subclassing.
 Options
 -------
 
-.. option:: ForbiddenSuperClassNames
+.. option:: ForbiddenSuperClassNames (added in 15.0.0)
 
    Semicolon-separated list of names of Objective-C classes which
    do not support subclassing.

--- a/clang-tools-extra/docs/clang-tidy/checks/openmp/exception-escape.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/openmp/exception-escape.rst
@@ -19,7 +19,7 @@ WARNING! This check may be expensive on large source files.
 Options
 -------
 
-.. option:: IgnoredExceptions
+.. option:: IgnoredExceptions (added in 15.0.0)
 
    Comma-separated list containing type names which are not counted as thrown
    exceptions in the check. Default value is an empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/enum-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/enum-size.rst
@@ -66,7 +66,7 @@ Does not provide auto-fixes.
 Options
 -------
 
-.. option:: EnumIgnoreList
+.. option:: EnumIgnoreList (added in 18.1.0)
 
     Option is used to ignore certain enum types. It accepts a
     semicolon-separated list of (fully qualified) enum type names or regular

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.rst
@@ -20,7 +20,7 @@ Examples:
 Options
 -------
 
-.. option:: StringLikeClasses
+.. option:: StringLikeClasses (added in 15.0.0)
 
    Semicolon-separated list of names of string-like classes. By default only
    ``::std::basic_string`` and ``::std::basic_string_view`` are considered.

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
@@ -21,12 +21,12 @@ following heuristic is employed:
 Options
 -------
 
-.. option:: WarnOnAllAutoCopies
+.. option:: WarnOnAllAutoCopies (added in 15.0.0)
 
    When `true`, warns on any use of ``auto`` as the type of the range-based for
    loop variable. Default is `false`.
 
-.. option:: AllowedTypes
+.. option:: AllowedTypes (added in 15.0.0)
 
    A semicolon-separated list of names of types allowed to be copied in each
    iteration. Regular expressions are accepted, e.g. ``[Rr]ef(erence)?$``

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-string-concatenation.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-string-concatenation.rst
@@ -53,7 +53,7 @@ In a slightly more efficient way like:
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 15.0.0)
 
    When `false`, the check will only check the string usage in ``while``, ``for``
    and ``for-range`` statements. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-vector-operation.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-vector-operation.rst
@@ -54,12 +54,12 @@ statement body:
 Options
 -------
 
-.. option:: VectorLikeClasses
+.. option:: VectorLikeClasses (added in 15.0.0)
 
    Semicolon-separated list of names of vector-like classes. By default only
    ``::std::vector`` is considered.
 
-.. option:: EnableProto
+.. option:: EnableProto (added in 15.0.0)
 
    When `true`, the check will also warn on inefficient operations for proto
    repeated fields. Otherwise, the check only warns on inefficient vector

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/move-const-arg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/move-const-arg.rst
@@ -31,12 +31,12 @@ Here are examples of each of the three cases:
 Options
 -------
 
-.. option:: CheckTriviallyCopyableMove
+.. option:: CheckTriviallyCopyableMove (added in 15.0.0)
 
    If `true`, enables detection of trivially copyable types that do not
    have a move constructor. Default is `true`.
 
-.. option:: CheckMoveToConstRef
+.. option:: CheckMoveToConstRef (added in 15.0.0)
 
    If `true`, enables detection of `std::move()` passed as a const
    reference argument. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
@@ -39,7 +39,7 @@ Example:
 Options
 -------
 
-.. option:: AllowedTypes
+.. option:: AllowedTypes (added in 15.0.0)
 
    A semicolon-separated list of names of types allowed to be initialized by
    copying. Regular expressions are accepted, e.g. ``[Rr]ef(erence)?$`` matches
@@ -48,7 +48,7 @@ Options
    is matched against the qualified type name (i.e. ``namespace::Type``),
    otherwise it is matched against only the type name (i.e. ``Type``).
 
-.. option:: ExcludedContainerTypes
+.. option:: ExcludedContainerTypes (added in 15.0.0)
 
    A semicolon-separated list of names of types whose methods are allowed to
    return the const reference the variable is copied from. When an expensive to

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -61,12 +61,12 @@ depends on function signatures.
 Options
 -------
 
-.. option:: IncludeStyle
+.. option:: IncludeStyle (added in 15.0.0)
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
 
-.. option:: AllowedTypes
+.. option:: AllowedTypes (added in 15.0.0)
 
    A semicolon-separated list of names of types allowed to be passed by value.
    Regular expressions are accepted, e.g. ``[Rr]ef(erence)?$`` matches every
@@ -75,7 +75,7 @@ Options
    matched against the qualified type name (i.e. ``namespace::Type``),
    otherwise it is matched against only the type name (i.e. ``Type``).
 
-.. option:: IgnoreCoroutines
+.. option:: IgnoreCoroutines (added in 21.1.0)
 
    A boolean specifying whether the check should suggest passing parameters by
    reference in coroutines. Passing parameters by reference in coroutines may

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/restrict-system-includes.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/restrict-system-includes.rst
@@ -43,7 +43,7 @@ headers.
 Options
 -------
 
-.. option:: Includes
+.. option:: Includes (added in 15.0.0)
 
    A string containing a comma separated glob list of allowed include
    filenames. Similar to the -checks glob list for running clang-tidy itself,

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/simd-intrinsics.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/simd-intrinsics.rst
@@ -35,13 +35,13 @@ library.
 Options
 -------
 
-.. option:: Suggest
+.. option:: Suggest (added in 15.0.0)
 
    If this option is set to `true` (default is `false`), the check will suggest
    `P0214`_ alternatives, otherwise it only points out the intrinsic function is
    non-portable.
 
-.. option:: Std
+.. option:: Std (added in 15.0.0)
 
    The namespace used to suggest `P0214`_ alternatives. If not specified, `std::`
    for `-std=c++20` and `std::experimental::` for `-std=c++11`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/ambiguous-smartptr-reset-call.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/ambiguous-smartptr-reset-call.rst
@@ -55,7 +55,7 @@ other smart pointers or other classes use the :option:`SmartPointers` option.
 Options
 -------
 
-.. option:: SmartPointers
+.. option:: SmartPointers (added in 21.1.0)
 
     Semicolon-separated list of fully qualified class names of custom smart
     pointers. Default value is `::std::unique_ptr;::std::shared_ptr;

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.rst
@@ -19,7 +19,7 @@ Examples:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 16.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-return-with-void-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-return-with-void-value.rst
@@ -38,12 +38,12 @@ is enabled.
 Options
 -------
 
-.. option::  IgnoreMacros
+.. option::  IgnoreMacros (added in 18.1.0)
 
   The value `false` specifies that return statements expanded
   from macros are not checked. The default value is `true`.
 
-.. option::  StrictMode
+.. option::  StrictMode (added in 18.1.0)
 
   The value `false` specifies that a direct return statement shall
   be excluded from the analysis if it is the only statement not

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/braces-around-statements.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/braces-around-statements.rst
@@ -27,7 +27,7 @@ After:
 Options
 -------
 
-.. option:: ShortStatementLines
+.. option:: ShortStatementLines (added in 15.0.0)
 
    Defines the minimal number of lines that the statement should have in order
    to trigger this check.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/const-return-type.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/const-return-type.rst
@@ -29,7 +29,7 @@ pointers or references to const values. For example, these are fine:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 16.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
@@ -15,7 +15,7 @@ access does not perform an errant memory access.
 Options
 -------
 
-.. option:: IgnoredContainers
+.. option:: IgnoredContainers (added in 17.0.1)
 
    Semicolon-separated list of containers regexp for which this check won't be
    enforced. Default is an empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
@@ -28,7 +28,7 @@ The check issues warning if a container has ``empty()`` and ``size()`` or
 Options
 -------
 
-.. option:: ExcludedComparisonTypes
+.. option:: ExcludedComparisonTypes (added in 17.0.1)
 
     A semicolon-separated list of class names for which the check will ignore
     comparisons of objects with default-constructed objects of the same type.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/else-after-return.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/else-after-return.rst
@@ -62,14 +62,14 @@ Would be transformed into:
 Options
 -------
 
-.. option:: WarnOnUnfixable
+.. option:: WarnOnUnfixable (added in 15.0.0)
 
    When `true`, emit a warning for cases where the check can't output a
    Fix-It. These can occur with declarations inside the ``else`` branch that
    would have an extended lifetime if the ``else`` branch was removed.
    Default value is `true`.
 
-.. option:: WarnOnConditionVariables
+.. option:: WarnOnConditionVariables (added in 15.0.0)
 
    When `true`, the check will attempt to refactor a variable defined inside
    the condition of the ``if`` statement that is used in the ``else`` branch

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/enum-initial-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/enum-initial-value.rst
@@ -59,7 +59,7 @@ This check corresponds to the CERT C Coding Standard recommendation `INT09-C. En
 Options
 -------
 
-.. option:: AllowExplicitZeroFirstInitialValue
+.. option:: AllowExplicitZeroFirstInitialValue (added in 19.1.0)
 
   If set to `false`, the first enumerator must not be explicitly initialized to
   a literal ``0``.
@@ -74,7 +74,7 @@ Options
     };
 
 
-.. option:: AllowExplicitSequentialInitialValues
+.. option:: AllowExplicitSequentialInitialValues (added in 19.1.0)
 
   If set to `false`, explicit initialization to sequential values are not
   allowed.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.rst
@@ -12,19 +12,19 @@ version 1.2 (19 April 2017).
 Options
 -------
 
-.. option:: Threshold
+.. option:: Threshold (added in 15.0.0)
 
    Flag functions with Cognitive Complexity exceeding this number.
    The default is `25`.
 
-.. option:: DescribeBasicIncrements
+.. option:: DescribeBasicIncrements (added in 15.0.0)
 
    If set to `true`, then for each function exceeding the complexity threshold
    the check will issue additional diagnostics on every piece of code (loop,
    `if` statement, etc.) which contributes to that complexity. See also the
    examples below. Default is `true`.
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will ignore code inside macros. Note, that also
    any macro arguments are ignored, even if they should count to the complexity.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.rst
@@ -10,41 +10,41 @@ Checks for large functions based on various metrics.
 Options
 -------
 
-.. option:: LineThreshold
+.. option:: LineThreshold (added in 15.0.0)
 
    Flag functions exceeding this number of lines. The default is `none` (ignore
    the number of lines).
 
-.. option:: StatementThreshold
+.. option:: StatementThreshold (added in 15.0.0)
 
    Flag functions exceeding this number of statements. This may differ
    significantly from the number of lines for macro-heavy code. The default is
    `800`.
 
-.. option:: BranchThreshold
+.. option:: BranchThreshold (added in 15.0.0)
 
    Flag functions exceeding this number of control statements. The default is
    `none` (ignore the number of branches).
 
-.. option:: ParameterThreshold
+.. option:: ParameterThreshold (added in 15.0.0)
 
    Flag functions that exceed a specified number of parameters. The default
    is `none` (ignore the number of parameters).
 
-.. option:: NestingThreshold
+.. option:: NestingThreshold (added in 15.0.0)
 
     Flag compound statements which create next nesting level after
     `NestingThreshold`. This may differ significantly from the expected value
     for macro-heavy code. The default is `none` (ignore the nesting level).
 
-.. option:: VariableThreshold
+.. option:: VariableThreshold (added in 15.0.0)
 
    Flag functions exceeding this number of variables declared in the body.
    The default is `none` (ignore the number of variables).
    Please note that function parameters and variables declared in lambdas,
    GNU Statement Expressions, and nested class inline functions are not counted.
 
-.. option:: CountMemberInitAsStmt
+.. option:: CountMemberInitAsStmt (added in 21.1.0)
 
    When `true`, count class member initializers in constructors as statements.
    Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.rst
@@ -18,7 +18,7 @@ The following options are described below:
  - :option:`MinimumLoopCounterNameLength`, :option:`IgnoredLoopCounterNames`
  - :option:`MinimumExceptionNameLength`, :option:`IgnoredExceptionVariableNames`
 
-.. option:: MinimumVariableNameLength
+.. option:: MinimumVariableNameLength (added in 15.0.0)
 
     All variables (other than loop counter, exception names and function
     parameters) are expected to have at least a length of
@@ -33,12 +33,12 @@ The following options are described below:
     This check does not have any fix suggestions in the general case since
     variable names have semantic value.
 
-.. option:: IgnoredVariableNames
+.. option:: IgnoredVariableNames (added in 15.0.0)
 
     Specifies a regular expression for variable names that are
     to be ignored. The default value is empty, thus no names are ignored.
 
-.. option:: MinimumParameterNameLength
+.. option:: MinimumParameterNameLength (added in 15.0.0)
 
     All function parameter names are expected to have a length of at least
     `MinimumParameterNameLength` (default is `3`). Setting it to `0` or `1`
@@ -55,12 +55,12 @@ The following options are described below:
     This check does not have any fix suggestions in the general case since
     variable names have semantic value.
 
-.. option:: IgnoredParameterNames
+.. option:: IgnoredParameterNames (added in 15.0.0)
 
     Specifies a regular expression for parameters that are to be ignored.
     The default value is `^[n]$` for historical reasons.
 
-.. option:: MinimumLoopCounterNameLength
+.. option:: MinimumLoopCounterNameLength (added in 15.0.0)
 
     Loop counter variables are expected to have a length of at least
     `MinimumLoopCounterNameLength` characters (default is `2`). Setting it to
@@ -74,7 +74,7 @@ The following options are described below:
          // ...
       }
 
-.. option:: IgnoredLoopCounterNames
+.. option:: IgnoredLoopCounterNames (added in 15.0.0)
 
     Specifies a regular expression for counter names that are to be ignored.
     The default value is `^[ijk_]$`; the first three symbols for historical
@@ -89,7 +89,7 @@ The following options are described below:
           // ...
       }
 
-.. option:: MinimumExceptionNameLength
+.. option:: MinimumExceptionNameLength (added in 15.0.0)
 
     Exception clause variables are expected to have a length of at least
     `MinimumExceptionNameLength` (default is `2`). Setting it to `0` or `1`
@@ -106,7 +106,7 @@ The following options are described below:
           // ...
       }
 
-.. option:: IgnoredExceptionVariableNames
+.. option:: IgnoredExceptionVariableNames (added in 15.0.0)
 
     Specifies a regular expression for exception variable names that are to
     be ignored. The default value is `^[e]$` mainly for historical reasons.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -116,27 +116,27 @@ Options description
 
 A detailed description of each option is presented below:
 
-.. option:: AbstractClassCase
+.. option:: AbstractClassCase (added in 15.0.0)
 
     When defined, the check will ensure abstract class names conform to the
     selected casing.
 
-.. option:: AbstractClassPrefix
+.. option:: AbstractClassPrefix (added in 15.0.0)
 
     When defined, the check will ensure abstract class names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: AbstractClassIgnoredRegexp
+.. option:: AbstractClassIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for abstract class names
     matching this regular expression.
 
-.. option:: AbstractClassSuffix
+.. option:: AbstractClassSuffix (added in 15.0.0)
 
     When defined, the check will ensure abstract class names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: AbstractClassHungarianPrefix
+.. option:: AbstractClassHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -169,7 +169,7 @@ After:
       pre_abstract_class_post();
     };
 
-.. option:: AggressiveDependentMemberLookup
+.. option:: AggressiveDependentMemberLookup (added in 15.0.0)
 
     When set to `true` the check will look in dependent base classes for dependent
     member references that need changing. This can lead to errors with template
@@ -227,7 +227,7 @@ After if AggressiveDependentMemberLookup is `true`:
       }
     };
 
-.. option:: CheckAnonFieldInParent
+.. option:: CheckAnonFieldInParent (added in 18.1.0)
 
     When set to `true`, fields in anonymous records (i.e. anonymous
     unions and structs) will be treated as names in the enclosing scope
@@ -253,27 +253,27 @@ that ``iv_`` and ``fv_`` are not coherent to public member names, because
 treated as private data members of ``Foo`` for the purpose of name checking
 and thus no warnings will be emitted.
 
-.. option:: ClassCase
+.. option:: ClassCase (added in 15.0.0)
 
     When defined, the check will ensure class names conform to the
     selected casing.
 
-.. option:: ClassPrefix
+.. option:: ClassPrefix (added in 15.0.0)
 
     When defined, the check will ensure class names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ClassIgnoredRegexp
+.. option:: ClassIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for class names matching
     this regular expression.
 
-.. option:: ClassSuffix
+.. option:: ClassSuffix (added in 15.0.0)
 
     When defined, the check will ensure class names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ClassHungarianPrefix
+.. option:: ClassHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -307,27 +307,27 @@ After:
       ~pre_foo_post();
     };
 
-.. option:: ClassConstantCase
+.. option:: ClassConstantCase (added in 15.0.0)
 
     When defined, the check will ensure class constant names conform to the
     selected casing.
 
-.. option:: ClassConstantPrefix
+.. option:: ClassConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure class constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ClassConstantIgnoredRegexp
+.. option:: ClassConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for class constant names
     matching this regular expression.
 
-.. option:: ClassConstantSuffix
+.. option:: ClassConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure class constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ClassConstantHungarianPrefix
+.. option:: ClassConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -359,27 +359,27 @@ After:
       static const int pre_class_constant_post;
     };
 
-.. option:: ClassMemberCase
+.. option:: ClassMemberCase (added in 15.0.0)
 
     When defined, the check will ensure class member names conform to the
     selected casing.
 
-.. option:: ClassMemberPrefix
+.. option:: ClassMemberPrefix (added in 15.0.0)
 
     When defined, the check will ensure class member names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ClassMemberIgnoredRegexp
+.. option:: ClassMemberIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for class member names
     matching this regular expression.
 
-.. option:: ClassMemberSuffix
+.. option:: ClassMemberSuffix (added in 15.0.0)
 
     When defined, the check will ensure class member names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ClassMemberHungarianPrefix
+.. option:: ClassMemberHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -411,22 +411,22 @@ After:
       static int pre_class_constant_post;
     };
 
-.. option:: ClassMethodCase
+.. option:: ClassMethodCase (added in 15.0.0)
 
     When defined, the check will ensure class method names conform to the
     selected casing.
 
-.. option:: ClassMethodPrefix
+.. option:: ClassMethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure class method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ClassMethodIgnoredRegexp
+.. option:: ClassMethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for class method names
     matching this regular expression.
 
-.. option:: ClassMethodSuffix
+.. option:: ClassMethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure class method names will add the
     suffix with the given value (regardless of casing).
@@ -457,22 +457,22 @@ After:
       int pre_class_member_post();
     };
 
-.. option:: ConceptCase
+.. option:: ConceptCase (added in 18.1.0)
 
     When defined, the check will ensure concept names conform to the
     selected casing.
 
-.. option:: ConceptPrefix
+.. option:: ConceptPrefix (added in 18.1.0)
 
     When defined, the check will ensure concept names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConceptIgnoredRegexp
+.. option:: ConceptIgnoredRegexp (added in 18.1.0)
 
     Identifier naming checks won't be enforced for concept names
     matching this regular expression.
 
-.. option:: ConceptSuffix
+.. option:: ConceptSuffix (added in 18.1.0)
 
     When defined, the check will ensure concept names will add the
     suffix with the given value (regardless of casing).
@@ -497,27 +497,27 @@ After:
 
     template<typename T> concept PreMyConceptPost = requires (T t) { {t++}; };
 
-.. option:: ConstantCase
+.. option:: ConstantCase (added in 15.0.0)
 
     When defined, the check will ensure constant names conform to the
     selected casing.
 
-.. option:: ConstantPrefix
+.. option:: ConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstantIgnoredRegexp
+.. option:: ConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constant names
     matching this regular expression.
 
-.. option:: ConstantSuffix
+.. option:: ConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ConstantHungarianPrefix
+.. option:: ConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -543,27 +543,27 @@ After:
 
     void function() { unsigned const pre_myconst_array_post[] = {1, 2, 3}; }
 
-.. option:: ConstantMemberCase
+.. option:: ConstantMemberCase (added in 15.0.0)
 
     When defined, the check will ensure constant member names conform to the
     selected casing.
 
-.. option:: ConstantMemberPrefix
+.. option:: ConstantMemberPrefix (added in 15.0.0)
 
     When defined, the check will ensure constant member names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstantMemberIgnoredRegexp
+.. option:: ConstantMemberIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constant member names
     matching this regular expression.
 
-.. option:: ConstantMemberSuffix
+.. option:: ConstantMemberSuffix (added in 15.0.0)
 
     When defined, the check will ensure constant member names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ConstantMemberHungarianPrefix
+.. option:: ConstantMemberHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -593,27 +593,27 @@ After:
       char const pre_my_constmember_string_post[4] = "123";
     }
 
-.. option:: ConstantParameterCase
+.. option:: ConstantParameterCase (added in 15.0.0)
 
     When defined, the check will ensure constant parameter names conform to the
     selected casing.
 
-.. option:: ConstantParameterPrefix
+.. option:: ConstantParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure constant parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstantParameterIgnoredRegexp
+.. option:: ConstantParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constant parameter names
     matching this regular expression.
 
-.. option:: ConstantParameterSuffix
+.. option:: ConstantParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure constant parameter names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ConstantParameterHungarianPrefix
+.. option:: ConstantParameterHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -639,27 +639,27 @@ After:
 
     void GLOBAL_FUNCTION(int PARAMETER_1, int const pre_const_parameter_post);
 
-.. option:: ConstantPointerParameterCase
+.. option:: ConstantPointerParameterCase (added in 15.0.0)
 
     When defined, the check will ensure constant pointer parameter names conform to the
     selected casing.
 
-.. option:: ConstantPointerParameterPrefix
+.. option:: ConstantPointerParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure constant pointer parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstantPointerParameterIgnoredRegexp
+.. option:: ConstantPointerParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constant pointer parameter
     names matching this regular expression.
 
-.. option:: ConstantPointerParameterSuffix
+.. option:: ConstantPointerParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure constant pointer parameter names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ConstantPointerParameterHungarianPrefix
+.. option:: ConstantPointerParameterHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -685,22 +685,22 @@ After:
 
     void GLOBAL_FUNCTION(int const *pre_const_parameter_post);
 
-.. option:: ConstexprFunctionCase
+.. option:: ConstexprFunctionCase (added in 15.0.0)
 
     When defined, the check will ensure constexpr function names conform to the
     selected casing.
 
-.. option:: ConstexprFunctionPrefix
+.. option:: ConstexprFunctionPrefix (added in 15.0.0)
 
     When defined, the check will ensure constexpr function names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstexprFunctionIgnoredRegexp
+.. option:: ConstexprFunctionIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constexpr function names
     matching this regular expression.
 
-.. option:: ConstexprFunctionSuffix
+.. option:: ConstexprFunctionSuffix (added in 15.0.0)
 
     When defined, the check will ensure constexpr function names will add the
     suffix with the given value (regardless of casing).
@@ -725,22 +725,22 @@ After:
 
     constexpr int pre_ce_function_post() { return 3; }
 
-.. option:: ConstexprMethodCase
+.. option:: ConstexprMethodCase (added in 15.0.0)
 
     When defined, the check will ensure constexpr method names conform to the
     selected casing.
 
-.. option:: ConstexprMethodPrefix
+.. option:: ConstexprMethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure constexpr method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstexprMethodIgnoredRegexp
+.. option:: ConstexprMethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constexpr method names
     matching this regular expression.
 
-.. option:: ConstexprMethodSuffix
+.. option:: ConstexprMethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure constexpr method names will add the
     suffix with the given value (regardless of casing).
@@ -771,27 +771,27 @@ After:
       constexpr int pre_cst_expr_method_post() { return 2; }
     }
 
-.. option:: ConstexprVariableCase
+.. option:: ConstexprVariableCase (added in 15.0.0)
 
     When defined, the check will ensure constexpr variable names conform to the
     selected casing.
 
-.. option:: ConstexprVariablePrefix
+.. option:: ConstexprVariablePrefix (added in 15.0.0)
 
     When defined, the check will ensure constexpr variable names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ConstexprVariableIgnoredRegexp
+.. option:: ConstexprVariableIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for constexpr variable names
     matching this regular expression.
 
-.. option:: ConstexprVariableSuffix
+.. option:: ConstexprVariableSuffix (added in 15.0.0)
 
     When defined, the check will ensure constexpr variable names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ConstexprVariableHungarianPrefix
+.. option:: ConstexprVariableHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -817,22 +817,22 @@ After:
 
     constexpr int pre_constexpr_variable_post = MyConstant;
 
-.. option:: EnumCase
+.. option:: EnumCase (added in 15.0.0)
 
     When defined, the check will ensure enumeration names conform to the
     selected casing.
 
-.. option:: EnumPrefix
+.. option:: EnumPrefix (added in 15.0.0)
 
     When defined, the check will ensure enumeration names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: EnumIgnoredRegexp
+.. option:: EnumIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for enumeration names
     matching this regular expression.
 
-.. option:: EnumSuffix
+.. option:: EnumSuffix (added in 15.0.0)
 
     When defined, the check will ensure enumeration names will add the
     suffix with the given value (regardless of casing).
@@ -857,27 +857,27 @@ After:
 
     enum pre_foo_post { One, Two, Three };
 
-.. option:: EnumConstantCase
+.. option:: EnumConstantCase (added in 15.0.0)
 
     When defined, the check will ensure enumeration constant names conform to the
     selected casing.
 
-.. option:: EnumConstantPrefix
+.. option:: EnumConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure enumeration constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: EnumConstantIgnoredRegexp
+.. option:: EnumConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for enumeration constant names
     matching this regular expression.
 
-.. option:: EnumConstantSuffix
+.. option:: EnumConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure enumeration constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: EnumConstantHungarianPrefix
+.. option:: EnumConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -903,22 +903,22 @@ After:
 
     enum FOO { pre_One_post, pre_Two_post, pre_Three_post };
 
-.. option:: FunctionCase
+.. option:: FunctionCase (added in 15.0.0)
 
     When defined, the check will ensure function names conform to the
     selected casing.
 
-.. option:: FunctionPrefix
+.. option:: FunctionPrefix (added in 15.0.0)
 
     When defined, the check will ensure function names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: FunctionIgnoredRegexp
+.. option:: FunctionIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for function names
     matching this regular expression.
 
-.. option:: FunctionSuffix
+.. option:: FunctionSuffix (added in 15.0.0)
 
     When defined, the check will ensure function names will add the
     suffix with the given value (regardless of casing).
@@ -943,34 +943,34 @@ After:
 
     char pre_my_function_string_post();
 
-.. option:: GetConfigPerFile
+.. option:: GetConfigPerFile (added in 15.0.0)
 
     When `true` the check will look for the configuration for where an
     identifier is declared. Useful for when included header files use a
     different style.
     Default value is `true`.
 
-.. option:: GlobalConstantCase
+.. option:: GlobalConstantCase (added in 15.0.0)
 
     When defined, the check will ensure global constant names conform to the
     selected casing.
 
-.. option:: GlobalConstantPrefix
+.. option:: GlobalConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure global constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: GlobalConstantIgnoredRegexp
+.. option:: GlobalConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for global constant names
     matching this regular expression.
 
-.. option:: GlobalConstantSuffix
+.. option:: GlobalConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure global constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: GlobalConstantHungarianPrefix
+.. option:: GlobalConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -996,27 +996,27 @@ After:
 
     unsigned const pre_myconstglobal_array_post[] = {1, 2, 3};
 
-.. option:: GlobalConstantPointerCase
+.. option:: GlobalConstantPointerCase (added in 15.0.0)
 
     When defined, the check will ensure global constant pointer names conform to the
     selected casing.
 
-.. option:: GlobalConstantPointerPrefix
+.. option:: GlobalConstantPointerPrefix (added in 15.0.0)
 
     When defined, the check will ensure global constant pointer names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: GlobalConstantPointerIgnoredRegexp
+.. option:: GlobalConstantPointerIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for global constant pointer
     names matching this regular expression.
 
-.. option:: GlobalConstantPointerSuffix
+.. option:: GlobalConstantPointerSuffix (added in 15.0.0)
 
     When defined, the check will ensure global constant pointer names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: GlobalConstantPointerHungarianPrefix
+.. option:: GlobalConstantPointerHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1042,22 +1042,22 @@ After:
 
     int *const pre_myconstantglobalpointer_post = nullptr;
 
-.. option:: GlobalFunctionCase
+.. option:: GlobalFunctionCase (added in 15.0.0)
 
     When defined, the check will ensure global function names conform to the
     selected casing.
 
-.. option:: GlobalFunctionPrefix
+.. option:: GlobalFunctionPrefix (added in 15.0.0)
 
     When defined, the check will ensure global function names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: GlobalFunctionIgnoredRegexp
+.. option:: GlobalFunctionIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for global function names
     matching this regular expression.
 
-.. option:: GlobalFunctionSuffix
+.. option:: GlobalFunctionSuffix (added in 15.0.0)
 
     When defined, the check will ensure global function names will add the
     suffix with the given value (regardless of casing).
@@ -1082,27 +1082,27 @@ After:
 
     void pre_global_function_post(int PARAMETER_1, int const CONST_parameter);
 
-.. option:: GlobalPointerCase
+.. option:: GlobalPointerCase (added in 15.0.0)
 
     When defined, the check will ensure global pointer names conform to the
     selected casing.
 
-.. option:: GlobalPointerPrefix
+.. option:: GlobalPointerPrefix (added in 15.0.0)
 
     When defined, the check will ensure global pointer names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: GlobalPointerIgnoredRegexp
+.. option:: GlobalPointerIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for global pointer names
     matching this regular expression.
 
-.. option:: GlobalPointerSuffix
+.. option:: GlobalPointerSuffix (added in 15.0.0)
 
     When defined, the check will ensure global pointer names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: GlobalPointerHungarianPrefix
+.. option:: GlobalPointerHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1128,27 +1128,27 @@ After:
 
     int *pre_global3_post;
 
-.. option:: GlobalVariableCase
+.. option:: GlobalVariableCase (added in 15.0.0)
 
     When defined, the check will ensure global variable names conform to the
     selected casing.
 
-.. option:: GlobalVariablePrefix
+.. option:: GlobalVariablePrefix (added in 15.0.0)
 
     When defined, the check will ensure global variable names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: GlobalVariableIgnoredRegexp
+.. option:: GlobalVariableIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for global variable names
     matching this regular expression.
 
-.. option:: GlobalVariableSuffix
+.. option:: GlobalVariableSuffix (added in 15.0.0)
 
     When defined, the check will ensure global variable names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: GlobalVariableHungarianPrefix
+.. option:: GlobalVariableHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1174,28 +1174,28 @@ After:
 
     int pre_global3_post;
 
-.. option:: IgnoreMainLikeFunctions
+.. option:: IgnoreMainLikeFunctions (added in 15.0.0)
 
     When set to `true` functions that have a similar signature to ``main`` or
     ``wmain`` won't enforce checks on the names of their parameters.
     Default value is `false`.
 
-.. option:: InlineNamespaceCase
+.. option:: InlineNamespaceCase (added in 15.0.0)
 
     When defined, the check will ensure inline namespaces names conform to the
     selected casing.
 
-.. option:: InlineNamespacePrefix
+.. option:: InlineNamespacePrefix (added in 15.0.0)
 
     When defined, the check will ensure inline namespaces names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: InlineNamespaceIgnoredRegexp
+.. option:: InlineNamespaceIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for inline namespaces names
     matching this regular expression.
 
-.. option:: InlineNamespaceSuffix
+.. option:: InlineNamespaceSuffix (added in 15.0.0)
 
     When defined, the check will ensure inline namespaces names will add the
     suffix with the given value (regardless of casing).
@@ -1228,27 +1228,27 @@ After:
     }
     } // namespace FOO_NS
 
-.. option:: LocalConstantCase
+.. option:: LocalConstantCase (added in 15.0.0)
 
     When defined, the check will ensure local constant names conform to the
     selected casing.
 
-.. option:: LocalConstantPrefix
+.. option:: LocalConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure local constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: LocalConstantIgnoredRegexp
+.. option:: LocalConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for local constant names
     matching this regular expression.
 
-.. option:: LocalConstantSuffix
+.. option:: LocalConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure local constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: LocalConstantHungarianPrefix
+.. option:: LocalConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1274,27 +1274,27 @@ After:
 
     void foo() { int const pre_local_constant_post = 3; }
 
-.. option:: LocalConstantPointerCase
+.. option:: LocalConstantPointerCase (added in 15.0.0)
 
     When defined, the check will ensure local constant pointer names conform to the
     selected casing.
 
-.. option:: LocalConstantPointerPrefix
+.. option:: LocalConstantPointerPrefix (added in 15.0.0)
 
     When defined, the check will ensure local constant pointer names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: LocalConstantPointerIgnoredRegexp
+.. option:: LocalConstantPointerIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for local constant pointer names
     matching this regular expression.
 
-.. option:: LocalConstantPointerSuffix
+.. option:: LocalConstantPointerSuffix (added in 15.0.0)
 
     When defined, the check will ensure local constant pointer names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: LocalConstantPointerHungarianPrefix
+.. option:: LocalConstantPointerHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1320,27 +1320,27 @@ After:
 
     void foo() { int const *pre_local_constant_post = 3; }
 
-.. option:: LocalPointerCase
+.. option:: LocalPointerCase (added in 15.0.0)
 
     When defined, the check will ensure local pointer names conform to the
     selected casing.
 
-.. option:: LocalPointerPrefix
+.. option:: LocalPointerPrefix (added in 15.0.0)
 
     When defined, the check will ensure local pointer names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: LocalPointerIgnoredRegexp
+.. option:: LocalPointerIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for local pointer names
     matching this regular expression.
 
-.. option:: LocalPointerSuffix
+.. option:: LocalPointerSuffix (added in 15.0.0)
 
     When defined, the check will ensure local pointer names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: LocalPointerHungarianPrefix
+.. option:: LocalPointerHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1366,17 +1366,17 @@ After:
 
     void foo() { int *pre_local_constant_post; }
 
-.. option:: LocalVariableCase
+.. option:: LocalVariableCase (added in 15.0.0)
 
     When defined, the check will ensure local variable names conform to the
     selected casing.
 
-.. option:: LocalVariablePrefix
+.. option:: LocalVariablePrefix (added in 15.0.0)
 
     When defined, the check will ensure local variable names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: LocalVariableIgnoredRegexp
+.. option:: LocalVariableIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for local variable names
     matching this regular expression.
@@ -1389,12 +1389,12 @@ For example using values of:
 Will exclude variables with a length less than or equal to 2 from the
 camel case check applied to other variables.
 
-.. option:: LocalVariableSuffix
+.. option:: LocalVariableSuffix (added in 15.0.0)
 
     When defined, the check will ensure local variable names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: LocalVariableHungarianPrefix
+.. option:: LocalVariableHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1420,22 +1420,22 @@ After:
 
     void foo() { int pre_local_constant_post; }
 
-.. option:: MacroDefinitionCase
+.. option:: MacroDefinitionCase (added in 15.0.0)
 
     When defined, the check will ensure macro definitions conform to the
     selected casing.
 
-.. option:: MacroDefinitionPrefix
+.. option:: MacroDefinitionPrefix (added in 15.0.0)
 
     When defined, the check will ensure macro definitions will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: MacroDefinitionIgnoredRegexp
+.. option:: MacroDefinitionIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for macro definitions
     matching this regular expression.
 
-.. option:: MacroDefinitionSuffix
+.. option:: MacroDefinitionSuffix (added in 15.0.0)
 
     When defined, the check will ensure macro definitions will add the
     suffix with the given value (regardless of casing).
@@ -1463,27 +1463,27 @@ After:
 Note: This will not warn on builtin macros or macros defined on the command line
 using the ``-D`` flag.
 
-.. option:: MemberCase
+.. option:: MemberCase (added in 15.0.0)
 
     When defined, the check will ensure member names conform to the
     selected casing.
 
-.. option:: MemberPrefix
+.. option:: MemberPrefix (added in 15.0.0)
 
     When defined, the check will ensure member names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: MemberIgnoredRegexp
+.. option:: MemberIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for member names
     matching this regular expression.
 
-.. option:: MemberSuffix
+.. option:: MemberSuffix (added in 15.0.0)
 
     When defined, the check will ensure member names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: MemberHungarianPrefix
+.. option:: MemberHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1513,22 +1513,22 @@ After:
       char pre_my_constmember_string_post[4];
     }
 
-.. option:: MethodCase
+.. option:: MethodCase (added in 15.0.0)
 
     When defined, the check will ensure method names conform to the
     selected casing.
 
-.. option:: MethodPrefix
+.. option:: MethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: MethodIgnoredRegexp
+.. option:: MethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for method names
     matching this regular expression.
 
-.. option:: MethodSuffix
+.. option:: MethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure method names will add the
     suffix with the given value (regardless of casing).
@@ -1557,22 +1557,22 @@ After:
       char pre_my_method_string_post();
     }
 
-.. option:: NamespaceCase
+.. option:: NamespaceCase (added in 15.0.0)
 
     When defined, the check will ensure namespace names conform to the
     selected casing.
 
-.. option:: NamespacePrefix
+.. option:: NamespacePrefix (added in 15.0.0)
 
     When defined, the check will ensure namespace names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: NamespaceIgnoredRegexp
+.. option:: NamespaceIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for namespace names
     matching this regular expression.
 
-.. option:: NamespaceSuffix
+.. option:: NamespaceSuffix (added in 15.0.0)
 
     When defined, the check will ensure namespace names will add the
     suffix with the given value (regardless of casing).
@@ -1601,27 +1601,27 @@ After:
     ...
     }
 
-.. option:: ParameterCase
+.. option:: ParameterCase (added in 15.0.0)
 
     When defined, the check will ensure parameter names conform to the
     selected casing.
 
-.. option:: ParameterPrefix
+.. option:: ParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ParameterIgnoredRegexp
+.. option:: ParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for parameter names
     matching this regular expression.
 
-.. option:: ParameterSuffix
+.. option:: ParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure parameter names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ParameterHungarianPrefix
+.. option:: ParameterHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1647,22 +1647,22 @@ After:
 
     void GLOBAL_FUNCTION(int pre_parameter_post, int const CONST_parameter);
 
-.. option:: ParameterPackCase
+.. option:: ParameterPackCase (added in 15.0.0)
 
     When defined, the check will ensure parameter pack names conform to the
     selected casing.
 
-.. option:: ParameterPackPrefix
+.. option:: ParameterPackPrefix (added in 15.0.0)
 
     When defined, the check will ensure parameter pack names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ParameterPackIgnoredRegexp
+.. option:: ParameterPackIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for parameter pack names
     matching this regular expression.
 
-.. option:: ParameterPackSuffix
+.. option:: ParameterPackSuffix (added in 15.0.0)
 
     When defined, the check will ensure parameter pack names will add the
     suffix with the given value (regardless of casing).
@@ -1691,27 +1691,27 @@ After:
       void FUNCTION(int... pre_type_parameters_post);
     }
 
-.. option:: PointerParameterCase
+.. option:: PointerParameterCase (added in 15.0.0)
 
     When defined, the check will ensure pointer parameter names conform to the
     selected casing.
 
-.. option:: PointerParameterPrefix
+.. option:: PointerParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure pointer parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: PointerParameterIgnoredRegexp
+.. option:: PointerParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for pointer parameter names
     matching this regular expression.
 
-.. option:: PointerParameterSuffix
+.. option:: PointerParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure pointer parameter names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: PointerParameterHungarianPrefix
+.. option:: PointerParameterHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1737,27 +1737,27 @@ After:
 
     void FUNCTION(int *pre_parameter_post);
 
-.. option:: PrivateMemberCase
+.. option:: PrivateMemberCase (added in 15.0.0)
 
     When defined, the check will ensure private member names conform to the
     selected casing.
 
-.. option:: PrivateMemberPrefix
+.. option:: PrivateMemberPrefix (added in 15.0.0)
 
     When defined, the check will ensure private member names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: PrivateMemberIgnoredRegexp
+.. option:: PrivateMemberIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for private member names
     matching this regular expression.
 
-.. option:: PrivateMemberSuffix
+.. option:: PrivateMemberSuffix (added in 15.0.0)
 
     When defined, the check will ensure private member names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: PrivateMemberHungarianPrefix
+.. option:: PrivateMemberHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1789,22 +1789,22 @@ After:
       int pre_member_variable_post;
     }
 
-.. option:: PrivateMethodCase
+.. option:: PrivateMethodCase (added in 15.0.0)
 
     When defined, the check will ensure private method names conform to the
     selected casing.
 
-.. option:: PrivateMethodPrefix
+.. option:: PrivateMethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure private method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: PrivateMethodIgnoredRegexp
+.. option:: PrivateMethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for private method names
     matching this regular expression.
 
-.. option:: PrivateMethodSuffix
+.. option:: PrivateMethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure private method names will add the
     suffix with the given value (regardless of casing).
@@ -1835,27 +1835,27 @@ After:
       int pre_member_method_post();
     }
 
-.. option:: ProtectedMemberCase
+.. option:: ProtectedMemberCase (added in 15.0.0)
 
     When defined, the check will ensure protected member names conform to the
     selected casing.
 
-.. option:: ProtectedMemberPrefix
+.. option:: ProtectedMemberPrefix (added in 15.0.0)
 
     When defined, the check will ensure protected member names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ProtectedMemberIgnoredRegexp
+.. option:: ProtectedMemberIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for protected member names
     matching this regular expression.
 
-.. option:: ProtectedMemberSuffix
+.. option:: ProtectedMemberSuffix (added in 15.0.0)
 
     When defined, the check will ensure protected member names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ProtectedMemberHungarianPrefix
+.. option:: ProtectedMemberHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1887,22 +1887,22 @@ After:
       int pre_member_variable_post;
     }
 
-.. option:: ProtectedMethodCase
+.. option:: ProtectedMethodCase (added in 15.0.0)
 
     When defined, the check will ensure protected method names conform to the
     selected casing.
 
-.. option:: ProtectedMethodPrefix
+.. option:: ProtectedMethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure protected method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ProtectedMethodIgnoredRegexp
+.. option:: ProtectedMethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for protected method names
     matching this regular expression.
 
-.. option:: ProtectedMethodSuffix
+.. option:: ProtectedMethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure protected method names will add the
     suffix with the given value (regardless of casing).
@@ -1933,27 +1933,27 @@ After:
       int pre_member_method_post();
     }
 
-.. option:: PublicMemberCase
+.. option:: PublicMemberCase (added in 15.0.0)
 
     When defined, the check will ensure public member names conform to the
     selected casing.
 
-.. option:: PublicMemberPrefix
+.. option:: PublicMemberPrefix (added in 15.0.0)
 
     When defined, the check will ensure public member names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: PublicMemberIgnoredRegexp
+.. option:: PublicMemberIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for public member names
     matching this regular expression.
 
-.. option:: PublicMemberSuffix
+.. option:: PublicMemberSuffix (added in 15.0.0)
 
     When defined, the check will ensure public member names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: PublicMemberHungarianPrefix
+.. option:: PublicMemberHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -1985,22 +1985,22 @@ After:
       int pre_member_variable_post;
     }
 
-.. option:: PublicMethodCase
+.. option:: PublicMethodCase (added in 15.0.0)
 
     When defined, the check will ensure public method names conform to the
     selected casing.
 
-.. option:: PublicMethodPrefix
+.. option:: PublicMethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure public method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: PublicMethodIgnoredRegexp
+.. option:: PublicMethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for public method names
     matching this regular expression.
 
-.. option:: PublicMethodSuffix
+.. option:: PublicMethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure public method names will add the
     suffix with the given value (regardless of casing).
@@ -2031,27 +2031,27 @@ After:
       int pre_member_method_post();
     }
 
-.. option:: ScopedEnumConstantCase
+.. option:: ScopedEnumConstantCase (added in 15.0.0)
 
     When defined, the check will ensure scoped enum constant names conform to
     the selected casing.
 
-.. option:: ScopedEnumConstantPrefix
+.. option:: ScopedEnumConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure scoped enum constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ScopedEnumConstantIgnoredRegexp
+.. option:: ScopedEnumConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for scoped enum constant names
     matching this regular expression.
 
-.. option:: ScopedEnumConstantSuffix
+.. option:: ScopedEnumConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure scoped enum constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: ScopedEnumConstantHungarianPrefix
+.. option:: ScopedEnumConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -2077,27 +2077,27 @@ After:
 
     enum class FOO { pre_One_post, pre_Two_post, pre_Three_post };
 
-.. option:: StaticConstantCase
+.. option:: StaticConstantCase (added in 15.0.0)
 
     When defined, the check will ensure static constant names conform to the
     selected casing.
 
-.. option:: StaticConstantPrefix
+.. option:: StaticConstantPrefix (added in 15.0.0)
 
     When defined, the check will ensure static constant names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: StaticConstantIgnoredRegexp
+.. option:: StaticConstantIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for static constant names
     matching this regular expression.
 
-.. option:: StaticConstantSuffix
+.. option:: StaticConstantSuffix (added in 15.0.0)
 
     When defined, the check will ensure static constant names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: StaticConstantHungarianPrefix
+.. option:: StaticConstantHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -2123,27 +2123,27 @@ After:
 
     static unsigned const pre_myconststatic_array_post[] = {1, 2, 3};
 
-.. option:: StaticVariableCase
+.. option:: StaticVariableCase (added in 15.0.0)
 
     When defined, the check will ensure static variable names conform to the
     selected casing.
 
-.. option:: StaticVariablePrefix
+.. option:: StaticVariablePrefix (added in 15.0.0)
 
     When defined, the check will ensure static variable names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: StaticVariableIgnoredRegexp
+.. option:: StaticVariableIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for static variable names
     matching this regular expression.
 
-.. option:: StaticVariableSuffix
+.. option:: StaticVariableSuffix (added in 15.0.0)
 
     When defined, the check will ensure static variable names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: StaticVariableHungarianPrefix
+.. option:: StaticVariableHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -2169,22 +2169,22 @@ After:
 
     static unsigned pre_mystatic_array_post[] = {1, 2, 3};
 
-.. option:: StructCase
+.. option:: StructCase (added in 15.0.0)
 
     When defined, the check will ensure struct names conform to the
     selected casing.
 
-.. option:: StructPrefix
+.. option:: StructPrefix (added in 15.0.0)
 
     When defined, the check will ensure struct names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: StructIgnoredRegexp
+.. option:: StructIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for struct names
     matching this regular expression.
 
-.. option:: StructSuffix
+.. option:: StructSuffix (added in 15.0.0)
 
     When defined, the check will ensure struct names will add the
     suffix with the given value (regardless of casing).
@@ -2215,22 +2215,22 @@ After:
       ~pre_foo_post();
     };
 
-.. option:: TemplateParameterCase
+.. option:: TemplateParameterCase (added in 15.0.0)
 
     When defined, the check will ensure template parameter names conform to the
     selected casing.
 
-.. option:: TemplateParameterPrefix
+.. option:: TemplateParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure template parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: TemplateParameterIgnoredRegexp
+.. option:: TemplateParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for template parameter names
     matching this regular expression.
 
-.. option:: TemplateParameterSuffix
+.. option:: TemplateParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure template parameter names will add the
     suffix with the given value (regardless of casing).
@@ -2255,22 +2255,22 @@ After:
 
     template <typename pre_t_post> class Foo {};
 
-.. option:: TemplateTemplateParameterCase
+.. option:: TemplateTemplateParameterCase (added in 15.0.0)
 
     When defined, the check will ensure template template parameter names conform to the
     selected casing.
 
-.. option:: TemplateTemplateParameterPrefix
+.. option:: TemplateTemplateParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure template template parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: TemplateTemplateParameterIgnoredRegexp
+.. option:: TemplateTemplateParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for template template parameter
     names matching this regular expression.
 
-.. option:: TemplateTemplateParameterSuffix
+.. option:: TemplateTemplateParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure template template parameter names will add the
     suffix with the given value (regardless of casing).
@@ -2297,22 +2297,22 @@ After:
     template <template <typename> class pre_tpl_parameter_post, int COUNT_params,
               typename... TYPE_parameters>
 
-.. option:: TypeAliasCase
+.. option:: TypeAliasCase (added in 15.0.0)
 
     When defined, the check will ensure type alias names conform to the
     selected casing.
 
-.. option:: TypeAliasPrefix
+.. option:: TypeAliasPrefix (added in 15.0.0)
 
     When defined, the check will ensure type alias names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: TypeAliasIgnoredRegexp
+.. option:: TypeAliasIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for type alias names
     matching this regular expression.
 
-.. option:: TypeAliasSuffix
+.. option:: TypeAliasSuffix (added in 15.0.0)
 
     When defined, the check will ensure type alias names will add the
     suffix with the given value (regardless of casing).
@@ -2337,22 +2337,22 @@ After:
 
     using pre_my_struct_type_post = my_structure;
 
-.. option:: TypedefCase
+.. option:: TypedefCase (added in 15.0.0)
 
     When defined, the check will ensure typedef names conform to the
     selected casing.
 
-.. option:: TypedefPrefix
+.. option:: TypedefPrefix (added in 15.0.0)
 
     When defined, the check will ensure typedef names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: TypedefIgnoredRegexp
+.. option:: TypedefIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for typedef names
     matching this regular expression.
 
-.. option:: TypedefSuffix
+.. option:: TypedefSuffix (added in 15.0.0)
 
     When defined, the check will ensure typedef names will add the
     suffix with the given value (regardless of casing).
@@ -2377,22 +2377,22 @@ After:
 
     typedef int pre_myint_post;
 
-.. option:: TypeTemplateParameterCase
+.. option:: TypeTemplateParameterCase (added in 15.0.0)
 
     When defined, the check will ensure type template parameter names conform to the
     selected casing.
 
-.. option:: TypeTemplateParameterPrefix
+.. option:: TypeTemplateParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure type template parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: TypeTemplateParameterIgnoredRegexp
+.. option:: TypeTemplateParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for type template names
     matching this regular expression.
 
-.. option:: TypeTemplateParameterSuffix
+.. option:: TypeTemplateParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure type template parameter names will add the
     suffix with the given value (regardless of casing).
@@ -2419,22 +2419,22 @@ After:
     template <template <typename> class TPL_parameter, int COUNT_params,
               typename... pre_type_parameters_post>
 
-.. option:: UnionCase
+.. option:: UnionCase (added in 15.0.0)
 
     When defined, the check will ensure union names conform to the
     selected casing.
 
-.. option:: UnionPrefix
+.. option:: UnionPrefix (added in 15.0.0)
 
     When defined, the check will ensure union names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: UnionIgnoredRegexp
+.. option:: UnionIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for union names
     matching this regular expression.
 
-.. option:: UnionSuffix
+.. option:: UnionSuffix (added in 15.0.0)
 
     When defined, the check will ensure union names will add the
     suffix with the given value (regardless of casing).
@@ -2465,22 +2465,22 @@ After:
       char b;
     };
 
-.. option:: ValueTemplateParameterCase
+.. option:: ValueTemplateParameterCase (added in 15.0.0)
 
     When defined, the check will ensure value template parameter names conform to the
     selected casing.
 
-.. option:: ValueTemplateParameterPrefix
+.. option:: ValueTemplateParameterPrefix (added in 15.0.0)
 
     When defined, the check will ensure value template parameter names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: ValueTemplateParameterIgnoredRegexp
+.. option:: ValueTemplateParameterIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for value template parameter
     names matching this regular expression.
 
-.. option:: ValueTemplateParameterSuffix
+.. option:: ValueTemplateParameterSuffix (added in 15.0.0)
 
     When defined, the check will ensure value template parameter names will add the
     suffix with the given value (regardless of casing).
@@ -2507,27 +2507,27 @@ After:
     template <template <typename> class TPL_parameter, int pre_count_params_post,
               typename... TYPE_parameters>
 
-.. option:: VariableCase
+.. option:: VariableCase (added in 15.0.0)
 
     When defined, the check will ensure variable names conform to the
     selected casing.
 
-.. option:: VariablePrefix
+.. option:: VariablePrefix (added in 15.0.0)
 
     When defined, the check will ensure variable names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: VariableIgnoredRegexp
+.. option:: VariableIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for variable names
     matching this regular expression.
 
-.. option:: VariableSuffix
+.. option:: VariableSuffix (added in 15.0.0)
 
     When defined, the check will ensure variable names will add the
     suffix with the given value (regardless of casing).
 
-.. option:: VariableHungarianPrefix
+.. option:: VariableHungarianPrefix (added in 15.0.0)
 
     When enabled, the check ensures that the declared identifier will
     have a Hungarian notation prefix based on the declared type.
@@ -2553,22 +2553,22 @@ After:
 
     unsigned pre_myvariable_post;
 
-.. option:: VirtualMethodCase
+.. option:: VirtualMethodCase (added in 15.0.0)
 
     When defined, the check will ensure virtual method names conform to the
     selected casing.
 
-.. option:: VirtualMethodPrefix
+.. option:: VirtualMethodPrefix (added in 15.0.0)
 
     When defined, the check will ensure virtual method names will add the
     prefixed with the given value (regardless of casing).
 
-.. option:: VirtualMethodIgnoredRegexp
+.. option:: VirtualMethodIgnoredRegexp (added in 15.0.0)
 
     Identifier naming checks won't be enforced for virtual method names
     matching this regular expression.
 
-.. option:: VirtualMethodSuffix
+.. option:: VirtualMethodSuffix (added in 15.0.0)
 
     When defined, the check will ensure virtual method names will add the
     suffix with the given value (regardless of casing).
@@ -2684,22 +2684,22 @@ Options for Hungarian Notation
 - :option:`HungarianNotation.PrimitiveType.*`
 - :option:`HungarianNotation.UserDefinedType.*`
 
-.. option:: HungarianNotation.General.TreatStructAsClass
+.. option:: HungarianNotation.General.TreatStructAsClass (added in 15.0.0)
 
     When defined, the check will treat naming of struct as a class.
     The default value is `false`.
 
-.. option:: HungarianNotation.DerivedType.Array
+.. option:: HungarianNotation.DerivedType.Array (added in 15.0.0)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `a`.
 
-.. option:: HungarianNotation.DerivedType.Pointer
+.. option:: HungarianNotation.DerivedType.Pointer (added in 15.0.0)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `p`.
 
-.. option:: HungarianNotation.DerivedType.FunctionPointer
+.. option:: HungarianNotation.DerivedType.FunctionPointer (added in 15.0.0)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `fn`.
@@ -2734,22 +2734,22 @@ After:
     FUNC_PTR fnFuncPtr = NULL;
 
 
-.. option:: HungarianNotation.CString.CharPointer
+.. option:: HungarianNotation.CString.CharPointer (added in 17.0.1)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `sz`.
 
-.. option:: HungarianNotation.CString.CharArray
+.. option:: HungarianNotation.CString.CharArray (added in 15.0.0)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `sz`.
 
-.. option:: HungarianNotation.CString.WideCharPointer
+.. option:: HungarianNotation.CString.WideCharPointer (added in 17.0.1)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `wsz`.
 
-.. option:: HungarianNotation.CString.WideCharArray
+.. option:: HungarianNotation.CString.WideCharArray (added in 15.0.0)
 
     When defined, the check will ensure variable name will add the prefix with
     the given string. The default prefix is `wsz`.
@@ -2788,13 +2788,13 @@ After:
     const wchar_t wszWideNameArray[] = L"Name";
 
 
-.. option:: HungarianNotation.PrimitiveType.*
+.. option:: HungarianNotation.PrimitiveType.* (added in 15.0.0)
 
     When defined, the check will ensure variable name of involved primitive
     types will add the prefix with the given string. The default prefixes are
     defined in the default mapping table.
 
-.. option:: HungarianNotation.UserDefinedType.*
+.. option:: HungarianNotation.UserDefinedType.* (added in 15.0.0)
 
     When defined, the check will ensure variable name of involved primitive
     types will add the prefix with the given string. The default prefixes are

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -124,17 +124,17 @@ are deliberately ignored, as it is not clear how to deal with such cases.
 Options
 -------
 
-.. option::  AllowIntegerConditions
+.. option::  AllowIntegerConditions (added in 15.0.0)
 
    When `true`, the check will allow conditional integer conversions. Default
    is `false`.
 
-.. option::  AllowPointerConditions
+.. option::  AllowPointerConditions (added in 15.0.0)
 
    When `true`, the check will allow conditional pointer conversions. Default
    is `false`.
 
-.. option::  UseUpperCaseLiteralSuffix
+.. option::  UseUpperCaseLiteralSuffix (added in 20.1.0)
 
    When `true`, the replacements will use an uppercase literal suffix in the
    provided fixes. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.rst
@@ -55,12 +55,12 @@ the definition or the first declaration seen in a translation unit.
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If this option is set to `true` (default is `true`), the check will not warn
    about names declared inside macros.
 
-.. option:: Strict
+.. option:: Strict (added in 15.0.0)
 
    If this option is set to `true` (default is `false`), then names must match
    exactly (or be absent).

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.rst
@@ -112,40 +112,40 @@ even if not present in the respective ignored values list.
 Options
 -------
 
-.. option:: IgnoredIntegerValues
+.. option:: IgnoredIntegerValues (added in 15.0.0)
 
    Semicolon-separated list of magic positive integers that will be accepted
    without a warning. Default values are `{1, 2, 3, 4}`, and `0` is accepted
    unconditionally.
 
-.. option:: IgnorePowersOf2IntegerValues
+.. option:: IgnorePowersOf2IntegerValues (added in 15.0.0)
 
    Boolean value indicating whether to accept all powers-of-two integer values
    without warning. Default value is `false`.
 
-.. option:: IgnoredFloatingPointValues
+.. option:: IgnoredFloatingPointValues (added in 15.0.0)
 
    Semicolon-separated list of magic positive floating point values that will
    be accepted without a warning. Default values are `{1.0, 100.0}` and `0.0`
    is accepted unconditionally.
 
-.. option:: IgnoreAllFloatingPointValues
+.. option:: IgnoreAllFloatingPointValues (added in 15.0.0)
 
    Boolean value indicating whether to accept all floating point values without
    warning. Default value is `false`.
 
-.. option:: IgnoreBitFieldsWidths
+.. option:: IgnoreBitFieldsWidths (added in 15.0.0)
 
    Boolean value indicating whether to accept magic numbers as bit field widths
    without warning. This is useful for example for register definitions which
    are generated from hardware specifications. Default value is `true`.
 
-.. option:: IgnoreTypeAliases
+.. option:: IgnoreTypeAliases (added in 17.0.1)
 
    Boolean value indicating whether to accept magic numbers in ``typedef`` or
    ``using`` declarations. Default value is `false`.
 
-.. option:: IgnoreUserDefinedLiterals
+.. option:: IgnoreUserDefinedLiterals (added in 17.0.1)
 
    Boolean value indicating whether to accept magic numbers in user-defined
    literals. Default value is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/named-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/named-parameter.rst
@@ -27,7 +27,7 @@ Corresponding cpplint.py check name: `readability/function`.
 Options
 -------
 
-.. option:: InsertPlainNamesInForwardDecls
+.. option:: InsertPlainNamesInForwardDecls (added in 21.1.0)
 
    If set to `true`, the check will insert parameter names without comments for
    forward declarations only. Otherwise, the check will insert parameter names

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/operators-representation.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/operators-representation.rst
@@ -73,13 +73,13 @@ Developers do not need to enforce all operators, and can mix the representations
 as desired by specifying a semicolon-separated list of both traditional and
 alternative tokens in the configuration, such as `and;||;not`.
 
-.. option:: BinaryOperators
+.. option:: BinaryOperators (added in 17.0.1)
 
     This option allows you to specify a semicolon-separated list of binary
     operators for which you want to enforce specific token representation.
     The default value is empty string.
 
-.. option:: OverloadedOperators
+.. option:: OverloadedOperators (added in 17.0.1)
 
     This option allows you to specify a semicolon-separated list of overloaded
     operators for which you want to enforce specific token representation.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/qualified-auto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/qualified-auto.rst
@@ -53,7 +53,7 @@ Would be transformed into:
 Options
 -------
 
-.. option:: AddConstToQualified
+.. option:: AddConstToQualified (added in 15.0.0)
 
    When set to `true` the check will add const qualifiers variables defined as
    ``auto *`` or ``auto &`` when applicable.
@@ -83,7 +83,7 @@ Otherwise it will be transformed into:
 
 Note in the LLVM alias, the default value is `false`.
 
-.. option:: AllowedTypes
+.. option:: AllowedTypes (added in 21.1.0)
 
   A semicolon-separated list of names of types to ignore when ``auto`` is
   deduced to that type or a pointer to that type. Note that this distinguishes

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-access-specifiers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-access-specifiers.rst
@@ -29,7 +29,7 @@ any changes of behavior.
 Options
 -------
 
-.. option:: CheckFirstDeclaration
+.. option:: CheckFirstDeclaration (added in 15.0.0)
 
    If set to `true`, the check will also diagnose if the first access
    specifier declaration is redundant (e.g. ``private`` inside ``class``,

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-casting.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-casting.rst
@@ -25,12 +25,12 @@ directly from lvalue to rvalue, are all disregarded by the check.
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 18.1.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.
 
-.. option:: IgnoreTypeAliases
+.. option:: IgnoreTypeAliases (added in 18.1.0)
 
    When set to `false`, the check will consider type aliases, and when set to
    `true`, it will resolve all type aliases and operate on the underlying

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-declaration.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-declaration.rst
@@ -31,7 +31,7 @@ manually:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.rst
@@ -26,7 +26,7 @@ defined entirely inside a class/struct/union definition are implicitly inlined.
 Options
 -------
 
-.. option:: StrictMode
+.. option:: StrictMode (added in 18.1.0)
 
    If set to `true`, the check will also flag functions and variables that
    already have internal linkage as redundant. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-member-init.rst
@@ -24,7 +24,7 @@ Example
 Options
 -------
 
-.. option:: IgnoreBaseInCopyConstructors
+.. option:: IgnoreBaseInCopyConstructors (added in 15.0.0)
 
     Default is `false`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.rst
@@ -17,7 +17,7 @@ Examples:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If this option is set to `true` (default is `true`), the check will not warn
    about calls inside macros.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.rst
@@ -9,7 +9,7 @@ Finds unnecessary calls to ``std::string::c_str()`` and ``std::string::data()``.
 Options
 -------
 
-.. option:: StringParameterFunctions
+.. option:: StringParameterFunctions (added in 17.0.1)
 
    A semicolon-separated list of (fully qualified) function/method/operator
    names, with the requirement that any parameter currently accepting a

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-init.rst
@@ -31,7 +31,7 @@ Examples
 Options
 -------
 
-.. option:: StringNames
+.. option:: StringNames (added in 15.0.0)
 
     Default is `::std::basic_string;::std::basic_string_view`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
@@ -82,27 +82,27 @@ Examples:
 Options
 -------
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 18.1.0)
 
    If `true`, ignore boolean expressions originating from expanded macros.
    Default is `false`.
 
-.. option:: ChainedConditionalReturn
+.. option:: ChainedConditionalReturn (added in 15.0.0)
 
    If `true`, conditional boolean return statements at the end of an
    ``if/else if`` chain will be transformed. Default is `false`.
 
-.. option:: ChainedConditionalAssignment
+.. option:: ChainedConditionalAssignment (added in 15.0.0)
 
    If `true`, conditional boolean assignments at the end of an ``if/else
    if`` chain will be transformed. Default is `false`.
 
-.. option:: SimplifyDeMorgan
+.. option:: SimplifyDeMorgan (added in 15.0.0)
 
    If `true`, DeMorgan's Theorem will be applied to simplify negated
    conjunctions and disjunctions.  Default is `true`.
 
-.. option:: SimplifyDeMorganRelaxed
+.. option:: SimplifyDeMorganRelaxed (added in 15.0.0)
 
    If `true`, :option:`SimplifyDeMorgan` will also transform negated
    conjunctions and disjunctions where there is no negation on either operand.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-subscript-expr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-subscript-expr.rst
@@ -17,7 +17,7 @@ Examples:
 Options
 -------
 
-.. option:: Types
+.. option:: Types (added in 15.0.0)
 
    The list of type(s) that triggers this check. Default is
    `::std::basic_string;::std::basic_string_view;::std::vector;::std::array;::std::span`

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/string-compare.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/string-compare.rst
@@ -58,7 +58,7 @@ inequality of two strings instead of using the correct operators.
 Options
 -------
 
-.. option:: StringLikeClasses
+.. option:: StringLikeClasses (added in 19.1.0)
 
    A string containing semicolon-separated names of string-like classes.
    By default contains only ``::std::basic_string``

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/suspicious-call-argument.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/suspicious-call-argument.rst
@@ -144,7 +144,7 @@ This heuristic is case-insensitive.
 Options
 -------
 
-.. option:: MinimumIdentifierNameLength
+.. option:: MinimumIdentifierNameLength (added in 15.0.0)
 
     Sets the minimum required length the argument and parameter names
     need to have. Names shorter than this length will be ignored.
@@ -152,7 +152,7 @@ Options
 
 .. _opt_Abbreviations:
 
-.. option:: Abbreviations
+.. option:: Abbreviations (added in 15.0.0)
 
     For the **Abbreviation** heuristic
     (:ref:`see here<abbreviation_heuristic>`), this option configures the
@@ -198,7 +198,7 @@ constructed dynamically.
 In the following, `<HeuristicName>` refers to one of the keys from the
 heuristics implemented.
 
-.. option:: <HeuristicName>
+.. option:: <HeuristicName> (added in 15.0.0)
 
     `True` or `False`, whether a particular heuristic, such as `Equality` or
     `Levenshtein` is enabled.
@@ -207,7 +207,7 @@ heuristics implemented.
 
 .. _opt_Bounds:
 
-.. option:: <HeuristicName>DissimilarBelow, <HeuristicName>SimilarAbove
+.. option:: <HeuristicName>DissimilarBelow, <HeuristicName>SimilarAbove (added in 15.0.0)
 
     A value between `0` and `100`, expressing a percentage.
     The bounds set what percentage of similarity the heuristic must deduce

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/uniqueptr-delete-release.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/uniqueptr-delete-release.rst
@@ -19,7 +19,7 @@ The latter is shorter, simpler and does not require use of raw pointer APIs.
 Options
 -------
 
-.. option:: PreferResetCall
+.. option:: PreferResetCall (added in 15.0.0)
 
   If `true`, refactor by calling the reset member function instead of
   assigning to ``nullptr``. Default value is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/uppercase-literal-suffix.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/uppercase-literal-suffix.rst
@@ -28,7 +28,7 @@ All valid combinations of suffixes are supported.
 Options
 -------
 
-.. option:: NewSuffixes
+.. option:: NewSuffixes (added in 15.0.0)
 
   Optionally, a list of the destination suffixes can be provided. When the
   suffix is found, a case-insensitive lookup in that list is made, and if a
@@ -50,7 +50,7 @@ Given a list `L;uL`:
 * ``ull`` will be kept as is, since it is not in the list
 * and so on.
 
-.. option:: IgnoreMacros
+.. option:: IgnoreMacros (added in 15.0.0)
 
    If this option is set to `true` (default is `true`), the check will not warn
    about literal suffixes inside macros.


### PR DESCRIPTION
As discussed on [discourse](https://discourse.llvm.org/t/improve-clang-tidy-documentation/88305), I have been working on adding the first version for which each clang-tidy checks and their options are available in the documentation.

I have made a Python script (not included in that PR) to track down the available checks/options for each LLVM releases (using the GitHub API to accurately gather/download the releases and then building them from sources).

The draft includes a lot of changes but since those changes were automatically generated by the script, they can easily be tuned if you think they should.

Here is a small summary of the modifications I have made:

- I added, for each clang-tidy check, the first version for which it was available (see `clang-tools-extra/docs/clang-tidy/checks/list.rst` file).
- I added, for each clang-tidy check option, the first version for which it was available (see every files in `clang-tools-extra/docs/clang-tidy/checks` subfolders).
- I added, for practical reasons (most people using the online documentation are using older versions of clang-tidy), the first version from which clang-tidy checks were removed, clearly indicating (strike-through) that they are no longer available. I had to modify `clang-tools-extra/docs/_static/clang-tools-extra-styles.css` file and add the following *code* to `clang-tools-extra/docs/clang-tidy/checks/list.rst` file to allow me to use strike-through:
```rst
.. role:: strike
   :class: strike
```

As I was working on this PR, few questions came to my mind:

1. Should I include the Python script I have made to generate those changes in this PR? Or maybe just share it with Gist? This would allow you to verify it to make sure the information I added is correct. I am not sure this script will ever be useful in the future as long as we make sure every newly added/removed check/option includes those information so maybe there is no need to add it in the code base.
2. I have also added information about removal of checks/options, which was not planned at first but since most users are not using the clang-tidy version corresponding to the online documentation, I believe this could be a nice add. Are you ok with that? Regarding the way to display it, I could make a separate category that would only contain the removed checks if you think this is better this way (for now, they are listed among the available checks, with strike-through and displaying the version on which it was removed).
3. In order to track down these pieces of information, I have built every clang-tidy/clang-tools-extra releases since 7.1.0 from sources. From what I have seen, people can contribute to those public releases and share their builds to make them available for everyone. I was wondering if there was a specific procedure to follow to submit my builds. If so, could you please tell me what steps to take?

I am not sure whether I should mention people (and who) for this draft PR but since you have been following this project on that Discourse discussion, I will invoke you @vbvictor! :p