### PR TITLE
[lldb] Configure pyright to the documented minimum python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ extend-exclude = '''
   third-party/
 )
 '''
+
+[tool.pyright]
+pythonVersion = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,6 @@ extend-exclude = '''
 '''
 
 [tool.pyright]
-pythonVersion = "3.8"
+executionEnvironments = [
+  { root = "lldb/packages/Python", pythonVersion = "3.8" }
+]


### PR DESCRIPTION
Pyright is an MIT-licensed static type checker and can be found at
    https://github.com/microsoft/pyright
there are also various integrations to use it as an LSP server in various editors which is the main way I use it.

It's useful on our python scripts to detect issues such as where functions are called with unexpected types or it's possible to access obj.attr on an object that doesn't have that attribute. It can be used without any configuration this config setting causes it to also report issues with type hints that do not meet our python 3.8 minimum such as this one from dap_server.py:
```
        init_commands: list[str],
```
subscripting the builtin type like that requires python 3.9 while the 3.8 equivalent is:
```
from typing import List
...
        init_commands: List[str],
```
In practice these scripts still work on 3.8 because type hints aren't normally evaluated during normal execution but since we have a minimum, we should fully comply with it.

Note: The error pyright reports for this particular issue isn't great:
```
error: Subscript for class "list" will generate runtime exception; enclose type expression in quotes
```
This is technically correct as it is possible to evaluate type hints at runtime but I believe anything that would do so would also evaluate the string form as well and still hit the runtime exception. A better suggestion in this case would have been the 3.8 compatible `List[str]`. However, it is better than silently passing code that doesn't confirm to the minimum.