### PR TITLE
[Flang][OpenMP] Increase detection capability for requires usm (and others)

### DIFF
--- a/flang/test/Lower/OpenMP/requires-usm.f90
+++ b/flang/test/Lower/OpenMP/requires-usm.f90
@@ -1,0 +1,22 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s
+! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -fopenmp -fopenmp-is-target-device -emit-hlfir %s -o - | FileCheck %s
+
+! Verify that we pick up USM and apply it correctly when it is specified
+! outside of the program.
+
+!CHECK:      module attributes {
+!CHECK-SAME: omp.requires = #omp<clause_requires unified_shared_memory>
+module declare_mod
+    implicit none
+!$omp requires unified_shared_memory
+ contains
+end module
+
+program main
+ use declare_mod
+ implicit none
+!$omp target
+!$omp end target
+end program


### PR DESCRIPTION
Currently, the compiler only picks up some cases where requires is designated such as in the main program. However, it'll gloss over cases such as when it is specified by a user in a module, that's then used elsewhere.

This patch attempts to amend that by searching the varying scopes in the current program module more comprehensively.