### PR TITLE
[MLIR][NFC] Clean up rewrite CAPI implementation and Python bindings

### DIFF
--- a/mlir/include/mlir/CAPI/Rewrite.h
+++ b/mlir/include/mlir/CAPI/Rewrite.h
@@ -31,6 +31,6 @@ DEFINE_C_API_PTR_METHODS(MlirPatternRewriter, mlir::PatternRewriter)
 DEFINE_C_API_PTR_METHODS(MlirPDLPatternModule, mlir::PDLPatternModule)
 DEFINE_C_API_PTR_METHODS(MlirPDLResultList, mlir::PDLResultList)
 DEFINE_C_API_PTR_METHODS(MlirPDLValue, const mlir::PDLValue)
-#endif
+#endif // MLIR_ENABLE_PDL_IN_PATTERNMATCH
 
 #endif // MLIR_CAPIREWRITER_H

--- a/mlir/include/mlir/CAPI/Rewrite.h
+++ b/mlir/include/mlir/CAPI/Rewrite.h
@@ -18,9 +18,19 @@
 #include "mlir-c/Rewrite.h"
 #include "mlir/CAPI/Wrap.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
 
 DEFINE_C_API_PTR_METHODS(MlirRewriterBase, mlir::RewriterBase)
 DEFINE_C_API_PTR_METHODS(MlirRewritePattern, const mlir::RewritePattern)
 DEFINE_C_API_PTR_METHODS(MlirRewritePatternSet, mlir::RewritePatternSet)
+DEFINE_C_API_PTR_METHODS(MlirFrozenRewritePatternSet,
+                         mlir::FrozenRewritePatternSet)
+DEFINE_C_API_PTR_METHODS(MlirPatternRewriter, mlir::PatternRewriter)
+
+#if MLIR_ENABLE_PDL_IN_PATTERNMATCH
+DEFINE_C_API_PTR_METHODS(MlirPDLPatternModule, mlir::PDLPatternModule)
+DEFINE_C_API_PTR_METHODS(MlirPDLResultList, mlir::PDLResultList)
+DEFINE_C_API_PTR_METHODS(MlirPDLValue, const mlir::PDLValue)
+#endif
 
 #endif // MLIR_CAPIREWRITER_H

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -261,7 +261,6 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
   //----------------------------------------------------------------------------
   // Mapping of the RewritePatternSet
   //----------------------------------------------------------------------------
-  nb::class_<MlirRewritePattern>(m, "RewritePattern");
   nb::class_<PyRewritePatternSet>(m, "RewritePatternSet")
       .def(
           "__init__",

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -270,17 +270,6 @@ void mlirIRRewriterDestroy(MlirRewriterBase rewriter) {
 /// RewritePatternSet and FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 
-static inline mlir::FrozenRewritePatternSet *
-unwrap(MlirFrozenRewritePatternSet module) {
-  assert(module.ptr && "unexpected null module");
-  return static_cast<mlir::FrozenRewritePatternSet *>(module.ptr);
-}
-
-static inline MlirFrozenRewritePatternSet
-wrap(mlir::FrozenRewritePatternSet *module) {
-  return {module};
-}
-
 MlirFrozenRewritePatternSet
 mlirFreezeRewritePattern(MlirRewritePatternSet set) {
   auto *m = new mlir::FrozenRewritePatternSet(std::move(*unwrap(set)));
@@ -310,15 +299,6 @@ mlirApplyPatternsAndFoldGreedilyWithOp(MlirOperation op,
 //===----------------------------------------------------------------------===//
 /// PatternRewriter API
 //===----------------------------------------------------------------------===//
-
-inline mlir::PatternRewriter *unwrap(MlirPatternRewriter rewriter) {
-  assert(rewriter.ptr && "unexpected null rewriter");
-  return static_cast<mlir::PatternRewriter *>(rewriter.ptr);
-}
-
-inline MlirPatternRewriter wrap(mlir::PatternRewriter *rewriter) {
-  return {rewriter};
-}
 
 MlirRewriterBase mlirPatternRewriterAsBase(MlirPatternRewriter rewriter) {
   return wrap(static_cast<mlir::RewriterBase *>(unwrap(rewriter)));
@@ -400,15 +380,6 @@ void mlirRewritePatternSetAdd(MlirRewritePatternSet set,
 //===----------------------------------------------------------------------===//
 
 #if MLIR_ENABLE_PDL_IN_PATTERNMATCH
-static inline mlir::PDLPatternModule *unwrap(MlirPDLPatternModule module) {
-  assert(module.ptr && "unexpected null module");
-  return static_cast<mlir::PDLPatternModule *>(module.ptr);
-}
-
-static inline MlirPDLPatternModule wrap(mlir::PDLPatternModule *module) {
-  return {module};
-}
-
 MlirPDLPatternModule mlirPDLPatternModuleFromModule(MlirModule op) {
   return wrap(new mlir::PDLPatternModule(
       mlir::OwningOpRef<mlir::ModuleOp>(unwrap(op))));
@@ -424,22 +395,6 @@ mlirRewritePatternSetFromPDLPatternModule(MlirPDLPatternModule op) {
   auto *m = new mlir::RewritePatternSet(std::move(*unwrap(op)));
   op.ptr = nullptr;
   return wrap(m);
-}
-
-inline const mlir::PDLValue *unwrap(MlirPDLValue value) {
-  assert(value.ptr && "unexpected null PDL value");
-  return static_cast<const mlir::PDLValue *>(value.ptr);
-}
-
-inline MlirPDLValue wrap(const mlir::PDLValue *value) { return {value}; }
-
-inline mlir::PDLResultList *unwrap(MlirPDLResultList results) {
-  assert(results.ptr && "unexpected null PDL results");
-  return static_cast<mlir::PDLResultList *>(results.ptr);
-}
-
-inline MlirPDLResultList wrap(mlir::PDLResultList *results) {
-  return {results};
 }
 
 MlirValue mlirPDLValueAsValue(MlirPDLValue value) {


### PR DESCRIPTION
This is a follow-up PR of #162699.

In this PR we clean CAPI and Python bindings of MLIR rewrite part by:
- remove all manually-defined `wrap`/`unwrap` functions;
- remove useless nanobind-defined Python class `RewritePattern`.