### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Ignore a lambda which gets called immediately

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -344,11 +344,12 @@ public:
         if (!Callee)
           return;
         Callee = Callee->IgnoreParenCasts();
-        if (auto *MTE = dyn_cast<MaterializeTemporaryExpr>(Callee))
+        if (auto *MTE = dyn_cast<MaterializeTemporaryExpr>(Callee)) {
           Callee = MTE->getSubExpr();
-        if (!Callee)
-          return;
-        Callee = Callee->IgnoreParenCasts();
+          if (!Callee)
+            return;
+          Callee = Callee->IgnoreParenCasts();
+        }
         if (auto *L = dyn_cast<LambdaExpr>(Callee)) {
           LambdasToIgnore.insert(L); // Calling a lambda upon creation is safe.
           return;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -343,6 +343,16 @@ public:
         auto *Callee = CE->getCallee();
         if (!Callee)
           return;
+        Callee = Callee->IgnoreParenCasts();
+        if (auto *MTE = dyn_cast<MaterializeTemporaryExpr>(Callee))
+          Callee = MTE->getSubExpr();
+        if (!Callee)
+          return;
+        Callee = Callee->IgnoreParenCasts();
+        if (auto *L = dyn_cast<LambdaExpr>(Callee)) {
+          LambdasToIgnore.insert(L); // Calling a lambda upon creation is safe.
+          return;
+        }
         auto *DRE = dyn_cast<DeclRefExpr>(Callee->IgnoreParenCasts());
         if (!DRE)
           return;

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -520,6 +520,23 @@ void capture_copy_in_lambda(CheckedObj& checked) {
   });
 }
 
+struct TemplateFunctionCallsLambda {
+  void ref() const;
+  void deref() const;
+
+  RefCountable* obj();
+
+  template <typename T>
+  RefPtr<T> method(T* t) {
+    auto ret = ([&]() -> RefPtr<T> {
+      if constexpr (T::isEncodable)
+        return t;
+      return obj() ? t : nullptr;
+    })();
+    return ret;
+  }
+};
+
 class Iterator {
 public:
   Iterator(void* array, unsigned long sizeOfElement, unsigned int index);


### PR DESCRIPTION
Recognize more ways in which a lambda can be declared and called immediately.