### PR TITLE
[ORC] Enable hashing of [NonOwning]SymbolStringPtr objects.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
@@ -14,6 +14,7 @@
 #define LLVM_EXECUTIONENGINE_ORC_SYMBOLSTRINGPOOL_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Compiler.h"
 #include <atomic>
@@ -71,6 +72,7 @@ private:
 /// from nullptr to enable comparison with these values.
 class SymbolStringPtrBase {
   friend class SymbolStringPool;
+  friend class SymbolStringPoolEntryUnsafe;
   friend struct DenseMapInfo<SymbolStringPtr>;
   friend struct DenseMapInfo<NonOwningSymbolStringPtr>;
 
@@ -204,7 +206,7 @@ public:
   SymbolStringPoolEntryUnsafe(PoolEntry *E) : E(E) {}
 
   /// Create an unsafe pool entry ref without changing the ref-count.
-  static SymbolStringPoolEntryUnsafe from(const SymbolStringPtr &S) {
+  static SymbolStringPoolEntryUnsafe from(const SymbolStringPtrBase &S) {
     return S.S;
   }
 
@@ -317,6 +319,10 @@ SymbolStringPool::getRefCount(const SymbolStringPtrBase &S) const {
 
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                                  const SymbolStringPtrBase &Sym);
+
+inline hash_code hash_value(const orc::SymbolStringPtrBase &S) {
+  return hash_value(orc::SymbolStringPoolEntryUnsafe::from(S).rawPtr());
+}
 
 } // end namespace orc
 

--- a/llvm/unittests/ExecutionEngine/Orc/SymbolStringPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SymbolStringPoolTest.cpp
@@ -180,4 +180,14 @@ TEST_F(SymbolStringPoolTest, SymbolStringPoolEntryUnsafe) {
   EXPECT_EQ(getRefCount(A), 1U);
 }
 
+TEST_F(SymbolStringPoolTest, Hashing) {
+  auto A = SP.intern("a");
+  auto B = NonOwningSymbolStringPtr(A);
+
+  hash_code AHash = hash_value(A);
+  hash_code BHash = hash_value(B);
+
+  EXPECT_EQ(AHash, BHash);
+}
+
 } // namespace


### PR DESCRIPTION
This will be used by an upcoming patch to hash collections of SymbolStringPtrs.