### PR TITLE
[lldb][test] Fix language note tests on Windows

### DIFF
--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -218,11 +218,11 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
             # Detail 1/3: note: requested expression language
             diag = details.GetItemAtIndex(0)
             self.assertEqual(str(diag.GetValueForKey("severity")), "note")
-            self.assertEqual(
-                str(diag.GetValueForKey("message")), "Ran expression as 'C++11'."
+            self.assertIn(
+                "Ran expression as 'C++", str(diag.GetValueForKey("message"))
             )
-            self.assertEqual(
-                str(diag.GetValueForKey("rendered")), "Ran expression as 'C++11'."
+            self.assertIn(
+                "Ran expression as 'C++", str(diag.GetValueForKey("rendered"))
             )
             self.assertEqual(str(diag.GetValueForKey("source_location")), "")
             self.assertEqual(str(diag.GetValueForKey("file")), "")

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -218,9 +218,7 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
             # Detail 1/3: note: requested expression language
             diag = details.GetItemAtIndex(0)
             self.assertEqual(str(diag.GetValueForKey("severity")), "note")
-            self.assertIn(
-                "Ran expression as 'C++", str(diag.GetValueForKey("message"))
-            )
+            self.assertIn("Ran expression as 'C++", str(diag.GetValueForKey("message")))
             self.assertIn(
                 "Ran expression as 'C++", str(diag.GetValueForKey("rendered"))
             )

--- a/lldb/test/Shell/Expr/TestExprLanguageNote.test
+++ b/lldb/test/Shell/Expr/TestExprLanguageNote.test
@@ -26,7 +26,7 @@ run
 expr blah
 
 # CHECK-TARGET: (lldb) expr
-# CHECK-TARGET: note: Ran expression as 'C++14'.
+# CHECK-TARGET: note: Ran expression as 'C++{{.*}}'
 
 expr -l objc -- blah
 


### PR DESCRIPTION
The LLDB test-suite compiles the tests on Windows with 'C++14' by default:
https://github.com/llvm/llvm-project/blob/3bfb5b0e7ccbcb9f127f5b9c958e6499ba9c0523/lldb/packages/Python/lldbsuite/test/make/Makefile.rules#L357-L360

This fixes Windows buildbot failures.