### PR TITLE
[clang][MinGW] Always link ntdll.dll

### DIFF
--- a/clang/lib/Driver/ToolChains/MinGW.cpp
+++ b/clang/lib/Driver/ToolChains/MinGW.cpp
@@ -359,14 +359,17 @@ void tools::MinGW::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-lshell32");
         CmdArgs.push_back("-luser32");
         CmdArgs.push_back("-lkernel32");
+        CmdArgs.push_back("-lntdll");
       }
 
       if (Args.hasArg(options::OPT_static)) {
         CmdArgs.push_back("--end-group");
       } else {
         AddLibGCC(Args, CmdArgs);
-        if (!HasWindowsApp)
+        if (!HasWindowsApp) {
           CmdArgs.push_back("-lkernel32");
+          CmdArgs.push_back("-lntdll");
+        }
       }
     }
 

--- a/clang/test/Driver/mingw-windowsapp.c
+++ b/clang/test/Driver/mingw-windowsapp.c
@@ -1,6 +1,6 @@
 // RUN: %clang -v --target=i686-pc-windows-gnu -### %s 2>&1 | FileCheck -check-prefix=CHECK_DEFAULT %s
 // RUN: %clang -v --target=i686-pc-windows-gnu -### %s -lwindowsapp 2>&1 | FileCheck -check-prefix=CHECK_WINDOWSAPP %s
 
-// CHECK_DEFAULT: "-lmsvcrt" "-ladvapi32" "-lshell32" "-luser32" "-lkernel32" "-lmingw32"
+// CHECK_DEFAULT: "-lmsvcrt" "-ladvapi32" "-lshell32" "-luser32" "-lkernel32" "-lntdll" "-lmingw32"
 // CHECK_WINDOWSAPP: "-lwindowsapp" "-lmingw32"
 // CHECK_WINDOWSAPP-SAME: "-lmsvcrt" "-lmingw32"


### PR DESCRIPTION
GCC with MCF threads has already linked ntdll.dll for serveral years. First, all supported windows versions are NT-based and even on 9x OSes such as Windows 95, ntdll.dll still exists. Plus the linker won't link to ntdll.dll if user does not use any ntdll functions.

There is no reason not to link ntdll.dll when kernel32.dll is always linked

https://github.com/gcc-mirror/gcc/blob/master/gcc/config/mingw/mingw32.h#L199 