### PR TITLE
[clang-format] Fix formatting of `requires` expressions in braced initializers

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -2569,6 +2569,12 @@ bool UnwrappedLineParser::parseBracedList(bool IsAngleBracket, bool IsEnum) {
       if (IsEnum && !Style.AllowShortEnumsOnASingleLine)
         addUnwrappedLine();
       break;
+    case tok::kw_requires: {
+      auto *RequiresToken = FormatTok;
+      nextToken();
+      parseRequiresExpression(RequiresToken);
+      break;
+    }
     default:
       nextToken();
       break;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26973,6 +26973,12 @@ TEST_F(FormatTest, RequiresExpressionIndentation) {
                Style);
 }
 
+TEST_F(FormatTest, RequiresExpressionInBracedInitializer) {
+  verifyFormat("bool foo{requires { 0; }};");
+  verifyFormat("int bar{requires(T t) { t.f(); }};");
+  verifyFormat("auto baz{requires { typename T::type; } && true};");
+}
+
 TEST_F(FormatTest, StatementAttributeLikeMacros) {
   FormatStyle Style = getLLVMStyle();
   StringRef Source = "void Foo::slot() {\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26973,12 +26973,6 @@ TEST_F(FormatTest, RequiresExpressionIndentation) {
                Style);
 }
 
-TEST_F(FormatTest, RequiresExpressionInBracedInitializer) {
-  verifyFormat("bool foo{requires { 0; }};");
-  verifyFormat("int bar{requires(T t) { t.f(); }};");
-  verifyFormat("auto baz{requires { typename T::type; } && true};");
-}
-
 TEST_F(FormatTest, StatementAttributeLikeMacros) {
   FormatStyle Style = getLLVMStyle();
   StringRef Source = "void Foo::slot() {\n"

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1490,6 +1490,12 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresExpressions) {
   EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_RequiresExpressionLParen);
   EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_RequiresExpressionLBrace);
 
+  Tokens = annotate("int bar{requires(int i) { i + 5; }};");
+  ASSERT_EQ(Tokens.size(), 17u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::kw_requires, TT_RequiresExpression);
+  EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_RequiresExpressionLParen);
+  EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_RequiresExpressionLBrace);
+
   Tokens = annotate("if (requires(int i) { i + 5; }) return;");
   ASSERT_EQ(Tokens.size(), 17u) << Tokens;
   EXPECT_TOKEN(Tokens[2], tok::kw_requires, TT_RequiresExpression);

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1490,11 +1490,10 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresExpressions) {
   EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_RequiresExpressionLParen);
   EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_RequiresExpressionLBrace);
 
-  Tokens = annotate("int bar{requires(int i) { i + 5; }};");
-  ASSERT_EQ(Tokens.size(), 17u) << Tokens;
+  Tokens = annotate("bool foo{requires { 0; }};");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::kw_requires, TT_RequiresExpression);
-  EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_RequiresExpressionLParen);
-  EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_RequiresExpressionLBrace);
+  EXPECT_TOKEN(Tokens[4], tok::l_brace, TT_RequiresExpressionLBrace);
 
   Tokens = annotate("if (requires(int i) { i + 5; }) return;");
   ASSERT_EQ(Tokens.size(), 17u) << Tokens;


### PR DESCRIPTION
When clang-format encountered a `requires` expression inside a braced initializer (e.g., `bool foo{requires { 0; }};`), it would incorrectly format the code to the following:

```cpp
bool bar{requires {0;
}
}
;
```

The issue was that `UnwrappedLineParser::parseBracedList` had no explicit handling for the `requires` keyword, so it would just call `nextToken()` instead of properly parsing the `requires` expression.

This fix adds a case for `tok::kw_requires` in `parseBracedList`, calling `parseRequiresExpression` to handle it correctly, matching the existing behavior in `parseParens`:

https://github.com/llvm/llvm-project/blob/7eee67202378932d03331ad04e7d07ed4d988381/clang/lib/Format/UnwrappedLineParser.cpp#L2713-L2718

Fixes https://github.com/llvm/llvm-project/issues/162984.
