### PR TITLE
[mlir][Examples] Do not run `test.wheel.toy` by default

### DIFF
--- a/mlir/test/Examples/standalone/test.wheel.toy
+++ b/mlir/test/Examples/standalone/test.wheel.toy
@@ -2,6 +2,7 @@
 # than 255 chars when combined with the fact that pip wants to install into a tmp directory buried under
 # C/Users/ContainerAdministrator/AppData/Local/Temp.
 # UNSUPPORTED: target={{.*(windows).*}}
+# REQUIRES: expensive_checks
 # REQUIRES: non-shared-libs-build
 # REQUIRES: bindings-python
 

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -348,6 +348,9 @@ if config.enable_assertions:
 else:
     config.available_features.add("noasserts")
 
+if config.expensive_checks:
+    config.available_features.add("expensive_checks")
+
 def have_host_jit_feature_support(feature_name):
     mlir_runner_exe = lit.util.which("mlir-runner", config.mlir_tools_dir)
 

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -11,6 +11,7 @@ config.llvm_shlib_ext = "@SHLIBEXT@"
 config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))
 config.python_executable = "@Python3_EXECUTABLE@"
 config.enable_assertions = @ENABLE_ASSERTIONS@
+config.expensive_checks = "@EXPENSIVE_CHECKS@"
 config.native_target = "@LLVM_NATIVE_ARCH@"
 config.host_os = "@HOST_OS@"
 config.host_cc = "@HOST_CC@"


### PR DESCRIPTION
This test takes ~16s to execute on my machine, which is an order of magnitude longer than any other mlir test. Put the `test.wheel.toy` test behind a `requires` check for expensive checks.

LLVM already has some tests enabled conditionally under expensive checks.