### PR TITLE
[ADT] Simplify addEnumValues with llvm::to_underlying (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -161,12 +161,10 @@ using TypeAtIndex = std::tuple_element_t<I, std::tuple<Ts...>>;
 /// Helper which adds two underlying types of enumeration type.
 /// Implicit conversion to a common type is accepted.
 template <typename EnumTy1, typename EnumTy2,
-          typename UT1 = std::enable_if_t<std::is_enum<EnumTy1>::value,
-                                          std::underlying_type_t<EnumTy1>>,
-          typename UT2 = std::enable_if_t<std::is_enum<EnumTy2>::value,
-                                          std::underlying_type_t<EnumTy2>>>
+          typename = std::enable_if_t<std::is_enum_v<EnumTy1> &&
+                                      std::is_enum_v<EnumTy2>>>
 constexpr auto addEnumValues(EnumTy1 LHS, EnumTy2 RHS) {
-  return static_cast<UT1>(LHS) + static_cast<UT2>(RHS);
+  return llvm::to_underlying(LHS) + llvm::to_underlying(RHS);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
llvm::to_underlying, forward ported from C++23, conveniently packages
static_cast and std::underlying_type_t like so:

  static_cast<std::underlying_type_t<EnumTy>>(E)
