### PR TITLE
[Github] Add --diff_from_common_commit to code format repro command

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// This pass merges conditional blocks of code and reduces the number of some extra test that will trigger the formatting job
 #include "llvm/Transforms/Instrumentation/ControlHeightReduction.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"

--- a/llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This pass merges conditional blocks of code and reduces the number of some extra test that will trigger the formatting job
 #include "llvm/Transforms/Instrumentation/ControlHeightReduction.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -205,9 +205,10 @@ class ClangFormatHelper(FormatHelper):
 
     @property
     def instructions(self) -> str:
-        # TODO(boomanaiden154): Add --diff_from_common_commit option when it has
-        # landed as in available in a released version.
-        return " ".join(self._construct_command(["origin/main", "HEAD"]))
+        return (
+            " ".join(self._construct_command(["origin/main", "HEAD"]))
+            + " --diff_from_common_commit"
+        )
 
     def should_include_extensionless_file(self, path: str) -> bool:
         return path.startswith("libcxx/include")


### PR DESCRIPTION
This ensures that we are not including any branches on main that are not in the current user's branch in the diff. We can add this to the command now that --diff_from_common_commit (or at least the fixed version) has landed in a release (21.1.1).