### PR TITLE
[ConstantFPRange] Add support for mul/div

### DIFF
--- a/llvm/include/llvm/IR/ConstantFPRange.h
+++ b/llvm/include/llvm/IR/ConstantFPRange.h
@@ -231,6 +231,15 @@ public:
   /// from a subtraction of a value in this range and a value in \p Other.
   LLVM_ABI ConstantFPRange sub(const ConstantFPRange &Other) const;
 
+  /// Return a new range representing the possible values resulting
+  /// from a multiplication of a value in this range and a value in \p Other.
+  LLVM_ABI ConstantFPRange mul(const ConstantFPRange &Other) const;
+
+  /// Return a new range representing the possible values resulting
+  /// from a division of a value in this range and a value in
+  /// \p Other.
+  LLVM_ABI ConstantFPRange div(const ConstantFPRange &Other) const;
+
   /// Flush denormal values to zero according to the specified mode.
   /// For dynamic mode, we return the union of all possible results.
   LLVM_ABI void flushDenormals(DenormalMode::DenormalModeKind Mode);


### PR DESCRIPTION
This patch adds support for fmul/fdiv operations. I will leave the frem support to a separate patch because its implementation is quite different from fmul/fdiv.
