### PR TITLE
TableGen: Account for Unsupporte LibcallImpl in bitset size

### DIFF
--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -592,7 +592,7 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
     DenseMap<PredicateWithCC, LibcallsWithCC> Pred2Funcs;
 
     SmallVector<uint64_t, 32> BitsetValues(
-        divideCeil(RuntimeLibcallImplDefList.size(), BitsPerStorageElt));
+        divideCeil(RuntimeLibcallImplDefList.size() + 1, BitsPerStorageElt));
 
     for (const Record *Elt : *Elements) {
       const RuntimeLibcallImpl *LibCallImpl = getRuntimeLibcallImpl(Elt);


### PR DESCRIPTION
The Unsupported case is special and doesn't have an entry in the
vector, and is directly emitted as the 0 case. This should be
harmless as it is, but could break if the right number of new
libcalls is added.