### PR TITLE
[Support] Use llvm::to_underlying in BinaryStreamWriter.h (NFC)

### DIFF
--- a/llvm/include/llvm/Support/BinaryStreamWriter.h
+++ b/llvm/include/llvm/Support/BinaryStreamWriter.h
@@ -10,6 +10,7 @@
 #define LLVM_SUPPORT_BINARYSTREAMWRITER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamError.h"
@@ -69,8 +70,7 @@ public:
     static_assert(std::is_enum<T>::value,
                   "Cannot call writeEnum with non-Enum type");
 
-    using U = std::underlying_type_t<T>;
-    return writeInteger<U>(static_cast<U>(Num));
+    return writeInteger(llvm::to_underlying(Num));
   }
 
   /// Write the unsigned integer Value to the underlying stream using ULEB128


### PR DESCRIPTION
llvm::to_underlying, forward ported from C++23, conveniently packages
static_cast and std::underlying_type_t like so:

  static_cast<std::underlying_type_t<EnumTy>>(E)
