### PR TITLE
[libc][annex_k] Add Annex K support macros.

### DIFF
--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -32,6 +32,12 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
 
 add_macro_header(
+  annex_k_macros
+  HDR
+    annex-k-macros.h
+)
+
+add_macro_header(
   assert_macros
   HDR
     assert-macros.h

--- a/libc/include/llvm-libc-macros/annex-k-macros.h
+++ b/libc/include/llvm-libc-macros/annex-k-macros.h
@@ -1,0 +1,26 @@
+//===-- Definition of macros to be used with Annex K functions ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H
+#define LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) ||              \
+    (defined(__cplusplus) && __cplusplus >= 201703L)
+
+// TODO(bassiounix): Who should def this macro (clang vs libc)? Where?
+#define __STDC_LIB_EXT1__ 201112L
+
+#if defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
+
+#define LIBC_HAS_ANNEX_K
+
+#endif // defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
+
+#endif // (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) ||
+       // (defined(__cplusplus) && __cplusplus >= 201703L)
+#endif // LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H

--- a/libc/include/llvm-libc-macros/annex-k-macros.h
+++ b/libc/include/llvm-libc-macros/annex-k-macros.h
@@ -13,7 +13,8 @@
     (defined(__cplusplus) && __cplusplus >= 201703L)
 
 // TODO(bassiounix): Who should def this macro (clang vs libc)? Where?
-#define __STDC_LIB_EXT1__ 201112L
+// TODO(bassiounix): uncomment/move when Annex K is fully implemented.
+// #define __STDC_LIB_EXT1__ 201112L
 
 #if defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
 


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add internal support macros required by Annex K interface in LLVM libc.