### PR TITLE
[clang] Remove unused local variables (NFC)

### DIFF
--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -218,7 +218,6 @@ void getSpirvExtOperand(StringRef SpvExtensionArg, raw_ostream &out) {
 
   if (SpvExtensionArg.compare_insensitive("DXC") == 0) {
     bool first = true;
-    std::string Operand;
     for (StringRef E : DxcSupportedExtensions) {
       if (!first)
         out << ",";

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2609,7 +2609,6 @@ public:
                                         bool IsRelatedToDecl,
                                         ASTContext &Ctx) override {
     SourceLocation Loc;
-    std::string Message;
 
     Loc = Node.get<Stmt>()->getBeginLoc();
     S.Diag(Loc, diag::warn_unsafe_buffer_usage_unique_ptr_array_access)


### PR DESCRIPTION
Identified with bugprone-unused-local-non-trivial-variable.
