### PR TITLE
[mlir] Remove unused local variables (NFC)

### DIFF
--- a/mlir/lib/Target/IRDLToCpp/IRDLToCpp.cpp
+++ b/mlir/lib/Target/IRDLToCpp/IRDLToCpp.cpp
@@ -464,12 +464,6 @@ static std::string generateOpDefinition(irdl::detail::dictionary &dict,
   auto opStrings = getStrings(op);
   fillDict(dict, opStrings);
 
-  const auto operandCount = opStrings.opOperandNames.size();
-  const auto operandNames =
-      operandCount ? joinNameList(opStrings.opOperandNames) : "{\"\"}";
-
-  const auto resultNames = joinNameList(opStrings.opResultNames);
-
   auto resultTypes = llvm::join(
       llvm::map_range(opStrings.opResultNames,
                       [](StringRef attr) -> std::string {

--- a/mlir/tools/mlir-tblgen/CppGenUtilities.cpp
+++ b/mlir/tools/mlir-tblgen/CppGenUtilities.cpp
@@ -18,8 +18,6 @@ void mlir::tblgen::emitSummaryAndDescComments(llvm::raw_ostream &os,
                                               llvm::StringRef summary,
                                               llvm::StringRef description,
                                               bool terminateComment) {
-
-  std::string comments = "";
   StringRef trimmedSummary = summary.trim();
   StringRef trimmedDesc = description.trim();
   raw_indented_ostream ros(os);

--- a/mlir/unittests/IR/RemarkTest.cpp
+++ b/mlir/unittests/IR/RemarkTest.cpp
@@ -149,7 +149,6 @@ TEST(Remark, TestNoOutputOptimizationRemark) {
 
   std::string categoryFailName("myImportantCategory");
   std::string myPassname1("myPass1");
-  std::string funcName("myFunc");
   SmallString<64> tmpPathStorage;
   sys::fs::createUniquePath("remarks-%%%%%%.yaml", tmpPathStorage,
                             /*MakeAbsolute=*/true);
@@ -271,9 +270,6 @@ TEST(Remark, TestCustomOptimizationRemarkDiagnostic) {
   std::string categoryInline("Inliner");
   std::string myPassname1("myPass1");
   std::string myPassname2("myPass2");
-  std::string funcName("myFunc");
-
-  std::string seenMsg = "";
 
   {
     MLIRContext context;


### PR DESCRIPTION
Identified with bugprone-unused-local-non-trivial-variable.
