### PR TITLE
[ADT] Allow arbitrary number of cases in StringSwitch

### DIFF
--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -17,6 +17,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstring>
+#include <initializer_list>
 #include <optional>
 
 namespace llvm {
@@ -85,55 +86,60 @@ public:
     return *this;
   }
 
+  StringSwitch &Cases(std::initializer_list<StringLiteral> CaseStrings,
+                      T Value) {
+    return CasesImpl(Value, CaseStrings);
+  }
+
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, T Value) {
-    return CasesImpl(Value, S0, S1);
+    return CasesImpl(Value, {S0, S1});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       T Value) {
-    return CasesImpl(Value, S0, S1, S2);
+    return CasesImpl(Value, {S0, S1, S2});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3);
+    return CasesImpl(Value, {S0, S1, S2, S3});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3, S4);
+    return CasesImpl(Value, {S0, S1, S2, S3, S4});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, StringLiteral S5,
                       T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3, S4, S5);
+    return CasesImpl(Value, {S0, S1, S2, S3, S4, S5});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, StringLiteral S5,
                       StringLiteral S6, T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3, S4, S5, S6);
+    return CasesImpl(Value, {S0, S1, S2, S3, S4, S5, S6});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, StringLiteral S5,
                       StringLiteral S6, StringLiteral S7, T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3, S4, S5, S6, S7);
+    return CasesImpl(Value, {S0, S1, S2, S3, S4, S5, S6, S7});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, StringLiteral S5,
                       StringLiteral S6, StringLiteral S7, StringLiteral S8,
                       T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3, S4, S5, S6, S7, S8);
+    return CasesImpl(Value, {S0, S1, S2, S3, S4, S5, S6, S7, S8});
   }
 
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, StringLiteral S5,
                       StringLiteral S6, StringLiteral S7, StringLiteral S8,
                       StringLiteral S9, T Value) {
-    return CasesImpl(Value, S0, S1, S2, S3, S4, S5, S6, S7, S8, S9);
+    return CasesImpl(Value, {S0, S1, S2, S3, S4, S5, S6, S7, S8, S9});
   }
 
   // Case-insensitive case matchers.
@@ -156,23 +162,28 @@ public:
     return *this;
   }
 
+  StringSwitch &CasesLower(std::initializer_list<StringLiteral> CaseStrings,
+                           T Value) {
+    return CasesLowerImpl(Value, CaseStrings);
+  }
+
   StringSwitch &CasesLower(StringLiteral S0, StringLiteral S1, T Value) {
-    return CasesLowerImpl(Value, S0, S1);
+    return CasesLowerImpl(Value, {S0, S1});
   }
 
   StringSwitch &CasesLower(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                            T Value) {
-    return CasesLowerImpl(Value, S0, S1, S2);
+    return CasesLowerImpl(Value, {S0, S1, S2});
   }
 
   StringSwitch &CasesLower(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                            StringLiteral S3, T Value) {
-    return CasesLowerImpl(Value, S0, S1, S2, S3);
+    return CasesLowerImpl(Value, {S0, S1, S2, S3});
   }
 
   StringSwitch &CasesLower(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                            StringLiteral S3, StringLiteral S4, T Value) {
-    return CasesLowerImpl(Value, S0, S1, S2, S3, S4);
+    return CasesLowerImpl(Value, {S0, S1, S2, S3, S4});
   }
 
   [[nodiscard]] R Default(T Value) {
@@ -211,16 +222,21 @@ private:
     return false;
   }
 
-  template <typename... Args> StringSwitch &CasesImpl(T &Value, Args... Cases) {
+  StringSwitch &CasesImpl(T &Value,
+                          std::initializer_list<StringLiteral> Cases) {
     // Stop matching after the string is found.
-    (... || CaseImpl(Value, Cases));
+    for (StringLiteral S : Cases)
+      if (CaseImpl(Value, S))
+        break;
     return *this;
   }
 
-  template <typename... Args>
-  StringSwitch &CasesLowerImpl(T &Value, Args... Cases) {
+  StringSwitch &CasesLowerImpl(T &Value,
+                               std::initializer_list<StringLiteral> Cases) {
     // Stop matching after the string is found.
-    (... || CaseLowerImpl(Value, Cases));
+    for (StringLiteral S : Cases)
+      if (CaseLowerImpl(Value, S))
+        break;
     return *this;
   }
 };


### PR DESCRIPTION
Prior to this patch, `.Cases` and `.CasesLower` were **not** variadic functions and accepted a fixed number of arguments: up to 10 for the former and up to 5 for the latter.
This is close to unfixable with variadic templates because of the following constraints:
* There would be a variadic number of cases and the single value would be at the very end. For a parameter pack approach to work, we would want the value to be the head and the cases strings to follow, but rotating a parameter pack is quite awkward and requires heavy template metaprogramming.
 * Even if we did rotate the parameter pack, the existing function signature forces conversion of cases to `StringLiteral` and the value to `T`. This is hard to achieve with variadic templates because we can't specify that all cases must be of type `StringLiteral`, and doing the conversion later won't work because of the attribute enable_if in `StringLiteral`'s constructor that doesn't work on non-literal character arrays.
 * Refactoring all the existing code to put the value first is very intrusive and bugprone when the value parameter is also a string literal.
 
Instead, generalize `.Cases` and `.CasesLower` and make the code manageable by taking an initializer list. The added benefit is that this clearly delineates where case strings end and where the value begins, which can be hard to tell when the value parameter is also a string literal.

I plan to eventually deprecate the manually-enumerated overloads of `.Cases.` and `.CasesLower`.
 