### PR TITLE
Remove prof branch weights if switch has 0-1 cases or no branch-weights set in SwitchInstProfUpdateWrapper

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3548,8 +3548,12 @@ public:
   SwitchInstProfUpdateWrapper(SwitchInst &SI) : SI(SI) { init(); }
 
   ~SwitchInstProfUpdateWrapper() {
-    if (Changed && Weights.has_value() && Weights->size() >= 2)
-      setBranchWeights(SI, Weights.value(), /*IsExpected=*/false);
+    if (Changed) {
+      if (Weights.has_value() && Weights->size() >= 2)
+        setBranchWeights(SI, Weights.value(), /*IsExpected=*/false);
+      else
+        SI.setMetadata(LLVMContext::MD_prof, nullptr);
+    }
   }
 
   /// Delegate the call to the underlying SwitchInst::removeCase() and remove


### PR DESCRIPTION
If the switch statement does not have any cases, or has only one case, or if no weights were set through the ProfUpdate wrapper, such switch statements should not have prof branch weights metadata. And this is what we did prior to commit 240b73e.