### PR TITLE
release/21.x: [clangd] Fix code action kind for readability-identifier-naming fixes (#162808)

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -81,7 +81,7 @@ CodeAction toCodeAction(const ClangdServer::CodeActionResult::Rename &R,
                         const URIForFile &File) {
   CodeAction CA;
   CA.title = R.FixMessage;
-  CA.kind = std::string(CodeAction::REFACTOR_KIND);
+  CA.kind = std::string(CodeAction::QUICKFIX_KIND);
   CA.command.emplace();
   CA.command->title = R.FixMessage;
   CA.command->command = std::string(ApplyRenameCommand);

--- a/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
@@ -235,7 +235,8 @@ TEST_F(LSPTest, ClangTidyRename) {
             .takeValue()
             .getAsArray())[0];
 
-  ASSERT_EQ((*RenameCommand.getAsObject())["title"], "change 'foo' to 'Foo'");
+  ASSERT_EQ((*RenameCommand.getAsObject())["title"],
+            "Apply fix: change 'foo' to 'Foo'");
 
   Client.expectServerCall("workspace/applyEdit");
   Client.call("workspace/executeCommand", RenameCommand);


### PR DESCRIPTION
Backport of #162808.

https://github.com/llvm/llvm-project/pull/78454 converted readability-identifier-naming fixes to use rename mechanism to rename the symbol project-wide. However, it set the code action kind to "refactor" instead of "quickfix", which caused the fixes to be filtered out when editors (like VS Code) request quick fixes for diagnostics. On VS Code, for example, users would see "No quick fixes available" despite the diagnostic indicating "(fix available)".

Fix that by changing the code action kind back to "quickfix".
