### PR TITLE
[Clang][Driver] Ensure default sysroot is computed and passed to cc1

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1083,12 +1083,13 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
   // If we have a --sysroot, and don't have an explicit -isysroot flag, add an
   // -isysroot to the CC1 invocation.
-  StringRef sysroot = C.getSysRoot();
-  if (sysroot != "") {
-    if (!Args.hasArg(options::OPT_isysroot)) {
-      CmdArgs.push_back("-isysroot");
-      CmdArgs.push_back(C.getArgs().MakeArgString(sysroot));
-    }
+  std::string sysroot = std::string(C.getSysRoot());
+  if (sysroot.empty()) {
+    sysroot = getToolChain().computeSysRoot();
+  }
+  if (!Args.hasArg(options::OPT_isysroot)) {
+    CmdArgs.push_back("-isysroot");
+    CmdArgs.push_back(C.getArgs().MakeArgString(sysroot));
   }
 
   // Parse additional include paths from environment variables.


### PR DESCRIPTION
Greetings, everyone.

I found an issue in #82084, and discussed my concerns in https://github.com/llvm/llvm-project/pull/82084#discussion_r2387373311 and I fixed it in my local branch, and @jansvoboda11 recommended me to submit a PR to fix it. Here are the descriptions for it.

Previously, the driver would only add the `-isysroot` flag to the `cc1` command if an initial sysroot (e.g., from the `--sysroot` argument) was non-empty.

This logic was flawed because it ignored toolchains that can compute a default sysroot (e.g., for bare-metal targets). When no sysroot was provided on the command line, the `computeSysRoot()` method was never called, and `cc1` was invoked without the necessary `-isysroot` flag. This could lead to failures in locating system headers, especially those added via sysroot-relative paths, such as `-isystem=/include/libncrt`, were incorrectly resolved instead of the intended target's sysroot.

This commit refactors the logic to:
1. First, check if the initial sysroot is empty.
2. If it is, call the toolchain's `computeSysRoot()` method to get the default computed sysroot.
3. Finally, pass the determined sysroot to `cc1` via `-isysroot` if one wasn't already specified by the user.

See discussion at: https://github.com/llvm/llvm-project/pull/82084/files#r2387373311

Thanks
Huaqi