### PR TITLE
[RISCV][LLD] Zcmt RISC-V extension in lld

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -67,6 +67,7 @@ class MipsGotSection;
 class MipsRldMapSection;
 class PPC32Got2Section;
 class PPC64LongBranchTargetSection;
+class TableJumpSection;
 class PltSection;
 class RelocationBaseSection;
 class RelroPaddingSection;
@@ -370,6 +371,7 @@ struct Config {
   bool resolveGroups;
   bool relrGlibc = false;
   bool relrPackDynRelocs = false;
+  bool relaxTbljal;
   llvm::DenseSet<llvm::StringRef> saveTempsArgs;
   llvm::SmallVector<std::pair<llvm::GlobPattern, uint32_t>, 0> shuffleSections;
   bool singleRoRx;
@@ -582,6 +584,7 @@ struct InStruct {
   std::unique_ptr<RelroPaddingSection> relroPadding;
   std::unique_ptr<SyntheticSection> armCmseSGSection;
   std::unique_ptr<PPC64LongBranchTargetSection> ppc64LongBranchTarget;
+  std::unique_ptr<TableJumpSection> riscvTableJumpSection;
   std::unique_ptr<SyntheticSection> mipsAbiFlags;
   std::unique_ptr<MipsGotSection> mipsGot;
   std::unique_ptr<SyntheticSection> mipsOptions;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1623,6 +1623,7 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   }
   ctx.arg.zCombreloc = getZFlag(args, "combreloc", "nocombreloc", true);
   ctx.arg.zCopyreloc = getZFlag(args, "copyreloc", "nocopyreloc", true);
+  ctx.arg.relaxTbljal = args.hasArg(OPT_relax_tbljal);
   ctx.arg.zForceBti = hasZOption(args, "force-bti");
   ctx.arg.zForceIbt = hasZOption(args, "force-ibt");
   ctx.arg.zZicfilp = getZZicfilp(ctx, args);

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -378,6 +378,11 @@ defm use_android_relr_tags: BB<"use-android-relr-tags",
     "Use SHT_ANDROID_RELR / DT_ANDROID_RELR* tags instead of SHT_RELR / DT_RELR*",
     "Use SHT_RELR / DT_RELR* tags (default)">;
 
+def relax_tbljal : FF<"relax-tbljal">,
+                   HelpText<"Enable conversion of call instructions to table "
+                            "jump instruction from the Zcmt extension for "
+                            "frequently called functions (RISC-V only)">;
+
 def pic_veneer: F<"pic-veneer">,
   HelpText<"Always generate position independent thunks (veneers)">;
 

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -4872,6 +4872,17 @@ template <class ELFT> void elf::createSyntheticSections(Ctx &ctx) {
     add(*ctx.in.ppc64LongBranchTarget);
   }
 
+  if (ctx.arg.emachine == EM_RISCV && ctx.arg.relaxTbljal) {
+    ctx.in.riscvTableJumpSection = std::make_unique<TableJumpSection>(ctx);
+    add(*ctx.in.riscvTableJumpSection);
+
+    Symbol *s = ctx.symtab->addSymbol(Defined{
+        ctx,
+        /*file=*/nullptr, "__jvt_base$", STB_GLOBAL, STT_NOTYPE, STT_NOTYPE,
+        /*value=*/0, /*size=*/0, ctx.in.riscvTableJumpSection.get()});
+    s->isUsedInRegularObj = true;
+  }
+
   ctx.in.gotPlt = std::make_unique<GotPltSection>(ctx);
   add(*ctx.in.gotPlt);
   ctx.in.igotPlt = std::make_unique<IgotPltSection>(ctx);

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -38,6 +38,9 @@ public:
   virtual void writeGotPltHeader(uint8_t *buf) const {}
   virtual void writeGotHeader(uint8_t *buf) const {}
   virtual void writeGotPlt(uint8_t *buf, const Symbol &s) const {};
+  virtual void writeTableJumpHeader(uint8_t *buf) const {};
+  virtual void writeTableJumpEntry(uint8_t *buf, const uint64_t symbol) const {
+  };
   virtual void writeIgotPlt(uint8_t *buf, const Symbol &s) const {}
   virtual int64_t getImplicitAddend(const uint8_t *buf, RelType type) const;
   virtual int getTlsGdRelaxSkip(RelType type) const { return 1; }

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1570,6 +1570,19 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
       changed |= a32p.createFixes();
     }
 
+    if (ctx.arg.relaxTbljal) {
+      if (!changed) {
+        // scan all R_RISCV_JAL, R_RISCV_CALL/R_RISCV_CALL_PLT for RISCV Zcmt
+        // Jump table.
+        for (InputSectionBase *inputSection : ctx.inputSections) {
+          ctx.in.riscvTableJumpSection->scanTableJumpEntries(
+              cast<InputSection>(*inputSection));
+        }
+        ctx.in.riscvTableJumpSection->finalizeContents();
+        changed |= ctx.target->relaxOnce(pass);
+      }
+    }
+
     finalizeSynthetic(ctx, ctx.in.got.get());
     if (ctx.in.mipsGot)
       ctx.in.mipsGot->updateAllocSize(ctx);

--- a/lld/test/ELF/riscv-no-tbljal-call.s
+++ b/lld/test/ELF/riscv-no-tbljal-call.s
@@ -1,0 +1,33 @@
+# REQUIRES: riscv
+
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax -mattr=zcmt %s -o %t.rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax -mattr=zcmt %s -o %t.rv64.o
+
+# tbljal conversion
+# RUN: ld.lld %t.rv32.o --relax-tbljal --defsym foo=0x150000 -o %t.rv32
+# RUN: ld.lld %t.rv64.o --relax-tbljal --defsym foo=0x150000 -o %t.rv64
+
+# jump table
+# RUN: llvm-objdump -h %t.rv32 | FileCheck --check-prefix=JUMPTABLE32 %s
+# RUN: llvm-objdump -h %t.rv64 | FileCheck --check-prefix=JUMPTABLE64 %s
+
+# JUMPTABLE32:  2 .riscv.jvt    00000000 00011100 TEXT
+# JUMPTABLE64:  2 .riscv.jvt    00000000 0000000000011140 TEXT
+
+.global _start
+.p2align 3
+_start:
+  call foo
+  tail foo_1
+  tail foo_2
+  tail foo_3
+
+foo_1:
+  nop
+
+foo_2:
+  nop
+
+foo_3:
+  nop
+

--- a/lld/test/ELF/riscv-tbljal-call.s
+++ b/lld/test/ELF/riscv-tbljal-call.s
@@ -1,0 +1,109 @@
+# REQUIRES: riscv
+
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax -mattr=zcmt %s -o %t.rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax -mattr=zcmt %s -o %t.rv64.o
+
+# tbljal conversion
+# RUN: ld.lld %t.rv32.o --relax-tbljal --defsym foo=0x150000 --defsym foo_1=0x150010 --defsym foo_3=0x150030 -o %t.rv32
+# RUN: ld.lld %t.rv64.o --relax-tbljal --defsym foo=0x150000 --defsym foo_1=0x150010 --defsym foo_3=0x150030 -o %t.rv64
+# RUN: llvm-objdump -d -M no-aliases --mattr=zcmt --no-show-raw-insn %t.rv32 | FileCheck --check-prefix=TBLJAL32 %s
+# RUN: llvm-objdump -d -M no-aliases --mattr=zcmt --no-show-raw-insn %t.rv64 | FileCheck --check-prefix=TBLJAL64 %s
+
+# jump table
+# RUN: llvm-objdump -j .riscv.jvt -s %t.rv32 | FileCheck --check-prefix=JUMPTABLE32 %s
+# RUN: llvm-objdump -j .riscv.jvt -s %t.rv64 | FileCheck --check-prefix=JUMPTABLE64 %s
+
+# TBLJAL32:      cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jalt 0x20
+# TBLJAL32-NEXT: cm.jt   0x2
+# TBLJAL32-NEXT: cm.jt   0x1
+# TBLJAL32-NEXT: cm.jt   0x1
+# TBLJAL32-NEXT: cm.jt   0x1
+# TBLJAL32-NEXT: cm.jt   0x0
+# TBLJAL32-NEXT: c.j     0x110f6 <foo_2>
+# TBLJAL32-NEXT: cm.jt   0x0
+# TBLJAL32-NEXT: cm.jt   0x0
+# TBLJAL32-NEXT: cm.jt   0x0
+# TBLJAL32-NEXT: cm.jt   0x0
+
+# TBLJAL64:      cm.jt   0x1
+# TBLJAL64-NEXT: cm.jt   0x1
+# TBLJAL64-NEXT: cm.jt   0x1
+# TBLJAL64-NEXT: cm.jt   0x0
+# TBLJAL64-NEXT: c.j     0x111e2 <foo_2>
+# TBLJAL64-NEXT: cm.jt   0x0
+# TBLJAL64-NEXT: cm.jt   0x0
+# TBLJAL64-NEXT: cm.jt   0x0
+# TBLJAL64-NEXT: cm.jt   0x0
+
+
+# JUMPTABLE32:      30001500 10001500 00001500 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00000000 00000000 00000000 00000000
+# JUMPTABLE32-NEXT: 00001500
+
+# JUMPTABLE64:      30001500 00000000 10001500 00000000
+
+.global _start
+.p2align 3
+_start:
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  call foo
+  tail foo
+  tail foo_1
+  tail foo_1
+  tail foo_1
+  tail foo_3
+  tail foo_2
+  tail foo_3
+  tail foo_3
+  tail foo_3
+  tail foo_3
+
+foo_2:
+  nop
+
+

--- a/lld/test/ELF/riscv-tbljal-many-jumps.s
+++ b/lld/test/ELF/riscv-tbljal-many-jumps.s
@@ -1,0 +1,266 @@
+# REQUIRES: riscv
+
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax -mattr=zcmt %s -o %t.rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax -mattr=zcmt %s -o %t.rv64.o
+
+# tbljal conversion
+# RUN: ld.lld %t.rv32.o --relax-tbljal --defsym foo=0x150000 --defsym foo_1=0x150010 --defsym foo_3=0x150030 -o %t.rv32
+# RUN: ld.lld %t.rv64.o --relax-tbljal --defsym foo=0x150000 --defsym foo_1=0x150010 --defsym foo_3=0x150030 -o %t.rv64
+
+# jump table
+# RUN: llvm-objdump -h %t.rv32 | FileCheck --check-prefix=JUMPTABLE32 %s
+# RUN: llvm-objdump -h %t.rv64 | FileCheck --check-prefix=JUMPTABLE64 %s
+
+# JUMPTABLE32:  2 .riscv.jvt    00000080 {{.*}} TEXT
+# JUMPTABLE64:  2 .riscv.jvt    00000100 {{.*}} TEXT
+
+
+.global _start
+.p2align 3
+_start:
+  tail foo
+  tail foo
+  tail foo
+  tail foo
+  tail foo_1
+  tail foo_1
+  tail foo_1
+  tail foo_3
+  tail foo_3
+  tail foo_3
+  tail foo_3
+  tail foo_3
+  tail foo_4
+  tail foo_4
+  tail foo_4
+  tail foo_4
+  tail foo_5
+  tail foo_5
+  tail foo_5
+  tail foo_5
+  tail foo_6
+  tail foo_6
+  tail foo_6
+  tail foo_6
+  tail foo_7
+  tail foo_7
+  tail foo_7
+  tail foo_7
+  tail foo_8
+  tail foo_8
+  tail foo_8
+  tail foo_8
+  tail foo_9
+  tail foo_9
+  tail foo_9
+  tail foo_9
+
+  tail foo_10
+  tail foo_10
+  tail foo_10
+  tail foo_10
+  tail foo_11
+  tail foo_11
+  tail foo_11
+  tail foo_11
+  tail foo_12
+  tail foo_12
+  tail foo_12
+  tail foo_12
+  tail foo_13
+  tail foo_13
+  tail foo_13
+  tail foo_13
+  tail foo_14
+  tail foo_14
+  tail foo_14
+  tail foo_14
+  tail foo_15
+  tail foo_15
+  tail foo_15
+  tail foo_15
+  tail foo_16
+  tail foo_16
+  tail foo_16
+  tail foo_16
+  tail foo_17
+  tail foo_17
+  tail foo_17
+  tail foo_17
+  tail foo_18
+  tail foo_18
+  tail foo_18
+  tail foo_18
+  tail foo_19
+  tail foo_19
+  tail foo_19
+  tail foo_19
+
+  tail foo_20
+  tail foo_20
+  tail foo_20
+  tail foo_20
+  tail foo_21
+  tail foo_21
+  tail foo_21
+  tail foo_21
+  tail foo_22
+  tail foo_22
+  tail foo_22
+  tail foo_22
+  tail foo_23
+  tail foo_23
+  tail foo_23
+  tail foo_23
+  tail foo_24
+  tail foo_24
+  tail foo_24
+  tail foo_24
+  tail foo_25
+  tail foo_25
+  tail foo_25
+  tail foo_25
+  tail foo_26
+  tail foo_26
+  tail foo_26
+  tail foo_26
+  tail foo_27
+  tail foo_27
+  tail foo_27
+  tail foo_27
+  tail foo_28
+  tail foo_28
+  tail foo_28
+  tail foo_28
+  tail foo_29
+  tail foo_29
+  tail foo_29
+  tail foo_29
+
+  tail foo_30
+  tail foo_30
+  tail foo_30
+  tail foo_30
+  tail foo_31
+  tail foo_31
+  tail foo_31
+  tail foo_31
+  tail foo_32
+  tail foo_32
+  tail foo_32
+  tail foo_32
+  tail foo_33
+  tail foo_33
+  tail foo_33
+  tail foo_33
+  tail foo_34
+  tail foo_34
+  tail foo_34
+  tail foo_34
+  tail foo_35
+  tail foo_35
+  tail foo_35
+  tail foo_35
+  tail foo_36
+  tail foo_36
+  tail foo_36
+  tail foo_36
+  tail foo_37
+  tail foo_37
+  tail foo_37
+  tail foo_37
+  tail foo_38
+  tail foo_38
+  tail foo_38
+  tail foo_38
+  tail foo_39
+  tail foo_39
+  tail foo_39
+  tail foo_39
+
+
+.space 16384
+
+foo_3:
+  nop
+
+foo_4:
+  nop
+
+foo_5:
+  nop
+
+foo_6:
+  nop
+
+foo_7:
+  nop
+
+foo_8:
+  nop
+
+foo_9:
+  nop
+
+foo_10:
+  nop
+foo_11:
+  nop
+foo_12:
+  nop
+foo_13:
+  nop
+foo_14:
+  nop
+foo_15:
+  nop
+foo_16:
+  nop
+foo_17:
+  nop
+foo_18:
+  nop
+foo_19:
+  nop
+
+foo_20:
+  nop
+foo_21:
+  nop
+foo_22:
+  nop
+foo_23:
+  nop
+foo_24:
+  nop
+foo_25:
+  nop
+foo_26:
+  nop
+foo_27:
+  nop
+foo_28:
+  nop
+foo_29:
+  nop
+
+foo_30:
+  nop
+foo_31:
+  nop
+foo_32:
+  nop
+foo_33:
+  nop
+foo_34:
+  nop
+foo_35:
+  nop
+foo_36:
+  nop
+foo_37:
+  nop
+foo_38:
+  nop
+foo_39:
+  nop

--- a/lld/test/ELF/riscv-tbljal-syms.s
+++ b/lld/test/ELF/riscv-tbljal-syms.s
@@ -1,0 +1,42 @@
+# REQUIRES: riscv
+
+// Check that relaxation correctly adjusts symbol addresses and sizes.
+
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax -mattr=zcmt %s -o %t.rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax -mattr=zcmt %s -o %t.rv64.o
+# RUN: ld.lld -Ttext=0x100000 --relax-tbljal %t.rv32.o -o %t.rv32
+# RUN: ld.lld -Ttext=0x100000 --relax-tbljal %t.rv64.o -o %t.rv64
+
+# RUN: llvm-readelf -s %t.rv32 | FileCheck --check-prefix=CHECK32 %s
+# RUN: llvm-readelf -s %t.rv64 | FileCheck --check-prefix=CHECK64 %s
+
+# CHECK32:      00100000     4 NOTYPE  LOCAL  DEFAULT     1 a
+# CHECK32-NEXT: 00100000     6 NOTYPE  LOCAL  DEFAULT     1 b
+# CHECK32-NEXT: 00100000     0 NOTYPE  LOCAL  DEFAULT     1 $x
+# CHECK32-NEXT: 00100004     2 NOTYPE  LOCAL  DEFAULT     1 c
+# CHECK32-NEXT: 00100004     6 NOTYPE  LOCAL  DEFAULT     1 d
+# CHECK32-NEXT: 00100000    10 NOTYPE  GLOBAL DEFAULT     1 _start
+# CHECK32-NEXT: 00100040     0 NOTYPE  GLOBAL DEFAULT     2 __jvt_base$
+
+# CHECK64:      00100000     4 NOTYPE  LOCAL  DEFAULT     1 a
+# CHECK64-NEXT: 00100000     8 NOTYPE  LOCAL  DEFAULT     1 b
+# CHECK64-NEXT: 00100000     0 NOTYPE  LOCAL  DEFAULT     1 $x
+# CHECK64-NEXT: 00100004     4 NOTYPE  LOCAL  DEFAULT     1 c
+# CHECK64-NEXT: 00100004     8 NOTYPE  LOCAL  DEFAULT     1 d
+# CHECK64-NEXT: 00100000    12 NOTYPE  GLOBAL DEFAULT     1 _start
+# CHECK64-NEXT: 00100040     0 NOTYPE  GLOBAL DEFAULT     2 __jvt_base$
+
+.global _start
+_start:
+a:
+b:
+  add  a0, a1, a2
+.size a, . - a
+c:
+d:
+  call _start
+.size b, . - b
+.size c, . - c
+  add a0, a1, a2
+.size d, . - d
+.size _start, . - _start


### PR DESCRIPTION
This patch implements optimizations for the zcmt extension in lld. A new
TableJumpSection has been added. Scans each R_RISCV_CALL/R_RISCV_CALL_PLT
relocType in each section before the linker relaxation, recording the symbol

In finalizeContents the recorded symbol names are sorted in descending order by
the number of jumps. The top symbols are compressed to table jumps during the
relax process.

This is a continuation of PR #77884 

Co-authored-by: Craig Topper <craig.topper@sifive.com>
Co-authored-by: VincentWu <43398706+Xinlong-Wu@users.noreply.github.com>
Co-authored-by: Scott Egerton <9487234+ScottEgerton@users.noreply.github.com>

===

# TODO:
- [x] 64-byte table alignment - https://github.com/llvm/llvm-project/pull/77884#discussion_r1905120046
- [x] clang-format
- [x] any jalr using anything other than zero/ra will be converted. - https://github.com/llvm/llvm-project/pull/77884#discussion_r1830991052 
- [x] R_RISCV_JAL relocations are also processed via this function. This means the instruction after the jal instruction is both processed for its bits in the rd field and deleted if the branch target is in the table. https://github.com/llvm/llvm-project/pull/77884#discussion_r1830991052 
- [x] ditto in scanTableJumpEntries

# Maybe not blocking..?
- [ ] To make this more useful, we need jal to have `R_RISCV_RELAX` from https://github.com/llvm/llvm-project/pull/151422
- [ ] Doesn't seem to work with `--gc-sections` see https://github.com/llvm/llvm-project/pull/163142#issuecomment-3402987651
- [ ] Invalid internal relocations in `--emit-relocs`