### PR TITLE
[TSan][Test-Only] Mark write-interpose.c unsupported on ios

### DIFF
--- a/compiler-rt/test/tsan/Darwin/write-interpose.c
+++ b/compiler-rt/test/tsan/Darwin/write-interpose.c
@@ -7,6 +7,8 @@
 // Note that running the below command with out `lock_during_write` should
 // deadlock (self-lock)
 // RUN: env DYLD_INSERT_LIBRARIES=%t.dylib TSAN_OPTIONS=verbosity=2:lock_during_write=disable_for_current_process %run %t 2>&1 | FileCheck %s
+//
+// UNSUPPORTED: ios
 
 #include <stdio.h>
 


### PR DESCRIPTION
This test is currently failing on ios-sim. This patch follows other sanitizer tests that use DYLD_INSERT_LIBRARIES and marks itself unsupported on ios platforms.

rdar://162287951