### PR TITLE
[mlir][bazel]: Add missing dependency for 24ac5066

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -475,6 +475,7 @@ mlir_c_api_cc_library(
         ":Pass",
         ":Support",
         ":config",
+        ":Rewrite",
         "//llvm:Support",
     ],
     includes = ["include"],


### PR DESCRIPTION
[mlir][bazel]: Add missing dependency for 24ac5066