### PR TITLE
[libclang/python] Return None instead of null cursors from Token.cursor

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3939,6 +3939,8 @@ class Token(Structure):
         cursor._tu = self._tu
 
         conf.lib.clang_annotateTokens(self._tu, byref(self), 1, byref(cursor))
+        if cursor.is_null():
+            return None
 
         return cursor
 

--- a/clang/bindings/python/tests/cindex/test_tokens.py
+++ b/clang/bindings/python/tests/cindex/test_tokens.py
@@ -53,3 +53,11 @@ class TestTokens(unittest.TestCase):
 
         self.assertEqual(extent.start.offset, 4)
         self.assertEqual(extent.end.offset, 7)
+
+    def test_null_cursor(self):
+        """Ensure that null cursors are converted to None by get_tokens"""
+        tu = get_tu("int i = 5;")
+        tokens = list(tu.get_tokens(extent=tu.cursor.extent))
+        for token in tokens:
+            print(token.spelling, token.kind, token.extent)
+        self.assertEqual(tokens[-1].cursor, None)

--- a/clang/bindings/python/tests/cindex/test_tokens.py
+++ b/clang/bindings/python/tests/cindex/test_tokens.py
@@ -55,9 +55,7 @@ class TestTokens(unittest.TestCase):
         self.assertEqual(extent.end.offset, 7)
 
     def test_null_cursor(self):
-        """Ensure that null cursors are converted to None by get_tokens"""
+        """Ensure that the cursor property converts null cursors to None"""
         tu = get_tu("int i = 5;")
         tokens = list(tu.get_tokens(extent=tu.cursor.extent))
-        for token in tokens:
-            print(token.spelling, token.kind, token.extent)
         self.assertEqual(tokens[-1].cursor, None)

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -136,6 +136,7 @@ Clang Frontend Potentially Breaking Changes
 
 Clang Python Bindings Potentially Breaking Changes
 --------------------------------------------------
+- Return ``None`` instead of null cursors from ``Token.cursor``
 - TypeKind ``ELABORATED`` is not used anymore, per clang AST changes removing
   ElaboratedTypes. The value becomes unused, and all the existing users should
   expect the former underlying type to be reported instead.


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/138103 , the `Cursor` class throws an error when any of its methods is called on a null cursor. Simultaneously, we adapted all methods to return `None` instead of a null cursor, so users should not encounter these. We have overlooked one way to end up with null cursors, namely the `Token.cursor` property, which may return null cursors under some circumstances.

Fixes #163180