### PR TITLE
[lldb][test] Replace seven.join_for_shell with shlex.join

### DIFF
--- a/lldb/packages/Python/lldbsuite/support/seven.py
+++ b/lldb/packages/Python/lldbsuite/support/seven.py
@@ -1,5 +1,4 @@
 import binascii
-import shlex
 import subprocess
 
 
@@ -38,8 +37,3 @@ def unhexlify(hexstr):
 def hexlify(data):
     """Hex-encode string data. The result if always a string."""
     return bitcast_to_string(binascii.hexlify(bitcast_to_bytes(data)))
-
-
-# TODO: Replace this with `shlex.join` when minimum Python version is >= 3.8
-def join_for_shell(split_command):
-    return " ".join([shlex.quote(part) for part in split_command])

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -36,6 +36,7 @@ import json
 import os.path
 import re
 import shutil
+import shlex
 import signal
 from subprocess import *
 import sys
@@ -56,7 +57,6 @@ from . import lldbutil
 from . import test_categories
 from lldbsuite.support import encoded_file
 from lldbsuite.support import funcutils
-from lldbsuite.support import seven
 from lldbsuite.test_event import build_exception
 
 # See also dotest.parseOptionsAndInitTestdirs(), where the environment variables
@@ -1508,7 +1508,7 @@ class Base(unittest.TestCase):
         self.runBuildCommand(command)
 
     def runBuildCommand(self, command):
-        self.trace(seven.join_for_shell(command))
+        self.trace(shlex.join(command))
         try:
             output = check_output(command, stderr=STDOUT, errors="replace")
         except CalledProcessError as cpe:

--- a/lldb/packages/Python/lldbsuite/test_event/build_exception.py
+++ b/lldb/packages/Python/lldbsuite/test_event/build_exception.py
@@ -1,10 +1,10 @@
-from lldbsuite.support import seven
+import shlex
 
 
 class BuildError(Exception):
     def __init__(self, called_process_error):
         super(BuildError, self).__init__("Error when building test subject")
-        self.command = seven.join_for_shell(called_process_error.cmd)
+        self.command = shlex.join(called_process_error.cmd)
         self.build_error = called_process_error.output
 
     def __str__(self):

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteFork.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteFork.py
@@ -2,6 +2,7 @@ import random
 
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
+from lldbsuite.support import seven
 
 from fork_testbase import GdbRemoteForkTestBase
 


### PR DESCRIPTION
shlex.join is available in Python 3.8, which is the LLVM Project's minimum version.

https://docs.python.org/3/library/shlex.html#shlex.join