### PR TITLE
[lldb][test][Shell] Remove Python 2 compatibility in build.py

### DIFF
--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -7,14 +7,8 @@ import shutil
 import signal
 import subprocess
 import sys
+import winreg
 
-if sys.platform == "win32":
-    # This module was renamed in Python 3.  Make sure to import it using a
-    # consistent name regardless of python version.
-    try:
-        import winreg
-    except:
-        import _winreg as winreg
 
 if __name__ != "__main__":
     raise RuntimeError("Do not import this script, run it instead")

--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -7,7 +7,9 @@ import shutil
 import signal
 import subprocess
 import sys
-import winreg
+
+if sys.platform == "win32":
+    import winreg
 
 
 if __name__ != "__main__":


### PR DESCRIPTION
_winreg was renamed to winreg in 3.0, and we require >= 3.8.

https://docs.python.org/3/whatsnew/3.0.html#library-changes