### PR TITLE
[mlir][python] add dict-style to IR attributes

### DIFF
--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2730,7 +2730,8 @@ public:
         operation->get(), toMlirStringRef(name)));
   }
 
-  void forEachAttr(llvm::function_ref<void(MlirStringRef, MlirAttribute)> fn) {
+  static void
+  forEachAttr(llvm::function_ref<void(MlirStringRef, MlirAttribute)> fn) {
     intptr_t n = mlirOperationGetNumAttributes(operation->get());
     for (intptr_t i = 0; i < n; ++i) {
       MlirNamedAttribute na = mlirOperationGetAttribute(operation->get(), i);

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2730,8 +2730,7 @@ public:
         operation->get(), toMlirStringRef(name)));
   }
 
-  void
-  forEachAttr(const std::function<void(MlirStringRef, MlirAttribute)> &fn) {
+  void forEachAttr(llvm::function_ref<void(MlirStringRef, MlirAttribute)> fn) {
     intptr_t n = mlirOperationGetNumAttributes(operation->get());
     for (intptr_t i = 0; i < n; ++i) {
       MlirNamedAttribute na = mlirOperationGetAttribute(operation->get(), i);

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2730,8 +2730,8 @@ public:
         operation->get(), toMlirStringRef(name)));
   }
 
-  template <typename F>
-  auto forEachAttr(F fn) {
+  void
+  forEachAttr(const std::function<void(MlirStringRef, MlirAttribute)> &fn) {
     intptr_t n = mlirOperationGetNumAttributes(operation->get());
     for (intptr_t i = 0; i < n; ++i) {
       MlirNamedAttribute na = mlirOperationGetAttribute(operation->get(), i);

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -594,6 +594,7 @@ def testOperationAttributes():
     # CHECK: Dict mapping {'dependent': 'text', 'other.attribute': 3.0, 'some.attribute': 1}
     print("Dict mapping", d)
 
+    # Check that exceptions are raised as expected.
     try:
         op.attributes["does_not_exist"]
     except KeyError:

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -569,14 +569,31 @@ def testOperationAttributes():
     # CHECK: Attribute value b'text'
     print(f"Attribute value {sattr.value_bytes}")
 
+    # Python dict-style iteration
     # We don't know in which order the attributes are stored.
-    # CHECK-DAG: NamedAttribute(dependent="text")
-    # CHECK-DAG: NamedAttribute(other.attribute=3.000000e+00 : f64)
-    # CHECK-DAG: NamedAttribute(some.attribute=1 : i8)
-    for attr in op.attributes:
-        print(str(attr))
+    # CHECK-DAG: dependent
+    # CHECK-DAG: other.attribute
+    # CHECK-DAG: some.attribute
+    for name in op.attributes:
+        print(name)
 
-    # Check that exceptions are raised as expected.
+    # Basic dict-like introspection
+    # CHECK: True
+    print("some.attribute" in op.attributes)
+    # CHECK: False
+    print("missing" in op.attributes)
+    # CHECK: Keys: ['dependent', 'other.attribute', 'some.attribute']
+    print("Keys:", sorted(op.attributes.keys()))
+    # CHECK: Values count 3
+    print("Values count", len(op.attributes.values()))
+    # CHECK: Items count 3
+    print("Items count", len(op.attributes.items()))
+
+    # Dict() conversion test
+    d = {k: v.value for k, v in dict(op.attributes).items()}
+    # CHECK: Dict mapping {'dependent': 'text', 'other.attribute': 3.0, 'some.attribute': 1}
+    print("Dict mapping", d)
+
     try:
         op.attributes["does_not_exist"]
     except KeyError:


### PR DESCRIPTION
It makes sense that Attribute dicts/maps should behave like dicts in the Python bindings.  Previously this was not the case.