### PR TITLE
[clang] NFC: NNS getLocalSourceRange user cleanup

### DIFF
--- a/clang-tools-extra/clangd/FindTarget.cpp
+++ b/clang-tools-extra/clangd/FindTarget.cpp
@@ -1040,16 +1040,11 @@ private:
     if (auto *S = N.get<Stmt>())
       return refInStmt(S, Resolver);
     if (auto *NNSL = N.get<NestedNameSpecifierLoc>()) {
+      if (auto TL = NNSL->getAsTypeLoc())
+        return refInTypeLoc(NNSL->getAsTypeLoc(), Resolver);
       // (!) 'DeclRelation::Alias' ensures we do not lose namespace aliases.
-      NestedNameSpecifierLoc Qualifier;
-      SourceLocation NameLoc;
-      if (auto TL = NNSL->getAsTypeLoc()) {
-        Qualifier = TL.getPrefix();
-        NameLoc = TL.getNonPrefixBeginLoc();
-      } else {
-        Qualifier = NNSL->getAsNamespaceAndPrefix().Prefix;
-        NameLoc = NNSL->getLocalBeginLoc();
-      }
+      NestedNameSpecifierLoc Qualifier = NNSL->getAsNamespaceAndPrefix().Prefix;
+      SourceLocation NameLoc = NNSL->getLocalBeginLoc();
       return {
           ReferenceLoc{Qualifier, NameLoc, false,
                        explicitReferenceTargets(

--- a/clang/include/clang/AST/NestedNameSpecifierBase.h
+++ b/clang/include/clang/AST/NestedNameSpecifierBase.h
@@ -361,6 +361,9 @@ public:
   /// Retrieve the source range covering just the last part of
   /// this nested-name-specifier, not including the prefix.
   ///
+  /// Note that this is the source range of this NestedNameSpecifier chunk,
+  /// and for a type this includes the prefix of that type.
+  ///
   /// For example, if this instance refers to a nested-name-specifier
   /// \c \::std::vector<int>::, the returned source range would cover
   /// from "vector" to the last '::'.

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -199,11 +199,6 @@ public:
   NestedNameSpecifierLoc getPrefix() const;
 
   /// This returns the position of the type after any elaboration, such as the
-  /// 'struct' keyword, and name qualifiers. This will the 'template' keyword if
-  /// present, or the name location otherwise.
-  SourceLocation getNonPrefixBeginLoc() const;
-
-  /// This returns the position of the type after any elaboration, such as the
   /// 'struct' keyword. This may be the position of the name qualifiers,
   /// 'template' keyword, or the name location otherwise.
   SourceLocation getNonElaboratedBeginLoc() const;

--- a/clang/lib/AST/TypeLoc.cpp
+++ b/clang/lib/AST/TypeLoc.cpp
@@ -494,39 +494,6 @@ NestedNameSpecifierLoc TypeLoc::getPrefix() const {
   }
 }
 
-SourceLocation TypeLoc::getNonPrefixBeginLoc() const {
-  switch (getTypeLocClass()) {
-  case TypeLoc::TemplateSpecialization: {
-    auto TL = castAs<TemplateSpecializationTypeLoc>();
-    SourceLocation Loc = TL.getTemplateKeywordLoc();
-    if (!Loc.isValid())
-      Loc = TL.getTemplateNameLoc();
-    return Loc;
-  }
-  case TypeLoc::DeducedTemplateSpecialization: {
-    auto TL = castAs<DeducedTemplateSpecializationTypeLoc>();
-    SourceLocation Loc = TL.getTemplateKeywordLoc();
-    if (!Loc.isValid())
-      Loc = TL.getTemplateNameLoc();
-    return Loc;
-  }
-  case TypeLoc::DependentName:
-    return castAs<DependentNameTypeLoc>().getNameLoc();
-  case TypeLoc::Enum:
-  case TypeLoc::Record:
-  case TypeLoc::InjectedClassName:
-    return castAs<TagTypeLoc>().getNameLoc();
-  case TypeLoc::Typedef:
-    return castAs<TypedefTypeLoc>().getNameLoc();
-  case TypeLoc::UnresolvedUsing:
-    return castAs<UnresolvedUsingTypeLoc>().getNameLoc();
-  case TypeLoc::Using:
-    return castAs<UsingTypeLoc>().getNameLoc();
-  default:
-    return getBeginLoc();
-  }
-}
-
 SourceLocation TypeLoc::getNonElaboratedBeginLoc() const {
   // For elaborated types (e.g. `struct a::A`) we want the portion after the
   // `struct` but including the namespace qualifier, `a::`.


### PR DESCRIPTION
This adds a note to the documentation of getLocalSourceRange, and cleans up one of the users of this function which was changed in https://github.com/llvm/llvm-project/pull/147835

This also removes `TypeLoc::getNonPrefixBeginLoc`, which was recently introduced in the above patch, as that became unused.