### PR TITLE
[llvm][unittests][NFCI] Depend on RPATH for loading test plugins

### DIFF
--- a/llvm/unittests/Analysis/InlineAdvisorPlugin/CMakeLists.txt
+++ b/llvm/unittests/Analysis/InlineAdvisorPlugin/CMakeLists.txt
@@ -1,5 +1,5 @@
-# The advisor plugin expects to not link against the Analysis, Support and Core 
-# libraries, but expects them to exist in the process loading the plugin. This 
+# The advisor plugin expects to not link against the Analysis, Support and Core
+# libraries, but expects them to exist in the process loading the plugin. This
 # doesn't work with DLLs on Windows (where a shared library can't have undefined
 # references), so just skip this testcase on Windows.
 if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_BUILD_LLVM_DYLIB)
@@ -7,15 +7,6 @@ if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_BUILD_LLVM_DYLIB)
   add_llvm_library(InlineAdvisorPlugin MODULE BUILDTREE_ONLY
     InlineAdvisorPlugin.cpp
     )
-  # Put PLUGIN next to the unit test executable.
-  set_output_directory(InlineAdvisorPlugin
-      BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-      LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-      )
   set_target_properties(InlineAdvisorPlugin PROPERTIES FOLDER "LLVM/Tests")
-
-  # The plugin depends on some of the output files of intrinsics_gen, so make sure
-  # it is built before the plugin.
-  add_dependencies(InlineAdvisorPlugin intrinsics_gen)
   add_dependencies(AnalysisTests InlineAdvisorPlugin)
 endif()

--- a/llvm/unittests/Analysis/InlineAdvisorPlugin/InlineAdvisorPlugin.cpp
+++ b/llvm/unittests/Analysis/InlineAdvisorPlugin/InlineAdvisorPlugin.cpp
@@ -3,8 +3,6 @@
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include "llvm/Analysis/InlineAdvisor.h"
 

--- a/llvm/unittests/Analysis/InlineOrderPlugin/CMakeLists.txt
+++ b/llvm/unittests/Analysis/InlineOrderPlugin/CMakeLists.txt
@@ -1,5 +1,5 @@
-# The order plugin expects to not link against the Analysis, Support and Core 
-# libraries, but expects them to exist in the process loading the plugin. This 
+# The order plugin expects to not link against the Analysis, Support and Core
+# libraries, but expects them to exist in the process loading the plugin. This
 # doesn't work with DLLs on Windows (where a shared library can't have undefined
 # references), so just skip this testcase on Windows.
 if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_BUILD_LLVM_DYLIB)
@@ -7,15 +7,6 @@ if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_BUILD_LLVM_DYLIB)
   add_llvm_library(InlineOrderPlugin MODULE BUILDTREE_ONLY
     InlineOrderPlugin.cpp
     )
-  # Put PLUGIN next to the unit test executable.
-  set_output_directory(InlineOrderPlugin
-      BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-      LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-      )
   set_target_properties(InlineOrderPlugin PROPERTIES FOLDER "Tests")
-
-  # The plugin depends on some of the output files of intrinsics_gen, so make sure
-  # it is built before the plugin.
-  add_dependencies(InlineOrderPlugin intrinsics_gen)
   add_dependencies(AnalysisTests InlineOrderPlugin)
 endif()

--- a/llvm/unittests/Analysis/InlineOrderPlugin/InlineOrderPlugin.cpp
+++ b/llvm/unittests/Analysis/InlineOrderPlugin/InlineOrderPlugin.cpp
@@ -3,8 +3,6 @@
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include "llvm/Analysis/InlineOrder.h"
 

--- a/llvm/unittests/Analysis/PluginInlineAdvisorAnalysisTest.cpp
+++ b/llvm/unittests/Analysis/PluginInlineAdvisorAnalysisTest.cpp
@@ -4,27 +4,12 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
 namespace llvm {
 
 namespace {
-
-void anchor() {}
-
-static std::string libPath(const std::string Name = "InlineAdvisorPlugin") {
-  const auto &Argvs = testing::internal::GetArgvs();
-  const char *Argv0 =
-      Argvs.size() > 0 ? Argvs[0].c_str() : "PluginInlineAdvisorAnalysisTest";
-  void *Ptr = (void *)(intptr_t)anchor;
-  std::string Path = sys::fs::getMainExecutable(Argv0, Ptr);
-  llvm::SmallString<256> Buf{sys::path::parent_path(Path)};
-  sys::path::append(Buf, (Name + LLVM_PLUGIN_EXT).c_str());
-  return std::string(Buf.str());
-}
 
 // Example of a custom InlineAdvisor that only inlines calls to functions called
 // "foo".
@@ -61,8 +46,7 @@ struct CompilerInstance {
 
   // connect the plugin to our compiler instance
   void setupPlugin() {
-    auto PluginPath = libPath();
-    ASSERT_NE("", PluginPath);
+    auto PluginPath{std::string{"InlineAdvisorPlugin"} + LLVM_PLUGIN_EXT};
     Expected<PassPlugin> Plugin = PassPlugin::Load(PluginPath);
     ASSERT_TRUE(!!Plugin) << "Plugin path: " << PluginPath;
     Plugin->registerPassBuilderCallbacks(PB);

--- a/llvm/unittests/Analysis/PluginInlineOrderAnalysisTest.cpp
+++ b/llvm/unittests/Analysis/PluginInlineOrderAnalysisTest.cpp
@@ -4,29 +4,12 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
-
-#include "llvm/Analysis/InlineOrder.h"
 
 namespace llvm {
 
 namespace {
-
-void anchor() {}
-
-std::string libPath(const std::string Name = "InlineOrderPlugin") {
-  const auto &Argvs = testing::internal::GetArgvs();
-  const char *Argv0 =
-      Argvs.size() > 0 ? Argvs[0].c_str() : "PluginInlineOrderAnalysisTest";
-  void *Ptr = (void *)(intptr_t)anchor;
-  std::string Path = sys::fs::getMainExecutable(Argv0, Ptr);
-  llvm::SmallString<256> Buf{sys::path::parent_path(Path)};
-  sys::path::append(Buf, (Name + LLVM_PLUGIN_EXT).c_str());
-  return std::string(Buf.str());
-}
 
 struct CompilerInstance {
   LLVMContext Ctx;
@@ -43,8 +26,7 @@ struct CompilerInstance {
 
   // Connect the plugin to our compiler instance.
   void setupPlugin() {
-    auto PluginPath = libPath();
-    ASSERT_NE("", PluginPath);
+    auto PluginPath{std::string{"InlineOrderPlugin"} + LLVM_PLUGIN_EXT};
     Expected<PassPlugin> Plugin = PassPlugin::Load(PluginPath);
     ASSERT_TRUE(!!Plugin) << "Plugin path: " << PluginPath;
     Plugin->registerPassBuilderCallbacks(PB);

--- a/llvm/unittests/Passes/Plugins/DoublerPlugin/CMakeLists.txt
+++ b/llvm/unittests/Passes/Plugins/DoublerPlugin/CMakeLists.txt
@@ -1,15 +1,5 @@
 add_llvm_library(DoublerPlugin MODULE BUILDTREE_ONLY
-    DoublerPlugin.cpp
-    )
-
-# Put PLUGIN next to the unit test executable.
-set_output_directory(DoublerPlugin
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-    LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-    )
+  DoublerPlugin.cpp
+)
 set_target_properties(DoublerPlugin PROPERTIES FOLDER "Tests")
-
-# The plugin depends on some of the output files of intrinsics_gen, so make sure
-# it is built before the plugin.
-add_dependencies(DoublerPlugin intrinsics_gen)
 add_dependencies(PluginsTests DoublerPlugin)

--- a/llvm/unittests/Passes/Plugins/PluginsTest.cpp
+++ b/llvm/unittests/Passes/Plugins/PluginsTest.cpp
@@ -27,27 +27,13 @@
 
 using namespace llvm;
 
-void anchor() {}
-
-static std::string LibPath(const std::string Name = "TestPlugin") {
-  const auto &Argvs = testing::internal::GetArgvs();
-  const char *Argv0 = Argvs.size() > 0 ? Argvs[0].c_str() : "PluginsTests";
-  void *Ptr = (void *)(intptr_t)anchor;
-  std::string Path = sys::fs::getMainExecutable(Argv0, Ptr);
-  llvm::SmallString<256> Buf{sys::path::parent_path(Path)};
-  sys::path::append(Buf, (Name + LLVM_PLUGIN_EXT).c_str());
-  return std::string(Buf.str());
-}
-
 TEST(PluginsTests, LoadPlugin) {
 #if !defined(LLVM_ENABLE_PLUGINS)
   // Skip the test if plugins are disabled.
   GTEST_SKIP();
 #endif
 
-  auto PluginPath = LibPath();
-  ASSERT_NE("", PluginPath);
-
+  auto PluginPath{std::string{"TestPlugin"} + LLVM_PLUGIN_EXT};
   Expected<PassPlugin> Plugin = PassPlugin::Load(PluginPath);
   ASSERT_TRUE(!!Plugin) << "Plugin path: " << PluginPath;
 
@@ -71,10 +57,8 @@ TEST(PluginsTests, LoadMultiplePlugins) {
   GTEST_SKIP();
 #endif
 
-  auto DoublerPluginPath = LibPath("DoublerPlugin");
-  auto TestPluginPath = LibPath("TestPlugin");
-  ASSERT_NE("", DoublerPluginPath);
-  ASSERT_NE("", TestPluginPath);
+  auto DoublerPluginPath{std::string{"DoublerPlugin"} + LLVM_PLUGIN_EXT};
+  auto TestPluginPath{std::string{"TestPlugin"} + LLVM_PLUGIN_EXT};
 
   Expected<PassPlugin> DoublerPlugin1 = PassPlugin::Load(DoublerPluginPath);
   ASSERT_TRUE(!!DoublerPlugin1)

--- a/llvm/unittests/Passes/Plugins/TestPlugin/CMakeLists.txt
+++ b/llvm/unittests/Passes/Plugins/TestPlugin/CMakeLists.txt
@@ -1,15 +1,6 @@
 add_llvm_library(TestPlugin MODULE BUILDTREE_ONLY
-    TestPlugin.cpp
-    )
-
-# Put PLUGIN next to the unit test executable.
-set_output_directory(TestPlugin
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-    LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-    )
+  TestPlugin.cpp
+)
 set_target_properties(TestPlugin PROPERTIES FOLDER "Tests")
 
-# The plugin depends on some of the output files of intrinsics_gen, so make sure
-# it is built before the plugin.
-add_dependencies(TestPlugin intrinsics_gen)
 add_dependencies(PluginsTests TestPlugin)

--- a/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
+++ b/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
@@ -33,19 +33,14 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "AIX")
 endif()
 
 function(dynlib_add_module NAME)
-  add_library(${NAME} MODULE
+  add_llvm_library(${NAME} MODULE BUILDTREE_ONLY
     PipSqueak.cpp
-    )
+  )
   set_target_properties(${NAME} PROPERTIES FOLDER "LLVM/Tests/Support")
 
   set_output_directory(${NAME}
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
     LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
-    )
-
-  set_target_properties(${NAME}
-    PROPERTIES PREFIX ""
-    SUFFIX ${LLVM_PLUGIN_EXT}
     )
 
   add_dependencies(DynamicLibraryTests ${NAME})


### PR DESCRIPTION
As proven by #159126 it's unnecessary to explicitly construct the path for loading the test plugins. On all supported platforms the RPATH is set appropriately for them to be found by the dynamic loader itself. Thus we can just rid ourselves of the extra code.

This also cleans up some of the CMake code and C++ includes slightly. Surprisingly `intrinsics_gen` isn't necessary for any of them as none of them actually do much.

See: #159126