### PR TITLE
[llvm][RISCV] Correct the order of statement in insertVSETMTK

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -1945,9 +1945,12 @@ bool RISCVInsertVSETVLI::insertVSETMTK(MachineBasicBlock &MBB,
                      .addImm(Log2_32(CurrInfo.getTWiden()) + 1);
 
     Changed = true;
+    Register Reg = Op.getReg();
+    Op.setReg(RISCV::NoRegister);
+    Op.setIsKill(false);
     if (LIS) {
       LIS->InsertMachineInstrInMaps(*TmpMI);
-      LiveInterval &LI = LIS->getInterval(Op.getReg());
+      LiveInterval &LI = LIS->getInterval(Reg);
 
       // Erase the AVL operand from the instruction.
       LIS->shrinkToUses(&LI);
@@ -1955,9 +1958,6 @@ bool RISCVInsertVSETVLI::insertVSETMTK(MachineBasicBlock &MBB,
       // SmallVector<LiveInterval *> SplitLIs;
       // LIS->splitSeparateComponents(LI, SplitLIs);
     }
-
-    Op.setReg(RISCV::NoRegister);
-    Op.setIsKill(false);
   }
   return Changed;
 }

--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -1946,7 +1946,7 @@ bool RISCVInsertVSETVLI::insertVSETMTK(MachineBasicBlock &MBB,
 
     Changed = true;
     Register Reg = Op.getReg();
-    Op.setReg(RISCV::NoRegister);
+    Op.setReg(Register());
     Op.setIsKill(false);
     if (LIS) {
       LIS->InsertMachineInstrInMaps(*TmpMI);


### PR DESCRIPTION
We need to set register to noreg before shrinking interval
