### PR TITLE
[HLSL] Add  _m and _<numeric> based accessors to hlsl::matrix

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7500,7 +7500,11 @@ def ext_subscript_non_lvalue : Extension<
 def err_typecheck_subscript_value : Error<
   "subscripted value is not an array, pointer, or vector">;
 def err_typecheck_subscript_not_integer : Error<
-  "array subscript is not an integer">;
+  "%select{array|matrix}0 subscript is not an integer">;
+def err_typecheck_subscript_not_in_bounds : Error<
+  "%select{row|column}0 subscript is out of bounds of %select{zero|one}1 based indexing">;
+def err_typecheck_subscript_out_of_bounds : Error<
+  "%select{row|column}0 subscripted is out of bounds">;
 def err_subscript_function_type : Error<
   "subscript of pointer to function type %0">;
 def err_subscript_incomplete_or_sizeless_type : Error<
@@ -12972,6 +12976,7 @@ def err_builtin_matrix_stride_too_small: Error<
   "stride must be greater or equal to the number of rows">;
 def err_builtin_matrix_invalid_dimension: Error<
   "%0 dimension is outside the allowed range [1, %1]">;
+def err_builtin_matrix_invalid_member: Error<"invalid matrix member">;
 
 def warn_mismatched_import : Warning<
   "import %select{module|name}0 (%1) does not match the import %select{module|name}0 (%2) of the "

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -225,6 +225,9 @@ public:
   bool transformInitList(const InitializedEntity &Entity, InitListExpr *Init);
   bool handleInitialization(VarDecl *VDecl, Expr *&Init);
   void deduceAddressSpace(VarDecl *Decl);
+  ExprResult tryBuildHLSLMatrixElementAccessor(Expr *Base,
+                                               SourceLocation MemberLoc,
+                                               const IdentifierInfo *MemberId);
 
 private:
   // HLSL resource type attributes need to be processed all at once.

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5334,7 +5334,7 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
   // C99 6.5.2.1p1
   if (!IndexExpr->getType()->isIntegerType() && !IndexExpr->isTypeDependent())
     return ExprError(Diag(LLoc, diag::err_typecheck_subscript_not_integer)
-                     << IndexExpr->getSourceRange());
+                     << /*array*/ 0 << IndexExpr->getSourceRange());
 
   if ((IndexExpr->getType()->isSpecificBuiltinType(BuiltinType::Char_S) ||
        IndexExpr->getType()->isSpecificBuiltinType(BuiltinType::Char_U)) &&
@@ -16261,7 +16261,7 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
           !Idx->getType()->isIntegerType())
         return ExprError(
             Diag(Idx->getBeginLoc(), diag::err_typecheck_subscript_not_integer)
-            << Idx->getSourceRange());
+            << /*array*/ 0 << Idx->getSourceRange());
 
       // Record this array index.
       Comps.push_back(OffsetOfNode(OC.LocStart, Exprs.size(), OC.LocEnd));

--- a/clang/test/AST/HLSL/matrix-member-access.hlsl
+++ b/clang/test/AST/HLSL/matrix-member-access.hlsl
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -ast-dump -o - %s | FileCheck %s 
+
+typedef float float3x3 __attribute__((matrix_type(3,3)));
+
+[numthreads(1,1,1)]
+void ok() {
+    float3x3 A;
+    // CHECK: BinaryOperator 0x{{[0-9a-fA-F]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> 'float' lvalue matrixcomponent '='
+    // CHECK-NEXT: MatrixSubscriptExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' lvalue matrixcomponent
+    // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'float3x3':'matrix<float, 3, 3>' lvalue Var 0x{{[0-9a-fA-F]+}} 'A' 'float3x3':'matrix<float, 3, 3>'
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 1
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 2
+    // CHECK-NEXT: FloatingLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'float' 3.140000e+00
+    A._m12 = 3.14;
+
+    // CHECK: VarDecl 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> col:{{[0-9]+}} r 'float' cinit
+    // CHECK-NEXT: ImplicitCastExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' <LValueToRValue>
+    // CHECK-NEXT: MatrixSubscriptExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' lvalue matrixcomponent
+    // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'float3x3':'matrix<float, 3, 3>' lvalue Var 0x{{[0-9a-fA-F]+}} 'A' 'float3x3':'matrix<float, 3, 3>'
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 0
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 0
+    float r = A._m00;
+
+    // CHECK: VarDecl 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> col:{{[0-9]+}} good1 'float' cinit
+    // CHECK-NEXT: ImplicitCastExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' <LValueToRValue>
+    // CHECK-NEXT: MatrixSubscriptExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' lvalue matrixcomponent
+    // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'float3x3':'matrix<float, 3, 3>' lvalue Var 0x{{[0-9a-fA-F]+}} 'A' 'float3x3':'matrix<float, 3, 3>'
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 0
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 0
+    float good1 = A._11;
+
+    // CHECK: VarDecl 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> col:{{[0-9]+}} good2 'float' cinit
+    // CHECK-NEXT: ImplicitCastExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' <LValueToRValue>
+    // CHECK-NEXT: MatrixSubscriptExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'float' lvalue matrixcomponent
+    // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'float3x3':'matrix<float, 3, 3>' lvalue Var 0x{{[0-9a-fA-F]+}} 'A' 'float3x3':'matrix<float, 3, 3>'
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 2
+    // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-fA-F]+}} <col:{{[0-9]+}}> 'unsigned int' 2    
+    float good2 = A._33;
+}

--- a/clang/test/CodeGenHLSL/matrix-member-access.hlsl
+++ b/clang/test/CodeGenHLSL/matrix-member-access.hlsl
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+half3x3 write_pi(half3x3 A) {
+    //CHECK:  [[MAT_INS:%.*]] = insertelement <9 x half> %{{[0-9]+}}, half 0xH4248, i32 7
+    //CHECK-NEXT:  store <9 x half> [[MAT_INS]], ptr %{{.*}}, align 2
+    A._m12 = 3.14;
+    return A;
+}
+
+half read_1x1(half3x3 A) {
+    //CHECK:  [[MAT_EXT:%.*]] = extractelement <9 x half> %{{[0-9]+}}, i32 0
+    return A._11;
+}
+half read_m0x0(half3x3 A) {
+    //CHECK:  [[MAT_EXT:%.*]] = extractelement <9 x half> %{{[0-9]+}}, i32 0
+    return A._m00;
+}
+
+half read_3x3(half3x3 A) {
+    //CHECK:  [[MAT_EXT:%.*]] = extractelement <9 x half> %{{[0-9]+}}, i32 8
+    return A._33;
+}

--- a/clang/test/SemaHLSL/matrix-member-access.hlsl
+++ b/clang/test/SemaHLSL/matrix-member-access.hlsl
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -finclude-default-header -verify %s
+
+void foo() {
+    float3x3 A;
+    float r = A._m00;      // read is ok
+    float good1 = A._11;    
+    float good2 = A._33;
+
+    float bad0 = A._m44;    // expected-error {{row subscript is out of bounds of zero based indexing}} expected-error {{column subscript is out of bounds of zero based indexing}}
+    float bad1 = A._m33;    // expected-error {{row subscripted is out of bounds}} expected-error {{column subscripted is out of bounds}}
+    float bad2 = A._mA2;    // expected-error {{matrix subscript is not an integer}}
+    float bad3 = A._m2F;    // expected-error {{matrix subscript is not an integer}}
+
+    float bad4 = A._00;    // expected-error {{row subscript is out of bounds of one based indexing}} expected-error {{column subscript is out of bounds of one based indexing}}
+    float bad5 = A._44;    // expected-error {{row subscripted is out of bounds}} expected-error {{column subscripted is out of bounds}}
+    float bad6 = A._55;    // expected-error {{row subscript is out of bounds of one based indexing}} expected-error {{column subscript is out of bounds of one based indexing}}
+
+    
+    A._m12 = 3.14;         // write is OK
+}


### PR DESCRIPTION
fixes #159438

HLSL supports 0 based index and one based index accessors that are equivalent to the column row bracket subscripting operators.

This change adds support for these accessors by hooking into LookupMemberExpr and adding them similar to how `CheckExtVectorComponent` and the hlsl specific scalar to vectorsplat accessors work.

Since these accessors are HLSL specific The implementation details are kept to SemaHLSL via `tryBuildHLSLMatrixElementAccessor`.