### PR TITLE
[ARM] Enable creation of ARMISD::CMN nodes

### DIFF
--- a/llvm/lib/Target/ARM/ARMFeatures.h
+++ b/llvm/lib/Target/ARM/ARMFeatures.h
@@ -51,7 +51,7 @@ inline bool isV8EligibleForIT(const InstrType *Instr) {
     // Outside of an IT block, these set CPSR.
     return IsCPSRDead(Instr);
   case ARM::tADDrSPi:
-  case ARM::tCMNz:
+  case ARM::tCMN:
   case ARM::tCMPi8:
   case ARM::tCMPr:
   case ARM::tLDRBi:

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -4457,6 +4457,29 @@ static bool isFloatingPointZero(SDValue Op) {
   return false;
 }
 
+static bool isSafeSignedCMN(SDValue Op, SelectionDAG &DAG) {
+  // 0 - INT_MIN sign wraps, so no signed wrap means cmn is safe.
+  if (Op->getFlags().hasNoSignedWrap())
+    return true;
+
+  // We can still figure out if the second operand is safe to use
+  // in a CMN instruction by checking if it is known to be not the minimum
+  // signed value. If it is not, then we can safely use CMN.
+  // Note: We can eventually remove this check and simply rely on
+  // Op->getFlags().hasNoSignedWrap() once SelectionDAG/ISelLowering
+  // consistently sets them appropriately when making said nodes.
+
+  KnownBits KnownSrc = DAG.computeKnownBits(Op.getOperand(1));
+  return !KnownSrc.getSignedMinValue().isMinSignedValue();
+}
+
+static bool isCMN(SDValue Op, ISD::CondCode CC, SelectionDAG &DAG) {
+  return Op.getOpcode() == ISD::SUB && isNullConstant(Op.getOperand(0)) &&
+         (isIntEqualitySetCC(CC) ||
+          (isUnsignedIntSetCC(CC) && DAG.isKnownNeverZero(Op.getOperand(1))) ||
+          (isSignedIntSetCC(CC) && isSafeSignedCMN(Op, DAG)));
+}
+
 /// Returns appropriate ARM CMP (cmp) and corresponding condition code for
 /// the given operands.
 SDValue ARMTargetLowering::getARMCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC,
@@ -4590,6 +4613,21 @@ SDValue ARMTargetLowering::getARMCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC,
     CompareType = ARMISD::CMPZ;
     break;
   }
+
+  // TODO: Remove CMPZ check once we generalize and remove the CMPZ enum from
+  // the codebase.
+
+  // TODO: When we have a solution to the vselect predicate not allowing pl/mi
+  // all the time, allow those cases to be cmn too no matter what.
+  if (CompareType != ARMISD::CMPZ && isCMN(RHS, CC, DAG)) {
+    CompareType = ARMISD::CMN;
+    RHS = RHS.getOperand(1);
+  } else if (CompareType != ARMISD::CMPZ && isCMN(LHS, CC, DAG)) {
+    CompareType = ARMISD::CMN;
+    LHS = LHS.getOperand(1);
+    CondCode = IntCCToARMCC(ISD::getSetCCSwappedOperands(CC));
+  }
+
   ARMcc = DAG.getConstant(CondCode, dl, MVT::i32);
   return DAG.getNode(CompareType, dl, FlagsVT, LHS, RHS);
 }

--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -250,7 +250,7 @@ def ARMBcci64        : SDNode<"ARMISD::BCC_i64", SDT_ARMBCC_i64,
 def ARMcmp           : SDNode<"ARMISD::CMP", SDT_ARMCmp>;
 
 // ARM CMN instructions.
-def ARMcmn           : SDNode<"ARMISD::CMN", SDT_ARMCmp>;
+def ARMcmn           : SDNode<"ARMISD::CMN", SDT_ARMCmp, [SDNPCommutative]>;
 
 // ARM compare that sets only Z flag.
 def ARMcmpZ          : SDNode<"ARMISD::CMPZ", SDT_ARMCmp, [SDNPCommutative]>;
@@ -5078,10 +5078,10 @@ def CMNri : AI1<0b1011, (outs), (ins GPR:$Rn, mod_imm:$imm), DPFrm, IIC_iCMPi,
 }
 
 // CMN register-register/shift
-def CMNzrr : AI1<0b1011, (outs), (ins GPR:$Rn, GPR:$Rm), DPFrm, IIC_iCMPr,
+def CMNrr : AI1<0b1011, (outs), (ins GPR:$Rn, GPR:$Rm), DPFrm, IIC_iCMPr,
                  "cmn", "\t$Rn, $Rm",
-                 [(set CPSR, (BinOpFrag<(ARMcmpZ node:$LHS,(ineg node:$RHS))>
-                   GPR:$Rn, GPR:$Rm))]>, Sched<[WriteCMP, ReadALU, ReadALU]> {
+                 [(set CPSR, (ARMcmn GPR:$Rn, GPR:$Rm))]>,
+                 Sched<[WriteCMP, ReadALU, ReadALU]> {
   bits<4> Rn;
   bits<4> Rm;
   let isCommutable = 1;
@@ -5095,12 +5095,11 @@ def CMNzrr : AI1<0b1011, (outs), (ins GPR:$Rn, GPR:$Rm), DPFrm, IIC_iCMPr,
   let Unpredictable{15-12} = 0b1111;
 }
 
-def CMNzrsi : AI1<0b1011, (outs),
+def CMNrsi : AI1<0b1011, (outs),
                   (ins GPR:$Rn, so_reg_imm:$shift), DPSoRegImmFrm, IIC_iCMPsr,
                   "cmn", "\t$Rn, $shift",
-                  [(set CPSR, (BinOpFrag<(ARMcmpZ node:$LHS,(ineg node:$RHS))>
-                    GPR:$Rn, so_reg_imm:$shift))]>,
-                    Sched<[WriteCMPsi, ReadALU]> {
+                  [(set CPSR, (ARMcmn GPR:$Rn, so_reg_imm:$shift))]>,
+                  Sched<[WriteCMPsi, ReadALU]> {
   bits<4> Rn;
   bits<12> shift;
   let Inst{25} = 0;
@@ -5114,12 +5113,11 @@ def CMNzrsi : AI1<0b1011, (outs),
   let Unpredictable{15-12} = 0b1111;
 }
 
-def CMNzrsr : AI1<0b1011, (outs),
+def CMNrsr : AI1<0b1011, (outs),
                   (ins GPRnopc:$Rn, so_reg_reg:$shift), DPSoRegRegFrm, IIC_iCMPsr,
                   "cmn", "\t$Rn, $shift",
-                  [(set CPSR, (BinOpFrag<(ARMcmpZ node:$LHS,(ineg node:$RHS))>
-                    GPRnopc:$Rn, so_reg_reg:$shift))]>,
-                    Sched<[WriteCMPsr, ReadALU]> {
+                  [(set CPSR, (ARMcmn GPRnopc:$Rn, so_reg_reg:$shift))]>,
+                  Sched<[WriteCMPsr, ReadALU]> {
   bits<4> Rn;
   bits<12> shift;
   let Inst{25} = 0;
@@ -5137,11 +5135,17 @@ def CMNzrsr : AI1<0b1011, (outs),
 
 }
 
+// ARMcmpZ patterns for CMN (compare-to-zero with negated operands)
 def : ARMPat<(ARMcmp  GPR:$src, mod_imm_neg:$imm),
              (CMNri   GPR:$src, mod_imm_neg:$imm)>;
-
 def : ARMPat<(ARMcmpZ GPR:$src, mod_imm_neg:$imm),
              (CMNri   GPR:$src, mod_imm_neg:$imm)>;
+def : ARMPat<(ARMcmpZ GPR:$src, (ineg GPR:$rhs)),
+             (CMNrr GPR:$src, GPR:$rhs)>;
+def : ARMPat<(ARMcmpZ GPR:$src, (ineg so_reg_imm:$rhs)),
+             (CMNrsi GPR:$src, so_reg_imm:$rhs)>;
+def : ARMPat<(ARMcmpZ GPRnopc:$src, (ineg so_reg_reg:$rhs)),
+             (CMNrsr GPRnopc:$src, so_reg_reg:$rhs)>;
 
 // Note that TST/TEQ don't set all the same flags that CMP does!
 defm TST  : AI1_cmp_irs<0b1000, "tst",

--- a/llvm/lib/Target/ARM/ARMInstrThumb.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb.td
@@ -1102,7 +1102,8 @@ def tASRrr :                    // A8.6.15
   T1sItDPEncode<0b0100, (outs tGPR:$Rdn), (ins tGPR:$Rn, tGPR:$Rm),
                 IIC_iMOVsr,
                 "asr", "\t$Rdn, $Rm",
-                [(set tGPR:$Rdn, (sra tGPR:$Rn, tGPR:$Rm))]>, Sched<[WriteALU]>;
+                [(set tGPR:$Rdn, (sra tGPR:$Rn, tGPR:$Rm))]>,
+                Sched<[WriteALU]>;
 
 // BIC register
 def tBIC :                      // A8.6.20
@@ -1114,21 +1115,12 @@ def tBIC :                      // A8.6.20
 
 // CMN register
 let isCompare = 1, Defs = [CPSR] in {
-//FIXME: Disable CMN, as CCodes are backwards from compare expectations
-//       Compare-to-zero still works out, just not the relationals
-//def tCMN :                     // A8.6.33
-//  T1pIDPEncode<0b1011, (outs), (ins tGPR:$lhs, tGPR:$rhs),
-//               IIC_iCMPr,
-//               "cmn", "\t$lhs, $rhs",
-//               [(set CPSR, (ARMcmp tGPR:$lhs, (ineg tGPR:$rhs)))]>;
-
-def tCMNz :                     // A8.6.33
+def tCMN :                     // A8.6.33
   T1pIDPEncode<0b1011, (outs), (ins tGPR:$Rn, tGPR:$Rm),
                IIC_iCMPr,
                "cmn", "\t$Rn, $Rm",
-               [(set CPSR, (ARMcmpZ tGPR:$Rn, (ineg tGPR:$Rm)))]>,
-  Sched<[WriteCMP]>;
-
+               [(set CPSR, (ARMcmn tGPR:$Rn, tGPR:$Rm))]>,
+               Sched<[WriteCMP]>;
 } // isCompare = 1, Defs = [CPSR]
 
 // CMP immediate
@@ -1583,6 +1575,11 @@ def tInt_WIN_eh_sjlj_longjmp
 // Comparisons
 def : T1Pat<(ARMcmpZ tGPR:$Rn, imm0_255:$imm8),
             (tCMPi8  tGPR:$Rn, imm0_255:$imm8)>;
+
+// Fold compare-equal of a negated register into CMN register form.
+def : T1Pat<(ARMcmpZ tGPR:$Rn, (ineg tGPR:$Rm)),
+            (tCMN tGPR:$Rn, tGPR:$Rm)>;
+
 def : T1Pat<(ARMcmpZ tGPR:$Rn, tGPR:$Rm),
             (tCMPr   tGPR:$Rn, tGPR:$Rm)>;
 

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -3509,12 +3509,11 @@ let isCompare = 1, Defs = [CPSR] in {
      let Inst{11-8} = 0b1111; // Rd
    }
    // register
-   def t2CMNzrr : T2TwoRegCmp<
+   def t2CMNrr : T2TwoRegCmp<
                 (outs), (ins GPRnopc:$Rn, rGPR:$Rm), IIC_iCMPr,
                 "cmn", ".w\t$Rn, $Rm",
-                [(set CPSR, (BinOpFrag<(ARMcmpZ node:$LHS,(ineg node:$RHS))>
-                  GPRnopc:$Rn, rGPR:$Rm))]>,
-                  Sched<[WriteCMP, ReadALU, ReadALU]> {
+                [(set CPSR, (ARMcmn GPRnopc:$Rn, rGPR:$Rm))]>,
+                Sched<[WriteCMP, ReadALU, ReadALU]> {
      let Inst{31-27} = 0b11101;
      let Inst{26-25} = 0b01;
      let Inst{24-21} = 0b1000;
@@ -3525,12 +3524,11 @@ let isCompare = 1, Defs = [CPSR] in {
      let Inst{5-4} = 0b00; // type
    }
    // shifted register
-   def t2CMNzrs : T2OneRegCmpShiftedReg<
+   def t2CMNrs : T2OneRegCmpShiftedReg<
                 (outs), (ins GPRnopc:$Rn, t2_so_reg:$ShiftedRm), IIC_iCMPsi,
                 "cmn", ".w\t$Rn, $ShiftedRm",
-                [(set CPSR, (BinOpFrag<(ARMcmpZ node:$LHS,(ineg node:$RHS))>
-                  GPRnopc:$Rn, t2_so_reg:$ShiftedRm))]>,
-                  Sched<[WriteCMPsi, ReadALU, ReadALU]> {
+                [(set CPSR, (ARMcmn GPRnopc:$Rn, t2_so_reg:$ShiftedRm))]>,
+                Sched<[WriteCMPsi, ReadALU, ReadALU]> {
      let Inst{31-27} = 0b11101;
      let Inst{26-25} = 0b01;
      let Inst{24-21} = 0b1000;
@@ -3545,13 +3543,19 @@ let isCompare = 1, Defs = [CPSR] in {
 def : t2InstAlias<"cmn${p} $Rn, $imm",
    (t2CMNri GPRnopc:$Rn, t2_so_imm:$imm, pred:$p)>;
 def : t2InstAlias<"cmn${p} $Rn, $shift",
-   (t2CMNzrs GPRnopc:$Rn, t2_so_reg:$shift, pred:$p)>;
+   (t2CMNrs GPRnopc:$Rn, t2_so_reg:$shift, pred:$p)>;
 
 def : T2Pat<(ARMcmp  GPR:$src, t2_so_imm_neg:$imm),
             (t2CMNri GPR:$src, t2_so_imm_neg:$imm)>;
 
 def : T2Pat<(ARMcmpZ GPRnopc:$src, t2_so_imm_neg:$imm),
             (t2CMNri GPRnopc:$src, t2_so_imm_neg:$imm)>;
+
+// Fold compare-to-zero of a negated register into CMN register forms.
+def : T2Pat<(ARMcmpZ GPRnopc:$Rn, (ineg rGPR:$Rm)),
+            (t2CMNrr GPRnopc:$Rn, rGPR:$Rm)>;
+def : T2Pat<(ARMcmpZ GPRnopc:$Rn, (ineg t2_so_reg:$ShiftedRm)),
+            (t2CMNrs GPRnopc:$Rn, t2_so_reg:$ShiftedRm)>;
 
 defm t2TST  : T2I_cmp_irs<0b0000, "tst", rGPR,
                           IIC_iTSTi, IIC_iTSTr, IIC_iTSTsi,
@@ -5111,7 +5115,7 @@ def : t2InstAlias<"subw${p} $Rdn, $imm",
 
 // Alias for compares without the ".w" optional width specifier.
 def : t2InstAlias<"cmn${p} $Rn, $Rm",
-                  (t2CMNzrr GPRnopc:$Rn, rGPR:$Rm, pred:$p)>;
+                  (t2CMNrr GPRnopc:$Rn, rGPR:$Rm, pred:$p)>;
 def : t2InstAlias<"teq${p} $Rn, $Rm",
                   (t2TEQrr rGPR:$Rn, rGPR:$Rm, pred:$p)>;
 def : t2InstAlias<"tst${p} $Rn, $Rm",

--- a/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
+++ b/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
@@ -112,9 +112,8 @@ InstructionInformation::InstructionInformation(const ARMBaseInstrInfo *TII) {
   Info[t2SDIV].IsDivide = Info[t2UDIV].IsDivide = true;
 
   std::initializer_list<unsigned> isInlineShiftALUList = {
-      t2ADCrs,  t2ADDSrs, t2ADDrs,  t2BICrs, t2EORrs,
-      t2ORNrs,  t2RSBSrs, t2RSBrs,  t2SBCrs, t2SUBrs,
-      t2SUBSrs, t2CMPrs,  t2CMNzrs, t2TEQrs, t2TSTrs,
+      t2ADCrs, t2ADDSrs, t2ADDrs,  t2BICrs, t2EORrs, t2ORNrs, t2RSBSrs, t2RSBrs,
+      t2SBCrs, t2SUBrs,  t2SUBSrs, t2CMPrs, t2CMNrs, t2TEQrs, t2TSTrs,
   };
   for (auto op : isInlineShiftALUList) {
     Info[op].IsInlineShiftALU = true;

--- a/llvm/lib/Target/ARM/ARMScheduleM55.td
+++ b/llvm/lib/Target/ARM/ARMScheduleM55.td
@@ -152,7 +152,7 @@ def : InstRW<[M55WriteDX_SI], (instregex "t2CS(EL|INC|INV|NEG)")>;
 // Thumb 2 instructions that could be reduced to a thumb 1 instruction and can
 // be dual issued with one of the above. This list is optimistic.
 def : InstRW<[M55WriteDX_DI], (instregex "t2ADDC?rr$", "t2ADDrr$",
-           "t2ADDSrr$", "t2ANDrr$", "t2ASRr[ir]$", "t2BICrr$", "t2CMNzrr$",
+           "t2ADDSrr$", "t2ANDrr$", "t2ASRr[ir]$", "t2BICrr$", "t2CMNrr$",
            "t2CMPr[ir]$", "t2EORrr$", "t2LSLr[ir]$", "t2LSRr[ir]$", "t2MVNr$",
            "t2ORRrr$", "t2REV(16|SH)?$", "t2RORrr$", "t2RSBr[ir]$", "t2RSBSri$",
            "t2SBCrr$", "t2SUBS?rr$", "t2TEQrr$", "t2TSTrr$", "t2STRi12$",
@@ -161,7 +161,7 @@ def : InstRW<[M55WriteDX_DI], (instregex "t2ADDC?rr$", "t2ADDrr$",
 def : InstRW<[M55WriteDX_DI], (instregex "t2SETPAN$", "tADC$", "tADDhirr$",
            "tADDrSP$", "tADDrSPi$", "tADDrr$", "tADDspi$", "tADDspr$", "tADR$",
            "tAND$", "tASRri$", "tASRrr$", "tBIC$", "tBKPT$", "tCBNZ$", "tCBZ$",
-           "tCMNz$", "tCMPhir$", "tCMPi8$", "tCMPr$", "tCPS$", "tEOR$", "tHINT$",
+           "tCMN$","tCMPhir$", "tCMPi8$", "tCMPr$", "tCPS$", "tEOR$", "tHINT$",
            "tHLT$", "tLSLri$", "tLSLrr$", "tLSRri$", "tLSRrr$", "tMOVSr$",
            "tMUL$", "tMVN$", "tORR$", "tPICADD$", "tPOP$", "tPUSH$", "tREV$",
            "tREV16$", "tREVSH$", "tROR$", "tRSB$", "tSBC$", "tSETEND$",

--- a/llvm/lib/Target/ARM/ARMScheduleM7.td
+++ b/llvm/lib/Target/ARM/ARMScheduleM7.td
@@ -324,7 +324,7 @@ def M7Ex1ReadNoFastBypass : SchedReadAdvance<-1, [WriteLd, M7LoadLatency1]>;
 
 def : InstRW<[WriteALUsi, M7Ex1ReadNoFastBypass, M7Read_ISS],
              (instregex "t2(ADC|ADDS|ADD|BIC|EOR|ORN|ORR|RSBS|RSB|SBC|SUBS)rs$",
-                        "t2(SUB|CMP|CMNz|TEQ|TST)rs$",
+                        "t2(SUB|CMP|CMN|TEQ|TST)rs$",
                         "t2(A|L)SRs1$")>;
 def : InstRW<[WriteALUsi, M7Read_ISS],
              (instregex "t2MVNs")>;

--- a/llvm/lib/Target/ARM/ARMScheduleM85.td
+++ b/llvm/lib/Target/ARM/ARMScheduleM85.td
@@ -410,7 +410,7 @@ def M85ReadALUsi : SchedReadVariant<[
 
 def : InstRW<[M85WriteALUsi, M85Read_EX1, M85ReadALUsi],
                (instregex "t2(ADC|ADDS|BIC|EOR|ORN|ORR|RSBS|RSB|SBC|"
-                          "SUBS|CMP|CMNz|TEQ|TST)rs$")>;
+                          "SUBS|CMP|CMN|TEQ|TST)rs$")>;
 def : InstRW<[M85WriteALUsi, M85ReadALUsi],
                (instregex "t2MVNs")>;
 
@@ -419,7 +419,7 @@ def : InstRW<[M85WriteALUsi, M85ReadALUsi],
 // shift resource.
 def : InstRW<[M85WriteALUsi, M85Read_EX1, M85ReadALUsi],
                (instregex "t2(ADC|ADDS|BIC|EOR|ORN|ORR|RSBS|RSB|SBC|"
-                          "SUBS|CMP|CMNz|TEQ|TST)rr$")>;
+                          "SUBS|CMP|CMN|TEQ|TST)rr$")>;
 def : InstRW<[M85WriteALUsi, M85ReadALUsi],
                (instregex "t2MVNr")>;
 

--- a/llvm/lib/Target/ARM/ARMScheduleR52.td
+++ b/llvm/lib/Target/ARM/ARMScheduleR52.td
@@ -330,9 +330,9 @@ def : InstRW<[R52WriteALU_EX1, R52Read_ISS, R52Read_ISS],
       (instregex "ASRr", "RORS?r", "LSR", "LSL")>;
 
 def : InstRW<[R52WriteCC, R52Read_EX1], (instregex "CMPri", "CMNri")>;
-def : InstRW<[R52WriteCC, R52Read_EX1, R52Read_EX1], (instregex "CMPrr", "CMNzrr")>;
-def : InstRW<[R52WriteCC, R52Read_EX1, R52Read_ISS], (instregex "CMPrsi", "CMNzrsi")>;
-def : InstRW<[R52WriteCC, R52Read_EX1, R52Read_ISS, R52Read_ISS], (instregex "CMPrsr", "CMNzrsr")>;
+def : InstRW<[R52WriteCC, R52Read_EX1, R52Read_EX1], (instregex "CMPrr", "CMNrr")>;
+def : InstRW<[R52WriteCC, R52Read_EX1, R52Read_ISS], (instregex "CMPrsi", "CMNrsi")>;
+def : InstRW<[R52WriteCC, R52Read_EX1, R52Read_ISS, R52Read_ISS], (instregex "CMPrsr", "CMNrsr")>;
 
 def : InstRW<[R52WriteALU_EX2, R52Read_ISS],
       (instregex "t2LDC", "RBIT", "REV", "REV16", "REVSH", "RRX")>;

--- a/llvm/lib/Target/ARM/Thumb2SizeReduction.cpp
+++ b/llvm/lib/Target/ARM/Thumb2SizeReduction.cpp
@@ -88,9 +88,7 @@ namespace {
   { ARM::t2ASRri, ARM::tASRri,  0,             5,   0,   1,   0,  0,0, 1,0,1 },
   { ARM::t2ASRrr, 0,            ARM::tASRrr,   0,   0,   0,   1,  0,0, 1,0,1 },
   { ARM::t2BICrr, 0,            ARM::tBIC,     0,   0,   0,   1,  0,0, 1,0,0 },
-  //FIXME: Disable CMN, as CCodes are backwards from compare expectations
-  //{ ARM::t2CMNrr, ARM::tCMN,  0,             0,   0,   1,   0,  2,0, 0,0,0 },
-  { ARM::t2CMNzrr, ARM::tCMNz,  0,             0,   0,   1,   0,  2,0, 0,0,0 },
+  { ARM::t2CMNrr, ARM::tCMN,    0,             0,   0,   1,   0,  2,0, 0,0,0 },
   { ARM::t2CMPri, ARM::tCMPi8,  0,             8,   0,   1,   0,  2,0, 0,0,0 },
   { ARM::t2CMPrr, ARM::tCMPhir, 0,             0,   0,   0,   0,  2,0, 0,1,0 },
   { ARM::t2EORrr, 0,            ARM::tEOR,     0,   0,   0,   1,  0,0, 1,0,0 },

--- a/llvm/test/CodeGen/ARM/cmp-to-cmn.ll
+++ b/llvm/test/CodeGen/ARM/cmp-to-cmn.ll
@@ -372,17 +372,15 @@ define i1 @almost_immediate_neg_ugt(i32 %x) {
 define i1 @cmn_nsw(i32 %a, i32 %b) {
 ; CHECK-ARM-LABEL: cmn_nsw:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    rsb r2, r1, #0
-; CHECK-ARM-NEXT:    mov r1, #0
-; CHECK-ARM-NEXT:    cmp r0, r2
-; CHECK-ARM-NEXT:    movwgt r1, #1
-; CHECK-ARM-NEXT:    mov r0, r1
+; CHECK-ARM-NEXT:    mov r2, #0
+; CHECK-ARM-NEXT:    cmn r0, r1
+; CHECK-ARM-NEXT:    movwgt r2, #1
+; CHECK-ARM-NEXT:    mov r0, r2
 ; CHECK-ARM-NEXT:    bx lr
 ;
 ; CHECK-T1-LABEL: cmn_nsw:
 ; CHECK-T1:       @ %bb.0:
-; CHECK-T1-NEXT:    rsbs r1, r1, #0
-; CHECK-T1-NEXT:    cmp r0, r1
+; CHECK-T1-NEXT:    cmn r0, r1
 ; CHECK-T1-NEXT:    bgt .LBB9_2
 ; CHECK-T1-NEXT:  @ %bb.1:
 ; CHECK-T1-NEXT:    movs r0, #0
@@ -393,12 +391,11 @@ define i1 @cmn_nsw(i32 %a, i32 %b) {
 ;
 ; CHECK-T2-LABEL: cmn_nsw:
 ; CHECK-T2:       @ %bb.0:
-; CHECK-T2-NEXT:    rsbs r2, r1, #0
-; CHECK-T2-NEXT:    movs r1, #0
-; CHECK-T2-NEXT:    cmp r0, r2
+; CHECK-T2-NEXT:    movs r2, #0
+; CHECK-T2-NEXT:    cmn r0, r1
 ; CHECK-T2-NEXT:    it gt
-; CHECK-T2-NEXT:    movgt r1, #1
-; CHECK-T2-NEXT:    mov r0, r1
+; CHECK-T2-NEXT:    movgt r2, #1
+; CHECK-T2-NEXT:    mov r0, r2
 ; CHECK-T2-NEXT:    bx lr
   %sub = sub nsw i32 0, %b
   %cmp = icmp sgt i32 %a, %sub
@@ -444,18 +441,16 @@ define i1 @cmn_nsw_neg(i32 %a, i32 %b) {
 define i1 @cmn_swap(i32 %a, i32 %b) {
 ; CHECK-ARM-LABEL: cmn_swap:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    rsb r2, r1, #0
-; CHECK-ARM-NEXT:    mov r1, #0
-; CHECK-ARM-NEXT:    cmp r2, r0
-; CHECK-ARM-NEXT:    movwgt r1, #1
-; CHECK-ARM-NEXT:    mov r0, r1
+; CHECK-ARM-NEXT:    mov r2, #0
+; CHECK-ARM-NEXT:    cmn r1, r0
+; CHECK-ARM-NEXT:    movwlt r2, #1
+; CHECK-ARM-NEXT:    mov r0, r2
 ; CHECK-ARM-NEXT:    bx lr
 ;
 ; CHECK-T1-LABEL: cmn_swap:
 ; CHECK-T1:       @ %bb.0:
-; CHECK-T1-NEXT:    rsbs r1, r1, #0
-; CHECK-T1-NEXT:    cmp r1, r0
-; CHECK-T1-NEXT:    bgt .LBB11_2
+; CHECK-T1-NEXT:    cmn r1, r0
+; CHECK-T1-NEXT:    blt .LBB11_2
 ; CHECK-T1-NEXT:  @ %bb.1:
 ; CHECK-T1-NEXT:    movs r0, #0
 ; CHECK-T1-NEXT:    bx lr
@@ -465,12 +460,11 @@ define i1 @cmn_swap(i32 %a, i32 %b) {
 ;
 ; CHECK-T2-LABEL: cmn_swap:
 ; CHECK-T2:       @ %bb.0:
-; CHECK-T2-NEXT:    rsbs r2, r1, #0
-; CHECK-T2-NEXT:    movs r1, #0
-; CHECK-T2-NEXT:    cmp r2, r0
-; CHECK-T2-NEXT:    it gt
-; CHECK-T2-NEXT:    movgt r1, #1
-; CHECK-T2-NEXT:    mov r0, r1
+; CHECK-T2-NEXT:    movs r2, #0
+; CHECK-T2-NEXT:    cmn r1, r0
+; CHECK-T2-NEXT:    it lt
+; CHECK-T2-NEXT:    movlt r2, #1
+; CHECK-T2-NEXT:    mov r0, r2
 ; CHECK-T2-NEXT:    bx lr
   %sub = sub nsw i32 0, %b
   %cmp = icmp sgt i32 %sub, %a

--- a/llvm/test/MC/ARM/arm-shift-encoding.s
+++ b/llvm/test/MC/ARM/arm-shift-encoding.s
@@ -76,7 +76,7 @@
 @ CHECK: str r9, [r10], r11       @ encoding: [0x0b,0x90,0x8a,0xe6]
 
 @ Uses printSORegImmOperand(), used by ADCrsi ADDrsi ANDrsi BICrsi EORrsi
-@ ORRrsi RSBrsi RSCrsi SBCrsi SUBrsi CMNzrsi CMPrsi MOVsi MVNsi TEQrsi TSTrsi
+@ ORRrsi RSBrsi RSCrsi SBCrsi SUBrsi CMNrsi CMPrsi MOVsi MVNsi TEQrsi TSTrsi
 
 	adc sp, lr, pc
 	adc r1, r8, r9, lsr #32

--- a/llvm/test/MC/ARM/thumb-shift-encoding.s
+++ b/llvm/test/MC/ARM/thumb-shift-encoding.s
@@ -1,7 +1,7 @@
 @ RUN: llvm-mc -mcpu=cortex-a8 -triple thumbv7 -show-encoding < %s | FileCheck %s
 
 @ Uses printT2SOOperand(), used by t2ADCrs t2ADDrs t2ANDrs t2BICrs t2EORrs
-@ t2ORNrs t2ORRrs t2RSBrs t2SBCrs t2SUBrs t2CMNzrs t2CMPrs t2MOVSsi t2MOVsi
+@ t2ORNrs t2ORRrs t2RSBrs t2SBCrs t2SUBrs t2CMNrs t2CMPrs t2MOVSsi t2MOVsi
 @ t2MVNs t2TEQrs t2TSTrs
 
 	sbc.w r12, lr, r0


### PR DESCRIPTION
Map ARMISD::CMN to tCMN instead of armcmpz.

Rename the cmn instructions to match this new reality.

Please note that I do not have merge permissions.