### PR TITLE
[Bazel] Add more llvm tools

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -5672,6 +5672,57 @@ cc_binary(
 )
 
 cc_binary(
+    name = "llvm-sim",
+    testonly = True,
+    srcs = glob([
+        "tools/llvm-sim/*.cpp",
+    ]),
+    copts = llvm_copts,
+    stamp = 0,
+    deps = [
+        ":Analysis",
+        ":Core",
+        ":IRReader",
+        ":Support",
+        ":config",
+    ],
+)
+
+cc_binary(
+    name = "llvm-ir2vec",
+    testonly = True,
+    srcs = glob([
+        "tools/llvm-ir2vec/*.cpp",
+    ]),
+    copts = llvm_copts,
+    stamp = 0,
+    deps = [
+        ":Analysis",
+        ":Core",
+        ":IRReader",
+        ":Support",
+        ":config",
+    ],
+)
+
+cc_binary(
+    name = "llvm-ctxprof-util",
+    testonly = True,
+    srcs = glob([
+        "tools/llvm-ctxprof-util/*.cpp",
+    ]),
+    copts = llvm_copts,
+    stamp = 0,
+    deps = [
+        ":Core",
+        ":Object",
+        ":ProfileData",
+        ":Support",
+        ":config",
+    ],
+)
+
+cc_binary(
     name = "obj2yaml",
     testonly = True,
     srcs = glob([


### PR DESCRIPTION
Adding llvm-ir2vec, llvm-ctxprof-util (and llvm-sim) in the Bazel configs. llvm-ctxprof-util and llvm-ir2vec are used in several LIT unit tests, and the missing binary is causing unit test failures.

llvm-ctxprof-util: https://github.com/llvm/llvm-project/blob/15cde999d47c3edc7647faf5fd967f5d5d88416a/llvm/test/Analysis/CtxProfAnalysis/flatten-icp.ll#L2

llvm-ir2vec: https://github.com/llvm/llvm-project/blob/55d4e92c8821d5543469118a76fe38db866377b7/llvm/utils/mlgo-utils/IR2Vec/generateTriplets.py#L60