### PR TITLE
[libc][annex_k] Add rsize_t.

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -136,6 +136,14 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  rsize_t
+  HDRS
+    rsize_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.rsize_t
+)
+
+add_proxy_header_library(
   size_t
   HDRS
     size_t.h

--- a/libc/hdr/types/rsize_t.h
+++ b/libc/hdr/types/rsize_t.h
@@ -1,0 +1,23 @@
+//===-- Proxy for rsize_t -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_SIZE_T_H
+#define LLVM_LIBC_HDR_TYPES_SIZE_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/rsize_t.h"
+
+#else
+
+#define __need_rsize_t
+#include <stddef.h>
+#undef __need_rsize_t
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_SIZE_T_H

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_header(off64_t HDR off64_t.h)
+add_header(rsize_t HDR rsize_t.h)
 add_header(size_t HDR size_t.h)
 add_header(ssize_t HDR ssize_t.h)
 add_header(__atfork_callback_t HDR __atfork_callback_t.h)

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -1,6 +1,13 @@
 add_header(off64_t HDR off64_t.h)
-add_header(rsize_t HDR rsize_t.h DEPENDS .size_t)
 add_header(size_t HDR size_t.h)
+add_header(
+  rsize_t
+  HDR
+    rsize_t.h
+  DEPENDS
+    .size_t
+    libc.include.llvm-libc-macros.annex_k_macros
+)
 add_header(ssize_t HDR ssize_t.h)
 add_header(__atfork_callback_t HDR __atfork_callback_t.h)
 add_header(__search_compare_t HDR __search_compare_t.h)

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_header(off64_t HDR off64_t.h)
-add_header(rsize_t HDR rsize_t.h)
+add_header(rsize_t HDR rsize_t.h DEPENDS .size_t)
 add_header(size_t HDR size_t.h)
 add_header(ssize_t HDR ssize_t.h)
 add_header(__atfork_callback_t HDR __atfork_callback_t.h)

--- a/libc/include/llvm-libc-types/rsize_t.h
+++ b/libc/include/llvm-libc-types/rsize_t.h
@@ -1,0 +1,18 @@
+//===-- Definition of size_t types ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_RSIZE_T_H
+#define LLVM_LIBC_TYPES_RSIZE_T_H
+
+#ifdef LIBC_HAS_ANNEX_K
+
+typedef __SIZE_TYPE__ rsize_t;
+
+#endif // LIBC_HAS_ANNEX_K
+
+#endif // LLVM_LIBC_TYPES_RSIZE_T_H

--- a/libc/include/llvm-libc-types/rsize_t.h
+++ b/libc/include/llvm-libc-types/rsize_t.h
@@ -11,7 +11,9 @@
 
 #ifdef LIBC_HAS_ANNEX_K
 
-typedef __SIZE_TYPE__ rsize_t;
+#include "./size_t.h"
+
+typedef size_t rsize_t;
 
 #endif // LIBC_HAS_ANNEX_K
 

--- a/libc/include/llvm-libc-types/rsize_t.h
+++ b/libc/include/llvm-libc-types/rsize_t.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_RSIZE_T_H
 #define LLVM_LIBC_TYPES_RSIZE_T_H
 
+#include "../llvm-libc-macros/annex-k-macros.h"
+
 #ifdef LIBC_HAS_ANNEX_K
 
 #include "./size_t.h"

--- a/libc/include/llvm-libc-types/rsize_t.h
+++ b/libc/include/llvm-libc-types/rsize_t.h
@@ -13,7 +13,7 @@
 
 #ifdef LIBC_HAS_ANNEX_K
 
-#include "./size_t.h"
+#include "size_t.h"
 
 typedef size_t rsize_t;
 

--- a/libc/include/llvm-libc-types/rsize_t.h
+++ b/libc/include/llvm-libc-types/rsize_t.h
@@ -1,4 +1,4 @@
-//===-- Definition of size_t types ----------------------------------------===//
+//===-- Definition of rsize_t types ---------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add `rsize_t` type required by Annex K interface in LLVM libc.