### PR TITLE
[libc][annex_k] Add constraint_handler_t.

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -171,6 +171,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  constraint_handler_t
+  HDRS
+    constraint_handler_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.constraint_handler_t
+    libc.include.stdlib
+)
+
+add_proxy_header_library(
   errno_t
   HDRS
     errno_t.h

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -176,7 +176,6 @@ add_proxy_header_library(
     constraint_handler_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.constraint_handler_t
-    libc.include.stdlib
 )
 
 add_proxy_header_library(

--- a/libc/hdr/types/constraint_handler_t.h
+++ b/libc/hdr/types/constraint_handler_t.h
@@ -1,0 +1,18 @@
+//===-- Proxy for constraint_handler_t ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_CONSTRAINT_HANDLER_T_H
+#define LLVM_LIBC_HDR_TYPES_CONSTRAINT_HANDLER_T_H
+
+#define LIBC_HAS_ANNEX_K
+
+#include "include/llvm-libc-types/constraint_handler_t.h"
+
+#undef LIBC_HAS_ANNEX_K
+
+#endif // LLVM_LIBC_HDR_TYPES_CONSTRAINT_HANDLER_T_H

--- a/libc/hdr/types/constraint_handler_t.h
+++ b/libc/hdr/types/constraint_handler_t.h
@@ -9,10 +9,22 @@
 #ifndef LLVM_LIBC_HDR_TYPES_CONSTRAINT_HANDLER_T_H
 #define LLVM_LIBC_HDR_TYPES_CONSTRAINT_HANDLER_T_H
 
-#define LIBC_HAS_ANNEX_K
+#ifndef __STDC_WANT_LIB_EXT1__
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
+
+#ifdef LIBC_FULL_BUILD
 
 #include "include/llvm-libc-types/constraint_handler_t.h"
 
-#undef LIBC_HAS_ANNEX_K
+#else // Overlay mode
+
+#include <stdlib.h>
+
+#endif // LIBC_FULL_BUILD
+
+#ifdef __STDC_WANT_LIB_EXT1__
+#undef __STDC_WANT_LIB_EXT1__
+#endif
 
 #endif // LLVM_LIBC_HDR_TYPES_CONSTRAINT_HANDLER_T_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -383,6 +383,7 @@ add_header_macro(
     .llvm-libc-types.__qsortcompare_t
     .llvm-libc-types.__qsortrcompare_t
     .llvm-libc-types.__search_compare_t
+    .llvm-libc-types.constraint_handler_t
     .llvm-libc-types.div_t
     .llvm-libc-types.ldiv_t
     .llvm-libc-types.lldiv_t

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -38,7 +38,14 @@ add_header(DIR HDR DIR.h)
 add_header(dev_t HDR dev_t.h)
 add_header(div_t HDR div_t.h)
 add_header(errno_t HDR errno_t.h DEPENDS libc.include.llvm-libc-macros.annex_k_macros)
-add_header(constraint_handler_t HDR constraint_handler_t.h DEPENDS .errno_t)
+add_header(
+  constraint_handler_t
+  HDR
+    constraint_handler_t.h
+  DEPENDS
+    .errno_t
+    libc.include.llvm-libc-macros.annex_k_macros
+)
 add_header(ldiv_t HDR ldiv_t.h)
 add_header(lldiv_t HDR lldiv_t.h)
 add_header(FILE HDR FILE.h)

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -581,3 +581,5 @@ add_header(EFI_SYSTEM_TABLE
     .EFI_TABLE_HEADER
     .char16_t
 )
+
+add_header(constraint_handler_t HDR constraint_handler_t.h DEPENDS .errno_t)

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -38,6 +38,7 @@ add_header(DIR HDR DIR.h)
 add_header(dev_t HDR dev_t.h)
 add_header(div_t HDR div_t.h)
 add_header(errno_t HDR errno_t.h DEPENDS libc.include.llvm-libc-macros.annex_k_macros)
+add_header(constraint_handler_t HDR constraint_handler_t.h DEPENDS .errno_t)
 add_header(ldiv_t HDR ldiv_t.h)
 add_header(lldiv_t HDR lldiv_t.h)
 add_header(FILE HDR FILE.h)
@@ -581,5 +582,3 @@ add_header(EFI_SYSTEM_TABLE
     .EFI_TABLE_HEADER
     .char16_t
 )
-
-add_header(constraint_handler_t HDR constraint_handler_t.h DEPENDS .errno_t)

--- a/libc/include/llvm-libc-types/constraint_handler_t.h
+++ b/libc/include/llvm-libc-types/constraint_handler_t.h
@@ -1,0 +1,21 @@
+//===-- Definition of type constraint_handler_t ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_INCLUDE_LLVM_LIBC_TYPES_CONSTRAINT_HANDLER_T_H
+#define LLVM_LIBC_INCLUDE_LLVM_LIBC_TYPES_CONSTRAINT_HANDLER_T_H
+
+#include "errno_t.h"
+
+#ifdef LIBC_HAS_ANNEX_K
+
+typedef void (*constraint_handler_t)(const char *__restrict, void *__restrict,
+                                     errno_t);
+
+#endif // LIBC_HAS_ANNEX_K
+
+#endif // LLVM_LIBC_INCLUDE_LLVM_LIBC_TYPES_CONSTRAINT_HANDLER_T_H

--- a/libc/include/llvm-libc-types/constraint_handler_t.h
+++ b/libc/include/llvm-libc-types/constraint_handler_t.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_INCLUDE_LLVM_LIBC_TYPES_CONSTRAINT_HANDLER_T_H
 #define LLVM_LIBC_INCLUDE_LLVM_LIBC_TYPES_CONSTRAINT_HANDLER_T_H
 
+#include "../llvm-libc-macros/annex-k-macros.h"
 #include "errno_t.h"
 
 #ifdef LIBC_HAS_ANNEX_K

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -12,6 +12,7 @@ types:
   - type_name: __qsortcompare_t
   - type_name: __qsortrcompare_t
   - type_name: __search_compare_t
+  - type_name: constraint_handler_t
   - type_name: div_t
   - type_name: ldiv_t
   - type_name: lldiv_t


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add `constraint_handler_t` type required by Annex K interface in LLVM libc.