### PR TITLE
[Clang][Sema] Use correct DeclContext when checking 'this'

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1433,7 +1433,7 @@ bool Sema::CheckCXXThisType(SourceLocation Loc, QualType Type) {
   const auto *Method = dyn_cast<CXXMethodDecl>(DC);
   if (Method && Method->isExplicitObjectMemberFunction()) {
     Diag(Loc, diag::err_invalid_this_use) << 1;
-  } else if (Method && isLambdaCallWithExplicitObjectParameter(CurContext)) {
+  } else if (Method && isLambdaCallWithExplicitObjectParameter(DC)) {
     Diag(Loc, diag::err_invalid_this_use) << 1;
   } else {
     Diag(Loc, diag::err_invalid_this_use) << 0;

--- a/clang/test/CXX/expr/expr.prim/expr.prim.this/p4.cpp
+++ b/clang/test/CXX/expr/expr.prim/expr.prim.this/p4.cpp
@@ -2,17 +2,17 @@
 
 namespace N0 {
   struct A {
-      static void f() {
-        []() -> decltype(this) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
-      }
+    static void f() {
+      []() -> decltype(this) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
+    }
   };
 } // namespace N0
 
 namespace N1 {
   struct A {
-      static void f() {
-        []() noexcept(decltype(this)()) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
-      }
+    static void f() {
+      []() noexcept(decltype(this)()) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
+    }
   };
 } // namespace N1
 

--- a/clang/test/CXX/expr/expr.prim/expr.prim.this/p4.cpp
+++ b/clang/test/CXX/expr/expr.prim/expr.prim.this/p4.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
+
+namespace N0 {
+  struct A {
+      static void f() {
+        []() -> decltype(this) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
+      }
+  };
+} // namespace N0
+
+namespace N1 {
+  struct A {
+      static void f() {
+        []() noexcept(decltype(this)()) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
+      }
+  };
+} // namespace N1
+
+namespace N2 {
+  struct A {
+    static void f() {
+      [](this auto&&) -> decltype(this) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
+    }
+  };
+} // namespace N2
+
+namespace N3 {
+  struct A {
+    static void f() {
+      [](this auto&&) noexcept(decltype(this)()) { }; // expected-error{{invalid use of 'this' outside of a non-static member function}}
+    }
+  };
+} // namespace N3
+
+namespace N4 {
+  struct A {
+    void f() {
+      []() -> decltype(this) { };
+    }
+  };
+} // namespace N4
+
+namespace N5 {
+  struct A {
+    void f() {
+      []() noexcept(decltype(this)()) { }; // expected-error{{conversion from 'decltype(this)' (aka 'N5::A *') to 'bool' is not allowed in a converted constant expression}}
+    }
+  };
+} // namespace N5
+
+namespace N6 {
+  struct A {
+    void f() {
+      [](this auto&&) -> decltype(this) { };
+    }
+  };
+} // namespace N6
+
+namespace N7 {
+  struct A {
+    void f() {
+      [](this auto&&) noexcept(decltype(this)()) { }; // expected-error{{conversion from 'decltype(this)' (aka 'N7::A *') to 'bool' is not allowed in a converted constant expression}}
+    }
+  };
+} // namespace N7

--- a/clang/test/CXX/expr/expr.prim/expr.prim.this/p4.cpp
+++ b/clang/test/CXX/expr/expr.prim/expr.prim.this/p4.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -Wno-unused-value -verify %s
 
 namespace N0 {
   struct A {


### PR DESCRIPTION
As mentioned in #163089, clang crashes for the following inputs:

```cpp
struct S {
    static void f() {
        auto x = []() -> decltype(this) {};
    }
};
```

```cpp
struct S {
    static void f() {
        auto x = []() noexcept(decltype(this)()) {};
    }
};
```

The crash happens because we currently pass  `CurContext` to `isLambdaCallWithExplicitObjectParameter` in `Sema::CheckCXXThisType` when we should be passing `DC` (returned from `getFunctionLevelDeclContext`). 

Fixes #163089.