### PR TITLE
Use the Propeller CFG profile in the PGO analysis map if it is available.

### DIFF
--- a/llvm/docs/Extensions.rst
+++ b/llvm/docs/Extensions.rst
@@ -416,14 +416,14 @@ as offsets relative to prior addresses.
 The following versioning schemes are currently supported (newer versions support
 features of the older versions).
 
+Version 5 (newest): Capable of encoding Post-Link CFG information, which
+provides basic block and edge frequencies obtained from a post-link tool like
+Propeller, reflecting the final binary layout. This feature is enabled by the 8th
+bit of the feature entry.
+The feature data will be two bytes long to accommodate future extensions.
+
 Version 4: Capable of encoding basic block hashes. This feature is
 enabled by the 7th bit of the feature byte.
-
-Version 5 (newest): The feature data will be two bytes long to accommodate
-future extensions. It is also capable of encoding Post-Link CFG information,
-which provides basic block and edge frequencies obtained from a post-link tool
-like Propeller, reflecting the final binary layout.
-
 
 Example:
 

--- a/llvm/docs/Extensions.rst
+++ b/llvm/docs/Extensions.rst
@@ -416,10 +416,13 @@ as offsets relative to prior addresses.
 The following versioning schemes are currently supported (newer versions support
 features of the older versions).
 
-Version 4 (newest): Capable of encoding basic block hashes. This feature is
+Version 4: Capable of encoding basic block hashes. This feature is
 enabled by the 7th bit of the feature byte.
 
-Starting from version 5, the feature data will be two bytes long.
+Version 5 (newest): The feature data will be two bytes long to accommodate
+future extensions. It is also capable of encoding Post-Link CFG information,
+which provides basic block and edge frequencies obtained from a post-link tool
+like Propeller, reflecting the final binary layout.
 
 
 Example:

--- a/llvm/docs/Extensions.rst
+++ b/llvm/docs/Extensions.rst
@@ -419,6 +419,9 @@ features of the older versions).
 Version 4 (newest): Capable of encoding basic block hashes. This feature is
 enabled by the 7th bit of the feature byte.
 
+Starting from version 5, the feature data will be two bytes long.
+
+
 Example:
 
 .. code-block:: gas

--- a/llvm/docs/Extensions.rst
+++ b/llvm/docs/Extensions.rst
@@ -526,6 +526,13 @@ those bits are:
    defined in ``llvm/Support/BranchProbability.h``. It indicates the probability
    that the block is followed by a given successor block during execution.
 
+#. Post-Link CFG - When enabled, the PGO Analysis Map will include CFG
+   information obtained from a post-link tool, such as Propeller. This feature
+   is enabled with the ``-pgo-analysis-map-emit-bb-sections-cfg`` flag. When
+   this option is active, the map will contain basic block and edge frequencies
+   from the basic block sections profile. This provides more accurate profiling
+   information that reflects the final binary layout.
+
 This extra data requires version 2 or above. This is necessary since successors
 of basic blocks won't know their index but will know their BB ID.
 

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -110,8 +110,8 @@ public:
   // Returns a pointer to the CFGProfile for the function \p FuncName.
   // Returns nullptr if no profile data is available for the function.
   const CFGProfile *getFunctionCFGProfile(StringRef FuncName) const {
-    auto It = ProgramDirectivesAndProfile.find(getAliasName(FuncName));
-    if (It == ProgramDirectivesAndProfile.end())
+    auto It = ProgramOptimizationProfile.find(getAliasName(FuncName));
+    if (It == ProgramOptimizationProfile.end())
       return nullptr;
     return &It->second.CFG;
   }

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -54,7 +54,6 @@ struct CFGProfile {
   // UniqueBBID.
   DenseMap<unsigned, uint64_t> BBHashes;
 
-
   // Returns the profile count for the given basic block or zero if it does not
   // exist.
   uint64_t getBlockCount(const UniqueBBID &BBID) const {

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -71,8 +71,8 @@ struct CFGProfile {
   }
 };
 
-// This represents the raw input profile for one function.
-struct FunctionProfile {
+// This represents the raw optimization profile for one function.
+struct FunctionOptimizationProfile {
   // BB Cluster information specified by `UniqueBBID`s.
   SmallVector<BBClusterInfo> ClusterInfo;
   // Paths to clone. A path a -> b -> c -> d implies cloning b, c, and d along
@@ -162,10 +162,10 @@ private:
   // data for (all or some of) its basic blocks. The cluster information for
   // every basic block includes its cluster ID along with the position of the
   // basic block in that cluster.
-  StringMap<FunctionProfile> ProgramDirectivesAndProfile;
+  StringMap<FunctionOptimizationProfile> ProgramOptimizationProfile;
 
   // Some functions have alias names. We use this map to find the main alias
-  // name which appears in ProgramDirectivesAndProfile as a key.
+  // name which appears in ProgramOptimizationProfile as a key.
   StringMap<StringRef> FuncAliasMap;
 };
 

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -71,7 +71,8 @@ struct CFGProfile {
   }
 };
 
-// This represents the raw optimization profile for one function.
+// This struct represents the raw optimization profile for a function,
+// including CFG data (block and edge counts) and layout directives (clustering and cloning paths).
 struct FunctionOptimizationProfile {
   // BB Cluster information specified by `UniqueBBID`s.
   SmallVector<BBClusterInfo> ClusterInfo;

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -72,7 +72,8 @@ struct CFGProfile {
 };
 
 // This struct represents the raw optimization profile for a function,
-// including CFG data (block and edge counts) and layout directives (clustering and cloning paths).
+// including CFG data (block and edge counts) and layout directives (clustering
+// and cloning paths).
 struct FunctionOptimizationProfile {
   // BB Cluster information specified by `UniqueBBID`s.
   SmallVector<BBClusterInfo> ClusterInfo;
@@ -157,10 +158,10 @@ private:
   // empty string if no debug info is available.
   StringMap<SmallString<128>> FunctionNameToDIFilename;
 
-  // This map contains the optimization profile for each function in the program.
-  // A function's optimization profile consists of CFG data (node and edge
-  // counts) and layout directives such as basic block clustering and cloning
-  // paths.
+  // This map contains the optimization profile for each function in the
+  // program. A function's optimization profile consists of CFG data (node and
+  // edge counts) and layout directives such as basic block clustering and
+  // cloning paths.
   StringMap<FunctionOptimizationProfile> ProgramOptimizationProfile;
 
   // Some functions have alias names. We use this map to find the main alias

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -158,7 +158,7 @@ private:
 
   // This contains the BB cluster information for the whole program.
   //
-  // For every function name, it contains the cloning and cluster information
+  // For every function name, it contains the cloning directives and profile data
   // for (all or some of) its basic blocks. The cluster information for every
   // basic block includes its cluster ID along with the position of the basic
   // block in that cluster.

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -158,10 +158,10 @@ private:
 
   // This contains the BB cluster information for the whole program.
   //
-  // For every function name, it contains the cloning directives and profile data
-  // for (all or some of) its basic blocks. The cluster information for every
-  // basic block includes its cluster ID along with the position of the basic
-  // block in that cluster.
+  // For every function name, it contains the cloning directives and profile
+  // data for (all or some of) its basic blocks. The cluster information for
+  // every basic block includes its cluster ID along with the position of the
+  // basic block in that cluster.
   StringMap<FunctionProfile> ProgramDirectivesAndProfile;
 
   // Some functions have alias names. We use this map to find the main alias

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -156,12 +156,10 @@ private:
   // empty string if no debug info is available.
   StringMap<SmallString<128>> FunctionNameToDIFilename;
 
-  // This contains the BB cluster information for the whole program.
-  //
-  // For every function name, it contains the cloning directives and profile
-  // data for (all or some of) its basic blocks. The cluster information for
-  // every basic block includes its cluster ID along with the position of the
-  // basic block in that cluster.
+  // This map contains the optimization profile for each function in the program.
+  // A function's optimization profile consists of CFG data (node and edge
+  // counts) and layout directives such as basic block clustering and cloning
+  // paths.
   StringMap<FunctionOptimizationProfile> ProgramOptimizationProfile;
 
   // Some functions have alias names. We use this map to find the main alias

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -175,7 +175,7 @@ private:
   unsigned GetInstance(unsigned LocalLabelVal);
 
   /// SHT_LLVM_BB_ADDR_MAP version to emit.
-  uint8_t BBAddrMapVersion = 4;
+  uint8_t BBAddrMapVersion = 5;
 
   /// The file name of the log file from the environment variable
   /// AS_SECURE_LOG_FILE.  Which must be set before the .secure_log_unique

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1476,7 +1476,7 @@ void AsmPrinter::emitBBAddrMapSection(const MachineFunction &MF) {
   OutStreamer->AddComment("feature");
   auto Features = getBBAddrMapFeature(MF, MBBSectionRanges.size(), HasCalls,
                                       FuncCFGProfile);
-  OutStreamer->emitInt8(Features.encode());
+  OutStreamer->emitInt16(Features.encode());
   // Emit BB Information for each basic block in the function.
   if (Features.MultiBBRange) {
     OutStreamer->AddComment("number of basic block ranges");

--- a/llvm/lib/CodeGen/BasicBlockMatchingAndInference.cpp
+++ b/llvm/lib/CodeGen/BasicBlockMatchingAndInference.cpp
@@ -119,24 +119,23 @@ BasicBlockMatchingAndInference::initWeightInfoByMatching(MachineFunction &MF) {
   StaleMatcher Matcher;
   Matcher.init(Blocks, Hashes);
   BasicBlockMatchingAndInference::WeightInfo MatchWeight;
-  auto [IsValid, PathAndClusterInfo] =
-      BSPR->getFunctionPathAndClusterInfo(MF.getName());
-  if (!IsValid)
+  const CFGProfile *CFG = BSPR->getFunctionCFGProfile(MF.getName());
+  if (CFG == nullptr)
     return MatchWeight;
-  for (auto &BlockCount : PathAndClusterInfo.NodeCounts) {
-    if (PathAndClusterInfo.BBHashes.count(BlockCount.first.BaseID)) {
-      auto Hash = PathAndClusterInfo.BBHashes[BlockCount.first.BaseID];
+  for (auto &BlockCount : CFG->NodeCounts) {
+    if (CFG->BBHashes.count(BlockCount.first.BaseID)) {
+      auto Hash = CFG->BBHashes.lookup(BlockCount.first.BaseID);
       MachineBasicBlock *Block = Matcher.matchBlock(BlendedBlockHash(Hash));
       // When a basic block has clone copies, sum their counts.
       if (Block != nullptr)
         MatchWeight.BlockWeights[Block] += BlockCount.second;
     }
   }
-  for (auto &PredItem : PathAndClusterInfo.EdgeCounts) {
+  for (auto &PredItem : CFG->EdgeCounts) {
     auto PredID = PredItem.first.BaseID;
-    if (!PathAndClusterInfo.BBHashes.count(PredID))
+    if (!CFG->BBHashes.count(PredID))
       continue;
-    auto PredHash = PathAndClusterInfo.BBHashes[PredID];
+    auto PredHash = CFG->BBHashes.lookup(PredID);
     MachineBasicBlock *PredBlock =
         Matcher.matchBlock(BlendedBlockHash(PredHash));
     if (PredBlock == nullptr)
@@ -144,8 +143,8 @@ BasicBlockMatchingAndInference::initWeightInfoByMatching(MachineFunction &MF) {
     for (auto &SuccItem : PredItem.second) {
       auto SuccID = SuccItem.first.BaseID;
       auto EdgeWeight = SuccItem.second;
-      if (PathAndClusterInfo.BBHashes.count(SuccID)) {
-        auto SuccHash = PathAndClusterInfo.BBHashes[SuccID];
+      if (CFG->BBHashes.count(SuccID)) {
+        auto SuccHash = CFG->BBHashes.lookup(SuccID);
         MachineBasicBlock *SuccBlock =
             Matcher.matchBlock(BlendedBlockHash(SuccHash));
         // When an edge has clone copies, sum their counts.

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -64,16 +64,16 @@ bool BasicBlockSectionsProfileReader::isFunctionHot(StringRef FuncName) const {
 SmallVector<BBClusterInfo>
 BasicBlockSectionsProfileReader::getClusterInfoForFunction(
     StringRef FuncName) const {
-  auto R = ProgramDirectivesAndProfile.find(getAliasName(FuncName));
-  return R != ProgramDirectivesAndProfile.end() ? R->second.ClusterInfo
+  auto R = ProgramOptimizationProfile.find(getAliasName(FuncName));
+  return R != ProgramOptimizationProfile.end() ? R->second.ClusterInfo
                                                 : SmallVector<BBClusterInfo>();
 }
 
 SmallVector<SmallVector<unsigned>>
 BasicBlockSectionsProfileReader::getClonePathsForFunction(
     StringRef FuncName) const {
-  auto R = ProgramDirectivesAndProfile.find(getAliasName(FuncName));
-  return R != ProgramDirectivesAndProfile.end()
+  auto R = ProgramOptimizationProfile.find(getAliasName(FuncName));
+  return R != ProgramOptimizationProfile.end()
              ? R->second.ClonePaths
              : SmallVector<SmallVector<unsigned>>();
 }
@@ -149,7 +149,7 @@ uint64_t BasicBlockSectionsProfileReader::getEdgeCount(
 //                                ....
 // ****************************************************************************
 Error BasicBlockSectionsProfileReader::ReadV1Profile() {
-  auto FI = ProgramDirectivesAndProfile.end();
+  auto FI = ProgramOptimizationProfile.end();
 
   // Current cluster ID corresponding to this function.
   unsigned CurrentCluster = 0;
@@ -193,7 +193,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
       if (!FunctionFound) {
         // Skip the following profile by setting the profile iterator (FI) to
         // the past-the-end element.
-        FI = ProgramDirectivesAndProfile.end();
+        FI = ProgramOptimizationProfile.end();
         DIFilename = "";
         continue;
       }
@@ -202,7 +202,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
 
       // Prepare for parsing clusters of this function name.
       // Start a new cluster map for this function name.
-      auto R = ProgramDirectivesAndProfile.try_emplace(Values.front());
+      auto R = ProgramOptimizationProfile.try_emplace(Values.front());
       // Report error when multiple profiles have been specified for the same
       // function.
       if (!R.second)
@@ -219,7 +219,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'c': // Basic block cluster specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramDirectivesAndProfile.end())
+      if (FI == ProgramOptimizationProfile.end())
         continue;
       // Reset current cluster position.
       CurrentPosition = 0;
@@ -240,7 +240,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'p': { // Basic block cloning path specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramDirectivesAndProfile.end())
+      if (FI == ProgramOptimizationProfile.end())
         continue;
       SmallSet<unsigned, 5> BBsInPath;
       FI->second.ClonePaths.push_back({});
@@ -260,7 +260,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'g': { // CFG profile specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramDirectivesAndProfile.end())
+      if (FI == ProgramOptimizationProfile.end())
         continue;
       // For each node, its CFG profile is encoded as
       // <src>:<count>,<sink_1>:<count_1>,<sink_2>:<count_2>,...
@@ -292,7 +292,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'h': { // Basic block hash secifier.
       // Skip the profile when the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramDirectivesAndProfile.end())
+      if (FI == ProgramOptimizationProfile.end())
         continue;
       for (auto BBIDHashStr : Values) {
         auto [BBIDStr, HashStr] = BBIDHashStr.split(':');
@@ -318,7 +318,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
 }
 
 Error BasicBlockSectionsProfileReader::ReadV0Profile() {
-  auto FI = ProgramDirectivesAndProfile.end();
+  auto FI = ProgramOptimizationProfile.end();
   // Current cluster ID corresponding to this function.
   unsigned CurrentCluster = 0;
   // Current position in the current cluster.
@@ -339,7 +339,7 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
     if (S.consume_front("!")) {
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramDirectivesAndProfile.end())
+      if (FI == ProgramOptimizationProfile.end())
         continue;
       SmallVector<StringRef, 4> BBIDs;
       S.split(BBIDs, ' ');
@@ -391,7 +391,7 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
       if (!FunctionFound) {
         // Skip the following profile by setting the profile iterator (FI) to
         // the past-the-end element.
-        FI = ProgramDirectivesAndProfile.end();
+        FI = ProgramOptimizationProfile.end();
         continue;
       }
       for (size_t i = 1; i < Aliases.size(); ++i)
@@ -399,7 +399,7 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
 
       // Prepare for parsing clusters of this function name.
       // Start a new cluster map for this function name.
-      auto R = ProgramDirectivesAndProfile.try_emplace(Aliases.front());
+      auto R = ProgramOptimizationProfile.try_emplace(Aliases.front());
       // Report error when multiple profiles have been specified for the same
       // function.
       if (!R.second)

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -66,7 +66,7 @@ BasicBlockSectionsProfileReader::getClusterInfoForFunction(
     StringRef FuncName) const {
   auto R = ProgramOptimizationProfile.find(getAliasName(FuncName));
   return R != ProgramOptimizationProfile.end() ? R->second.ClusterInfo
-                                                : SmallVector<BBClusterInfo>();
+                                               : SmallVector<BBClusterInfo>();
 }
 
 SmallVector<SmallVector<unsigned>>

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -290,10 +290,10 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
                 Twine("unsigned integer expected: '") + CountStr + "'");
           if (i == 0) {
             // The first element represents the source and its total count.
-            FI->second.NodeCounts[SrcBBID = *BBID] = Count;
+            FI->second.Cfg.NodeCounts[SrcBBID = *BBID] = Count;
             continue;
           }
-          FI->second.EdgeCounts[SrcBBID][*BBID] = Count;
+          FI->second.Cfg.EdgeCounts[SrcBBID][*BBID] = Count;
         }
       }
       continue;

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -64,16 +64,16 @@ bool BasicBlockSectionsProfileReader::isFunctionHot(StringRef FuncName) const {
 SmallVector<BBClusterInfo>
 BasicBlockSectionsProfileReader::getClusterInfoForFunction(
     StringRef FuncName) const {
-  auto R = ProgramPathAndClusterInfo.find(getAliasName(FuncName));
-  return R != ProgramPathAndClusterInfo.end() ? R->second.ClusterInfo
+  auto R = ProgramDirectivesAndProfile.find(getAliasName(FuncName));
+  return R != ProgramDirectivesAndProfile.end() ? R->second.ClusterInfo
                                               : SmallVector<BBClusterInfo>();
 }
 
 SmallVector<SmallVector<unsigned>>
 BasicBlockSectionsProfileReader::getClonePathsForFunction(
     StringRef FuncName) const {
-  auto R = ProgramPathAndClusterInfo.find(getAliasName(FuncName));
-  return R != ProgramPathAndClusterInfo.end()
+  auto R = ProgramDirectivesAndProfile.find(getAliasName(FuncName));
+  return R != ProgramDirectivesAndProfile.end()
              ? R->second.ClonePaths
              : SmallVector<SmallVector<unsigned>>();
 }
@@ -81,25 +81,15 @@ BasicBlockSectionsProfileReader::getClonePathsForFunction(
 uint64_t BasicBlockSectionsProfileReader::getEdgeCount(
     StringRef FuncName, const UniqueBBID &SrcBBID,
     const UniqueBBID &SinkBBID) const {
-  auto It = ProgramPathAndClusterInfo.find(getAliasName(FuncName));
-  if (It == ProgramPathAndClusterInfo.end())
-    return 0;
-  auto NodeIt = It->second.EdgeCounts.find(SrcBBID);
-  if (NodeIt == It->second.EdgeCounts.end())
+  const CFGProfile *CFG = getFunctionCFGProfile(FuncName);
+  if (CFG == nullptr) return 0;
+  auto NodeIt = CFG->EdgeCounts.find(SrcBBID);
+  if (NodeIt == CFG->EdgeCounts.end())
     return 0;
   auto EdgeIt = NodeIt->second.find(SinkBBID);
   if (EdgeIt == NodeIt->second.end())
     return 0;
   return EdgeIt->second;
-}
-
-std::pair<bool, FunctionPathAndClusterInfo>
-BasicBlockSectionsProfileReader::getFunctionPathAndClusterInfo(
-    StringRef FuncName) const {
-  auto R = ProgramPathAndClusterInfo.find(getAliasName(FuncName));
-  return R != ProgramPathAndClusterInfo.end()
-             ? std::pair(true, R->second)
-             : std::pair(false, FunctionPathAndClusterInfo());
 }
 
 // Reads the version 1 basic block sections profile. Profile for each function
@@ -158,7 +148,7 @@ BasicBlockSectionsProfileReader::getFunctionPathAndClusterInfo(
 //                                ....
 // ****************************************************************************
 Error BasicBlockSectionsProfileReader::ReadV1Profile() {
-  auto FI = ProgramPathAndClusterInfo.end();
+  auto FI = ProgramDirectivesAndProfile.end();
 
   // Current cluster ID corresponding to this function.
   unsigned CurrentCluster = 0;
@@ -202,7 +192,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
       if (!FunctionFound) {
         // Skip the following profile by setting the profile iterator (FI) to
         // the past-the-end element.
-        FI = ProgramPathAndClusterInfo.end();
+        FI = ProgramDirectivesAndProfile.end();
         DIFilename = "";
         continue;
       }
@@ -211,7 +201,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
 
       // Prepare for parsing clusters of this function name.
       // Start a new cluster map for this function name.
-      auto R = ProgramPathAndClusterInfo.try_emplace(Values.front());
+      auto R = ProgramDirectivesAndProfile.try_emplace(Values.front());
       // Report error when multiple profiles have been specified for the same
       // function.
       if (!R.second)
@@ -228,7 +218,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'c': // Basic block cluster specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramPathAndClusterInfo.end())
+      if (FI == ProgramDirectivesAndProfile.end())
         continue;
       // Reset current cluster position.
       CurrentPosition = 0;
@@ -249,7 +239,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'p': { // Basic block cloning path specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramPathAndClusterInfo.end())
+      if (FI == ProgramDirectivesAndProfile.end())
         continue;
       SmallSet<unsigned, 5> BBsInPath;
       FI->second.ClonePaths.push_back({});
@@ -269,7 +259,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'g': { // CFG profile specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramPathAndClusterInfo.end())
+      if (FI == ProgramDirectivesAndProfile.end())
         continue;
       // For each node, its CFG profile is encoded as
       // <src>:<count>,<sink_1>:<count_1>,<sink_2>:<count_2>,...
@@ -290,10 +280,10 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
                 Twine("unsigned integer expected: '") + CountStr + "'");
           if (i == 0) {
             // The first element represents the source and its total count.
-            FI->second.Cfg.NodeCounts[SrcBBID = *BBID] = Count;
+            FI->second.CFG.NodeCounts[SrcBBID = *BBID] = Count;
             continue;
           }
-          FI->second.Cfg.EdgeCounts[SrcBBID][*BBID] = Count;
+          FI->second.CFG.EdgeCounts[SrcBBID][*BBID] = Count;
         }
       }
       continue;
@@ -301,7 +291,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 'h': { // Basic block hash secifier.
       // Skip the profile when the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramPathAndClusterInfo.end())
+      if (FI == ProgramDirectivesAndProfile.end())
         continue;
       for (auto BBIDHashStr : Values) {
         auto [BBIDStr, HashStr] = BBIDHashStr.split(':');
@@ -313,7 +303,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
           return createProfileParseError(
               Twine("unsigned integer expected in hex format: '") + HashStr +
               "'");
-        FI->second.BBHashes[BBID] = Hash;
+        FI->second.CFG.BBHashes[BBID] = Hash;
       }
       continue;
     }
@@ -327,7 +317,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
 }
 
 Error BasicBlockSectionsProfileReader::ReadV0Profile() {
-  auto FI = ProgramPathAndClusterInfo.end();
+  auto FI = ProgramDirectivesAndProfile.end();
   // Current cluster ID corresponding to this function.
   unsigned CurrentCluster = 0;
   // Current position in the current cluster.
@@ -348,7 +338,7 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
     if (S.consume_front("!")) {
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramPathAndClusterInfo.end())
+      if (FI == ProgramDirectivesAndProfile.end())
         continue;
       SmallVector<StringRef, 4> BBIDs;
       S.split(BBIDs, ' ');
@@ -400,7 +390,7 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
       if (!FunctionFound) {
         // Skip the following profile by setting the profile iterator (FI) to
         // the past-the-end element.
-        FI = ProgramPathAndClusterInfo.end();
+        FI = ProgramDirectivesAndProfile.end();
         continue;
       }
       for (size_t i = 1; i < Aliases.size(); ++i)
@@ -408,7 +398,7 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
 
       // Prepare for parsing clusters of this function name.
       // Start a new cluster map for this function name.
-      auto R = ProgramPathAndClusterInfo.try_emplace(Aliases.front());
+      auto R = ProgramDirectivesAndProfile.try_emplace(Aliases.front());
       // Report error when multiple profiles have been specified for the same
       // function.
       if (!R.second)
@@ -517,16 +507,14 @@ BasicBlockSectionsProfileReaderWrapperPass::getClonePathsForFunction(
   return BBSPR.getClonePathsForFunction(FuncName);
 }
 
+const CFGProfile *BasicBlockSectionsProfileReaderWrapperPass::getFunctionCFGProfile(StringRef FuncName) const {
+  return BBSPR.getFunctionCFGProfile(FuncName);
+}
+
 uint64_t BasicBlockSectionsProfileReaderWrapperPass::getEdgeCount(
     StringRef FuncName, const UniqueBBID &SrcBBID,
     const UniqueBBID &SinkBBID) const {
   return BBSPR.getEdgeCount(FuncName, SrcBBID, SinkBBID);
-}
-
-std::pair<bool, FunctionPathAndClusterInfo>
-BasicBlockSectionsProfileReaderWrapperPass::getFunctionPathAndClusterInfo(
-    StringRef FuncName) const {
-  return BBSPR.getFunctionPathAndClusterInfo(FuncName);
 }
 
 BasicBlockSectionsProfileReader &

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -66,7 +66,7 @@ BasicBlockSectionsProfileReader::getClusterInfoForFunction(
     StringRef FuncName) const {
   auto R = ProgramDirectivesAndProfile.find(getAliasName(FuncName));
   return R != ProgramDirectivesAndProfile.end() ? R->second.ClusterInfo
-                                              : SmallVector<BBClusterInfo>();
+                                                : SmallVector<BBClusterInfo>();
 }
 
 SmallVector<SmallVector<unsigned>>
@@ -82,7 +82,8 @@ uint64_t BasicBlockSectionsProfileReader::getEdgeCount(
     StringRef FuncName, const UniqueBBID &SrcBBID,
     const UniqueBBID &SinkBBID) const {
   const CFGProfile *CFG = getFunctionCFGProfile(FuncName);
-  if (CFG == nullptr) return 0;
+  if (CFG == nullptr)
+    return 0;
   auto NodeIt = CFG->EdgeCounts.find(SrcBBID);
   if (NodeIt == CFG->EdgeCounts.end())
     return 0;
@@ -507,7 +508,9 @@ BasicBlockSectionsProfileReaderWrapperPass::getClonePathsForFunction(
   return BBSPR.getClonePathsForFunction(FuncName);
 }
 
-const CFGProfile *BasicBlockSectionsProfileReaderWrapperPass::getFunctionCFGProfile(StringRef FuncName) const {
+const CFGProfile *
+BasicBlockSectionsProfileReaderWrapperPass::getFunctionCFGProfile(
+    StringRef FuncName) const {
   return BBSPR.getFunctionCFGProfile(FuncName);
 }
 

--- a/llvm/test/CodeGen/X86/basic-block-address-map-empty-function.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-empty-function.ll
@@ -19,7 +19,7 @@ entry:
 ; CHECK:	func:
 ; CHECK:	.Lfunc_begin1:
 ; CHECK:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text{{$}}
-; CHECK-NEXT:		.byte 4			# version
+; CHECK-NEXT:		.byte 5			# version
 ; BASIC-NEXT:		.byte 0			# feature
 ; PGO-NEXT:		.byte 3			# feature
 ; CHECK-NEXT:		.quad	.Lfunc_begin1	# function address

--- a/llvm/test/CodeGen/X86/basic-block-address-map-empty-function.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-empty-function.ll
@@ -19,7 +19,7 @@ entry:
 ; CHECK:	func:
 ; CHECK:	.Lfunc_begin1:
 ; CHECK:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text{{$}}
-; CHECK-NEXT:		.byte 5			# version
-; BASIC-NEXT:		.byte 0			# feature
-; PGO-NEXT:		.byte 3			# feature
+; CHECK-NEXT:		.byte  5			# version
+; BASIC-NEXT:		.short 0			# feature
+; PGO-NEXT:		.short 3			# feature
 ; CHECK-NEXT:		.quad	.Lfunc_begin1	# function address

--- a/llvm/test/CodeGen/X86/basic-block-address-map-function-sections.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-function-sections.ll
@@ -10,7 +10,7 @@ define dso_local i32 @_Z3barv() {
 ; CHECK-LABEL:	_Z3barv:
 ; CHECK-NEXT:	[[BAR_BEGIN:.Lfunc_begin[0-9]+]]:
 ; CHECK:		.section .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3barv{{$}}
-; CHECK-NEXT:		.byte 4			# version
+; CHECK-NEXT:		.byte 5			# version
 ; CHECK-NEXT:		.byte 0			# feature
 ; CHECK-NEXT:		.quad [[BAR_BEGIN]]	# function address
 
@@ -23,7 +23,7 @@ define dso_local i32 @_Z3foov() {
 ; CHECK-LABEL:	_Z3foov:
 ; CHECK-NEXT:	[[FOO_BEGIN:.Lfunc_begin[0-9]+]]:
 ; CHECK:		.section  .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3foov{{$}}
-; CHECK-NEXT:		.byte 4			# version
+; CHECK-NEXT:		.byte 5			# version
 ; CHECK-NEXT:		.byte 32                # feature
 ; CHECK-NEXT:		.quad [[FOO_BEGIN]]	# function address
 
@@ -36,6 +36,6 @@ define linkonce_odr dso_local i32 @_Z4fooTIiET_v() comdat {
 ; CHECK-LABEL:	_Z4fooTIiET_v:
 ; CHECK-NEXT:	[[FOOCOMDAT_BEGIN:.Lfunc_begin[0-9]+]]:
 ; CHECK:		.section .llvm_bb_addr_map,"oG",@llvm_bb_addr_map,.text._Z4fooTIiET_v,_Z4fooTIiET_v,comdat{{$}}
-; CHECK-NEXT:		.byte 4				# version
+; CHECK-NEXT:		.byte 5				# version
 ; CHECK-NEXT:		.byte 0				# feature
 ; CHECK-NEXT:		.quad [[FOOCOMDAT_BEGIN]]	# function address

--- a/llvm/test/CodeGen/X86/basic-block-address-map-function-sections.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-function-sections.ll
@@ -10,8 +10,8 @@ define dso_local i32 @_Z3barv() {
 ; CHECK-LABEL:	_Z3barv:
 ; CHECK-NEXT:	[[BAR_BEGIN:.Lfunc_begin[0-9]+]]:
 ; CHECK:		.section .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3barv{{$}}
-; CHECK-NEXT:		.byte 5			# version
-; CHECK-NEXT:		.byte 0			# feature
+; CHECK-NEXT:		.byte  5			# version
+; CHECK-NEXT:		.short 0			# feature
 ; CHECK-NEXT:		.quad [[BAR_BEGIN]]	# function address
 
 
@@ -23,8 +23,8 @@ define dso_local i32 @_Z3foov() {
 ; CHECK-LABEL:	_Z3foov:
 ; CHECK-NEXT:	[[FOO_BEGIN:.Lfunc_begin[0-9]+]]:
 ; CHECK:		.section  .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3foov{{$}}
-; CHECK-NEXT:		.byte 5			# version
-; CHECK-NEXT:		.byte 32                # feature
+; CHECK-NEXT:		.byte  5			# version
+; CHECK-NEXT:		.short 32                # feature
 ; CHECK-NEXT:		.quad [[FOO_BEGIN]]	# function address
 
 
@@ -36,6 +36,6 @@ define linkonce_odr dso_local i32 @_Z4fooTIiET_v() comdat {
 ; CHECK-LABEL:	_Z4fooTIiET_v:
 ; CHECK-NEXT:	[[FOOCOMDAT_BEGIN:.Lfunc_begin[0-9]+]]:
 ; CHECK:		.section .llvm_bb_addr_map,"oG",@llvm_bb_addr_map,.text._Z4fooTIiET_v,_Z4fooTIiET_v,comdat{{$}}
-; CHECK-NEXT:		.byte 5				# version
-; CHECK-NEXT:		.byte 0				# feature
+; CHECK-NEXT:		.byte  5				# version
+; CHECK-NEXT:		.short 0				# feature
 ; CHECK-NEXT:		.quad [[FOOCOMDAT_BEGIN]]	# function address

--- a/llvm/test/CodeGen/X86/basic-block-address-map-pgo-features.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-pgo-features.ll
@@ -69,7 +69,7 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-LABEL:	.Lfunc_end0:
 
 ; CHECK: 	.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3bazb{{$}}
-; CHECK-NEXT:	.byte	4		# version
+; CHECK-NEXT:	.byte	5		# version
 ; BASIC-NEXT:	.byte	32		# feature
 ; PGO-ALL-NEXT:	.byte	39		# feature
 ; FEC-ONLY-NEXT:.byte	33		# feature

--- a/llvm/test/CodeGen/X86/basic-block-address-map-pgo-features.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-pgo-features.ll
@@ -70,11 +70,11 @@ declare i32 @__gxx_personality_v0(...)
 
 ; CHECK: 	.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3bazb{{$}}
 ; CHECK-NEXT:	.byte	5		# version
-; BASIC-NEXT:	.byte	32		# feature
-; PGO-ALL-NEXT:	.byte	39		# feature
-; FEC-ONLY-NEXT:.byte	33		# feature
-; BBF-ONLY-NEXT:.byte	34		# feature
-; BRP-ONLY-NEXT:.byte	36		# feature
+; BASIC-NEXT:	.short	32		# feature
+; PGO-ALL-NEXT:	.short	39		# feature
+; FEC-ONLY-NEXT:.short	33		# feature
+; BBF-ONLY-NEXT:.short	34		# feature
+; BRP-ONLY-NEXT:.short	36		# feature
 ; CHECK-NEXT:	.quad	.Lfunc_begin0	# function address
 ; CHECK-NEXT:	.byte	6		# number of basic blocks
 ; CHECK-NEXT:	.byte	0		# BB id
@@ -146,7 +146,7 @@ declare i32 @__gxx_personality_v0(...)
 ; PGO-BRP-NEXT:	.byte	5		# successor BB ID
 ; PGO-BRP-NEXT:	.ascii	"\200\200\200\200\b"	# successor branch probability
 
-; SKIP-BB-ENTRIES:      .byte	49                              # feature
+; SKIP-BB-ENTRIES:      .short  49                              # feature
 ; SKIP-BB-ENTRIES-NEXT:	.quad	.Lfunc_begin0                   # function address
 ; SKIP-BB-ENTRIES-NEXT:	.byte	6                               # number of basic blocks
 ; SKIP-BB-ENTRIES-NEXT:	.byte	100                             # function entry count

--- a/llvm/test/CodeGen/X86/basic-block-address-map-with-basic-block-sections.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-with-basic-block-sections.ll
@@ -47,7 +47,7 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-LABEL:	.Lfunc_end0:
 
 ; CHECK:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.hot._Z3bazb
-; CHECK-NEXT:   .byte   4                       # version
+; CHECK-NEXT:   .byte   5                       # version
 ; CHECK-NEXT:   .byte   40                      # feature
 ; CHECK-NEXT:   .byte   2                       # number of basic block ranges
 ; CHECK-NEXT:	.quad	.Lfunc_begin0           # base address

--- a/llvm/test/CodeGen/X86/basic-block-address-map-with-basic-block-sections.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-with-basic-block-sections.ll
@@ -48,7 +48,7 @@ declare i32 @__gxx_personality_v0(...)
 
 ; CHECK:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.hot._Z3bazb
 ; CHECK-NEXT:   .byte   5                       # version
-; CHECK-NEXT:   .byte   40                      # feature
+; CHECK-NEXT:   .short  40                      # feature
 ; CHECK-NEXT:   .byte   2                       # number of basic block ranges
 ; CHECK-NEXT:	.quad	.Lfunc_begin0           # base address
 ; CHECK-NEXT:	.byte	2                       # number of basic blocks

--- a/llvm/test/CodeGen/X86/basic-block-address-map-with-emit-bb-hash.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-with-emit-bb-hash.ll
@@ -51,7 +51,7 @@ declare i32 @__gxx_personality_v0(...)
 ;; Verify that with -unique-section-names=false, the unique id of the text section gets assigned to the llvm_bb_addr_map section.
 ; NOUNIQ:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text,unique,1
 ; CHECK-NEXT:   .byte   5		# version
-; CHECK-NEXT:   .byte   96		# feature
+; CHECK-NEXT:   .short  96		# feature
 ; CHECK-NEXT:	.quad	.Lfunc_begin0	# function address
 ; CHECK-NEXT:	.byte	6		# number of basic blocks
 ; CHECK-NEXT:   .byte	0		# BB id

--- a/llvm/test/CodeGen/X86/basic-block-address-map-with-emit-bb-hash.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-with-emit-bb-hash.ll
@@ -50,7 +50,7 @@ declare i32 @__gxx_personality_v0(...)
 ; UNIQ:			.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3bazb{{$}}
 ;; Verify that with -unique-section-names=false, the unique id of the text section gets assigned to the llvm_bb_addr_map section.
 ; NOUNIQ:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text,unique,1
-; CHECK-NEXT:   .byte   4		# version
+; CHECK-NEXT:   .byte   5		# version
 ; CHECK-NEXT:   .byte   96		# feature
 ; CHECK-NEXT:	.quad	.Lfunc_begin0	# function address
 ; CHECK-NEXT:	.byte	6		# number of basic blocks

--- a/llvm/test/CodeGen/X86/basic-block-address-map-with-mfs.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-with-mfs.ll
@@ -59,8 +59,8 @@ declare i32 @qux()
 
 ; CHECK:                .section        .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.hot.foo
 ; CHECK-NEXT:   .byte   5               # version
-; BASIC-NEXT:   .byte   40              # feature
-; PGO-NEXT:     .byte   47              # feature
+; BASIC-NEXT:   .short  40              # feature
+; PGO-NEXT:     .short  47              # feature
 ; CHECK-NEXT:   .byte   2               # number of basic block ranges
 ; CHECK-NEXT:   .quad   .Lfunc_begin0   # base address
 ; CHECK-NEXT:   .byte   2               # number of basic blocks

--- a/llvm/test/CodeGen/X86/basic-block-address-map-with-mfs.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-with-mfs.ll
@@ -58,7 +58,7 @@ declare i32 @qux()
 ; CHECK-LABEL:  .Lfunc_end0:
 
 ; CHECK:                .section        .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.hot.foo
-; CHECK-NEXT:   .byte   4               # version
+; CHECK-NEXT:   .byte   5               # version
 ; BASIC-NEXT:   .byte   40              # feature
 ; PGO-NEXT:     .byte   47              # feature
 ; CHECK-NEXT:   .byte   2               # number of basic block ranges

--- a/llvm/test/CodeGen/X86/basic-block-address-map.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map.ll
@@ -53,7 +53,7 @@ declare i32 @__gxx_personality_v0(...)
 ;; Verify that with -unique-section-names=false, the unique id of the text section gets assigned to the llvm_bb_addr_map section.
 ; NOUNIQ:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text,unique,1
 ; CHECK-NEXT:   .byte   5		# version
-; CHECK-NEXT:   .byte   32		# feature
+; CHECK-NEXT:   .short  32		# feature
 ; CHECK-NEXT:	.quad	.Lfunc_begin0	# function address
 ; CHECK-NEXT:	.byte	6		# number of basic blocks
 ; CHECK-NEXT:   .byte	0		# BB id

--- a/llvm/test/CodeGen/X86/basic-block-address-map.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map.ll
@@ -52,7 +52,7 @@ declare i32 @__gxx_personality_v0(...)
 ; UNIQ:			.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text._Z3bazb{{$}}
 ;; Verify that with -unique-section-names=false, the unique id of the text section gets assigned to the llvm_bb_addr_map section.
 ; NOUNIQ:		.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text,unique,1
-; CHECK-NEXT:   .byte   4		# version
+; CHECK-NEXT:   .byte   5		# version
 ; CHECK-NEXT:   .byte   32		# feature
 ; CHECK-NEXT:	.quad	.Lfunc_begin0	# function address
 ; CHECK-NEXT:	.byte	6		# number of basic blocks

--- a/llvm/test/CodeGen/X86/basic-block-sections-pgo-features.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-pgo-features.ll
@@ -1,0 +1,100 @@
+; Verify PGO analysis map features with basic block sections profile.
+;
+; RUN: echo 'v1' > %t
+; RUN: echo 'f foo' >> %t
+; RUN: echo 'g 0:1000,1:800,2:200 1:800,3:800 2:200,3:200 3:1000' >> %t
+; RUN: echo 'c 0 1 2' >> %t
+;
+; RUN: llc < %s -O0 -mtriple=x86_64-pc-linux -function-sections -basic-block-sections=%t -basic-block-address-map -pgo-analysis-map=all -pgo-analysis-map-emit-bb-sections-cfg | FileCheck %s
+
+define void @foo(i1 %cond) nounwind !prof !0 {
+entry:
+  br label %bb1
+
+bb1:
+  br i1 %cond, label %bb2, label %bb3, !prof !1
+
+bb2:
+  br label %bb3
+
+bb3:
+  ret void
+}
+
+!0 = !{!"function_entry_count", i64 1500}
+!1 = !{!"branch_weights", i32 1200, i32 300}
+
+;; Verify that foo's PGO map contains both IRPGO and Propeller CFG profiles.
+
+; CHECK: 	.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.foo
+; CHECK-NEXT:	.byte	5		# version
+; CHECK-NEXT:	.byte	143		# feature
+; CHECK:	.quad	.Lfunc_begin0	# base address
+; CHECK:	.byte	0		# BB id
+; CHECK:	.byte	1		# BB id
+; CHECK:	.byte	2		# BB id
+; CHECK:	.byte	3		# BB id
+
+; CHECK:	.ascii	"\334\013"				# function entry count
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200 "		# basic block frequency
+; CHECK-NEXT:	.ascii	"\350\007"				# basic block frequency (propeller)
+; CHECK-NEXT:	.byte	1					# basic block successor count
+; CHECK-NEXT:	.byte	1					# successor BB ID
+; CHECK-NEXT:	.ascii	"\200\200\200\200\b"			# successor branch probability
+; CHECK-NEXT:	.ascii	"\240\006"				# successor branch frequency (propeller)
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200 " 	# basic block frequency
+; CHECK-NEXT:	.ascii	"\240\006"				# basic block frequency (propeller)
+; CHECK-NEXT:	.byte	2					# basic block successor count
+; CHECK-NEXT:	.byte	2					# successor BB ID
+; CHECK-NEXT:	.ascii	"\200\200\200\200\004"			# successor branch probability
+; CHECK-NEXT:	.byte	0					# successor branch frequency (propeller)
+; CHECK-NEXT:	.byte	3					# successor BB ID
+; CHECK-NEXT:	.ascii	"\200\200\200\200\004"			# successor branch probability
+; CHECK-NEXT:	.ascii	"\240\006"				# successor branch frequency (propeller)
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200\020"	# basic block frequency
+; CHECK-NEXT:	.ascii	"\310\001"				# basic block frequency (propeller)
+; CHECK-NEXT:	.byte	1					# basic block successor count
+; CHECK-NEXT:	.byte	3					# successor BB ID
+; CHECK-NEXT:	.ascii	"\200\200\200\200\b"			# successor branch probability
+; CHECK-NEXT:	.ascii	"\310\001"				# successor branch frequency (propeller)
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200 "		# basic block frequency
+; CHECK-NEXT:	.ascii	"\350\007"				# basic block frequency (propeller)
+; CHECK-NEXT:	.byte	0					# basic block successor count
+
+define void @bar(i1 %cond) nounwind !prof !2 {
+entry:
+  br i1 %cond, label %bb1, label %bb2, !prof !3
+
+bb1:
+  ret void
+
+bb2:
+  ret void
+}
+
+!2 = !{!"function_entry_count", i64 80}
+!3 = !{!"branch_weights", i32 2, i32 78}
+
+;; Verify that the PGO map for bar only includes IRPGO data since it doesn't
+;; have Propeller profile.
+
+; CHECK: 	.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.bar
+; CHECK-NEXT:	.byte	5		# version
+; CHECK-NEXT:	.byte	7		# feature
+; CHECK:	.quad	.Lfunc_begin1	# function address
+; CHECK:	.byte	0		# BB id
+; CHECK:	.byte	1		# BB id
+; CHECK:	.byte	2		# BB id
+
+; CHECK:	.byte	80                              # function entry count
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200 " # basic block frequency
+; CHECK-NEXT:	.byte	2                               # basic block successor count
+; CHECK-NEXT:	.byte	1                               # successor BB ID
+; CHECK-NEXT:	.ascii	"\200\200\200\200\004"          # successor branch probability
+; CHECK-NEXT:	.byte	2                               # successor BB ID
+; CHECK-NEXT:	.ascii	"\200\200\200\200\004"          # successor branch probability
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200\020" # basic block frequency
+; CHECK-NEXT:	.byte	0                               # basic block successor count
+; CHECK-NEXT:	.ascii	"\200\200\200\200\200\200\200\020" # basic block frequency
+; CHECK-NEXT:	.byte	0                               # basic block successor count
+

--- a/llvm/test/CodeGen/X86/basic-block-sections-pgo-features.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-pgo-features.ll
@@ -28,7 +28,7 @@ bb3:
 
 ; CHECK: 	.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.foo
 ; CHECK-NEXT:	.byte	5		# version
-; CHECK-NEXT:	.byte	143		# feature
+; CHECK-NEXT:	.short	143		# feature
 ; CHECK:	.quad	.Lfunc_begin0	# base address
 ; CHECK:	.byte	0		# BB id
 ; CHECK:	.byte	1		# BB id
@@ -80,7 +80,7 @@ bb2:
 
 ; CHECK: 	.section	.llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.bar
 ; CHECK-NEXT:	.byte	5		# version
-; CHECK-NEXT:	.byte	7		# feature
+; CHECK-NEXT:	.short	7		# feature
 ; CHECK:	.quad	.Lfunc_begin1	# function address
 ; CHECK:	.byte	0		# BB id
 ; CHECK:	.byte	1		# BB id


### PR DESCRIPTION
This PR implements the emitting of the post-link CFG information in PGO analysis map, as explained in the [RFC](https://discourse.llvm.org/t/rfc-extending-the-pgo-analysis-map-with-propeller-cfg-frequencies/88617). This is enabled by a flag `pgo-analysis-map-emit-bb-sections-cfg`.

This PR bumps the SHT_LLVM_BB_ADDR_MAP version to 5.
Also includes some refactoring changes related to storing the CFG in the Basic block sections profile reader.