### PR TITLE
[lldb] Don't emit .lldbinit warning as an error

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2591,7 +2591,7 @@ void CommandInterpreter::SourceInitFileCwd(CommandReturnObject &result) {
         llvm::sys::path::parent_path(home_init_file.GetPath())) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
-      result.AppendError(InitFileWarning);
+      result.AppendWarning(InitFileWarning);
     }
   }
   }

--- a/lldb/test/Shell/Driver/LocalLLDBInit.test
+++ b/lldb/test/Shell/Driver/LocalLLDBInit.test
@@ -9,7 +9,7 @@
 # RUN: env HOME=%t.home %lldb-init -local-lldbinit -o 'settings show frame-format' 2>&1 | FileCheck %s --check-prefix=ALLOWINIT --check-prefix=NOINIT
 # RUN: %lldb -o 'settings show frame-format' 2>&1 | FileCheck %s --check-prefix=NOINIT --check-prefix=CHECK
 
-# WARNINIT: There is a .lldbinit file in the current directory which is not being read.
+# WARNINIT: warning: There is a .lldbinit file in the current directory which is not being read.
 # NOINIT-NOT: There is a .lldbinit file in the current directory which is not being read.
 # CHECK-NOT: bogus
 # ALLOWINIT: name 'prlnt' is not defined


### PR DESCRIPTION
Actually emit a warning, rather than an error, when there's an .lldbinit file in the current directly. Currently, the message is prepended by "error" which looks rather odd, as the warning refers to itself as a warning.