### PR TITLE
[lldb-mcp] Register a NoOpMonitorCallback when launching lldb from lldb-mcp

### DIFF
--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -85,6 +85,8 @@ FileSpec driverPath() {
 llvm::Error launch() {
   FileSpec lldb_exec = driverPath();
   lldb_private::ProcessLaunchInfo info;
+  info.SetMonitorProcessCallback(
+      &lldb_private::ProcessLaunchInfo::NoOpMonitorCallback);
   info.SetExecutableFile(lldb_exec,
                          /*add_exe_file_as_first_arg=*/true);
   info.GetArguments().AppendArgument("-O");


### PR DESCRIPTION
Register a callback to avoid tripping the monitor assertion in LaunchProcess on Darwin.

Fixes #163269