### PR TITLE
[RISCV] Modify RegMask Settings of Scalar Library Functions to Reduce Spills

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -785,6 +785,8 @@ RISCVRegisterInfo::getCallPreservedMask(const MachineFunction & MF,
   case RISCVABI::ABI_LP64D:
     if (CC == CallingConv::RISCV_VectorCall)
       return CSR_ILP32D_LP64D_V_RegMask;
+    if(Subtarget.hasStdExtV())
+      return CSR_ILP32D_LP64D_V_RegMask;
     return CSR_ILP32D_LP64D_RegMask;
   }
 }

--- a/llvm/test/CodeGen/RISCV/combine-storetomstore.ll
+++ b/llvm/test/CodeGen/RISCV/combine-storetomstore.ll
@@ -504,54 +504,25 @@ declare void @use_vec(<8 x i32>)
 define void @test_masked_store_intervening(<8 x i32> %x, ptr %ptr, <8 x i1> %mask) nounwind {
 ; RISCV-LABEL: test_masked_store_intervening:
 ; RISCV:       # %bb.0:
-; RISCV-NEXT:    addi sp, sp, -32
-; RISCV-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; RISCV-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; RISCV-NEXT:    csrr a1, vlenb
-; RISCV-NEXT:    slli a2, a1, 2
-; RISCV-NEXT:    add a1, a2, a1
-; RISCV-NEXT:    sub sp, sp, a1
-; RISCV-NEXT:    csrr a1, vlenb
-; RISCV-NEXT:    slli a1, a1, 2
-; RISCV-NEXT:    add a1, sp, a1
-; RISCV-NEXT:    addi a1, a1, 16
-; RISCV-NEXT:    vs1r.v v0, (a1) # vscale x 8-byte Folded Spill
-; RISCV-NEXT:    mv s0, a0
-; RISCV-NEXT:    csrr a1, vlenb
-; RISCV-NEXT:    slli a1, a1, 1
-; RISCV-NEXT:    add a1, sp, a1
-; RISCV-NEXT:    addi a1, a1, 16
-; RISCV-NEXT:    vs2r.v v8, (a1) # vscale x 16-byte Folded Spill
-; RISCV-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RISCV-NEXT:    vle32.v v8, (a0)
-; RISCV-NEXT:    addi a1, sp, 16
-; RISCV-NEXT:    vs2r.v v8, (a1) # vscale x 16-byte Folded Spill
-; RISCV-NEXT:    vmv.v.i v8, 0
-; RISCV-NEXT:    vse32.v v8, (a0)
-; RISCV-NEXT:    call use_vec
-; RISCV-NEXT:    csrr a0, vlenb
-; RISCV-NEXT:    slli a0, a0, 2
-; RISCV-NEXT:    add a0, sp, a0
-; RISCV-NEXT:    addi a0, a0, 16
-; RISCV-NEXT:    vl1r.v v0, (a0) # vscale x 8-byte Folded Reload
-; RISCV-NEXT:    csrr a0, vlenb
-; RISCV-NEXT:    slli a0, a0, 1
-; RISCV-NEXT:    add a0, sp, a0
-; RISCV-NEXT:    addi a0, a0, 16
-; RISCV-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RISCV-NEXT:    addi a0, sp, 16
-; RISCV-NEXT:    vl2r.v v10, (a0) # vscale x 16-byte Folded Reload
-; RISCV-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RISCV-NEXT:    vmerge.vvm v8, v10, v8, v0
-; RISCV-NEXT:    vse32.v v8, (s0)
-; RISCV-NEXT:    csrr a0, vlenb
-; RISCV-NEXT:    slli a1, a0, 2
-; RISCV-NEXT:    add a0, a1, a0
-; RISCV-NEXT:    add sp, sp, a0
-; RISCV-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; RISCV-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; RISCV-NEXT:    addi sp, sp, 32
-; RISCV-NEXT:    ret
+; RISCV-NEXT:	addi	sp, sp, -16
+; RISCV-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; RISCV-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; RISCV-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RISCV-NEXT:	vmv1r.v	v26, v0
+; RISCV-NEXT:	mv	s0, a0
+; RISCV-NEXT:	vmv2r.v	v24, v8
+; RISCV-NEXT:	vle32.v	v28, (a0)
+; RISCV-NEXT:	vmv.v.i	v8, 0
+; RISCV-NEXT:	vse32.v	v8, (a0)
+; RISCV-NEXT:	call	use_vec
+; RISCV-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RISCV-NEXT:	vmv1r.v	v0, v26
+; RISCV-NEXT:	vmerge.vvm	v8, v28, v24, v0
+; RISCV-NEXT:	vse32.v	v8, (s0)
+; RISCV-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; RISCV-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; RISCV-NEXT:	addi	sp, sp, 16
+; RISCV-NEXT:	ret
   %load = load <8 x i32>, ptr %ptr, align 32
   store <8 x i32> zeroinitializer, ptr %ptr, align 32
   %tmp = load <8 x i32>, ptr %ptr

--- a/llvm/test/CodeGen/RISCV/intrinsic-cttz-elts-vscale.ll
+++ b/llvm/test/CodeGen/RISCV/intrinsic-cttz-elts-vscale.ll
@@ -55,57 +55,47 @@ define i32 @ctz_nxv4i32(<vscale x 4 x i32> %a) #0 {
 define i64 @ctz_nxv8i1_no_range(<vscale x 8 x i16> %a) {
 ; RV32-LABEL: ctz_nxv8i1_no_range:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -48
-; RV32-NEXT:    .cfi_def_cfa_offset 48
-; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    sub sp, sp, a0
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 2 * vlenb
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    srli a0, a0, 3
-; RV32-NEXT:    li a2, 8
-; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    li a3, 0
-; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a0, 16(sp)
-; RV32-NEXT:    sw a1, 20(sp)
-; RV32-NEXT:    addi a2, sp, 16
-; RV32-NEXT:    vsetvli a3, zero, e64, m8, ta, ma
-; RV32-NEXT:    vlse64.v v16, (a2), zero
-; RV32-NEXT:    vid.v v8
-; RV32-NEXT:    li a2, -1
-; RV32-NEXT:    addi a3, sp, 32
-; RV32-NEXT:    vl2r.v v24, (a3) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetvli zero, zero, e16, m2, ta, ma
-; RV32-NEXT:    vmsne.vi v0, v24, 0
-; RV32-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
-; RV32-NEXT:    vmadd.vx v8, a2, v16
-; RV32-NEXT:    vmv.v.i v16, 0
-; RV32-NEXT:    li a2, 32
-; RV32-NEXT:    vmerge.vim v16, v16, -1, v0
-; RV32-NEXT:    vand.vv v8, v8, v16
-; RV32-NEXT:    vredmaxu.vs v8, v8, v8
-; RV32-NEXT:    vmv.x.s a3, v8
-; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV32-NEXT:    vsrl.vx v8, v8, a2
-; RV32-NEXT:    sltu a2, a0, a3
-; RV32-NEXT:    vmv.x.s a4, v8
-; RV32-NEXT:    sub a1, a1, a4
-; RV32-NEXT:    sub a1, a1, a2
-; RV32-NEXT:    sub a0, a0, a3
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 1
-; RV32-NEXT:    add sp, sp, a2
-; RV32-NEXT:    .cfi_def_cfa sp, 48
-; RV32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    addi sp, sp, 48
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	.cfi_def_cfa_offset 16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; RV32-NEXT:	vmv2r.v	v24, v8
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	srli	a0, a0, 3
+; RV32-NEXT:	li	a2, 8
+; RV32-NEXT:	li	a1, 0
+; RV32-NEXT:	li	a3, 0
+; RV32-NEXT:	call	__muldi3
+; RV32-NEXT:	sw	a0, 0(sp)
+; RV32-NEXT:	sw	a1, 4(sp)
+; RV32-NEXT:	mv	a2, sp
+; RV32-NEXT:	vsetvli	a3, zero, e64, m8, ta, ma
+; RV32-NEXT:	vlse64.v	v16, (a2), zero
+; RV32-NEXT:	vid.v	v8
+; RV32-NEXT:	li	a2, -1
+; RV32-NEXT:	vsetvli	zero, zero, e16, m2, ta, ma
+; RV32-NEXT:	vmsne.vi	v0, v24, 0
+; RV32-NEXT:	vsetvli	zero, zero, e64, m8, ta, ma
+; RV32-NEXT:	vmadd.vx	v8, a2, v16
+; RV32-NEXT:	vmv.v.i	v16, 0
+; RV32-NEXT:	li	a2, 32
+; RV32-NEXT:	vmerge.vim	v16, v16, -1, v0
+; RV32-NEXT:	vand.vv	v8, v8, v16
+; RV32-NEXT:	vredmaxu.vs	v8, v8, v8
+; RV32-NEXT:	vmv.x.s	a3, v8
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vsrl.vx	v8, v8, a2
+; RV32-NEXT:	sltu	a2, a0, a3
+; RV32-NEXT:	vmv.x.s	a4, v8
+; RV32-NEXT:	sub	a1, a1, a4
+; RV32-NEXT:	sub	a1, a1, a2
+; RV32-NEXT:	sub	a0, a0, a3
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: ctz_nxv8i1_no_range:
 ; RV64:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/pr135206.ll
+++ b/llvm/test/CodeGen/RISCV/pr135206.ll
@@ -9,72 +9,53 @@ declare void @bar()
 define i1 @foo() nounwind "probe-stack"="inline-asm" "target-features"="+v" {
 ; CHECK-LABEL: foo:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -2032
-; CHECK-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 2016(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s1, 2008(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s2, 2000(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s3, 1992(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    lui a0, 7
-; CHECK-NEXT:    sub t1, sp, a0
-; CHECK-NEXT:    lui t2, 1
-; CHECK-NEXT:  .LBB0_1: # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    sub sp, sp, t2
-; CHECK-NEXT:    sd zero, 0(sp)
-; CHECK-NEXT:    bne sp, t1, .LBB0_1
-; CHECK-NEXT:  # %bb.2:
-; CHECK-NEXT:    addi sp, sp, -2048
-; CHECK-NEXT:    addi sp, sp, -96
-; CHECK-NEXT:    csrr t1, vlenb
-; CHECK-NEXT:    lui t2, 1
-; CHECK-NEXT:  .LBB0_3: # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    sub sp, sp, t2
-; CHECK-NEXT:    sd zero, 0(sp)
-; CHECK-NEXT:    sub t1, t1, t2
-; CHECK-NEXT:    bge t1, t2, .LBB0_3
-; CHECK-NEXT:  # %bb.4:
-; CHECK-NEXT:    sub sp, sp, t1
-; CHECK-NEXT:    li a0, 86
-; CHECK-NEXT:    addi s0, sp, 48
-; CHECK-NEXT:    addi s1, sp, 32
-; CHECK-NEXT:    addi s2, sp, 16
-; CHECK-NEXT:    lui a1, 353637
-; CHECK-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
-; CHECK-NEXT:    vmv.v.x v8, a0
-; CHECK-NEXT:    lui a0, 8
-; CHECK-NEXT:    addi a0, a0, 32
-; CHECK-NEXT:    add a0, sp, a0
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    addi a0, a1, 1622
-; CHECK-NEXT:    vse8.v v8, (s0)
-; CHECK-NEXT:    vse8.v v8, (s1)
-; CHECK-NEXT:    vse8.v v8, (s2)
-; CHECK-NEXT:    slli a1, a0, 32
-; CHECK-NEXT:    add s3, a0, a1
-; CHECK-NEXT:    sd s3, 64(sp)
-; CHECK-NEXT:    call bar
-; CHECK-NEXT:    lui a0, 8
-; CHECK-NEXT:    addi a0, a0, 32
-; CHECK-NEXT:    add a0, sp, a0
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
-; CHECK-NEXT:    vse8.v v8, (s0)
-; CHECK-NEXT:    vse8.v v8, (s1)
-; CHECK-NEXT:    vse8.v v8, (s2)
-; CHECK-NEXT:    sd s3, 64(sp)
-; CHECK-NEXT:    li a0, 0
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    add sp, sp, a1
-; CHECK-NEXT:    lui a1, 8
-; CHECK-NEXT:    addi a1, a1, -1952
-; CHECK-NEXT:    add sp, sp, a1
-; CHECK-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 2016(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s1, 2008(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s2, 2000(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s3, 1992(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 2032
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -2032
+; CHECK-NEXT:	sd	ra, 2024(sp)                    # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 2016(sp)                    # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s1, 2008(sp)                    # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s2, 2000(sp)                    # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s3, 1992(sp)                    # 8-byte Folded Spill
+; CHECK-NEXT:	lui	a0, 7
+; CHECK-NEXT:	sub	t1, sp, a0
+; CHECK-NEXT:	lui	t2, 1
+; CHECK-NEXT:.LBB0_1:                                # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:	sub	sp, sp, t2
+; CHECK-NEXT:	sd	zero, 0(sp)
+; CHECK-NEXT:	bne	sp, t1, .LBB0_1
+; CHECK-NEXT:# %bb.2:
+; CHECK-NEXT:	addi	sp, sp, -2048
+; CHECK-NEXT:	addi	sp, sp, -80
+; CHECK-NEXT:	li	a0, 86
+; CHECK-NEXT:	addi	s0, sp, 48
+; CHECK-NEXT:	addi	s1, sp, 32
+; CHECK-NEXT:	addi	s2, sp, 16
+; CHECK-NEXT:	lui	a1, 353637
+; CHECK-NEXT:	vsetivli	zero, 16, e8, m1, ta, ma
+; CHECK-NEXT:	vmv.v.x	v24, a0
+; CHECK-NEXT:	addi	a0, a1, 1622
+; CHECK-NEXT:	vse8.v	v24, (s0)
+; CHECK-NEXT:	vse8.v	v24, (s1)
+; CHECK-NEXT:	vse8.v	v24, (s2)
+; CHECK-NEXT:	slli	a1, a0, 32
+; CHECK-NEXT:	add	s3, a0, a1
+; CHECK-NEXT:	sd	s3, 64(sp)
+; CHECK-NEXT:	call	bar
+; CHECK-NEXT:	vsetivli	zero, 16, e8, m1, ta, ma
+; CHECK-NEXT:	vse8.v	v24, (s0)
+; CHECK-NEXT:	vse8.v	v24, (s1)
+; CHECK-NEXT:	vse8.v	v24, (s2)
+; CHECK-NEXT:	sd	s3, 64(sp)
+; CHECK-NEXT:	li	a0, 0
+; CHECK-NEXT:	lui	a1, 8
+; CHECK-NEXT:	addi	a1, a1, -1968
+; CHECK-NEXT:	add	sp, sp, a1
+; CHECK-NEXT:	ld	ra, 2024(sp)                    # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 2016(sp)                    # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s1, 2008(sp)                    # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s2, 2000(sp)                    # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s3, 1992(sp)                    # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 2032
+; CHECK-NEXT:	ret
   %1 = alloca %"buff", align 8
   call void @llvm.memset.p0.i64(ptr %1, i8 86, i64 56, i1 false)
   call void @bar()

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fpowi.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fpowi.ll
@@ -39,64 +39,56 @@ declare <1 x float> @llvm.powi.v1f32.i32(<1 x float>, i32)
 define <2 x float> @powi_v2f32(<2 x float> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v2f32:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    fsd fs0, 16(sp) # 8-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    addi a1, sp, 16
-; RV32-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vslidedown.vi v9, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v9
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fmv.s fs0, fa0
-; RV32-NEXT:    flw fa0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vfmv.v.f v8, fa0
-; RV32-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    fld fs0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	fsd	fs0, 0(sp)                      # 8-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:	vmv1r.v	v24, v8
+; RV32-NEXT:	vslidedown.vi	v8, v8, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fmv.s	fs0, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:	vfmv.v.f	v8, fa0
+; RV32-NEXT:	vfslide1down.vf	v8, v8, fs0
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	fld	fs0, 0(sp)                      # 8-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v2f32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    fsd fs0, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    addi a1, sp, 32
-; RV64-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    sext.w s0, a0
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vslidedown.vi v9, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v9
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fmv.s fs0, fa0
-; RV64-NEXT:    flw fa0, 32(sp) # 8-byte Folded Reload
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vfmv.v.f v8, fa0
-; RV64-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    fld fs0, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	fsd	fs0, 8(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:	vmv1r.v	v24, v8
+; RV64-NEXT:	sext.w	s0, a0
+; RV64-NEXT:	vslidedown.vi	v8, v8, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fmv.s	fs0, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:	vfmv.v.f	v8, fa0
+; RV64-NEXT:	vfslide1down.vf	v8, v8, fs0
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	fld	fs0, 8(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	ret
   %a = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> %x, i32 %y)
   ret <2 x float> %a
 }
@@ -105,106 +97,70 @@ declare <2 x float> @llvm.powi.v2f32.i32(<2 x float>, i32)
 define <3 x float> @powi_v3f32(<3 x float> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v3f32:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    fsd fs0, 16(sp) # 8-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 16
-; RV32-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v9, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v9
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fmv.s fs0, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    flw fa0, 16(a0) # 8-byte Folded Reload
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vfmv.v.f v8, fa0
-; RV32-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vslidedown.vi v8, v8, 1
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    fld fs0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	fsd	fs0, 0(sp)                      # 8-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vmv1r.v	v24, v8
+; RV32-NEXT:	vslidedown.vi	v8, v8, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fmv.s	fs0, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.v.f	v8, fa0
+; RV32-NEXT:	vfslide1down.vf	v25, v8, fs0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 2
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v8, v25, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v8, 1
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	fld	fs0, 0(sp)                      # 8-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v3f32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    fsd fs0, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    sext.w s0, a0
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v9, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v9
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fmv.s fs0, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    flw fa0, 32(a0) # 8-byte Folded Reload
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vfmv.v.f v8, fa0
-; RV64-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vslidedown.vi v8, v8, 1
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    fld fs0, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	fsd	fs0, 8(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vmv1r.v	v24, v8
+; RV64-NEXT:	sext.w	s0, a0
+; RV64-NEXT:	vslidedown.vi	v8, v8, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fmv.s	fs0, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.v.f	v8, fa0
+; RV64-NEXT:	vfslide1down.vf	v25, v8, fs0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 2
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v8, v25, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v8, 1
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	fld	fs0, 8(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	ret
   %a = call <3 x float> @llvm.powi.v3f32.i32(<3 x float> %x, i32 %y)
   ret <3 x float> %a
 }
@@ -213,130 +169,80 @@ declare <3 x float> @llvm.powi.v3f32.i32(<3 x float>, i32)
 define <4 x float> @powi_v4f32(<4 x float> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v4f32:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    fsd fs0, 16(sp) # 8-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 16
-; RV32-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v9, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v9
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fmv.s fs0, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    flw fa0, 16(a0) # 8-byte Folded Reload
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vfmv.v.f v8, fa0
-; RV32-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 3
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    fld fs0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	fsd	fs0, 0(sp)                      # 8-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vmv1r.v	v24, v8
+; RV32-NEXT:	vslidedown.vi	v8, v8, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fmv.s	fs0, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.v.f	v8, fa0
+; RV32-NEXT:	vfslide1down.vf	v25, v8, fs0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 2
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v25, v25, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 3
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v8, v25, fa0
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	fld	fs0, 0(sp)                      # 8-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v4f32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    fsd fs0, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    sext.w s0, a0
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v9, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v9
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fmv.s fs0, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    flw fa0, 32(a0) # 8-byte Folded Reload
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vfmv.v.f v8, fa0
-; RV64-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 3
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    fld fs0, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	fsd	fs0, 8(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vmv1r.v	v24, v8
+; RV64-NEXT:	sext.w	s0, a0
+; RV64-NEXT:	vslidedown.vi	v8, v8, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fmv.s	fs0, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.v.f	v8, fa0
+; RV64-NEXT:	vfslide1down.vf	v25, v8, fs0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 2
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v25, v25, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 3
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v8, v25, fa0
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	fld	fs0, 8(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	ret
   %a = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %x, i32 %y)
   ret <4 x float> %a
 }
@@ -345,260 +251,132 @@ declare <4 x float> @llvm.powi.v4f32.i32(<4 x float>, i32)
 define <8 x float> @powi_v8f32(<8 x float> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v8f32:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    fsd fs0, 16(sp) # 8-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 16
-; RV32-NEXT:    vs2r.v v8, (a1) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v10, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v10
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fmv.s fs0, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfmv.v.f v8, fa0
-; RV32-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 3
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 4
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 5
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 6
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 7
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 2
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    fld fs0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	fsd	fs0, 0(sp)                      # 8-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vmv2r.v	v24, v8
+; RV32-NEXT:	vslidedown.vi	v8, v24, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fmv.s	fs0, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfmv.v.f	v8, fa0
+; RV32-NEXT:	vfslide1down.vf	v26, v8, fs0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 2
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 3
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 4
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 5
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 6
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 7
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v8, v26, fa0
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	fld	fs0, 0(sp)                      # 8-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v8f32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    fsd fs0, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs2r.v v8, (a1) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    sext.w s0, a0
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v10, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v10
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fmv.s fs0, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfmv.v.f v8, fa0
-; RV64-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 3
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 4
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 5
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 6
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 7
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 2
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    fld fs0, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	fsd	fs0, 8(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vmv2r.v	v24, v8
+; RV64-NEXT:	sext.w	s0, a0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fmv.s	fs0, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfmv.v.f	v8, fa0
+; RV64-NEXT:	vfslide1down.vf	v26, v8, fs0
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 2
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 3
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 4
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 5
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 6
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 7
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v8, v26, fa0
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	fld	fs0, 8(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	ret
   %a = call <8 x float> @llvm.powi.v8f32.i32(<8 x float> %x, i32 %y)
   ret <8 x float> %a
 }
@@ -607,247 +385,207 @@ declare <8 x float> @llvm.powi.v8f32.i32(<8 x float>, i32)
 define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v16f32:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -272
-; RV32-NEXT:    sw ra, 268(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 264(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s2, 260(sp) # 4-byte Folded Spill
-; RV32-NEXT:    addi s0, sp, 272
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    andi sp, sp, -64
-; RV32-NEXT:    mv s2, a0
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vs4r.v v8, (a0) # vscale x 32-byte Folded Spill
-; RV32-NEXT:    addi a0, sp, 64
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vse32.v v8, (a0)
-; RV32-NEXT:    flw fa0, 124(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 188(sp)
-; RV32-NEXT:    flw fa0, 120(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 184(sp)
-; RV32-NEXT:    flw fa0, 116(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 180(sp)
-; RV32-NEXT:    flw fa0, 112(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 176(sp)
-; RV32-NEXT:    flw fa0, 108(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 172(sp)
-; RV32-NEXT:    flw fa0, 104(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 168(sp)
-; RV32-NEXT:    flw fa0, 100(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 164(sp)
-; RV32-NEXT:    flw fa0, 96(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 160(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 128(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 3
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 140(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 136(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 132(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 7
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 156(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 6
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 152(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 5
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 148(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 4
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 144(sp)
-; RV32-NEXT:    addi a0, sp, 128
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vle32.v v8, (a0)
-; RV32-NEXT:    addi sp, s0, -272
-; RV32-NEXT:    lw ra, 268(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 264(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s2, 260(sp) # 4-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 272
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -192
+; RV32-NEXT:	sw	ra, 188(sp)                     # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 184(sp)                     # 4-byte Folded Spill
+; RV32-NEXT:	sw	s2, 180(sp)                     # 4-byte Folded Spill
+; RV32-NEXT:	addi	s0, sp, 192
+; RV32-NEXT:	andi	sp, sp, -64
+; RV32-NEXT:	mv	s2, a0
+; RV32-NEXT:	vsetivli	zero, 16, e32, m4, ta, ma
+; RV32-NEXT:	vmv4r.v	v24, v8
+; RV32-NEXT:	mv	a0, sp
+; RV32-NEXT:	vse32.v	v8, (a0)
+; RV32-NEXT:	flw	fa0, 60(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 124(sp)
+; RV32-NEXT:	flw	fa0, 56(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 120(sp)
+; RV32-NEXT:	flw	fa0, 52(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 116(sp)
+; RV32-NEXT:	flw	fa0, 48(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 112(sp)
+; RV32-NEXT:	flw	fa0, 44(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 108(sp)
+; RV32-NEXT:	flw	fa0, 40(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 104(sp)
+; RV32-NEXT:	flw	fa0, 36(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 100(sp)
+; RV32-NEXT:	flw	fa0, 32(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 96(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 64(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 3
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 76(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 2
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 72(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 68(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 7
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 92(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 6
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 88(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 5
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 84(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 4
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powisf2
+; RV32-NEXT:	fsw	fa0, 80(sp)
+; RV32-NEXT:	addi	a0, sp, 64
+; RV32-NEXT:	vsetivli	zero, 16, e32, m4, ta, ma
+; RV32-NEXT:	vle32.v	v8, (a0)
+; RV32-NEXT:	addi	sp, s0, -192
+; RV32-NEXT:	lw	ra, 188(sp)                     # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 184(sp)                     # 4-byte Folded Reload
+; RV32-NEXT:	lw	s2, 180(sp)                     # 4-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 192
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v16f32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -272
-; RV64-NEXT:    sd ra, 264(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 256(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s2, 248(sp) # 8-byte Folded Spill
-; RV64-NEXT:    addi s0, sp, 272
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    andi sp, sp, -64
-; RV64-NEXT:    addi a1, sp, 240
-; RV64-NEXT:    vs4r.v v8, (a1) # vscale x 32-byte Folded Spill
-; RV64-NEXT:    addi a1, sp, 64
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vse32.v v8, (a1)
-; RV64-NEXT:    flw fa0, 124(sp)
-; RV64-NEXT:    sext.w s2, a0
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 188(sp)
-; RV64-NEXT:    flw fa0, 120(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 184(sp)
-; RV64-NEXT:    flw fa0, 116(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 180(sp)
-; RV64-NEXT:    flw fa0, 112(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 176(sp)
-; RV64-NEXT:    flw fa0, 108(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 172(sp)
-; RV64-NEXT:    flw fa0, 104(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 168(sp)
-; RV64-NEXT:    flw fa0, 100(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 164(sp)
-; RV64-NEXT:    flw fa0, 96(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 160(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 128(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 3
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 140(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 136(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 132(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 7
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 156(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 6
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 152(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 5
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 148(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 4
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 144(sp)
-; RV64-NEXT:    addi a0, sp, 128
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vle32.v v8, (a0)
-; RV64-NEXT:    addi sp, s0, -272
-; RV64-NEXT:    ld ra, 264(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 256(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s2, 248(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 272
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -192
+; RV64-NEXT:	sd	ra, 184(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 176(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s2, 168(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	addi	s0, sp, 192
+; RV64-NEXT:	andi	sp, sp, -64
+; RV64-NEXT:	vsetivli	zero, 16, e32, m4, ta, ma
+; RV64-NEXT:	vmv4r.v	v24, v8
+; RV64-NEXT:	mv	a1, sp
+; RV64-NEXT:	vse32.v	v8, (a1)
+; RV64-NEXT:	flw	fa0, 60(sp)
+; RV64-NEXT:	sext.w	s2, a0
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 124(sp)
+; RV64-NEXT:	flw	fa0, 56(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 120(sp)
+; RV64-NEXT:	flw	fa0, 52(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 116(sp)
+; RV64-NEXT:	flw	fa0, 48(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 112(sp)
+; RV64-NEXT:	flw	fa0, 44(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 108(sp)
+; RV64-NEXT:	flw	fa0, 40(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 104(sp)
+; RV64-NEXT:	flw	fa0, 36(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 100(sp)
+; RV64-NEXT:	flw	fa0, 32(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 96(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 64(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 3
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 76(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 2
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 72(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 68(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 7
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 92(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 6
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 88(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 5
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 84(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 4
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powisf2
+; RV64-NEXT:	fsw	fa0, 80(sp)
+; RV64-NEXT:	addi	a0, sp, 64
+; RV64-NEXT:	vsetivli	zero, 16, e32, m4, ta, ma
+; RV64-NEXT:	vle32.v	v8, (a0)
+; RV64-NEXT:	addi	sp, s0, -192
+; RV64-NEXT:	ld	ra, 184(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 176(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s2, 168(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 192
+; RV64-NEXT:	ret
   %a = call <16 x float> @llvm.powi.v16f32.i32(<16 x float> %x, i32 %y)
   ret <16 x float> %a
 }
@@ -888,64 +626,56 @@ declare <1 x double> @llvm.powi.v1f64.i32(<1 x double>, i32)
 define <2 x double> @powi_v2f64(<2 x double> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v2f64:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    fsd fs0, 16(sp) # 8-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    addi a1, sp, 16
-; RV32-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v9, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v9
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fmv.d fs0, fa0
-; RV32-NEXT:    fld fa0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; RV32-NEXT:    vfmv.v.f v8, fa0
-; RV32-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    fld fs0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	fsd	fs0, 0(sp)                      # 8-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vmv1r.v	v24, v8
+; RV32-NEXT:	vslidedown.vi	v8, v8, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fmv.d	fs0, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; RV32-NEXT:	vfmv.v.f	v8, fa0
+; RV32-NEXT:	vfslide1down.vf	v8, v8, fs0
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	fld	fs0, 0(sp)                      # 8-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v2f64:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    fsd fs0, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    addi a1, sp, 32
-; RV64-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    sext.w s0, a0
-; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v9, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v9
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fmv.d fs0, fa0
-; RV64-NEXT:    fld fa0, 32(sp) # 8-byte Folded Reload
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; RV64-NEXT:    vfmv.v.f v8, fa0
-; RV64-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    fld fs0, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	fsd	fs0, 8(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV64-NEXT:	vmv1r.v	v24, v8
+; RV64-NEXT:	sext.w	s0, a0
+; RV64-NEXT:	vslidedown.vi	v8, v8, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fmv.d	fs0, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; RV64-NEXT:	vfmv.v.f	v8, fa0
+; RV64-NEXT:	vfslide1down.vf	v8, v8, fs0
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	fld	fs0, 8(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	ret
   %a = call <2 x double> @llvm.powi.v2f64.i32(<2 x double> %x, i32 %y)
   ret <2 x double> %a
 }
@@ -954,144 +684,80 @@ declare <2 x double> @llvm.powi.v2f64.i32(<2 x double>, i32)
 define <4 x double> @powi_v4f64(<4 x double> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v4f64:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    fsd fs0, 16(sp) # 8-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 16
-; RV32-NEXT:    vs2r.v v8, (a1) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v10, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v10
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fmv.d fs0, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV32-NEXT:    vfmv.v.f v8, fa0
-; RV32-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vslidedown.vi v8, v8, 3
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s0
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV32-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 2
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    fld fs0, 16(sp) # 8-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	fsd	fs0, 0(sp)                      # 8-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vmv2r.v	v24, v8
+; RV32-NEXT:	vslidedown.vi	v8, v24, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fmv.d	fs0, fa0
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV32-NEXT:	vfmv.v.f	v8, fa0
+; RV32-NEXT:	vfslide1down.vf	v26, v8, fs0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 2
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV32-NEXT:	vslidedown.vi	v8, v24, 3
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s0
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV32-NEXT:	vfslide1down.vf	v8, v26, fa0
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	fld	fs0, 0(sp)                      # 8-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v4f64:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    fsd fs0, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs2r.v v8, (a1) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    sext.w s0, a0
-; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v10, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v10
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fmv.d fs0, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV64-NEXT:    vfmv.v.f v8, fa0
-; RV64-NEXT:    vfslide1down.vf v8, v8, fs0
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vslidedown.vi v8, v8, 3
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s0
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV64-NEXT:    vfslide1down.vf v8, v8, fa0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 2
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    fld fs0, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	fsd	fs0, 8(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV64-NEXT:	vmv2r.v	v24, v8
+; RV64-NEXT:	sext.w	s0, a0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fmv.d	fs0, fa0
+; RV64-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV64-NEXT:	vfmv.v.f	v8, fa0
+; RV64-NEXT:	vfslide1down.vf	v26, v8, fs0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 2
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v26, v26, fa0
+; RV64-NEXT:	vslidedown.vi	v8, v24, 3
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s0
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV64-NEXT:	vfslide1down.vf	v8, v26, fa0
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	fld	fs0, 8(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	ret
   %a = call <4 x double> @llvm.powi.v4f64.i32(<4 x double> %x, i32 %y)
   ret <4 x double> %a
 }
@@ -1100,151 +766,127 @@ declare <4 x double> @llvm.powi.v4f64.i32(<4 x double>, i32)
 define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-LABEL: powi_v8f64:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -272
-; RV32-NEXT:    sw ra, 268(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 264(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s2, 260(sp) # 4-byte Folded Spill
-; RV32-NEXT:    addi s0, sp, 272
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    andi sp, sp, -64
-; RV32-NEXT:    mv s2, a0
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vs4r.v v8, (a0) # vscale x 32-byte Folded Spill
-; RV32-NEXT:    addi a0, sp, 64
-; RV32-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
-; RV32-NEXT:    vse64.v v8, (a0)
-; RV32-NEXT:    fld fa0, 120(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 184(sp)
-; RV32-NEXT:    fld fa0, 112(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 176(sp)
-; RV32-NEXT:    fld fa0, 104(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 168(sp)
-; RV32-NEXT:    fld fa0, 96(sp)
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 160(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 128(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 1
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 136(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 3
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 152(sp)
-; RV32-NEXT:    addi a0, sp, 256
-; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV32-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
-; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 144(sp)
-; RV32-NEXT:    addi a0, sp, 128
-; RV32-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
-; RV32-NEXT:    vle64.v v8, (a0)
-; RV32-NEXT:    addi sp, s0, -272
-; RV32-NEXT:    lw ra, 268(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 264(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s2, 260(sp) # 4-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 272
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -192
+; RV32-NEXT:	sw	ra, 188(sp)                     # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 184(sp)                     # 4-byte Folded Spill
+; RV32-NEXT:	sw	s2, 180(sp)                     # 4-byte Folded Spill
+; RV32-NEXT:	addi	s0, sp, 192
+; RV32-NEXT:	andi	sp, sp, -64
+; RV32-NEXT:	mv	s2, a0
+; RV32-NEXT:	vsetivli	zero, 8, e64, m4, ta, ma
+; RV32-NEXT:	vmv4r.v	v24, v8
+; RV32-NEXT:	mv	a0, sp
+; RV32-NEXT:	vse64.v	v8, (a0)
+; RV32-NEXT:	fld	fa0, 56(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 120(sp)
+; RV32-NEXT:	fld	fa0, 48(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 112(sp)
+; RV32-NEXT:	fld	fa0, 40(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 104(sp)
+; RV32-NEXT:	fld	fa0, 32(sp)
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 96(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vfmv.f.s	fa0, v24
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 64(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 1
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 72(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e64, m2, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 3
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 88(sp)
+; RV32-NEXT:	vsetivli	zero, 1, e64, m2, ta, ma
+; RV32-NEXT:	vslidedown.vi	v8, v24, 2
+; RV32-NEXT:	vfmv.f.s	fa0, v8
+; RV32-NEXT:	mv	a0, s2
+; RV32-NEXT:	call	__powidf2
+; RV32-NEXT:	fsd	fa0, 80(sp)
+; RV32-NEXT:	addi	a0, sp, 64
+; RV32-NEXT:	vsetivli	zero, 8, e64, m4, ta, ma
+; RV32-NEXT:	vle64.v	v8, (a0)
+; RV32-NEXT:	addi	sp, s0, -192
+; RV32-NEXT:	lw	ra, 188(sp)                     # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 184(sp)                     # 4-byte Folded Reload
+; RV32-NEXT:	lw	s2, 180(sp)                     # 4-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 192
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: powi_v8f64:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -272
-; RV64-NEXT:    sd ra, 264(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 256(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s2, 248(sp) # 8-byte Folded Spill
-; RV64-NEXT:    addi s0, sp, 272
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    andi sp, sp, -64
-; RV64-NEXT:    addi a1, sp, 240
-; RV64-NEXT:    vs4r.v v8, (a1) # vscale x 32-byte Folded Spill
-; RV64-NEXT:    addi a1, sp, 64
-; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
-; RV64-NEXT:    vse64.v v8, (a1)
-; RV64-NEXT:    fld fa0, 120(sp)
-; RV64-NEXT:    sext.w s2, a0
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 184(sp)
-; RV64-NEXT:    fld fa0, 112(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 176(sp)
-; RV64-NEXT:    fld fa0, 104(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 168(sp)
-; RV64-NEXT:    fld fa0, 96(sp)
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 160(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 128(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 1
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 136(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 3
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 152(sp)
-; RV64-NEXT:    addi a0, sp, 240
-; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
-; RV64-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
-; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 144(sp)
-; RV64-NEXT:    addi a0, sp, 128
-; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
-; RV64-NEXT:    vle64.v v8, (a0)
-; RV64-NEXT:    addi sp, s0, -272
-; RV64-NEXT:    ld ra, 264(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 256(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s2, 248(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 272
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -192
+; RV64-NEXT:	sd	ra, 184(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 176(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s2, 168(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	addi	s0, sp, 192
+; RV64-NEXT:	andi	sp, sp, -64
+; RV64-NEXT:	vsetivli	zero, 8, e64, m4, ta, ma
+; RV64-NEXT:	vmv4r.v	v24, v8
+; RV64-NEXT:	mv	a1, sp
+; RV64-NEXT:	vse64.v	v8, (a1)
+; RV64-NEXT:	fld	fa0, 56(sp)
+; RV64-NEXT:	sext.w	s2, a0
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 120(sp)
+; RV64-NEXT:	fld	fa0, 48(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 112(sp)
+; RV64-NEXT:	fld	fa0, 40(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 104(sp)
+; RV64-NEXT:	fld	fa0, 32(sp)
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 96(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV64-NEXT:	vfmv.f.s	fa0, v24
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 64(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 1
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 72(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e64, m2, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 3
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 88(sp)
+; RV64-NEXT:	vsetivli	zero, 1, e64, m2, ta, ma
+; RV64-NEXT:	vslidedown.vi	v8, v24, 2
+; RV64-NEXT:	vfmv.f.s	fa0, v8
+; RV64-NEXT:	mv	a0, s2
+; RV64-NEXT:	call	__powidf2
+; RV64-NEXT:	fsd	fa0, 80(sp)
+; RV64-NEXT:	addi	a0, sp, 64
+; RV64-NEXT:	vsetivli	zero, 8, e64, m4, ta, ma
+; RV64-NEXT:	vle64.v	v8, (a0)
+; RV64-NEXT:	addi	sp, s0, -192
+; RV64-NEXT:	ld	ra, 184(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 176(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s2, 168(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	addi	sp, sp, 192
+; RV64-NEXT:	ret
   %a = call <8 x double> @llvm.powi.v8f64.i32(<8 x double> %x, i32 %y)
   ret <8 x double> %a
 }

--- a/llvm/test/CodeGen/RISCV/rvv/fpclamptosat_vec.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fpclamptosat_vec.ll
@@ -432,83 +432,57 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: stest_f16i32:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a2, a1, 1
-; CHECK-V-NEXT:    add a1, a2, a1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x03, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 3 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-V-NEXT:    vnclip.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a1, a0, 1
-; CHECK-V-NEXT:    add a0, a1, a0
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 2
+; CHECK-V-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; CHECK-V-NEXT:	vnclip.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <4 x half> %x to <4 x i64>
   %0 = icmp slt <4 x i64> %conv, <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>
@@ -612,83 +586,57 @@ define <4 x i32> @utest_f16i32(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: utest_f16i32:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a2, a1, 1
-; CHECK-V-NEXT:    add a1, a2, a1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x03, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 3 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a1, a0, 1
-; CHECK-V-NEXT:    add a0, a1, a0
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 2
+; CHECK-V-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <4 x half> %x to <4 x i64>
   %0 = icmp ult <4 x i64> %conv, <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>
@@ -802,84 +750,58 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f16i32:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a2, a1, 1
-; CHECK-V-NEXT:    add a1, a2, a1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x03, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 3 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v10, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v10, 2
-; CHECK-V-NEXT:    vmax.vx v10, v8, zero
-; CHECK-V-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a1, a0, 1
-; CHECK-V-NEXT:    add a0, a1, a0
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v24, 2
+; CHECK-V-NEXT:	vmax.vx	v10, v8, zero
+; CHECK-V-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <4 x half> %x to <4 x i64>
   %0 = icmp slt <4 x i64> %conv, <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>
@@ -1425,165 +1347,103 @@ define <8 x i16> @stest_f16i16(<8 x half> %x) {
 ;
 ; CHECK-V-LABEL: stest_f16i16:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-V-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s3, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s4, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s5, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s6, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    .cfi_offset s3, -40
-; CHECK-V-NEXT:    .cfi_offset s4, -48
-; CHECK-V-NEXT:    .cfi_offset s5, -56
-; CHECK-V-NEXT:    .cfi_offset s6, -64
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 2
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0x04, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 4 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu s3, 24(a0)
-; CHECK-V-NEXT:    lhu s4, 32(a0)
-; CHECK-V-NEXT:    lhu s5, 40(a0)
-; CHECK-V-NEXT:    lhu s6, 48(a0)
-; CHECK-V-NEXT:    lhu a0, 56(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s6
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s5
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s4
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s3
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 4
-; CHECK-V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
-; CHECK-V-NEXT:    vnclip.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 2
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 80
-; CHECK-V-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s4, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s6, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    .cfi_restore s3
-; CHECK-V-NEXT:    .cfi_restore s4
-; CHECK-V-NEXT:    .cfi_restore s5
-; CHECK-V-NEXT:    .cfi_restore s6
-; CHECK-V-NEXT:    addi sp, sp, 80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 64
+; CHECK-V-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s5, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s6, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	.cfi_offset s3, -40
+; CHECK-V-NEXT:	.cfi_offset s4, -48
+; CHECK-V-NEXT:	.cfi_offset s5, -56
+; CHECK-V-NEXT:	.cfi_offset s6, -64
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	s3, 24(a0)
+; CHECK-V-NEXT:	lhu	s4, 32(a0)
+; CHECK-V-NEXT:	lhu	s5, 40(a0)
+; CHECK-V-NEXT:	lhu	s6, 48(a0)
+; CHECK-V-NEXT:	lhu	a0, 56(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s6
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s5
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s4
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v26, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 2
+; CHECK-V-NEXT:	fmv.w.x	fa0, s3
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	vslideup.vi	v26, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v26, 2
+; CHECK-V-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 4
+; CHECK-V-NEXT:	vsetvli	zero, zero, e16, m1, ta, ma
+; CHECK-V-NEXT:	vnclip.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s5, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s6, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	.cfi_restore s3
+; CHECK-V-NEXT:	.cfi_restore s4
+; CHECK-V-NEXT:	.cfi_restore s5
+; CHECK-V-NEXT:	.cfi_restore s6
+; CHECK-V-NEXT:	addi	sp, sp, 64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
   %0 = icmp slt <8 x i32> %conv, <i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767>
@@ -1767,165 +1627,103 @@ define <8 x i16> @utest_f16i16(<8 x half> %x) {
 ;
 ; CHECK-V-LABEL: utest_f16i16:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-V-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s3, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s4, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s5, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s6, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    .cfi_offset s3, -40
-; CHECK-V-NEXT:    .cfi_offset s4, -48
-; CHECK-V-NEXT:    .cfi_offset s5, -56
-; CHECK-V-NEXT:    .cfi_offset s6, -64
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 2
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0x04, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 4 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu s3, 24(a0)
-; CHECK-V-NEXT:    lhu s4, 32(a0)
-; CHECK-V-NEXT:    lhu s5, 40(a0)
-; CHECK-V-NEXT:    lhu s6, 48(a0)
-; CHECK-V-NEXT:    lhu a0, 56(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s6
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s5
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s4
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s3
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 4
-; CHECK-V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 2
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 80
-; CHECK-V-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s4, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s6, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    .cfi_restore s3
-; CHECK-V-NEXT:    .cfi_restore s4
-; CHECK-V-NEXT:    .cfi_restore s5
-; CHECK-V-NEXT:    .cfi_restore s6
-; CHECK-V-NEXT:    addi sp, sp, 80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 64
+; CHECK-V-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s5, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s6, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	.cfi_offset s3, -40
+; CHECK-V-NEXT:	.cfi_offset s4, -48
+; CHECK-V-NEXT:	.cfi_offset s5, -56
+; CHECK-V-NEXT:	.cfi_offset s6, -64
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	s3, 24(a0)
+; CHECK-V-NEXT:	lhu	s4, 32(a0)
+; CHECK-V-NEXT:	lhu	s5, 40(a0)
+; CHECK-V-NEXT:	lhu	s6, 48(a0)
+; CHECK-V-NEXT:	lhu	a0, 56(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s6
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s5
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s4
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v26, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 2
+; CHECK-V-NEXT:	fmv.w.x	fa0, s3
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	vslideup.vi	v26, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v26, 2
+; CHECK-V-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 4
+; CHECK-V-NEXT:	vsetvli	zero, zero, e16, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s5, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s6, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	.cfi_restore s3
+; CHECK-V-NEXT:	.cfi_restore s4
+; CHECK-V-NEXT:	.cfi_restore s5
+; CHECK-V-NEXT:	.cfi_restore s6
+; CHECK-V-NEXT:	addi	sp, sp, 64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <8 x half> %x to <8 x i32>
   %0 = icmp ult <8 x i32> %conv, <i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535>
@@ -2131,166 +1929,104 @@ define <8 x i16> @ustest_f16i16(<8 x half> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f16i16:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-V-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s3, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s4, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s5, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s6, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    .cfi_offset s3, -40
-; CHECK-V-NEXT:    .cfi_offset s4, -48
-; CHECK-V-NEXT:    .cfi_offset s5, -56
-; CHECK-V-NEXT:    .cfi_offset s6, -64
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 2
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0x04, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 4 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu s3, 24(a0)
-; CHECK-V-NEXT:    lhu s4, 32(a0)
-; CHECK-V-NEXT:    lhu s5, 40(a0)
-; CHECK-V-NEXT:    lhu s6, 48(a0)
-; CHECK-V-NEXT:    lhu a0, 56(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s6
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s5
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s4
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s3
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v10, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-V-NEXT:    vmax.vx v10, v8, zero
-; CHECK-V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 2
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 80
-; CHECK-V-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s4, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s6, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    .cfi_restore s3
-; CHECK-V-NEXT:    .cfi_restore s4
-; CHECK-V-NEXT:    .cfi_restore s5
-; CHECK-V-NEXT:    .cfi_restore s6
-; CHECK-V-NEXT:    addi sp, sp, 80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 64
+; CHECK-V-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s5, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s6, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	.cfi_offset s3, -40
+; CHECK-V-NEXT:	.cfi_offset s4, -48
+; CHECK-V-NEXT:	.cfi_offset s5, -56
+; CHECK-V-NEXT:	.cfi_offset s6, -64
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	s3, 24(a0)
+; CHECK-V-NEXT:	lhu	s4, 32(a0)
+; CHECK-V-NEXT:	lhu	s5, 40(a0)
+; CHECK-V-NEXT:	lhu	s6, 48(a0)
+; CHECK-V-NEXT:	lhu	a0, 56(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s6
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s5
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s4
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v26, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 2
+; CHECK-V-NEXT:	fmv.w.x	fa0, s3
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	vslideup.vi	v26, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v26, 2
+; CHECK-V-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v24, 4
+; CHECK-V-NEXT:	vmax.vx	v10, v8, zero
+; CHECK-V-NEXT:	vsetvli	zero, zero, e16, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s5, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s6, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	.cfi_restore s3
+; CHECK-V-NEXT:	.cfi_restore s4
+; CHECK-V-NEXT:	.cfi_restore s5
+; CHECK-V-NEXT:	.cfi_restore s6
+; CHECK-V-NEXT:	addi	sp, sp, 64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
   %0 = icmp slt <8 x i32> %conv, <i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535>
@@ -2390,94 +2126,88 @@ define <2 x i64> @stest_f64i64(<2 x double> %x) {
 ;
 ; CHECK-V-LABEL: stest_f64i64:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    fld fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    li a2, -1
-; CHECK-V-NEXT:    srli a3, a2, 1
-; CHECK-V-NEXT:    beqz a1, .LBB18_3
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    srli a4, a1, 63
-; CHECK-V-NEXT:    bnez s1, .LBB18_4
-; CHECK-V-NEXT:  .LBB18_2:
-; CHECK-V-NEXT:    sltu a5, s0, a3
-; CHECK-V-NEXT:    beqz a5, .LBB18_5
-; CHECK-V-NEXT:    j .LBB18_6
-; CHECK-V-NEXT:  .LBB18_3:
-; CHECK-V-NEXT:    sltu a4, a0, a3
-; CHECK-V-NEXT:    beqz s1, .LBB18_2
-; CHECK-V-NEXT:  .LBB18_4: # %entry
-; CHECK-V-NEXT:    srli a5, s1, 63
-; CHECK-V-NEXT:    bnez a5, .LBB18_6
-; CHECK-V-NEXT:  .LBB18_5: # %entry
-; CHECK-V-NEXT:    mv s0, a3
-; CHECK-V-NEXT:  .LBB18_6: # %entry
-; CHECK-V-NEXT:    neg a6, a5
-; CHECK-V-NEXT:    neg a5, a4
-; CHECK-V-NEXT:    and a5, a5, a1
-; CHECK-V-NEXT:    bnez a4, .LBB18_8
-; CHECK-V-NEXT:  # %bb.7: # %entry
-; CHECK-V-NEXT:    mv a0, a3
-; CHECK-V-NEXT:  .LBB18_8: # %entry
-; CHECK-V-NEXT:    and a4, a6, s1
-; CHECK-V-NEXT:    slli a1, a2, 63
-; CHECK-V-NEXT:    beq a5, a2, .LBB18_11
-; CHECK-V-NEXT:  # %bb.9: # %entry
-; CHECK-V-NEXT:    srli a5, a5, 63
-; CHECK-V-NEXT:    xori a3, a5, 1
-; CHECK-V-NEXT:    bne a4, a2, .LBB18_12
-; CHECK-V-NEXT:  .LBB18_10:
-; CHECK-V-NEXT:    sltu a2, a1, s0
-; CHECK-V-NEXT:    beqz a2, .LBB18_13
-; CHECK-V-NEXT:    j .LBB18_14
-; CHECK-V-NEXT:  .LBB18_11:
-; CHECK-V-NEXT:    sltu a3, a1, a0
-; CHECK-V-NEXT:    beq a4, a2, .LBB18_10
-; CHECK-V-NEXT:  .LBB18_12: # %entry
-; CHECK-V-NEXT:    srli a4, a4, 63
-; CHECK-V-NEXT:    xori a2, a4, 1
-; CHECK-V-NEXT:    bnez a2, .LBB18_14
-; CHECK-V-NEXT:  .LBB18_13: # %entry
-; CHECK-V-NEXT:    mv s0, a1
-; CHECK-V-NEXT:  .LBB18_14: # %entry
-; CHECK-V-NEXT:    bnez a3, .LBB18_16
-; CHECK-V-NEXT:  # %bb.15: # %entry
-; CHECK-V-NEXT:    mv a0, a1
-; CHECK-V-NEXT:  .LBB18_16: # %entry
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, s0
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	li	a2, -1
+; CHECK-V-NEXT:	srli	a3, a2, 1
+; CHECK-V-NEXT:	beqz	a1, .LBB18_3
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	srli	a4, a1, 63
+; CHECK-V-NEXT:	bnez	s1, .LBB18_4
+; CHECK-V-NEXT:.LBB18_2:
+; CHECK-V-NEXT:	sltu	a5, s0, a3
+; CHECK-V-NEXT:	beqz	a5, .LBB18_5
+; CHECK-V-NEXT:	j	.LBB18_6
+; CHECK-V-NEXT:.LBB18_3:
+; CHECK-V-NEXT:	sltu	a4, a0, a3
+; CHECK-V-NEXT:	beqz	s1, .LBB18_2
+; CHECK-V-NEXT:.LBB18_4:                               # %entry
+; CHECK-V-NEXT:	srli	a5, s1, 63
+; CHECK-V-NEXT:	bnez	a5, .LBB18_6
+; CHECK-V-NEXT:.LBB18_5:                               # %entry
+; CHECK-V-NEXT:	mv	s0, a3
+; CHECK-V-NEXT:.LBB18_6:                               # %entry
+; CHECK-V-NEXT:	neg	a6, a5
+; CHECK-V-NEXT:	neg	a5, a4
+; CHECK-V-NEXT:	and	a5, a5, a1
+; CHECK-V-NEXT:	bnez	a4, .LBB18_8
+; CHECK-V-NEXT:# %bb.7:                                # %entry
+; CHECK-V-NEXT:	mv	a0, a3
+; CHECK-V-NEXT:.LBB18_8:                               # %entry
+; CHECK-V-NEXT:	and	a4, a6, s1
+; CHECK-V-NEXT:	slli	a1, a2, 63
+; CHECK-V-NEXT:	beq	a5, a2, .LBB18_11
+; CHECK-V-NEXT:# %bb.9:                                # %entry
+; CHECK-V-NEXT:	srli	a5, a5, 63
+; CHECK-V-NEXT:	xori	a3, a5, 1
+; CHECK-V-NEXT:	bne	a4, a2, .LBB18_12
+; CHECK-V-NEXT:.LBB18_10:
+; CHECK-V-NEXT:	sltu	a2, a1, s0
+; CHECK-V-NEXT:	beqz	a2, .LBB18_13
+; CHECK-V-NEXT:	j	.LBB18_14
+; CHECK-V-NEXT:.LBB18_11:
+; CHECK-V-NEXT:	sltu	a3, a1, a0
+; CHECK-V-NEXT:	beq	a4, a2, .LBB18_10
+; CHECK-V-NEXT:.LBB18_12:                              # %entry
+; CHECK-V-NEXT:	srli	a4, a4, 63
+; CHECK-V-NEXT:	xori	a2, a4, 1
+; CHECK-V-NEXT:	bnez	a2, .LBB18_14
+; CHECK-V-NEXT:.LBB18_13:                              # %entry
+; CHECK-V-NEXT:	mv	s0, a1
+; CHECK-V-NEXT:.LBB18_14:                              # %entry
+; CHECK-V-NEXT:	bnez	a3, .LBB18_16
+; CHECK-V-NEXT:# %bb.15:                               # %entry
+; CHECK-V-NEXT:	mv	a0, a1
+; CHECK-V-NEXT:.LBB18_16:                              # %entry
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, s0
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %0 = icmp slt <2 x i128> %conv, <i128 9223372036854775807, i128 9223372036854775807>
@@ -2528,49 +2258,43 @@ define <2 x i64> @utest_f64i64(<2 x double> %x) {
 ;
 ; CHECK-V-LABEL: utest_f64i64:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixunsdfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    fld fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixunsdfti
-; CHECK-V-NEXT:    snez a1, a1
-; CHECK-V-NEXT:    snez a2, s1
-; CHECK-V-NEXT:    addi a2, a2, -1
-; CHECK-V-NEXT:    addi a1, a1, -1
-; CHECK-V-NEXT:    and a2, a2, s0
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, a2
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixunsdfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixunsdfti
+; CHECK-V-NEXT:	snez	a1, a1
+; CHECK-V-NEXT:	snez	a2, s1
+; CHECK-V-NEXT:	addi	a2, a2, -1
+; CHECK-V-NEXT:	addi	a1, a1, -1
+; CHECK-V-NEXT:	and	a2, a2, s0
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, a2
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <2 x double> %x to <2 x i128>
   %0 = icmp ult <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -2645,76 +2369,70 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f64i64:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    fld fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    mv a2, s1
-; CHECK-V-NEXT:    blez s1, .LBB20_2
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    li a2, 1
-; CHECK-V-NEXT:  .LBB20_2: # %entry
-; CHECK-V-NEXT:    slti a4, a1, 1
-; CHECK-V-NEXT:    slti a3, s1, 1
-; CHECK-V-NEXT:    blez a1, .LBB20_4
-; CHECK-V-NEXT:  # %bb.3: # %entry
-; CHECK-V-NEXT:    li a1, 1
-; CHECK-V-NEXT:  .LBB20_4: # %entry
-; CHECK-V-NEXT:    neg a3, a3
-; CHECK-V-NEXT:    neg a4, a4
-; CHECK-V-NEXT:    and a0, a4, a0
-; CHECK-V-NEXT:    beqz a1, .LBB20_7
-; CHECK-V-NEXT:  # %bb.5: # %entry
-; CHECK-V-NEXT:    sgtz a1, a1
-; CHECK-V-NEXT:    and a3, a3, s0
-; CHECK-V-NEXT:    bnez a2, .LBB20_8
-; CHECK-V-NEXT:  .LBB20_6:
-; CHECK-V-NEXT:    snez a2, a3
-; CHECK-V-NEXT:    j .LBB20_9
-; CHECK-V-NEXT:  .LBB20_7:
-; CHECK-V-NEXT:    snez a1, a0
-; CHECK-V-NEXT:    and a3, a3, s0
-; CHECK-V-NEXT:    beqz a2, .LBB20_6
-; CHECK-V-NEXT:  .LBB20_8: # %entry
-; CHECK-V-NEXT:    sgtz a2, a2
-; CHECK-V-NEXT:  .LBB20_9: # %entry
-; CHECK-V-NEXT:    neg a2, a2
-; CHECK-V-NEXT:    neg a1, a1
-; CHECK-V-NEXT:    and a2, a2, a3
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, a2
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	mv	a2, s1
+; CHECK-V-NEXT:	blez	s1, .LBB20_2
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	li	a2, 1
+; CHECK-V-NEXT:.LBB20_2:                               # %entry
+; CHECK-V-NEXT:	slti	a4, a1, 1
+; CHECK-V-NEXT:	slti	a3, s1, 1
+; CHECK-V-NEXT:	blez	a1, .LBB20_4
+; CHECK-V-NEXT:# %bb.3:                                # %entry
+; CHECK-V-NEXT:	li	a1, 1
+; CHECK-V-NEXT:.LBB20_4:                               # %entry
+; CHECK-V-NEXT:	neg	a3, a3
+; CHECK-V-NEXT:	neg	a4, a4
+; CHECK-V-NEXT:	and	a0, a4, a0
+; CHECK-V-NEXT:	beqz	a1, .LBB20_7
+; CHECK-V-NEXT:# %bb.5:                                # %entry
+; CHECK-V-NEXT:	sgtz	a1, a1
+; CHECK-V-NEXT:	and	a3, a3, s0
+; CHECK-V-NEXT:	bnez	a2, .LBB20_8
+; CHECK-V-NEXT:.LBB20_6:
+; CHECK-V-NEXT:	snez	a2, a3
+; CHECK-V-NEXT:	j	.LBB20_9
+; CHECK-V-NEXT:.LBB20_7:
+; CHECK-V-NEXT:	snez	a1, a0
+; CHECK-V-NEXT:	and	a3, a3, s0
+; CHECK-V-NEXT:	beqz	a2, .LBB20_6
+; CHECK-V-NEXT:.LBB20_8:                               # %entry
+; CHECK-V-NEXT:	sgtz	a2, a2
+; CHECK-V-NEXT:.LBB20_9:                               # %entry
+; CHECK-V-NEXT:	neg	a2, a2
+; CHECK-V-NEXT:	neg	a1, a1
+; CHECK-V-NEXT:	and	a2, a2, a3
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, a2
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %0 = icmp slt <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -2812,94 +2530,88 @@ define <2 x i64> @stest_f32i64(<2 x float> %x) {
 ;
 ; CHECK-V-LABEL: stest_f32i64:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    flw fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    li a2, -1
-; CHECK-V-NEXT:    srli a3, a2, 1
-; CHECK-V-NEXT:    beqz a1, .LBB21_3
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    srli a4, a1, 63
-; CHECK-V-NEXT:    bnez s1, .LBB21_4
-; CHECK-V-NEXT:  .LBB21_2:
-; CHECK-V-NEXT:    sltu a5, s0, a3
-; CHECK-V-NEXT:    beqz a5, .LBB21_5
-; CHECK-V-NEXT:    j .LBB21_6
-; CHECK-V-NEXT:  .LBB21_3:
-; CHECK-V-NEXT:    sltu a4, a0, a3
-; CHECK-V-NEXT:    beqz s1, .LBB21_2
-; CHECK-V-NEXT:  .LBB21_4: # %entry
-; CHECK-V-NEXT:    srli a5, s1, 63
-; CHECK-V-NEXT:    bnez a5, .LBB21_6
-; CHECK-V-NEXT:  .LBB21_5: # %entry
-; CHECK-V-NEXT:    mv s0, a3
-; CHECK-V-NEXT:  .LBB21_6: # %entry
-; CHECK-V-NEXT:    neg a6, a5
-; CHECK-V-NEXT:    neg a5, a4
-; CHECK-V-NEXT:    and a5, a5, a1
-; CHECK-V-NEXT:    bnez a4, .LBB21_8
-; CHECK-V-NEXT:  # %bb.7: # %entry
-; CHECK-V-NEXT:    mv a0, a3
-; CHECK-V-NEXT:  .LBB21_8: # %entry
-; CHECK-V-NEXT:    and a4, a6, s1
-; CHECK-V-NEXT:    slli a1, a2, 63
-; CHECK-V-NEXT:    beq a5, a2, .LBB21_11
-; CHECK-V-NEXT:  # %bb.9: # %entry
-; CHECK-V-NEXT:    srli a5, a5, 63
-; CHECK-V-NEXT:    xori a3, a5, 1
-; CHECK-V-NEXT:    bne a4, a2, .LBB21_12
-; CHECK-V-NEXT:  .LBB21_10:
-; CHECK-V-NEXT:    sltu a2, a1, s0
-; CHECK-V-NEXT:    beqz a2, .LBB21_13
-; CHECK-V-NEXT:    j .LBB21_14
-; CHECK-V-NEXT:  .LBB21_11:
-; CHECK-V-NEXT:    sltu a3, a1, a0
-; CHECK-V-NEXT:    beq a4, a2, .LBB21_10
-; CHECK-V-NEXT:  .LBB21_12: # %entry
-; CHECK-V-NEXT:    srli a4, a4, 63
-; CHECK-V-NEXT:    xori a2, a4, 1
-; CHECK-V-NEXT:    bnez a2, .LBB21_14
-; CHECK-V-NEXT:  .LBB21_13: # %entry
-; CHECK-V-NEXT:    mv s0, a1
-; CHECK-V-NEXT:  .LBB21_14: # %entry
-; CHECK-V-NEXT:    bnez a3, .LBB21_16
-; CHECK-V-NEXT:  # %bb.15: # %entry
-; CHECK-V-NEXT:    mv a0, a1
-; CHECK-V-NEXT:  .LBB21_16: # %entry
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, s0
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	li	a2, -1
+; CHECK-V-NEXT:	srli	a3, a2, 1
+; CHECK-V-NEXT:	beqz	a1, .LBB21_3
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	srli	a4, a1, 63
+; CHECK-V-NEXT:	bnez	s1, .LBB21_4
+; CHECK-V-NEXT:.LBB21_2:
+; CHECK-V-NEXT:	sltu	a5, s0, a3
+; CHECK-V-NEXT:	beqz	a5, .LBB21_5
+; CHECK-V-NEXT:	j	.LBB21_6
+; CHECK-V-NEXT:.LBB21_3:
+; CHECK-V-NEXT:	sltu	a4, a0, a3
+; CHECK-V-NEXT:	beqz	s1, .LBB21_2
+; CHECK-V-NEXT:.LBB21_4:                               # %entry
+; CHECK-V-NEXT:	srli	a5, s1, 63
+; CHECK-V-NEXT:	bnez	a5, .LBB21_6
+; CHECK-V-NEXT:.LBB21_5:                               # %entry
+; CHECK-V-NEXT:	mv	s0, a3
+; CHECK-V-NEXT:.LBB21_6:                               # %entry
+; CHECK-V-NEXT:	neg	a6, a5
+; CHECK-V-NEXT:	neg	a5, a4
+; CHECK-V-NEXT:	and	a5, a5, a1
+; CHECK-V-NEXT:	bnez	a4, .LBB21_8
+; CHECK-V-NEXT:# %bb.7:                                # %entry
+; CHECK-V-NEXT:	mv	a0, a3
+; CHECK-V-NEXT:.LBB21_8:                               # %entry
+; CHECK-V-NEXT:	and	a4, a6, s1
+; CHECK-V-NEXT:	slli	a1, a2, 63
+; CHECK-V-NEXT:	beq	a5, a2, .LBB21_11
+; CHECK-V-NEXT:# %bb.9:                                # %entry
+; CHECK-V-NEXT:	srli	a5, a5, 63
+; CHECK-V-NEXT:	xori	a3, a5, 1
+; CHECK-V-NEXT:	bne	a4, a2, .LBB21_12
+; CHECK-V-NEXT:.LBB21_10:
+; CHECK-V-NEXT:	sltu	a2, a1, s0
+; CHECK-V-NEXT:	beqz	a2, .LBB21_13
+; CHECK-V-NEXT:	j	.LBB21_14
+; CHECK-V-NEXT:.LBB21_11:
+; CHECK-V-NEXT:	sltu	a3, a1, a0
+; CHECK-V-NEXT:	beq	a4, a2, .LBB21_10
+; CHECK-V-NEXT:.LBB21_12:                              # %entry
+; CHECK-V-NEXT:	srli	a4, a4, 63
+; CHECK-V-NEXT:	xori	a2, a4, 1
+; CHECK-V-NEXT:	bnez	a2, .LBB21_14
+; CHECK-V-NEXT:.LBB21_13:                              # %entry
+; CHECK-V-NEXT:	mv	s0, a1
+; CHECK-V-NEXT:.LBB21_14:                              # %entry
+; CHECK-V-NEXT:	bnez	a3, .LBB21_16
+; CHECK-V-NEXT:# %bb.15:                               # %entry
+; CHECK-V-NEXT:	mv	a0, a1
+; CHECK-V-NEXT:.LBB21_16:                              # %entry
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, s0
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %0 = icmp slt <2 x i128> %conv, <i128 9223372036854775807, i128 9223372036854775807>
@@ -2950,49 +2662,43 @@ define <2 x i64> @utest_f32i64(<2 x float> %x) {
 ;
 ; CHECK-V-LABEL: utest_f32i64:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixunssfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    flw fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixunssfti
-; CHECK-V-NEXT:    snez a1, a1
-; CHECK-V-NEXT:    snez a2, s1
-; CHECK-V-NEXT:    addi a2, a2, -1
-; CHECK-V-NEXT:    addi a1, a1, -1
-; CHECK-V-NEXT:    and a2, a2, s0
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, a2
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixunssfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixunssfti
+; CHECK-V-NEXT:	snez	a1, a1
+; CHECK-V-NEXT:	snez	a2, s1
+; CHECK-V-NEXT:	addi	a2, a2, -1
+; CHECK-V-NEXT:	addi	a1, a1, -1
+; CHECK-V-NEXT:	and	a2, a2, s0
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, a2
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <2 x float> %x to <2 x i128>
   %0 = icmp ult <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -3067,76 +2773,70 @@ define <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f32i64:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    flw fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    mv a2, s1
-; CHECK-V-NEXT:    blez s1, .LBB23_2
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    li a2, 1
-; CHECK-V-NEXT:  .LBB23_2: # %entry
-; CHECK-V-NEXT:    slti a4, a1, 1
-; CHECK-V-NEXT:    slti a3, s1, 1
-; CHECK-V-NEXT:    blez a1, .LBB23_4
-; CHECK-V-NEXT:  # %bb.3: # %entry
-; CHECK-V-NEXT:    li a1, 1
-; CHECK-V-NEXT:  .LBB23_4: # %entry
-; CHECK-V-NEXT:    neg a3, a3
-; CHECK-V-NEXT:    neg a4, a4
-; CHECK-V-NEXT:    and a0, a4, a0
-; CHECK-V-NEXT:    beqz a1, .LBB23_7
-; CHECK-V-NEXT:  # %bb.5: # %entry
-; CHECK-V-NEXT:    sgtz a1, a1
-; CHECK-V-NEXT:    and a3, a3, s0
-; CHECK-V-NEXT:    bnez a2, .LBB23_8
-; CHECK-V-NEXT:  .LBB23_6:
-; CHECK-V-NEXT:    snez a2, a3
-; CHECK-V-NEXT:    j .LBB23_9
-; CHECK-V-NEXT:  .LBB23_7:
-; CHECK-V-NEXT:    snez a1, a0
-; CHECK-V-NEXT:    and a3, a3, s0
-; CHECK-V-NEXT:    beqz a2, .LBB23_6
-; CHECK-V-NEXT:  .LBB23_8: # %entry
-; CHECK-V-NEXT:    sgtz a2, a2
-; CHECK-V-NEXT:  .LBB23_9: # %entry
-; CHECK-V-NEXT:    neg a2, a2
-; CHECK-V-NEXT:    neg a1, a1
-; CHECK-V-NEXT:    and a2, a2, a3
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, a2
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	mv	a2, s1
+; CHECK-V-NEXT:	blez	s1, .LBB23_2
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	li	a2, 1
+; CHECK-V-NEXT:.LBB23_2:                               # %entry
+; CHECK-V-NEXT:	slti	a4, a1, 1
+; CHECK-V-NEXT:	slti	a3, s1, 1
+; CHECK-V-NEXT:	blez	a1, .LBB23_4
+; CHECK-V-NEXT:# %bb.3:                                # %entry
+; CHECK-V-NEXT:	li	a1, 1
+; CHECK-V-NEXT:.LBB23_4:                               # %entry
+; CHECK-V-NEXT:	neg	a3, a3
+; CHECK-V-NEXT:	neg	a4, a4
+; CHECK-V-NEXT:	and	a0, a4, a0
+; CHECK-V-NEXT:	beqz	a1, .LBB23_7
+; CHECK-V-NEXT:# %bb.5:                                # %entry
+; CHECK-V-NEXT:	sgtz	a1, a1
+; CHECK-V-NEXT:	and	a3, a3, s0
+; CHECK-V-NEXT:	bnez	a2, .LBB23_8
+; CHECK-V-NEXT:.LBB23_6:
+; CHECK-V-NEXT:	snez	a2, a3
+; CHECK-V-NEXT:	j	.LBB23_9
+; CHECK-V-NEXT:.LBB23_7:
+; CHECK-V-NEXT:	snez	a1, a0
+; CHECK-V-NEXT:	and	a3, a3, s0
+; CHECK-V-NEXT:	beqz	a2, .LBB23_6
+; CHECK-V-NEXT:.LBB23_8:                               # %entry
+; CHECK-V-NEXT:	sgtz	a2, a2
+; CHECK-V-NEXT:.LBB23_9:                               # %entry
+; CHECK-V-NEXT:	neg	a2, a2
+; CHECK-V-NEXT:	neg	a1, a1
+; CHECK-V-NEXT:	and	a2, a2, a3
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, a2
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %0 = icmp slt <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -3989,83 +3689,57 @@ define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: stest_f16i32_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a2, a1, 1
-; CHECK-V-NEXT:    add a1, a2, a1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x03, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 3 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-V-NEXT:    vnclip.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a1, a0, 1
-; CHECK-V-NEXT:    add a0, a1, a0
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 2
+; CHECK-V-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; CHECK-V-NEXT:	vnclip.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <4 x half> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>)
@@ -4167,83 +3841,57 @@ define <4 x i32> @utest_f16i32_mm(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: utest_f16i32_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a2, a1, 1
-; CHECK-V-NEXT:    add a1, a2, a1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x03, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 3 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a1, a0, 1
-; CHECK-V-NEXT:    add a0, a1, a0
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 2
+; CHECK-V-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <4 x half> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.umin.v4i64(<4 x i64> %conv, <4 x i64> <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>)
@@ -4356,84 +4004,58 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f16i32_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a2, a1, 1
-; CHECK-V-NEXT:    add a1, a2, a1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x03, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 3 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v10, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v10, 2
-; CHECK-V-NEXT:    vmax.vx v10, v8, zero
-; CHECK-V-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a1, a0, 1
-; CHECK-V-NEXT:    add a0, a1, a0
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v24, 2
+; CHECK-V-NEXT:	vmax.vx	v10, v8, zero
+; CHECK-V-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <4 x half> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>)
@@ -4967,165 +4589,103 @@ define <8 x i16> @stest_f16i16_mm(<8 x half> %x) {
 ;
 ; CHECK-V-LABEL: stest_f16i16_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-V-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s3, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s4, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s5, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s6, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    .cfi_offset s3, -40
-; CHECK-V-NEXT:    .cfi_offset s4, -48
-; CHECK-V-NEXT:    .cfi_offset s5, -56
-; CHECK-V-NEXT:    .cfi_offset s6, -64
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 2
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0x04, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 4 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu s3, 24(a0)
-; CHECK-V-NEXT:    lhu s4, 32(a0)
-; CHECK-V-NEXT:    lhu s5, 40(a0)
-; CHECK-V-NEXT:    lhu s6, 48(a0)
-; CHECK-V-NEXT:    lhu a0, 56(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s6
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s5
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s4
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s3
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 4
-; CHECK-V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
-; CHECK-V-NEXT:    vnclip.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 2
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 80
-; CHECK-V-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s4, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s6, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    .cfi_restore s3
-; CHECK-V-NEXT:    .cfi_restore s4
-; CHECK-V-NEXT:    .cfi_restore s5
-; CHECK-V-NEXT:    .cfi_restore s6
-; CHECK-V-NEXT:    addi sp, sp, 80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 64
+; CHECK-V-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s5, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s6, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	.cfi_offset s3, -40
+; CHECK-V-NEXT:	.cfi_offset s4, -48
+; CHECK-V-NEXT:	.cfi_offset s5, -56
+; CHECK-V-NEXT:	.cfi_offset s6, -64
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	s3, 24(a0)
+; CHECK-V-NEXT:	lhu	s4, 32(a0)
+; CHECK-V-NEXT:	lhu	s5, 40(a0)
+; CHECK-V-NEXT:	lhu	s6, 48(a0)
+; CHECK-V-NEXT:	lhu	a0, 56(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s6
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s5
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s4
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v26, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 2
+; CHECK-V-NEXT:	fmv.w.x	fa0, s3
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	vslideup.vi	v26, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v26, 2
+; CHECK-V-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 4
+; CHECK-V-NEXT:	vsetvli	zero, zero, e16, m1, ta, ma
+; CHECK-V-NEXT:	vnclip.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s5, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s6, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	.cfi_restore s3
+; CHECK-V-NEXT:	.cfi_restore s4
+; CHECK-V-NEXT:	.cfi_restore s5
+; CHECK-V-NEXT:	.cfi_restore s6
+; CHECK-V-NEXT:	addi	sp, sp, 64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
   %spec.store.select = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %conv, <8 x i32> <i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767>)
@@ -5307,165 +4867,103 @@ define <8 x i16> @utest_f16i16_mm(<8 x half> %x) {
 ;
 ; CHECK-V-LABEL: utest_f16i16_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-V-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s3, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s4, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s5, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s6, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    .cfi_offset s3, -40
-; CHECK-V-NEXT:    .cfi_offset s4, -48
-; CHECK-V-NEXT:    .cfi_offset s5, -56
-; CHECK-V-NEXT:    .cfi_offset s6, -64
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 2
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0x04, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 4 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu s3, 24(a0)
-; CHECK-V-NEXT:    lhu s4, 32(a0)
-; CHECK-V-NEXT:    lhu s5, 40(a0)
-; CHECK-V-NEXT:    lhu s6, 48(a0)
-; CHECK-V-NEXT:    lhu a0, 56(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s6
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s5
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s4
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s3
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.lu.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v10, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v10, v8, 4
-; CHECK-V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 2
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 80
-; CHECK-V-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s4, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s6, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    .cfi_restore s3
-; CHECK-V-NEXT:    .cfi_restore s4
-; CHECK-V-NEXT:    .cfi_restore s5
-; CHECK-V-NEXT:    .cfi_restore s6
-; CHECK-V-NEXT:    addi sp, sp, 80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 64
+; CHECK-V-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s5, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s6, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	.cfi_offset s3, -40
+; CHECK-V-NEXT:	.cfi_offset s4, -48
+; CHECK-V-NEXT:	.cfi_offset s5, -56
+; CHECK-V-NEXT:	.cfi_offset s6, -64
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	s3, 24(a0)
+; CHECK-V-NEXT:	lhu	s4, 32(a0)
+; CHECK-V-NEXT:	lhu	s5, 40(a0)
+; CHECK-V-NEXT:	lhu	s6, 48(a0)
+; CHECK-V-NEXT:	lhu	a0, 56(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s6
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s5
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s4
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v26, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 2
+; CHECK-V-NEXT:	fmv.w.x	fa0, s3
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	vslideup.vi	v26, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.lu.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v10, a0
+; CHECK-V-NEXT:	vslideup.vi	v10, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v26, 2
+; CHECK-V-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v10, v24, 4
+; CHECK-V-NEXT:	vsetvli	zero, zero, e16, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s5, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s6, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	.cfi_restore s3
+; CHECK-V-NEXT:	.cfi_restore s4
+; CHECK-V-NEXT:	.cfi_restore s5
+; CHECK-V-NEXT:	.cfi_restore s6
+; CHECK-V-NEXT:	addi	sp, sp, 64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <8 x half> %x to <8 x i32>
   %spec.store.select = call <8 x i32> @llvm.umin.v8i32(<8 x i32> %conv, <8 x i32> <i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535>)
@@ -5670,166 +5168,104 @@ define <8 x i16> @ustest_f16i16_mm(<8 x half> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f16i16_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-V-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s3, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s4, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s5, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s6, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    .cfi_offset s3, -40
-; CHECK-V-NEXT:    .cfi_offset s4, -48
-; CHECK-V-NEXT:    .cfi_offset s5, -56
-; CHECK-V-NEXT:    .cfi_offset s6, -64
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 2
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0x04, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 4 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu s3, 24(a0)
-; CHECK-V-NEXT:    lhu s4, 32(a0)
-; CHECK-V-NEXT:    lhu s5, 40(a0)
-; CHECK-V-NEXT:    lhu s6, 48(a0)
-; CHECK-V-NEXT:    lhu a0, 56(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s6
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s5
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s4
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s3
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl2r.v v10, (a0) # vscale x 16-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-V-NEXT:    vmax.vx v10, v8, zero
-; CHECK-V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
-; CHECK-V-NEXT:    vnclipu.wi v8, v10, 0
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 2
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 80
-; CHECK-V-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s4, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s6, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    .cfi_restore s3
-; CHECK-V-NEXT:    .cfi_restore s4
-; CHECK-V-NEXT:    .cfi_restore s5
-; CHECK-V-NEXT:    .cfi_restore s6
-; CHECK-V-NEXT:    addi sp, sp, 80
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 64
+; CHECK-V-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s5, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s6, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	.cfi_offset s3, -40
+; CHECK-V-NEXT:	.cfi_offset s4, -48
+; CHECK-V-NEXT:	.cfi_offset s5, -56
+; CHECK-V-NEXT:	.cfi_offset s6, -64
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	s3, 24(a0)
+; CHECK-V-NEXT:	lhu	s4, 32(a0)
+; CHECK-V-NEXT:	lhu	s5, 40(a0)
+; CHECK-V-NEXT:	lhu	s6, 48(a0)
+; CHECK-V-NEXT:	lhu	a0, 56(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s6
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s5
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s4
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	vslideup.vi	v24, v26, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v24, v25, 2
+; CHECK-V-NEXT:	fmv.w.x	fa0, s3
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v26, a0
+; CHECK-V-NEXT:	vslideup.vi	v26, v25, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v25, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v26, 2
+; CHECK-V-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v24, 4
+; CHECK-V-NEXT:	vmax.vx	v10, v8, zero
+; CHECK-V-NEXT:	vsetvli	zero, zero, e16, m1, ta, ma
+; CHECK-V-NEXT:	vnclipu.wi	v8, v10, 0
+; CHECK-V-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s5, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s6, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	.cfi_restore s3
+; CHECK-V-NEXT:	.cfi_restore s4
+; CHECK-V-NEXT:	.cfi_restore s5
+; CHECK-V-NEXT:	.cfi_restore s6
+; CHECK-V-NEXT:	addi	sp, sp, 64
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
   %spec.store.select = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %conv, <8 x i32> <i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535, i32 65535>)
@@ -5930,97 +5366,91 @@ define <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ;
 ; CHECK-V-LABEL: stest_f64i64_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    fld fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    li a2, -1
-; CHECK-V-NEXT:    srli a3, a2, 1
-; CHECK-V-NEXT:    beqz a1, .LBB45_2
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    srli a4, a1, 63
-; CHECK-V-NEXT:    beqz a4, .LBB45_3
-; CHECK-V-NEXT:    j .LBB45_4
-; CHECK-V-NEXT:  .LBB45_2:
-; CHECK-V-NEXT:    sltu a4, a0, a3
-; CHECK-V-NEXT:    bnez a4, .LBB45_4
-; CHECK-V-NEXT:  .LBB45_3: # %entry
-; CHECK-V-NEXT:    mv a0, a3
-; CHECK-V-NEXT:  .LBB45_4: # %entry
-; CHECK-V-NEXT:    beqz s1, .LBB45_6
-; CHECK-V-NEXT:  # %bb.5: # %entry
-; CHECK-V-NEXT:    srli a6, s1, 63
-; CHECK-V-NEXT:    j .LBB45_7
-; CHECK-V-NEXT:  .LBB45_6:
-; CHECK-V-NEXT:    sltu a6, s0, a3
-; CHECK-V-NEXT:  .LBB45_7: # %entry
-; CHECK-V-NEXT:    neg a5, a6
-; CHECK-V-NEXT:    and a5, a5, s1
-; CHECK-V-NEXT:    bnez a6, .LBB45_9
-; CHECK-V-NEXT:  # %bb.8: # %entry
-; CHECK-V-NEXT:    mv s0, a3
-; CHECK-V-NEXT:  .LBB45_9: # %entry
-; CHECK-V-NEXT:    neg a4, a4
-; CHECK-V-NEXT:    slli a3, a2, 63
-; CHECK-V-NEXT:    beq a5, a2, .LBB45_11
-; CHECK-V-NEXT:  # %bb.10: # %entry
-; CHECK-V-NEXT:    srli a5, a5, 63
-; CHECK-V-NEXT:    xori a5, a5, 1
-; CHECK-V-NEXT:    and a1, a4, a1
-; CHECK-V-NEXT:    beqz a5, .LBB45_12
-; CHECK-V-NEXT:    j .LBB45_13
-; CHECK-V-NEXT:  .LBB45_11:
-; CHECK-V-NEXT:    sltu a5, a3, s0
-; CHECK-V-NEXT:    and a1, a4, a1
-; CHECK-V-NEXT:    bnez a5, .LBB45_13
-; CHECK-V-NEXT:  .LBB45_12: # %entry
-; CHECK-V-NEXT:    mv s0, a3
-; CHECK-V-NEXT:  .LBB45_13: # %entry
-; CHECK-V-NEXT:    beq a1, a2, .LBB45_15
-; CHECK-V-NEXT:  # %bb.14: # %entry
-; CHECK-V-NEXT:    srli a1, a1, 63
-; CHECK-V-NEXT:    xori a1, a1, 1
-; CHECK-V-NEXT:    beqz a1, .LBB45_16
-; CHECK-V-NEXT:    j .LBB45_17
-; CHECK-V-NEXT:  .LBB45_15:
-; CHECK-V-NEXT:    sltu a1, a3, a0
-; CHECK-V-NEXT:    bnez a1, .LBB45_17
-; CHECK-V-NEXT:  .LBB45_16: # %entry
-; CHECK-V-NEXT:    mv a0, a3
-; CHECK-V-NEXT:  .LBB45_17: # %entry
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, s0
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	li	a2, -1
+; CHECK-V-NEXT:	srli	a3, a2, 1
+; CHECK-V-NEXT:	beqz	a1, .LBB45_2
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	srli	a4, a1, 63
+; CHECK-V-NEXT:	beqz	a4, .LBB45_3
+; CHECK-V-NEXT:	j	.LBB45_4
+; CHECK-V-NEXT:.LBB45_2:
+; CHECK-V-NEXT:	sltu	a4, a0, a3
+; CHECK-V-NEXT:	bnez	a4, .LBB45_4
+; CHECK-V-NEXT:.LBB45_3:                               # %entry
+; CHECK-V-NEXT:	mv	a0, a3
+; CHECK-V-NEXT:.LBB45_4:                               # %entry
+; CHECK-V-NEXT:	beqz	s1, .LBB45_6
+; CHECK-V-NEXT:# %bb.5:                                # %entry
+; CHECK-V-NEXT:	srli	a6, s1, 63
+; CHECK-V-NEXT:	j	.LBB45_7
+; CHECK-V-NEXT:.LBB45_6:
+; CHECK-V-NEXT:	sltu	a6, s0, a3
+; CHECK-V-NEXT:.LBB45_7:                               # %entry
+; CHECK-V-NEXT:	neg	a5, a6
+; CHECK-V-NEXT:	and	a5, a5, s1
+; CHECK-V-NEXT:	bnez	a6, .LBB45_9
+; CHECK-V-NEXT:# %bb.8:                                # %entry
+; CHECK-V-NEXT:	mv	s0, a3
+; CHECK-V-NEXT:.LBB45_9:                               # %entry
+; CHECK-V-NEXT:	neg	a4, a4
+; CHECK-V-NEXT:	slli	a3, a2, 63
+; CHECK-V-NEXT:	beq	a5, a2, .LBB45_11
+; CHECK-V-NEXT:# %bb.10:                               # %entry
+; CHECK-V-NEXT:	srli	a5, a5, 63
+; CHECK-V-NEXT:	xori	a5, a5, 1
+; CHECK-V-NEXT:	and	a1, a4, a1
+; CHECK-V-NEXT:	beqz	a5, .LBB45_12
+; CHECK-V-NEXT:	j	.LBB45_13
+; CHECK-V-NEXT:.LBB45_11:
+; CHECK-V-NEXT:	sltu	a5, a3, s0
+; CHECK-V-NEXT:	and	a1, a4, a1
+; CHECK-V-NEXT:	bnez	a5, .LBB45_13
+; CHECK-V-NEXT:.LBB45_12:                              # %entry
+; CHECK-V-NEXT:	mv	s0, a3
+; CHECK-V-NEXT:.LBB45_13:                              # %entry
+; CHECK-V-NEXT:	beq	a1, a2, .LBB45_15
+; CHECK-V-NEXT:# %bb.14:                               # %entry
+; CHECK-V-NEXT:	srli	a1, a1, 63
+; CHECK-V-NEXT:	xori	a1, a1, 1
+; CHECK-V-NEXT:	beqz	a1, .LBB45_16
+; CHECK-V-NEXT:	j	.LBB45_17
+; CHECK-V-NEXT:.LBB45_15:
+; CHECK-V-NEXT:	sltu	a1, a3, a0
+; CHECK-V-NEXT:	bnez	a1, .LBB45_17
+; CHECK-V-NEXT:.LBB45_16:                              # %entry
+; CHECK-V-NEXT:	mv	a0, a3
+; CHECK-V-NEXT:.LBB45_17:                              # %entry
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, s0
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 9223372036854775807, i128 9223372036854775807>)
@@ -6069,52 +5499,43 @@ define <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ;
 ; CHECK-V-LABEL: utest_f64i64_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vfmv.f.s fa0, v8
-; CHECK-V-NEXT:    call __fixunsdfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v8, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v8
-; CHECK-V-NEXT:    call __fixunsdfti
-; CHECK-V-NEXT:    snez a1, a1
-; CHECK-V-NEXT:    snez a2, s1
-; CHECK-V-NEXT:    addi a1, a1, -1
-; CHECK-V-NEXT:    addi a2, a2, -1
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    and a2, a2, s0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a2
-; CHECK-V-NEXT:    vmv.s.x v9, a0
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m8, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixunsdfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vslidedown.vi	v8, v24, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixunsdfti
+; CHECK-V-NEXT:	snez	a1, a1
+; CHECK-V-NEXT:	snez	a2, s1
+; CHECK-V-NEXT:	addi	a1, a1, -1
+; CHECK-V-NEXT:	addi	a2, a2, -1
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	and	a2, a2, s0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a2
+; CHECK-V-NEXT:	vmv.s.x	v9, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <2 x double> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.umin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -6177,65 +5598,59 @@ define <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f64i64_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    fld fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixdfti
-; CHECK-V-NEXT:    mv a2, a1
-; CHECK-V-NEXT:    blez a1, .LBB47_2
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    li a2, 1
-; CHECK-V-NEXT:  .LBB47_2: # %entry
-; CHECK-V-NEXT:    mv a3, s1
-; CHECK-V-NEXT:    blez s1, .LBB47_4
-; CHECK-V-NEXT:  # %bb.3: # %entry
-; CHECK-V-NEXT:    li a3, 1
-; CHECK-V-NEXT:  .LBB47_4: # %entry
-; CHECK-V-NEXT:    slti a1, a1, 1
-; CHECK-V-NEXT:    slti a4, s1, 1
-; CHECK-V-NEXT:    srli a3, a3, 63
-; CHECK-V-NEXT:    srli a2, a2, 63
-; CHECK-V-NEXT:    neg a1, a1
-; CHECK-V-NEXT:    neg a4, a4
-; CHECK-V-NEXT:    addi a3, a3, -1
-; CHECK-V-NEXT:    addi a2, a2, -1
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    and a4, a4, s0
-; CHECK-V-NEXT:    and a3, a3, a4
-; CHECK-V-NEXT:    and a0, a2, a0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, a3
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e64, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixdfti
+; CHECK-V-NEXT:	mv	a2, a1
+; CHECK-V-NEXT:	blez	a1, .LBB47_2
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	li	a2, 1
+; CHECK-V-NEXT:.LBB47_2:                               # %entry
+; CHECK-V-NEXT:	mv	a3, s1
+; CHECK-V-NEXT:	blez	s1, .LBB47_4
+; CHECK-V-NEXT:# %bb.3:                                # %entry
+; CHECK-V-NEXT:	li	a3, 1
+; CHECK-V-NEXT:.LBB47_4:                               # %entry
+; CHECK-V-NEXT:	slti	a1, a1, 1
+; CHECK-V-NEXT:	slti	a4, s1, 1
+; CHECK-V-NEXT:	srli	a3, a3, 63
+; CHECK-V-NEXT:	srli	a2, a2, 63
+; CHECK-V-NEXT:	neg	a1, a1
+; CHECK-V-NEXT:	neg	a4, a4
+; CHECK-V-NEXT:	addi	a3, a3, -1
+; CHECK-V-NEXT:	addi	a2, a2, -1
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	and	a4, a4, s0
+; CHECK-V-NEXT:	and	a3, a3, a4
+; CHECK-V-NEXT:	and	a0, a2, a0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, a3
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -6334,97 +5749,91 @@ define <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ;
 ; CHECK-V-LABEL: stest_f32i64_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    flw fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    li a2, -1
-; CHECK-V-NEXT:    srli a3, a2, 1
-; CHECK-V-NEXT:    beqz a1, .LBB48_2
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    srli a4, a1, 63
-; CHECK-V-NEXT:    beqz a4, .LBB48_3
-; CHECK-V-NEXT:    j .LBB48_4
-; CHECK-V-NEXT:  .LBB48_2:
-; CHECK-V-NEXT:    sltu a4, a0, a3
-; CHECK-V-NEXT:    bnez a4, .LBB48_4
-; CHECK-V-NEXT:  .LBB48_3: # %entry
-; CHECK-V-NEXT:    mv a0, a3
-; CHECK-V-NEXT:  .LBB48_4: # %entry
-; CHECK-V-NEXT:    beqz s1, .LBB48_6
-; CHECK-V-NEXT:  # %bb.5: # %entry
-; CHECK-V-NEXT:    srli a6, s1, 63
-; CHECK-V-NEXT:    j .LBB48_7
-; CHECK-V-NEXT:  .LBB48_6:
-; CHECK-V-NEXT:    sltu a6, s0, a3
-; CHECK-V-NEXT:  .LBB48_7: # %entry
-; CHECK-V-NEXT:    neg a5, a6
-; CHECK-V-NEXT:    and a5, a5, s1
-; CHECK-V-NEXT:    bnez a6, .LBB48_9
-; CHECK-V-NEXT:  # %bb.8: # %entry
-; CHECK-V-NEXT:    mv s0, a3
-; CHECK-V-NEXT:  .LBB48_9: # %entry
-; CHECK-V-NEXT:    neg a4, a4
-; CHECK-V-NEXT:    slli a3, a2, 63
-; CHECK-V-NEXT:    beq a5, a2, .LBB48_11
-; CHECK-V-NEXT:  # %bb.10: # %entry
-; CHECK-V-NEXT:    srli a5, a5, 63
-; CHECK-V-NEXT:    xori a5, a5, 1
-; CHECK-V-NEXT:    and a1, a4, a1
-; CHECK-V-NEXT:    beqz a5, .LBB48_12
-; CHECK-V-NEXT:    j .LBB48_13
-; CHECK-V-NEXT:  .LBB48_11:
-; CHECK-V-NEXT:    sltu a5, a3, s0
-; CHECK-V-NEXT:    and a1, a4, a1
-; CHECK-V-NEXT:    bnez a5, .LBB48_13
-; CHECK-V-NEXT:  .LBB48_12: # %entry
-; CHECK-V-NEXT:    mv s0, a3
-; CHECK-V-NEXT:  .LBB48_13: # %entry
-; CHECK-V-NEXT:    beq a1, a2, .LBB48_15
-; CHECK-V-NEXT:  # %bb.14: # %entry
-; CHECK-V-NEXT:    srli a1, a1, 63
-; CHECK-V-NEXT:    xori a1, a1, 1
-; CHECK-V-NEXT:    beqz a1, .LBB48_16
-; CHECK-V-NEXT:    j .LBB48_17
-; CHECK-V-NEXT:  .LBB48_15:
-; CHECK-V-NEXT:    sltu a1, a3, a0
-; CHECK-V-NEXT:    bnez a1, .LBB48_17
-; CHECK-V-NEXT:  .LBB48_16: # %entry
-; CHECK-V-NEXT:    mv a0, a3
-; CHECK-V-NEXT:  .LBB48_17: # %entry
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, s0
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	li	a2, -1
+; CHECK-V-NEXT:	srli	a3, a2, 1
+; CHECK-V-NEXT:	beqz	a1, .LBB48_2
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	srli	a4, a1, 63
+; CHECK-V-NEXT:	beqz	a4, .LBB48_3
+; CHECK-V-NEXT:	j	.LBB48_4
+; CHECK-V-NEXT:.LBB48_2:
+; CHECK-V-NEXT:	sltu	a4, a0, a3
+; CHECK-V-NEXT:	bnez	a4, .LBB48_4
+; CHECK-V-NEXT:.LBB48_3:                               # %entry
+; CHECK-V-NEXT:	mv	a0, a3
+; CHECK-V-NEXT:.LBB48_4:                               # %entry
+; CHECK-V-NEXT:	beqz	s1, .LBB48_6
+; CHECK-V-NEXT:# %bb.5:                                # %entry
+; CHECK-V-NEXT:	srli	a6, s1, 63
+; CHECK-V-NEXT:	j	.LBB48_7
+; CHECK-V-NEXT:.LBB48_6:
+; CHECK-V-NEXT:	sltu	a6, s0, a3
+; CHECK-V-NEXT:.LBB48_7:                               # %entry
+; CHECK-V-NEXT:	neg	a5, a6
+; CHECK-V-NEXT:	and	a5, a5, s1
+; CHECK-V-NEXT:	bnez	a6, .LBB48_9
+; CHECK-V-NEXT:# %bb.8:                                # %entry
+; CHECK-V-NEXT:	mv	s0, a3
+; CHECK-V-NEXT:.LBB48_9:                               # %entry
+; CHECK-V-NEXT:	neg	a4, a4
+; CHECK-V-NEXT:	slli	a3, a2, 63
+; CHECK-V-NEXT:	beq	a5, a2, .LBB48_11
+; CHECK-V-NEXT:# %bb.10:                               # %entry
+; CHECK-V-NEXT:	srli	a5, a5, 63
+; CHECK-V-NEXT:	xori	a5, a5, 1
+; CHECK-V-NEXT:	and	a1, a4, a1
+; CHECK-V-NEXT:	beqz	a5, .LBB48_12
+; CHECK-V-NEXT:	j	.LBB48_13
+; CHECK-V-NEXT:.LBB48_11:
+; CHECK-V-NEXT:	sltu	a5, a3, s0
+; CHECK-V-NEXT:	and	a1, a4, a1
+; CHECK-V-NEXT:	bnez	a5, .LBB48_13
+; CHECK-V-NEXT:.LBB48_12:                              # %entry
+; CHECK-V-NEXT:	mv	s0, a3
+; CHECK-V-NEXT:.LBB48_13:                              # %entry
+; CHECK-V-NEXT:	beq	a1, a2, .LBB48_15
+; CHECK-V-NEXT:# %bb.14:                               # %entry
+; CHECK-V-NEXT:	srli	a1, a1, 63
+; CHECK-V-NEXT:	xori	a1, a1, 1
+; CHECK-V-NEXT:	beqz	a1, .LBB48_16
+; CHECK-V-NEXT:	j	.LBB48_17
+; CHECK-V-NEXT:.LBB48_15:
+; CHECK-V-NEXT:	sltu	a1, a3, a0
+; CHECK-V-NEXT:	bnez	a1, .LBB48_17
+; CHECK-V-NEXT:.LBB48_16:                              # %entry
+; CHECK-V-NEXT:	mv	a0, a3
+; CHECK-V-NEXT:.LBB48_17:                              # %entry
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, s0
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 9223372036854775807, i128 9223372036854775807>)
@@ -6473,52 +5882,43 @@ define <2 x i64> @utest_f32i64_mm(<2 x float> %x) {
 ;
 ; CHECK-V-LABEL: utest_f32i64_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vfmv.f.s fa0, v8
-; CHECK-V-NEXT:    call __fixunssfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v8, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v8
-; CHECK-V-NEXT:    call __fixunssfti
-; CHECK-V-NEXT:    snez a1, a1
-; CHECK-V-NEXT:    snez a2, s1
-; CHECK-V-NEXT:    addi a1, a1, -1
-; CHECK-V-NEXT:    addi a2, a2, -1
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    and a2, a2, s0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a2
-; CHECK-V-NEXT:    vmv.s.x v9, a0
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m4, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixunssfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vslidedown.vi	v8, v24, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixunssfti
+; CHECK-V-NEXT:	snez	a1, a1
+; CHECK-V-NEXT:	snez	a2, s1
+; CHECK-V-NEXT:	addi	a1, a1, -1
+; CHECK-V-NEXT:	addi	a2, a2, -1
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	and	a2, a2, s0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a2
+; CHECK-V-NEXT:	vmv.s.x	v9, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptoui <2 x float> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.umin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -6581,65 +5981,59 @@ define <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f32i64_mm:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-V-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    sub sp, sp, a0
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; CHECK-V-NEXT:    addi a0, sp, 32
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-V-NEXT:    vfmv.f.s fa0, v9
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    mv s0, a0
-; CHECK-V-NEXT:    mv s1, a1
-; CHECK-V-NEXT:    flw fa0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    call __fixsfti
-; CHECK-V-NEXT:    mv a2, a1
-; CHECK-V-NEXT:    blez a1, .LBB50_2
-; CHECK-V-NEXT:  # %bb.1: # %entry
-; CHECK-V-NEXT:    li a2, 1
-; CHECK-V-NEXT:  .LBB50_2: # %entry
-; CHECK-V-NEXT:    mv a3, s1
-; CHECK-V-NEXT:    blez s1, .LBB50_4
-; CHECK-V-NEXT:  # %bb.3: # %entry
-; CHECK-V-NEXT:    li a3, 1
-; CHECK-V-NEXT:  .LBB50_4: # %entry
-; CHECK-V-NEXT:    slti a1, a1, 1
-; CHECK-V-NEXT:    slti a4, s1, 1
-; CHECK-V-NEXT:    srli a3, a3, 63
-; CHECK-V-NEXT:    srli a2, a2, 63
-; CHECK-V-NEXT:    neg a1, a1
-; CHECK-V-NEXT:    neg a4, a4
-; CHECK-V-NEXT:    addi a3, a3, -1
-; CHECK-V-NEXT:    addi a2, a2, -1
-; CHECK-V-NEXT:    and a0, a1, a0
-; CHECK-V-NEXT:    and a4, a4, s0
-; CHECK-V-NEXT:    and a3, a3, a4
-; CHECK-V-NEXT:    and a0, a2, a0
-; CHECK-V-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    vmv.s.x v9, a3
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-V-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    addi sp, sp, 64
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv1r.v	v24, v8
+; CHECK-V-NEXT:	vslidedown.vi	v8, v8, 1
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v8
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	mv	s0, a0
+; CHECK-V-NEXT:	mv	s1, a1
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vfmv.f.s	fa0, v24
+; CHECK-V-NEXT:	call	__fixsfti
+; CHECK-V-NEXT:	mv	a2, a1
+; CHECK-V-NEXT:	blez	a1, .LBB50_2
+; CHECK-V-NEXT:# %bb.1:                                # %entry
+; CHECK-V-NEXT:	li	a2, 1
+; CHECK-V-NEXT:.LBB50_2:                               # %entry
+; CHECK-V-NEXT:	mv	a3, s1
+; CHECK-V-NEXT:	blez	s1, .LBB50_4
+; CHECK-V-NEXT:# %bb.3:                                # %entry
+; CHECK-V-NEXT:	li	a3, 1
+; CHECK-V-NEXT:.LBB50_4:                               # %entry
+; CHECK-V-NEXT:	slti	a1, a1, 1
+; CHECK-V-NEXT:	slti	a4, s1, 1
+; CHECK-V-NEXT:	srli	a3, a3, 63
+; CHECK-V-NEXT:	srli	a2, a2, 63
+; CHECK-V-NEXT:	neg	a1, a1
+; CHECK-V-NEXT:	neg	a4, a4
+; CHECK-V-NEXT:	addi	a3, a3, -1
+; CHECK-V-NEXT:	addi	a2, a2, -1
+; CHECK-V-NEXT:	and	a0, a1, a0
+; CHECK-V-NEXT:	and	a4, a4, s0
+; CHECK-V-NEXT:	and	a3, a3, a4
+; CHECK-V-NEXT:	and	a0, a2, a0
+; CHECK-V-NEXT:	vsetivli	zero, 2, e64, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vmv.s.x	v9, a3
+; CHECK-V-NEXT:	vslideup.vi	v8, v9, 1
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -7132,81 +6526,57 @@ define <4 x i32> @ustest_f16i32_nsat(<4 x half> %x) {
 ;
 ; CHECK-V-LABEL: ustest_f16i32_nsat:
 ; CHECK-V:       # %bb.0: # %entry
-; CHECK-V-NEXT:    addi sp, sp, -48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-V-NEXT:    .cfi_offset ra, -8
-; CHECK-V-NEXT:    .cfi_offset s0, -16
-; CHECK-V-NEXT:    .cfi_offset s1, -24
-; CHECK-V-NEXT:    .cfi_offset s2, -32
-; CHECK-V-NEXT:    csrr a1, vlenb
-; CHECK-V-NEXT:    slli a1, a1, 1
-; CHECK-V-NEXT:    sub sp, sp, a1
-; CHECK-V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 2 * vlenb
-; CHECK-V-NEXT:    lhu s0, 0(a0)
-; CHECK-V-NEXT:    lhu s1, 8(a0)
-; CHECK-V-NEXT:    lhu s2, 16(a0)
-; CHECK-V-NEXT:    lhu a0, 24(a0)
-; CHECK-V-NEXT:    fmv.w.x fa0, a0
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s2
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    fmv.w.x fa0, s1
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    fmv.w.x fa0, s0
-; CHECK-V-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-V-NEXT:    call __extendhfsf2
-; CHECK-V-NEXT:    fcvt.l.s a0, fa0, rtz
-; CHECK-V-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-V-NEXT:    vmv.s.x v8, a0
-; CHECK-V-NEXT:    addi a0, sp, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    add a0, sp, a0
-; CHECK-V-NEXT:    addi a0, a0, 16
-; CHECK-V-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-V-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-V-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-V-NEXT:    vmin.vx v8, v8, zero
-; CHECK-V-NEXT:    vmax.vx v8, v8, zero
-; CHECK-V-NEXT:    csrr a0, vlenb
-; CHECK-V-NEXT:    slli a0, a0, 1
-; CHECK-V-NEXT:    add sp, sp, a0
-; CHECK-V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-V-NEXT:    .cfi_restore ra
-; CHECK-V-NEXT:    .cfi_restore s0
-; CHECK-V-NEXT:    .cfi_restore s1
-; CHECK-V-NEXT:    .cfi_restore s2
-; CHECK-V-NEXT:    addi sp, sp, 48
-; CHECK-V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-V-NEXT:    ret
+; CHECK-V-NEXT:	addi	sp, sp, -32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-V-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-V-NEXT:	.cfi_offset ra, -8
+; CHECK-V-NEXT:	.cfi_offset s0, -16
+; CHECK-V-NEXT:	.cfi_offset s1, -24
+; CHECK-V-NEXT:	.cfi_offset s2, -32
+; CHECK-V-NEXT:	lhu	s0, 0(a0)
+; CHECK-V-NEXT:	lhu	s1, 8(a0)
+; CHECK-V-NEXT:	lhu	s2, 16(a0)
+; CHECK-V-NEXT:	lhu	a0, 24(a0)
+; CHECK-V-NEXT:	fmv.w.x	fa0, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s2
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v25, a0
+; CHECK-V-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-V-NEXT:	fmv.w.x	fa0, s1
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	fmv.w.x	fa0, s0
+; CHECK-V-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v24, a0
+; CHECK-V-NEXT:	call	__extendhfsf2
+; CHECK-V-NEXT:	fcvt.l.s	a0, fa0, rtz
+; CHECK-V-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-V-NEXT:	vmv.s.x	v8, a0
+; CHECK-V-NEXT:	vslideup.vi	v8, v24, 1
+; CHECK-V-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-V-NEXT:	vslideup.vi	v8, v25, 2
+; CHECK-V-NEXT:	vmin.vx	v8, v8, zero
+; CHECK-V-NEXT:	vmax.vx	v8, v8, zero
+; CHECK-V-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-V-NEXT:	.cfi_restore ra
+; CHECK-V-NEXT:	.cfi_restore s0
+; CHECK-V-NEXT:	.cfi_restore s1
+; CHECK-V-NEXT:	.cfi_restore s2
+; CHECK-V-NEXT:	addi	sp, sp, 32
+; CHECK-V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-V-NEXT:	ret
 entry:
   %conv = fptosi <4 x half> %x to <4 x i32>
   %spec.store.select = call <4 x i32> @llvm.smin.v4i32(<4 x i32> zeroinitializer, <4 x i32> %conv)

--- a/llvm/test/CodeGen/RISCV/rvv/frm-insert.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/frm-insert.ll
@@ -84,37 +84,29 @@ declare void @foo()
 define <vscale x 1 x float> @just_call(<vscale x 1 x float> %0) nounwind {
 ; CHECK-LABEL: just_call:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -48
-; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 48
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v24, v8
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v8, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 ;
 ; UNOPT-LABEL: just_call:
 ; UNOPT:       # %bb.0: # %entry
-; UNOPT-NEXT:    addi sp, sp, -48
-; UNOPT-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; UNOPT-NEXT:    csrr a0, vlenb
-; UNOPT-NEXT:    sub sp, sp, a0
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; UNOPT-NEXT:    call foo
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; UNOPT-NEXT:    csrr a0, vlenb
-; UNOPT-NEXT:    add sp, sp, a0
-; UNOPT-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; UNOPT-NEXT:    addi sp, sp, 48
-; UNOPT-NEXT:    ret
+; UNOPT-NEXT:	addi	sp, sp, -16
+; UNOPT-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; UNOPT-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; UNOPT-NEXT:	vmv1r.v	v24, v8
+; UNOPT-NEXT:	call	foo
+; UNOPT-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; UNOPT-NEXT:	vmv1r.v	v8, v24
+; UNOPT-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; UNOPT-NEXT:	addi	sp, sp, 16
+; UNOPT-NEXT:	ret
 entry:
   call void @foo()
   ret <vscale x 1 x float> %0
@@ -123,45 +115,33 @@ entry:
 define <vscale x 1 x float> @before_call1(<vscale x 1 x float> %0, <vscale x 1 x float> %1, i64 %2) nounwind {
 ; CHECK-LABEL: before_call1:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -48
-; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    fsrmi a1, 0
-; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; CHECK-NEXT:    vfadd.vv v8, v8, v9
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    fsrm a1
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 48
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	fsrmi	a1, 0
+; CHECK-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; CHECK-NEXT:	vfadd.vv	v24, v8, v9
+; CHECK-NEXT:	fsrm	a1
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v8, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 ;
 ; UNOPT-LABEL: before_call1:
 ; UNOPT:       # %bb.0: # %entry
-; UNOPT-NEXT:    addi sp, sp, -48
-; UNOPT-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; UNOPT-NEXT:    csrr a1, vlenb
-; UNOPT-NEXT:    sub sp, sp, a1
-; UNOPT-NEXT:    fsrmi a1, 0
-; UNOPT-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; UNOPT-NEXT:    vfadd.vv v8, v8, v9
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; UNOPT-NEXT:    fsrm a1
-; UNOPT-NEXT:    call foo
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; UNOPT-NEXT:    csrr a0, vlenb
-; UNOPT-NEXT:    add sp, sp, a0
-; UNOPT-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; UNOPT-NEXT:    addi sp, sp, 48
-; UNOPT-NEXT:    ret
+; UNOPT-NEXT:	addi	sp, sp, -16
+; UNOPT-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; UNOPT-NEXT:	fsrmi	a1, 0
+; UNOPT-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; UNOPT-NEXT:	vfadd.vv	v24, v8, v9
+; UNOPT-NEXT:	fsrm	a1
+; UNOPT-NEXT:	call	foo
+; UNOPT-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; UNOPT-NEXT:	vmv1r.v	v8, v24
+; UNOPT-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; UNOPT-NEXT:	addi	sp, sp, 16
+; UNOPT-NEXT:	ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vfadd.nxv1f32.nxv1f32(
     <vscale x 1 x float> poison,
@@ -175,41 +155,29 @@ entry:
 define <vscale x 1 x float> @before_call2(<vscale x 1 x float> %0, <vscale x 1 x float> %1, i64 %2) nounwind {
 ; CHECK-LABEL: before_call2:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -48
-; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; CHECK-NEXT:    vfadd.vv v8, v8, v9
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 48
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; CHECK-NEXT:	vfadd.vv	v24, v8, v9
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v8, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 ;
 ; UNOPT-LABEL: before_call2:
 ; UNOPT:       # %bb.0: # %entry
-; UNOPT-NEXT:    addi sp, sp, -48
-; UNOPT-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; UNOPT-NEXT:    csrr a1, vlenb
-; UNOPT-NEXT:    sub sp, sp, a1
-; UNOPT-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; UNOPT-NEXT:    vfadd.vv v8, v8, v9
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; UNOPT-NEXT:    call foo
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; UNOPT-NEXT:    csrr a0, vlenb
-; UNOPT-NEXT:    add sp, sp, a0
-; UNOPT-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; UNOPT-NEXT:    addi sp, sp, 48
-; UNOPT-NEXT:    ret
+; UNOPT-NEXT:	addi	sp, sp, -16
+; UNOPT-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; UNOPT-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; UNOPT-NEXT:	vfadd.vv	v24, v8, v9
+; UNOPT-NEXT:	call	foo
+; UNOPT-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; UNOPT-NEXT:	vmv1r.v	v8, v24
+; UNOPT-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; UNOPT-NEXT:	addi	sp, sp, 16
+; UNOPT-NEXT:	ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vfadd.nxv1f32.nxv1f32(
     <vscale x 1 x float> poison,
@@ -223,45 +191,33 @@ entry:
 define <vscale x 1 x float> @after_call1(<vscale x 1 x float> %0, <vscale x 1 x float> %1, i64 %2) nounwind {
 ; CHECK-LABEL: after_call1:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -48
-; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    fsrmi a1, 0
-; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; CHECK-NEXT:    vfadd.vv v8, v8, v9
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    fsrm a1
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 48
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	fsrmi	a1, 0
+; CHECK-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; CHECK-NEXT:	vfadd.vv	v24, v8, v9
+; CHECK-NEXT:	fsrm	a1
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v8, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 ;
 ; UNOPT-LABEL: after_call1:
 ; UNOPT:       # %bb.0: # %entry
-; UNOPT-NEXT:    addi sp, sp, -48
-; UNOPT-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; UNOPT-NEXT:    csrr a1, vlenb
-; UNOPT-NEXT:    sub sp, sp, a1
-; UNOPT-NEXT:    fsrmi a1, 0
-; UNOPT-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; UNOPT-NEXT:    vfadd.vv v8, v8, v9
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; UNOPT-NEXT:    fsrm a1
-; UNOPT-NEXT:    call foo
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; UNOPT-NEXT:    csrr a0, vlenb
-; UNOPT-NEXT:    add sp, sp, a0
-; UNOPT-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; UNOPT-NEXT:    addi sp, sp, 48
-; UNOPT-NEXT:    ret
+; UNOPT-NEXT:	addi	sp, sp, -16
+; UNOPT-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; UNOPT-NEXT:	fsrmi	a1, 0
+; UNOPT-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; UNOPT-NEXT:	vfadd.vv	v24, v8, v9
+; UNOPT-NEXT:	fsrm	a1
+; UNOPT-NEXT:	call	foo
+; UNOPT-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; UNOPT-NEXT:	vmv1r.v	v8, v24
+; UNOPT-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; UNOPT-NEXT:	addi	sp, sp, 16
+; UNOPT-NEXT:	ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vfadd.nxv1f32.nxv1f32(
     <vscale x 1 x float> poison,
@@ -275,41 +231,29 @@ entry:
 define <vscale x 1 x float> @after_call2(<vscale x 1 x float> %0, <vscale x 1 x float> %1, i64 %2) nounwind {
 ; CHECK-LABEL: after_call2:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -48
-; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; CHECK-NEXT:    vfadd.vv v8, v8, v9
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 48
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; CHECK-NEXT:	vfadd.vv	v24, v8, v9
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v8, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 ;
 ; UNOPT-LABEL: after_call2:
 ; UNOPT:       # %bb.0: # %entry
-; UNOPT-NEXT:    addi sp, sp, -48
-; UNOPT-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; UNOPT-NEXT:    csrr a1, vlenb
-; UNOPT-NEXT:    sub sp, sp, a1
-; UNOPT-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; UNOPT-NEXT:    vfadd.vv v8, v8, v9
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; UNOPT-NEXT:    call foo
-; UNOPT-NEXT:    addi a0, sp, 32
-; UNOPT-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; UNOPT-NEXT:    csrr a0, vlenb
-; UNOPT-NEXT:    add sp, sp, a0
-; UNOPT-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; UNOPT-NEXT:    addi sp, sp, 48
-; UNOPT-NEXT:    ret
+; UNOPT-NEXT:	addi	sp, sp, -16
+; UNOPT-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; UNOPT-NEXT:	vsetvli	zero, a0, e32, mf2, ta, ma
+; UNOPT-NEXT:	vfadd.vv	v24, v8, v9
+; UNOPT-NEXT:	call	foo
+; UNOPT-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; UNOPT-NEXT:	vmv1r.v	v8, v24
+; UNOPT-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; UNOPT-NEXT:	addi	sp, sp, 16
+; UNOPT-NEXT:	ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vfadd.nxv1f32.nxv1f32(
     <vscale x 1 x float> poison,

--- a/llvm/test/CodeGen/RISCV/rvv/inline-asm.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/inline-asm.ll
@@ -365,15 +365,15 @@ entry:
 define <vscale x 4 x i8> @test_specify_reg_mf2(<vscale x 4 x i8> %in, <vscale x 4 x i8> %in2) nounwind {
 ; CHECK-LABEL: test_specify_reg_mf2:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv1r.v v2, v9
-; CHECK-NEXT:    vmv1r.v v1, v8
-; CHECK-NEXT:    #APP
-; CHECK-NEXT:    vadd.vv v0, v1, v2
-; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv1r.v v8, v0
-; CHECK-NEXT:    ret
+; CHECK-NEXT: 	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT: 	vmv1r.v	v1, v8
+; CHECK-NEXT: 	vmv1r.v	v2, v9
+; CHECK-NEXT: 	#APP
+; CHECK-NEXT: 	vadd.vv	v0, v1, v2
+; CHECK-NEXT: 	#NO_APP
+; CHECK-NEXT: 	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT: 	vmv1r.v	v8, v0
+; CHECK-NEXT: 	ret
 entry:
   %0 = tail call <vscale x 4 x i8> asm "vadd.vv $0, $1, $2", "={v0},{v1},{v2}"(<vscale x 4 x i8> %in, <vscale x 4 x i8> %in2)
   ret <vscale x 4 x i8> %0
@@ -382,15 +382,15 @@ entry:
 define <vscale x 8 x i8> @test_specify_reg_m1(<vscale x 8 x i8> %in, <vscale x 8 x i8> %in2) nounwind {
 ; CHECK-LABEL: test_specify_reg_m1:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv1r.v v2, v9
-; CHECK-NEXT:    vmv1r.v v1, v8
-; CHECK-NEXT:    #APP
-; CHECK-NEXT:    vadd.vv v0, v1, v2
-; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv1r.v v8, v0
-; CHECK-NEXT:    ret
+; CHECK-NEXT: 	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT: 	vmv1r.v	v1, v8
+; CHECK-NEXT: 	vmv1r.v	v2, v9
+; CHECK-NEXT: 	#APP
+; CHECK-NEXT: 	vadd.vv	v0, v1, v2
+; CHECK-NEXT: 	#NO_APP
+; CHECK-NEXT: 	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT: 	vmv1r.v	v8, v0
+; CHECK-NEXT: 	ret
 entry:
   %0 = tail call <vscale x 8 x i8> asm "vadd.vv $0, $1, $2", "={v0},{v1},{v2}"(<vscale x 8 x i8> %in, <vscale x 8 x i8> %in2)
   ret <vscale x 8 x i8> %0
@@ -399,15 +399,15 @@ entry:
 define <vscale x 16 x i8> @test_specify_reg_m2(<vscale x 16 x i8> %in, <vscale x 16 x i8> %in2) nounwind {
 ; CHECK-LABEL: test_specify_reg_m2:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv2r.v v4, v10
-; CHECK-NEXT:    vmv2r.v v2, v8
-; CHECK-NEXT:    #APP
-; CHECK-NEXT:    vadd.vv v0, v2, v4
-; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv2r.v v8, v0
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv2r.v	v2, v8
+; CHECK-NEXT:	vmv2r.v	v4, v10
+; CHECK-NEXT:	#APP
+; CHECK-NEXT:	vadd.vv	v0, v2, v4
+; CHECK-NEXT:	#NO_APP
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv2r.v	v8, v0
+; CHECK-NEXT:	ret
 entry:
   %0 = tail call <vscale x 16 x i8> asm "vadd.vv $0, $1, $2", "={v0},{v2},{v4}"(<vscale x 16 x i8> %in, <vscale x 16 x i8> %in2)
   ret <vscale x 16 x i8> %0
@@ -416,13 +416,13 @@ entry:
 define <vscale x 1 x i1> @test_specify_reg_mask(<vscale x 1 x i1> %in, <vscale x 1 x i1> %in2) nounwind {
 ; CHECK-LABEL: test_specify_reg_mask:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
-; CHECK-NEXT:    vmv1r.v v2, v8
-; CHECK-NEXT:    vmv1r.v v1, v0
-; CHECK-NEXT:    #APP
-; CHECK-NEXT:    vmand.mm v0, v1, v2
-; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v1, v0
+; CHECK-NEXT:	vmv1r.v	v2, v8
+; CHECK-NEXT:	#APP
+; CHECK-NEXT:	vmand.mm	v0, v1, v2
+; CHECK-NEXT:	#NO_APP
+; CHECK-NEXT:	ret
 entry:
   %0 = tail call <vscale x 1 x i1> asm "vmand.mm $0, $1, $2", "={v0},{v1},{v2}"(<vscale x 1 x i1> %in, <vscale x 1 x i1> %in2)
   ret <vscale x 1 x i1> %0

--- a/llvm/test/CodeGen/RISCV/rvv/lrint-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/lrint-sdnode.ll
@@ -544,95 +544,85 @@ define <vscale x 32 x iXLen> @lrint_nxv32bf16(<vscale x 32 x bfloat> %x) {
 ;
 ; RV64-i64-LABEL: lrint_nxv32bf16:
 ; RV64-i64:       # %bb.0:
-; RV64-i64-NEXT:    addi sp, sp, -64
-; RV64-i64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-i64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-i64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-i64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-i64-NEXT:    .cfi_offset ra, -8
-; RV64-i64-NEXT:    .cfi_offset s0, -16
-; RV64-i64-NEXT:    .cfi_offset s1, -24
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 5
-; RV64-i64-NEXT:    sub sp, sp, a1
-; RV64-i64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x20, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 32 * vlenb
-; RV64-i64-NEXT:    mv s0, a0
-; RV64-i64-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v16, v8
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v20, v10
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v8, v12
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v24, v14
-; RV64-i64-NEXT:    vsetvli zero, zero, e32, m4, ta, ma
-; RV64-i64-NEXT:    vfwcvt.x.f.v v0, v16
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 3
-; RV64-i64-NEXT:    mv a1, a0
-; RV64-i64-NEXT:    slli a0, a0, 1
-; RV64-i64-NEXT:    add a0, a0, a1
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    vfwcvt.x.f.v v0, v20
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 4
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    vfwcvt.x.f.v v16, v8
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 3
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    vfwcvt.x.f.v v8, v24
-; RV64-i64-NEXT:    addi a0, sp, 32
-; RV64-i64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    csrr s1, vlenb
-; RV64-i64-NEXT:    li a1, 24
-; RV64-i64-NEXT:    mv a0, s1
-; RV64-i64-NEXT:    call __muldi3
-; RV64-i64-NEXT:    add a0, s0, a0
-; RV64-i64-NEXT:    addi a1, sp, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (a0)
-; RV64-i64-NEXT:    slli a0, s1, 4
-; RV64-i64-NEXT:    slli s1, s1, 3
-; RV64-i64-NEXT:    add a0, s0, a0
-; RV64-i64-NEXT:    add s1, s0, s1
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 3
-; RV64-i64-NEXT:    add a1, sp, a1
-; RV64-i64-NEXT:    addi a1, a1, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (a0)
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 4
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (s1)
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 3
-; RV64-i64-NEXT:    mv a1, a0
-; RV64-i64-NEXT:    slli a0, a0, 1
-; RV64-i64-NEXT:    add a0, a0, a1
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (s0)
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 5
-; RV64-i64-NEXT:    add sp, sp, a0
-; RV64-i64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-i64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-i64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-i64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-i64-NEXT:    .cfi_restore ra
-; RV64-i64-NEXT:    .cfi_restore s0
-; RV64-i64-NEXT:    .cfi_restore s1
-; RV64-i64-NEXT:    addi sp, sp, 64
-; RV64-i64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-i64-NEXT:    ret
+; RV64-i64-NEXT:	addi	sp, sp, -64
+; RV64-i64-NEXT:	.cfi_def_cfa_offset 64
+; RV64-i64-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; RV64-i64-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; RV64-i64-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; RV64-i64-NEXT:	.cfi_offset ra, -8
+; RV64-i64-NEXT:	.cfi_offset s0, -16
+; RV64-i64-NEXT:	.cfi_offset s1, -24
+; RV64-i64-NEXT:	csrr	a1, vlenb
+; RV64-i64-NEXT:	slli	a1, a1, 3
+; RV64-i64-NEXT:	mv	a2, a1
+; RV64-i64-NEXT:	slli	a1, a1, 1
+; RV64-i64-NEXT:	add	a1, a1, a2
+; RV64-i64-NEXT:	sub	sp, sp, a1
+; RV64-i64-NEXT:	.cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x18, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 24 * vlenb
+; RV64-i64-NEXT:	mv	s0, a0
+; RV64-i64-NEXT:	vsetvli	a0, zero, e16, m2, ta, ma
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v16, v8
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v20, v10
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v8, v12
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v4, v14
+; RV64-i64-NEXT:	vsetvli	zero, zero, e32, m4, ta, ma
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v24, v16
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 4
+; RV64-i64-NEXT:	add	a0, sp, a0
+; RV64-i64-NEXT:	addi	a0, a0, 32
+; RV64-i64-NEXT:	vs8r.v	v24, (a0)                       # vscale x 64-byte Folded Spill
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v24, v20
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 3
+; RV64-i64-NEXT:	add	a0, sp, a0
+; RV64-i64-NEXT:	addi	a0, a0, 32
+; RV64-i64-NEXT:	vs8r.v	v24, (a0)                       # vscale x 64-byte Folded Spill
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v16, v8
+; RV64-i64-NEXT:	addi	a0, sp, 32
+; RV64-i64-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v24, v4
+; RV64-i64-NEXT:	csrr	s1, vlenb
+; RV64-i64-NEXT:	li	a1, 24
+; RV64-i64-NEXT:	mv	a0, s1
+; RV64-i64-NEXT:	call	__muldi3
+; RV64-i64-NEXT:	add	a0, s0, a0
+; RV64-i64-NEXT:	vs8r.v	v24, (a0)
+; RV64-i64-NEXT:	slli	a0, s1, 4
+; RV64-i64-NEXT:	slli	s1, s1, 3
+; RV64-i64-NEXT:	add	a0, s0, a0
+; RV64-i64-NEXT:	add	s1, s0, s1
+; RV64-i64-NEXT:	addi	a1, sp, 32
+; RV64-i64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-i64-NEXT:	vs8r.v	v8, (a0)
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 3
+; RV64-i64-NEXT:	add	a0, sp, a0
+; RV64-i64-NEXT:	addi	a0, a0, 32
+; RV64-i64-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV64-i64-NEXT:	vs8r.v	v8, (s1)
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 4
+; RV64-i64-NEXT:	add	a0, sp, a0
+; RV64-i64-NEXT:	addi	a0, a0, 32
+; RV64-i64-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV64-i64-NEXT:	vs8r.v	v8, (s0)
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 3
+; RV64-i64-NEXT:	mv	a1, a0
+; RV64-i64-NEXT:	slli	a0, a0, 1
+; RV64-i64-NEXT:	add	a0, a0, a1
+; RV64-i64-NEXT:	add	sp, sp, a0
+; RV64-i64-NEXT:	.cfi_def_cfa sp, 64
+; RV64-i64-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; RV64-i64-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; RV64-i64-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; RV64-i64-NEXT:	.cfi_restore ra
+; RV64-i64-NEXT:	.cfi_restore s0
+; RV64-i64-NEXT:	.cfi_restore s1
+; RV64-i64-NEXT:	addi	sp, sp, 64
+; RV64-i64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-i64-NEXT:	ret
   %a = call <vscale x 32 x iXLen> @llvm.lrint.nxv32iXLen.nxv32bf16(<vscale x 32 x bfloat> %x)
   ret <vscale x 32 x iXLen> %a
 }

--- a/llvm/test/CodeGen/RISCV/rvv/lround-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/lround-sdnode.ll
@@ -662,97 +662,87 @@ define <vscale x 32 x iXLen> @lround_nxv32bf16(<vscale x 32 x bfloat> %x) {
 ;
 ; RV64-i64-LABEL: lround_nxv32bf16:
 ; RV64-i64:       # %bb.0:
-; RV64-i64-NEXT:    addi sp, sp, -64
-; RV64-i64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-i64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-i64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-i64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-i64-NEXT:    .cfi_offset ra, -8
-; RV64-i64-NEXT:    .cfi_offset s0, -16
-; RV64-i64-NEXT:    .cfi_offset s1, -24
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 5
-; RV64-i64-NEXT:    sub sp, sp, a1
-; RV64-i64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x20, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 32 * vlenb
-; RV64-i64-NEXT:    mv s0, a0
-; RV64-i64-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v16, v8
-; RV64-i64-NEXT:    fsrmi a0, 4
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v20, v10
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v8, v12
-; RV64-i64-NEXT:    vfwcvtbf16.f.f.v v24, v14
-; RV64-i64-NEXT:    vsetvli zero, zero, e32, m4, ta, ma
-; RV64-i64-NEXT:    vfwcvt.x.f.v v0, v16
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 3
-; RV64-i64-NEXT:    mv a2, a1
-; RV64-i64-NEXT:    slli a1, a1, 1
-; RV64-i64-NEXT:    add a1, a1, a2
-; RV64-i64-NEXT:    add a1, sp, a1
-; RV64-i64-NEXT:    addi a1, a1, 32
-; RV64-i64-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    vfwcvt.x.f.v v0, v20
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 4
-; RV64-i64-NEXT:    add a1, sp, a1
-; RV64-i64-NEXT:    addi a1, a1, 32
-; RV64-i64-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    vfwcvt.x.f.v v16, v8
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 3
-; RV64-i64-NEXT:    add a1, sp, a1
-; RV64-i64-NEXT:    addi a1, a1, 32
-; RV64-i64-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    vfwcvt.x.f.v v8, v24
-; RV64-i64-NEXT:    addi a1, sp, 32
-; RV64-i64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-i64-NEXT:    csrr s1, vlenb
-; RV64-i64-NEXT:    li a1, 24
-; RV64-i64-NEXT:    fsrm a0
-; RV64-i64-NEXT:    mv a0, s1
-; RV64-i64-NEXT:    call __muldi3
-; RV64-i64-NEXT:    add a0, s0, a0
-; RV64-i64-NEXT:    addi a1, sp, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (a0)
-; RV64-i64-NEXT:    slli a0, s1, 4
-; RV64-i64-NEXT:    slli s1, s1, 3
-; RV64-i64-NEXT:    add a0, s0, a0
-; RV64-i64-NEXT:    add s1, s0, s1
-; RV64-i64-NEXT:    csrr a1, vlenb
-; RV64-i64-NEXT:    slli a1, a1, 3
-; RV64-i64-NEXT:    add a1, sp, a1
-; RV64-i64-NEXT:    addi a1, a1, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (a0)
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 4
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (s1)
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 3
-; RV64-i64-NEXT:    mv a1, a0
-; RV64-i64-NEXT:    slli a0, a0, 1
-; RV64-i64-NEXT:    add a0, a0, a1
-; RV64-i64-NEXT:    add a0, sp, a0
-; RV64-i64-NEXT:    addi a0, a0, 32
-; RV64-i64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-i64-NEXT:    vs8r.v v8, (s0)
-; RV64-i64-NEXT:    csrr a0, vlenb
-; RV64-i64-NEXT:    slli a0, a0, 5
-; RV64-i64-NEXT:    add sp, sp, a0
-; RV64-i64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-i64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-i64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-i64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-i64-NEXT:    .cfi_restore ra
-; RV64-i64-NEXT:    .cfi_restore s0
-; RV64-i64-NEXT:    .cfi_restore s1
-; RV64-i64-NEXT:    addi sp, sp, 64
-; RV64-i64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-i64-NEXT:    ret
+; RV64-i64-NEXT:	addi	sp, sp, -64
+; RV64-i64-NEXT:	.cfi_def_cfa_offset 64
+; RV64-i64-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; RV64-i64-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; RV64-i64-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; RV64-i64-NEXT:	.cfi_offset ra, -8
+; RV64-i64-NEXT:	.cfi_offset s0, -16
+; RV64-i64-NEXT:	.cfi_offset s1, -24
+; RV64-i64-NEXT:	csrr	a1, vlenb
+; RV64-i64-NEXT:	slli	a1, a1, 3
+; RV64-i64-NEXT:	mv	a2, a1
+; RV64-i64-NEXT:	slli	a1, a1, 1
+; RV64-i64-NEXT:	add	a1, a1, a2
+; RV64-i64-NEXT:	sub	sp, sp, a1
+; RV64-i64-NEXT:	.cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x18, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 24 * vlenb
+; RV64-i64-NEXT:	mv	s0, a0
+; RV64-i64-NEXT:	vsetvli	a0, zero, e16, m2, ta, ma
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v16, v8
+; RV64-i64-NEXT:	fsrmi	a0, 4
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v20, v10
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v8, v12
+; RV64-i64-NEXT:	vfwcvtbf16.f.f.v	v4, v14
+; RV64-i64-NEXT:	vsetvli	zero, zero, e32, m4, ta, ma
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v24, v16
+; RV64-i64-NEXT:	csrr	a1, vlenb
+; RV64-i64-NEXT:	slli	a1, a1, 4
+; RV64-i64-NEXT:	add	a1, sp, a1
+; RV64-i64-NEXT:	addi	a1, a1, 32
+; RV64-i64-NEXT:	vs8r.v	v24, (a1)                       # vscale x 64-byte Folded Spill
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v24, v20
+; RV64-i64-NEXT:	csrr	a1, vlenb
+; RV64-i64-NEXT:	slli	a1, a1, 3
+; RV64-i64-NEXT:	add	a1, sp, a1
+; RV64-i64-NEXT:	addi	a1, a1, 32
+; RV64-i64-NEXT:	vs8r.v	v24, (a1)                       # vscale x 64-byte Folded Spill
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v16, v8
+; RV64-i64-NEXT:	addi	a1, sp, 32
+; RV64-i64-NEXT:	vs8r.v	v16, (a1)                       # vscale x 64-byte Folded Spill
+; RV64-i64-NEXT:	vfwcvt.x.f.v	v24, v4
+; RV64-i64-NEXT:	csrr	s1, vlenb
+; RV64-i64-NEXT:	li	a1, 24
+; RV64-i64-NEXT:	fsrm	a0
+; RV64-i64-NEXT:	mv	a0, s1
+; RV64-i64-NEXT:	call	__muldi3
+; RV64-i64-NEXT:	add	a0, s0, a0
+; RV64-i64-NEXT:	vs8r.v	v24, (a0)
+; RV64-i64-NEXT:	slli	a0, s1, 4
+; RV64-i64-NEXT:	slli	s1, s1, 3
+; RV64-i64-NEXT:	add	a0, s0, a0
+; RV64-i64-NEXT:	add	s1, s0, s1
+; RV64-i64-NEXT:	addi	a1, sp, 32
+; RV64-i64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-i64-NEXT:	vs8r.v	v8, (a0)
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 3
+; RV64-i64-NEXT:	add	a0, sp, a0
+; RV64-i64-NEXT:	addi	a0, a0, 32
+; RV64-i64-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV64-i64-NEXT:	vs8r.v	v8, (s1)
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 4
+; RV64-i64-NEXT:	add	a0, sp, a0
+; RV64-i64-NEXT:	addi	a0, a0, 32
+; RV64-i64-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV64-i64-NEXT:	vs8r.v	v8, (s0)
+; RV64-i64-NEXT:	csrr	a0, vlenb
+; RV64-i64-NEXT:	slli	a0, a0, 3
+; RV64-i64-NEXT:	mv	a1, a0
+; RV64-i64-NEXT:	slli	a0, a0, 1
+; RV64-i64-NEXT:	add	a0, a0, a1
+; RV64-i64-NEXT:	add	sp, sp, a0
+; RV64-i64-NEXT:	.cfi_def_cfa sp, 64
+; RV64-i64-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; RV64-i64-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; RV64-i64-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; RV64-i64-NEXT:	.cfi_restore ra
+; RV64-i64-NEXT:	.cfi_restore s0
+; RV64-i64-NEXT:	.cfi_restore s1
+; RV64-i64-NEXT:	addi	sp, sp, 64
+; RV64-i64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-i64-NEXT:	ret
   %a = call <vscale x 32 x iXLen> @llvm.lround.nxv32iXLen.nxv32bf16(<vscale x 32 x bfloat> %x)
   ret <vscale x 32 x iXLen> %a
 }

--- a/llvm/test/CodeGen/RISCV/rvv/nontemporal-vp-scalable.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/nontemporal-vp-scalable.ll
@@ -34456,213 +34456,197 @@ define void @test_nontemporal_vp_store_nxv64i8_DEFAULT(<vscale x 64 x i8> %val, 
 define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_P1(<vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_gather_nxv64i8_P1:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 4
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64V-NEXT:    mv s0, a6
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s1, vlenb
-; CHECK-RV64V-NEXT:    slli a0, s1, 3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 4
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    addi a0, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s1, 2
-; CHECK-RV64V-NEXT:    sub a1, s0, a2
-; CHECK-RV64V-NEXT:    sltu a3, s0, a1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a3, a3, a1
-; CHECK-RV64V-NEXT:    slli a1, s1, 1
-; CHECK-RV64V-NEXT:    sub a4, a3, a1
-; CHECK-RV64V-NEXT:    sltu a5, a3, a4
-; CHECK-RV64V-NEXT:    addi a5, a5, -1
-; CHECK-RV64V-NEXT:    and a6, a5, a4
-; CHECK-RV64V-NEXT:    sub a4, a6, s1
-; CHECK-RV64V-NEXT:    mv a5, a6
-; CHECK-RV64V-NEXT:    bltu a6, s1, .LBB910_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a5, s1
-; CHECK-RV64V-NEXT:  .LBB910_2:
-; CHECK-RV64V-NEXT:    sltu a7, a6, a4
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB910_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:  .LBB910_4:
-; CHECK-RV64V-NEXT:    add a6, s2, a0
-; CHECK-RV64V-NEXT:    addi a0, a7, -1
-; CHECK-RV64V-NEXT:    sub a7, a3, s1
-; CHECK-RV64V-NEXT:    sltu t0, a3, a7
-; CHECK-RV64V-NEXT:    addi t0, t0, -1
-; CHECK-RV64V-NEXT:    and a7, t0, a7
-; CHECK-RV64V-NEXT:    bltu a3, s1, .LBB910_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:  .LBB910_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a6)
-; CHECK-RV64V-NEXT:    addi a6, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 3
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a7, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64V-NEXT:    and a0, a0, a4
-; CHECK-RV64V-NEXT:    bltu s0, a2, .LBB910_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv s0, a2
-; CHECK-RV64V-NEXT:  .LBB910_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64V-NEXT:    sub a0, s0, a1
-; CHECK-RV64V-NEXT:    sltu a2, s0, a0
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    and a0, a2, a0
-; CHECK-RV64V-NEXT:    sub a2, a0, s1
-; CHECK-RV64V-NEXT:    sltu a3, a0, a2
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a2, a3, a2
-; CHECK-RV64V-NEXT:    bltu a0, s1, .LBB910_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:  .LBB910_10:
-; CHECK-RV64V-NEXT:    csrr a3, vlenb
-; CHECK-RV64V-NEXT:    slli a3, a3, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    slli a3, a3, 1
-; CHECK-RV64V-NEXT:    add a3, a3, a4
-; CHECK-RV64V-NEXT:    add a3, sp, a3
-; CHECK-RV64V-NEXT:    addi a3, a3, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, a1, .LBB910_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv s0, a1
-; CHECK-RV64V-NEXT:  .LBB910_12:
-; CHECK-RV64V-NEXT:    sub a0, s0, s1
-; CHECK-RV64V-NEXT:    sltu a1, s0, a0
-; CHECK-RV64V-NEXT:    addi a1, a1, -1
-; CHECK-RV64V-NEXT:    and a0, a1, a0
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, s1, .LBB910_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv s0, s1
-; CHECK-RV64V-NEXT:  .LBB910_14:
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64V-NEXT:	mv	s0, a6
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	s1, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, s1, 3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 4
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	addi	a0, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s1, 2
+; CHECK-RV64V-NEXT:	sub	a1, s0, a2
+; CHECK-RV64V-NEXT:	sltu	a3, s0, a1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a3, a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, s1, 1
+; CHECK-RV64V-NEXT:	sub	a4, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a5, a3, a4
+; CHECK-RV64V-NEXT:	addi	a5, a5, -1
+; CHECK-RV64V-NEXT:	and	a6, a5, a4
+; CHECK-RV64V-NEXT:	sub	a4, a6, s1
+; CHECK-RV64V-NEXT:	mv	a5, a6
+; CHECK-RV64V-NEXT:	bltu	a6, s1, .LBB910_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a5, s1
+; CHECK-RV64V-NEXT:.LBB910_2:
+; CHECK-RV64V-NEXT:	sltu	a7, a6, a4
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB910_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:.LBB910_4:
+; CHECK-RV64V-NEXT:	add	a6, s2, a0
+; CHECK-RV64V-NEXT:	addi	a0, a7, -1
+; CHECK-RV64V-NEXT:	sub	a7, a3, s1
+; CHECK-RV64V-NEXT:	sltu	t0, a3, a7
+; CHECK-RV64V-NEXT:	addi	t0, t0, -1
+; CHECK-RV64V-NEXT:	and	a7, t0, a7
+; CHECK-RV64V-NEXT:	bltu	a3, s1, .LBB910_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:.LBB910_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a6)
+; CHECK-RV64V-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a7, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 3
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64V-NEXT:	and	a0, a0, a4
+; CHECK-RV64V-NEXT:	bltu	s0, a2, .LBB910_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	s0, a2
+; CHECK-RV64V-NEXT:.LBB910_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64V-NEXT:	sub	a0, s0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	and	a0, a2, a0
+; CHECK-RV64V-NEXT:	sub	a2, a0, s1
+; CHECK-RV64V-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a2, a3, a2
+; CHECK-RV64V-NEXT:	bltu	a0, s1, .LBB910_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:.LBB910_10:
+; CHECK-RV64V-NEXT:	csrr	a3, vlenb
+; CHECK-RV64V-NEXT:	slli	a3, a3, 4
+; CHECK-RV64V-NEXT:	add	a3, sp, a3
+; CHECK-RV64V-NEXT:	addi	a3, a3, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, a1, .LBB910_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	s0, a1
+; CHECK-RV64V-NEXT:.LBB910_12:
+; CHECK-RV64V-NEXT:	sub	a0, s0, s1
+; CHECK-RV64V-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64V-NEXT:	addi	a1, a1, -1
+; CHECK-RV64V-NEXT:	and	a0, a1, a0
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 5
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, s1, .LBB910_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	s0, s1
+; CHECK-RV64V-NEXT:.LBB910_14:
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv64i8_P1:
 ; CHECK-RV32V:       # %bb.0:
@@ -34730,213 +34714,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_P1(<vscale x 64 x 
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv64i8_P1:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64VC-NEXT:    mv s0, a6
-; CHECK-RV64VC-NEXT:    mv s2, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s1, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, s1, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a7, s1, 2
-; CHECK-RV64VC-NEXT:    sub a1, s0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a3, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, s1, 1
-; CHECK-RV64VC-NEXT:    sub a2, a3, a1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    sub t0, a2, s1
-; CHECK-RV64VC-NEXT:    mv a5, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s1, .LBB910_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a5, s1
-; CHECK-RV64VC-NEXT:  .LBB910_2:
-; CHECK-RV64VC-NEXT:    sltu a6, a2, t0
-; CHECK-RV64VC-NEXT:    bltu a3, a1, .LBB910_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a3, a1
-; CHECK-RV64VC-NEXT:  .LBB910_4:
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    addi a6, a6, -1
-; CHECK-RV64VC-NEXT:    sub a2, a3, s1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    bltu a3, s1, .LBB910_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a3, s1
-; CHECK-RV64VC-NEXT:  .LBB910_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64VC-NEXT:    and a0, a6, t0
-; CHECK-RV64VC-NEXT:    bltu s0, a7, .LBB910_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv s0, a7
-; CHECK-RV64VC-NEXT:  .LBB910_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64VC-NEXT:    sub a0, s0, a1
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a0
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a2
-; CHECK-RV64VC-NEXT:    sub a2, a0, s1
-; CHECK-RV64VC-NEXT:    sltu a3, a0, a2
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a3
-; CHECK-RV64VC-NEXT:    bltu a0, s1, .LBB910_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:  .LBB910_10:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    slli a3, a3, 1
-; CHECK-RV64VC-NEXT:    add a3, a3, a4
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, a1, .LBB910_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv s0, a1
-; CHECK-RV64VC-NEXT:  .LBB910_12:
-; CHECK-RV64VC-NEXT:    sub a0, s0, s1
-; CHECK-RV64VC-NEXT:    sltu a1, s0, a0
-; CHECK-RV64VC-NEXT:    addi a1, a1, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, s1, .LBB910_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv s0, s1
-; CHECK-RV64VC-NEXT:  .LBB910_14:
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s0, a6
+; CHECK-RV64VC-NEXT:	mv	s2, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	s1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a7, s1, 2
+; CHECK-RV64VC-NEXT:	sub	a1, s0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a3, a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, s1, 1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, a1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	sub	t0, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a5, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s1, .LBB910_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a5, s1
+; CHECK-RV64VC-NEXT:.LBB910_2:
+; CHECK-RV64VC-NEXT:	sltu	a6, a2, t0
+; CHECK-RV64VC-NEXT:	bltu	a3, a1, .LBB910_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a3, a1
+; CHECK-RV64VC-NEXT:.LBB910_4:
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	addi	a6, a6, -1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, s1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	bltu	a3, s1, .LBB910_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a3, s1
+; CHECK-RV64VC-NEXT:.LBB910_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64VC-NEXT:	and	a0, a6, t0
+; CHECK-RV64VC-NEXT:	bltu	s0, a7, .LBB910_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	s0, a7
+; CHECK-RV64VC-NEXT:.LBB910_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64VC-NEXT:	sub	a0, s0, a1
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a2
+; CHECK-RV64VC-NEXT:	sub	a2, a0, s1
+; CHECK-RV64VC-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a3
+; CHECK-RV64VC-NEXT:	bltu	a0, s1, .LBB910_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:.LBB910_10:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 4
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, a1, .LBB910_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	s0, a1
+; CHECK-RV64VC-NEXT:.LBB910_12:
+; CHECK-RV64VC-NEXT:	sub	a0, s0, s1
+; CHECK-RV64VC-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a1, a1, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 5
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, s1, .LBB910_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	s0, s1
+; CHECK-RV64VC-NEXT:.LBB910_14:
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv64i8_P1:
 ; CHECK-RV32VC:       # %bb.0:
@@ -35009,213 +34977,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_P1(<vscale x 64 x 
 define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_PALL(<vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_gather_nxv64i8_PALL:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 4
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64V-NEXT:    mv s0, a6
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s1, vlenb
-; CHECK-RV64V-NEXT:    slli a0, s1, 3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 4
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    addi a0, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s1, 2
-; CHECK-RV64V-NEXT:    sub a1, s0, a2
-; CHECK-RV64V-NEXT:    sltu a3, s0, a1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a3, a3, a1
-; CHECK-RV64V-NEXT:    slli a1, s1, 1
-; CHECK-RV64V-NEXT:    sub a4, a3, a1
-; CHECK-RV64V-NEXT:    sltu a5, a3, a4
-; CHECK-RV64V-NEXT:    addi a5, a5, -1
-; CHECK-RV64V-NEXT:    and a6, a5, a4
-; CHECK-RV64V-NEXT:    sub a4, a6, s1
-; CHECK-RV64V-NEXT:    mv a5, a6
-; CHECK-RV64V-NEXT:    bltu a6, s1, .LBB911_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a5, s1
-; CHECK-RV64V-NEXT:  .LBB911_2:
-; CHECK-RV64V-NEXT:    sltu a7, a6, a4
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB911_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:  .LBB911_4:
-; CHECK-RV64V-NEXT:    add a6, s2, a0
-; CHECK-RV64V-NEXT:    addi a0, a7, -1
-; CHECK-RV64V-NEXT:    sub a7, a3, s1
-; CHECK-RV64V-NEXT:    sltu t0, a3, a7
-; CHECK-RV64V-NEXT:    addi t0, t0, -1
-; CHECK-RV64V-NEXT:    and a7, t0, a7
-; CHECK-RV64V-NEXT:    bltu a3, s1, .LBB911_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:  .LBB911_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a6)
-; CHECK-RV64V-NEXT:    addi a6, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 3
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a7, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64V-NEXT:    and a0, a0, a4
-; CHECK-RV64V-NEXT:    bltu s0, a2, .LBB911_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv s0, a2
-; CHECK-RV64V-NEXT:  .LBB911_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64V-NEXT:    sub a0, s0, a1
-; CHECK-RV64V-NEXT:    sltu a2, s0, a0
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    and a0, a2, a0
-; CHECK-RV64V-NEXT:    sub a2, a0, s1
-; CHECK-RV64V-NEXT:    sltu a3, a0, a2
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a2, a3, a2
-; CHECK-RV64V-NEXT:    bltu a0, s1, .LBB911_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:  .LBB911_10:
-; CHECK-RV64V-NEXT:    csrr a3, vlenb
-; CHECK-RV64V-NEXT:    slli a3, a3, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    slli a3, a3, 1
-; CHECK-RV64V-NEXT:    add a3, a3, a4
-; CHECK-RV64V-NEXT:    add a3, sp, a3
-; CHECK-RV64V-NEXT:    addi a3, a3, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, a1, .LBB911_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv s0, a1
-; CHECK-RV64V-NEXT:  .LBB911_12:
-; CHECK-RV64V-NEXT:    sub a0, s0, s1
-; CHECK-RV64V-NEXT:    sltu a1, s0, a0
-; CHECK-RV64V-NEXT:    addi a1, a1, -1
-; CHECK-RV64V-NEXT:    and a0, a1, a0
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, s1, .LBB911_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv s0, s1
-; CHECK-RV64V-NEXT:  .LBB911_14:
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64V-NEXT:	mv	s0, a6
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	s1, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, s1, 3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 4
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	addi	a0, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s1, 2
+; CHECK-RV64V-NEXT:	sub	a1, s0, a2
+; CHECK-RV64V-NEXT:	sltu	a3, s0, a1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a3, a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, s1, 1
+; CHECK-RV64V-NEXT:	sub	a4, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a5, a3, a4
+; CHECK-RV64V-NEXT:	addi	a5, a5, -1
+; CHECK-RV64V-NEXT:	and	a6, a5, a4
+; CHECK-RV64V-NEXT:	sub	a4, a6, s1
+; CHECK-RV64V-NEXT:	mv	a5, a6
+; CHECK-RV64V-NEXT:	bltu	a6, s1, .LBB911_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a5, s1
+; CHECK-RV64V-NEXT:.LBB911_2:
+; CHECK-RV64V-NEXT:	sltu	a7, a6, a4
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB911_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:.LBB911_4:
+; CHECK-RV64V-NEXT:	add	a6, s2, a0
+; CHECK-RV64V-NEXT:	addi	a0, a7, -1
+; CHECK-RV64V-NEXT:	sub	a7, a3, s1
+; CHECK-RV64V-NEXT:	sltu	t0, a3, a7
+; CHECK-RV64V-NEXT:	addi	t0, t0, -1
+; CHECK-RV64V-NEXT:	and	a7, t0, a7
+; CHECK-RV64V-NEXT:	bltu	a3, s1, .LBB911_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:.LBB911_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a6)
+; CHECK-RV64V-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a7, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 3
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64V-NEXT:	and	a0, a0, a4
+; CHECK-RV64V-NEXT:	bltu	s0, a2, .LBB911_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	s0, a2
+; CHECK-RV64V-NEXT:.LBB911_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64V-NEXT:	sub	a0, s0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	and	a0, a2, a0
+; CHECK-RV64V-NEXT:	sub	a2, a0, s1
+; CHECK-RV64V-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a2, a3, a2
+; CHECK-RV64V-NEXT:	bltu	a0, s1, .LBB911_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:.LBB911_10:
+; CHECK-RV64V-NEXT:	csrr	a3, vlenb
+; CHECK-RV64V-NEXT:	slli	a3, a3, 4
+; CHECK-RV64V-NEXT:	add	a3, sp, a3
+; CHECK-RV64V-NEXT:	addi	a3, a3, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, a1, .LBB911_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	s0, a1
+; CHECK-RV64V-NEXT:.LBB911_12:
+; CHECK-RV64V-NEXT:	sub	a0, s0, s1
+; CHECK-RV64V-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64V-NEXT:	addi	a1, a1, -1
+; CHECK-RV64V-NEXT:	and	a0, a1, a0
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 5
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, s1, .LBB911_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	s0, s1
+; CHECK-RV64V-NEXT:.LBB911_14:
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv64i8_PALL:
 ; CHECK-RV32V:       # %bb.0:
@@ -35283,213 +35235,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_PALL(<vscale x 64 
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv64i8_PALL:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64VC-NEXT:    mv s0, a6
-; CHECK-RV64VC-NEXT:    mv s2, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s1, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, s1, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a7, s1, 2
-; CHECK-RV64VC-NEXT:    sub a1, s0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a3, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, s1, 1
-; CHECK-RV64VC-NEXT:    sub a2, a3, a1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    sub t0, a2, s1
-; CHECK-RV64VC-NEXT:    mv a5, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s1, .LBB911_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a5, s1
-; CHECK-RV64VC-NEXT:  .LBB911_2:
-; CHECK-RV64VC-NEXT:    sltu a6, a2, t0
-; CHECK-RV64VC-NEXT:    bltu a3, a1, .LBB911_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a3, a1
-; CHECK-RV64VC-NEXT:  .LBB911_4:
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    addi a6, a6, -1
-; CHECK-RV64VC-NEXT:    sub a2, a3, s1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    bltu a3, s1, .LBB911_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a3, s1
-; CHECK-RV64VC-NEXT:  .LBB911_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64VC-NEXT:    and a0, a6, t0
-; CHECK-RV64VC-NEXT:    bltu s0, a7, .LBB911_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv s0, a7
-; CHECK-RV64VC-NEXT:  .LBB911_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64VC-NEXT:    sub a0, s0, a1
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a0
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a2
-; CHECK-RV64VC-NEXT:    sub a2, a0, s1
-; CHECK-RV64VC-NEXT:    sltu a3, a0, a2
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a3
-; CHECK-RV64VC-NEXT:    bltu a0, s1, .LBB911_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:  .LBB911_10:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    slli a3, a3, 1
-; CHECK-RV64VC-NEXT:    add a3, a3, a4
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, a1, .LBB911_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv s0, a1
-; CHECK-RV64VC-NEXT:  .LBB911_12:
-; CHECK-RV64VC-NEXT:    sub a0, s0, s1
-; CHECK-RV64VC-NEXT:    sltu a1, s0, a0
-; CHECK-RV64VC-NEXT:    addi a1, a1, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, s1, .LBB911_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv s0, s1
-; CHECK-RV64VC-NEXT:  .LBB911_14:
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s0, a6
+; CHECK-RV64VC-NEXT:	mv	s2, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	s1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a7, s1, 2
+; CHECK-RV64VC-NEXT:	sub	a1, s0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a3, a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, s1, 1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, a1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	sub	t0, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a5, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s1, .LBB911_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a5, s1
+; CHECK-RV64VC-NEXT:.LBB911_2:
+; CHECK-RV64VC-NEXT:	sltu	a6, a2, t0
+; CHECK-RV64VC-NEXT:	bltu	a3, a1, .LBB911_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a3, a1
+; CHECK-RV64VC-NEXT:.LBB911_4:
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	addi	a6, a6, -1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, s1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	bltu	a3, s1, .LBB911_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a3, s1
+; CHECK-RV64VC-NEXT:.LBB911_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64VC-NEXT:	and	a0, a6, t0
+; CHECK-RV64VC-NEXT:	bltu	s0, a7, .LBB911_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	s0, a7
+; CHECK-RV64VC-NEXT:.LBB911_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64VC-NEXT:	sub	a0, s0, a1
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a2
+; CHECK-RV64VC-NEXT:	sub	a2, a0, s1
+; CHECK-RV64VC-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a3
+; CHECK-RV64VC-NEXT:	bltu	a0, s1, .LBB911_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:.LBB911_10:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 4
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, a1, .LBB911_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	s0, a1
+; CHECK-RV64VC-NEXT:.LBB911_12:
+; CHECK-RV64VC-NEXT:	sub	a0, s0, s1
+; CHECK-RV64VC-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a1, a1, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 5
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, s1, .LBB911_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	s0, s1
+; CHECK-RV64VC-NEXT:.LBB911_14:
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv64i8_PALL:
 ; CHECK-RV32VC:       # %bb.0:
@@ -35562,213 +35498,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_PALL(<vscale x 64 
 define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_S1(<vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_gather_nxv64i8_S1:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 4
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64V-NEXT:    mv s0, a6
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s1, vlenb
-; CHECK-RV64V-NEXT:    slli a0, s1, 3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 4
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    addi a0, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s1, 2
-; CHECK-RV64V-NEXT:    sub a1, s0, a2
-; CHECK-RV64V-NEXT:    sltu a3, s0, a1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a3, a3, a1
-; CHECK-RV64V-NEXT:    slli a1, s1, 1
-; CHECK-RV64V-NEXT:    sub a4, a3, a1
-; CHECK-RV64V-NEXT:    sltu a5, a3, a4
-; CHECK-RV64V-NEXT:    addi a5, a5, -1
-; CHECK-RV64V-NEXT:    and a6, a5, a4
-; CHECK-RV64V-NEXT:    sub a4, a6, s1
-; CHECK-RV64V-NEXT:    mv a5, a6
-; CHECK-RV64V-NEXT:    bltu a6, s1, .LBB912_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a5, s1
-; CHECK-RV64V-NEXT:  .LBB912_2:
-; CHECK-RV64V-NEXT:    sltu a7, a6, a4
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB912_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:  .LBB912_4:
-; CHECK-RV64V-NEXT:    add a6, s2, a0
-; CHECK-RV64V-NEXT:    addi a0, a7, -1
-; CHECK-RV64V-NEXT:    sub a7, a3, s1
-; CHECK-RV64V-NEXT:    sltu t0, a3, a7
-; CHECK-RV64V-NEXT:    addi t0, t0, -1
-; CHECK-RV64V-NEXT:    and a7, t0, a7
-; CHECK-RV64V-NEXT:    bltu a3, s1, .LBB912_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:  .LBB912_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a6)
-; CHECK-RV64V-NEXT:    addi a6, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 3
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a7, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64V-NEXT:    and a0, a0, a4
-; CHECK-RV64V-NEXT:    bltu s0, a2, .LBB912_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv s0, a2
-; CHECK-RV64V-NEXT:  .LBB912_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64V-NEXT:    sub a0, s0, a1
-; CHECK-RV64V-NEXT:    sltu a2, s0, a0
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    and a0, a2, a0
-; CHECK-RV64V-NEXT:    sub a2, a0, s1
-; CHECK-RV64V-NEXT:    sltu a3, a0, a2
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a2, a3, a2
-; CHECK-RV64V-NEXT:    bltu a0, s1, .LBB912_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:  .LBB912_10:
-; CHECK-RV64V-NEXT:    csrr a3, vlenb
-; CHECK-RV64V-NEXT:    slli a3, a3, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    slli a3, a3, 1
-; CHECK-RV64V-NEXT:    add a3, a3, a4
-; CHECK-RV64V-NEXT:    add a3, sp, a3
-; CHECK-RV64V-NEXT:    addi a3, a3, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, a1, .LBB912_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv s0, a1
-; CHECK-RV64V-NEXT:  .LBB912_12:
-; CHECK-RV64V-NEXT:    sub a0, s0, s1
-; CHECK-RV64V-NEXT:    sltu a1, s0, a0
-; CHECK-RV64V-NEXT:    addi a1, a1, -1
-; CHECK-RV64V-NEXT:    and a0, a1, a0
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, s1, .LBB912_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv s0, s1
-; CHECK-RV64V-NEXT:  .LBB912_14:
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64V-NEXT:	mv	s0, a6
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	s1, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, s1, 3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 4
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	addi	a0, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s1, 2
+; CHECK-RV64V-NEXT:	sub	a1, s0, a2
+; CHECK-RV64V-NEXT:	sltu	a3, s0, a1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a3, a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, s1, 1
+; CHECK-RV64V-NEXT:	sub	a4, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a5, a3, a4
+; CHECK-RV64V-NEXT:	addi	a5, a5, -1
+; CHECK-RV64V-NEXT:	and	a6, a5, a4
+; CHECK-RV64V-NEXT:	sub	a4, a6, s1
+; CHECK-RV64V-NEXT:	mv	a5, a6
+; CHECK-RV64V-NEXT:	bltu	a6, s1, .LBB912_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a5, s1
+; CHECK-RV64V-NEXT:.LBB912_2:
+; CHECK-RV64V-NEXT:	sltu	a7, a6, a4
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB912_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:.LBB912_4:
+; CHECK-RV64V-NEXT:	add	a6, s2, a0
+; CHECK-RV64V-NEXT:	addi	a0, a7, -1
+; CHECK-RV64V-NEXT:	sub	a7, a3, s1
+; CHECK-RV64V-NEXT:	sltu	t0, a3, a7
+; CHECK-RV64V-NEXT:	addi	t0, t0, -1
+; CHECK-RV64V-NEXT:	and	a7, t0, a7
+; CHECK-RV64V-NEXT:	bltu	a3, s1, .LBB912_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:.LBB912_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a6)
+; CHECK-RV64V-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a7, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 3
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64V-NEXT:	and	a0, a0, a4
+; CHECK-RV64V-NEXT:	bltu	s0, a2, .LBB912_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	s0, a2
+; CHECK-RV64V-NEXT:.LBB912_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64V-NEXT:	sub	a0, s0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	and	a0, a2, a0
+; CHECK-RV64V-NEXT:	sub	a2, a0, s1
+; CHECK-RV64V-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a2, a3, a2
+; CHECK-RV64V-NEXT:	bltu	a0, s1, .LBB912_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:.LBB912_10:
+; CHECK-RV64V-NEXT:	csrr	a3, vlenb
+; CHECK-RV64V-NEXT:	slli	a3, a3, 4
+; CHECK-RV64V-NEXT:	add	a3, sp, a3
+; CHECK-RV64V-NEXT:	addi	a3, a3, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, a1, .LBB912_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	s0, a1
+; CHECK-RV64V-NEXT:.LBB912_12:
+; CHECK-RV64V-NEXT:	sub	a0, s0, s1
+; CHECK-RV64V-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64V-NEXT:	addi	a1, a1, -1
+; CHECK-RV64V-NEXT:	and	a0, a1, a0
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 5
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, s1, .LBB912_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	s0, s1
+; CHECK-RV64V-NEXT:.LBB912_14:
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv64i8_S1:
 ; CHECK-RV32V:       # %bb.0:
@@ -35836,213 +35756,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_S1(<vscale x 64 x 
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv64i8_S1:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64VC-NEXT:    mv s0, a6
-; CHECK-RV64VC-NEXT:    mv s2, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s1, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, s1, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a7, s1, 2
-; CHECK-RV64VC-NEXT:    sub a1, s0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a3, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, s1, 1
-; CHECK-RV64VC-NEXT:    sub a2, a3, a1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    sub t0, a2, s1
-; CHECK-RV64VC-NEXT:    mv a5, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s1, .LBB912_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a5, s1
-; CHECK-RV64VC-NEXT:  .LBB912_2:
-; CHECK-RV64VC-NEXT:    sltu a6, a2, t0
-; CHECK-RV64VC-NEXT:    bltu a3, a1, .LBB912_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a3, a1
-; CHECK-RV64VC-NEXT:  .LBB912_4:
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    addi a6, a6, -1
-; CHECK-RV64VC-NEXT:    sub a2, a3, s1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    bltu a3, s1, .LBB912_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a3, s1
-; CHECK-RV64VC-NEXT:  .LBB912_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64VC-NEXT:    and a0, a6, t0
-; CHECK-RV64VC-NEXT:    bltu s0, a7, .LBB912_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv s0, a7
-; CHECK-RV64VC-NEXT:  .LBB912_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64VC-NEXT:    sub a0, s0, a1
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a0
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a2
-; CHECK-RV64VC-NEXT:    sub a2, a0, s1
-; CHECK-RV64VC-NEXT:    sltu a3, a0, a2
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a3
-; CHECK-RV64VC-NEXT:    bltu a0, s1, .LBB912_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:  .LBB912_10:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    slli a3, a3, 1
-; CHECK-RV64VC-NEXT:    add a3, a3, a4
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, a1, .LBB912_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv s0, a1
-; CHECK-RV64VC-NEXT:  .LBB912_12:
-; CHECK-RV64VC-NEXT:    sub a0, s0, s1
-; CHECK-RV64VC-NEXT:    sltu a1, s0, a0
-; CHECK-RV64VC-NEXT:    addi a1, a1, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, s1, .LBB912_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv s0, s1
-; CHECK-RV64VC-NEXT:  .LBB912_14:
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s0, a6
+; CHECK-RV64VC-NEXT:	mv	s2, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	s1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a7, s1, 2
+; CHECK-RV64VC-NEXT:	sub	a1, s0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a3, a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, s1, 1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, a1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	sub	t0, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a5, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s1, .LBB912_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a5, s1
+; CHECK-RV64VC-NEXT:.LBB912_2:
+; CHECK-RV64VC-NEXT:	sltu	a6, a2, t0
+; CHECK-RV64VC-NEXT:	bltu	a3, a1, .LBB912_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a3, a1
+; CHECK-RV64VC-NEXT:.LBB912_4:
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	addi	a6, a6, -1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, s1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	bltu	a3, s1, .LBB912_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a3, s1
+; CHECK-RV64VC-NEXT:.LBB912_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64VC-NEXT:	and	a0, a6, t0
+; CHECK-RV64VC-NEXT:	bltu	s0, a7, .LBB912_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	s0, a7
+; CHECK-RV64VC-NEXT:.LBB912_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64VC-NEXT:	sub	a0, s0, a1
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a2
+; CHECK-RV64VC-NEXT:	sub	a2, a0, s1
+; CHECK-RV64VC-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a3
+; CHECK-RV64VC-NEXT:	bltu	a0, s1, .LBB912_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:.LBB912_10:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 4
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, a1, .LBB912_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	s0, a1
+; CHECK-RV64VC-NEXT:.LBB912_12:
+; CHECK-RV64VC-NEXT:	sub	a0, s0, s1
+; CHECK-RV64VC-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a1, a1, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 5
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, s1, .LBB912_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	s0, s1
+; CHECK-RV64VC-NEXT:.LBB912_14:
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv64i8_S1:
 ; CHECK-RV32VC:       # %bb.0:
@@ -36115,213 +36019,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_S1(<vscale x 64 x 
 define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_ALL(<vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_gather_nxv64i8_ALL:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 4
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64V-NEXT:    mv s0, a6
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s1, vlenb
-; CHECK-RV64V-NEXT:    slli a0, s1, 3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 4
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    addi a0, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s1, 2
-; CHECK-RV64V-NEXT:    sub a1, s0, a2
-; CHECK-RV64V-NEXT:    sltu a3, s0, a1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a3, a3, a1
-; CHECK-RV64V-NEXT:    slli a1, s1, 1
-; CHECK-RV64V-NEXT:    sub a4, a3, a1
-; CHECK-RV64V-NEXT:    sltu a5, a3, a4
-; CHECK-RV64V-NEXT:    addi a5, a5, -1
-; CHECK-RV64V-NEXT:    and a6, a5, a4
-; CHECK-RV64V-NEXT:    sub a4, a6, s1
-; CHECK-RV64V-NEXT:    mv a5, a6
-; CHECK-RV64V-NEXT:    bltu a6, s1, .LBB913_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a5, s1
-; CHECK-RV64V-NEXT:  .LBB913_2:
-; CHECK-RV64V-NEXT:    sltu a7, a6, a4
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB913_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:  .LBB913_4:
-; CHECK-RV64V-NEXT:    add a6, s2, a0
-; CHECK-RV64V-NEXT:    addi a0, a7, -1
-; CHECK-RV64V-NEXT:    sub a7, a3, s1
-; CHECK-RV64V-NEXT:    sltu t0, a3, a7
-; CHECK-RV64V-NEXT:    addi t0, t0, -1
-; CHECK-RV64V-NEXT:    and a7, t0, a7
-; CHECK-RV64V-NEXT:    bltu a3, s1, .LBB913_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:  .LBB913_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a6)
-; CHECK-RV64V-NEXT:    addi a6, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 3
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a7, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64V-NEXT:    and a0, a0, a4
-; CHECK-RV64V-NEXT:    bltu s0, a2, .LBB913_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv s0, a2
-; CHECK-RV64V-NEXT:  .LBB913_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64V-NEXT:    sub a0, s0, a1
-; CHECK-RV64V-NEXT:    sltu a2, s0, a0
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    and a0, a2, a0
-; CHECK-RV64V-NEXT:    sub a2, a0, s1
-; CHECK-RV64V-NEXT:    sltu a3, a0, a2
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a2, a3, a2
-; CHECK-RV64V-NEXT:    bltu a0, s1, .LBB913_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:  .LBB913_10:
-; CHECK-RV64V-NEXT:    csrr a3, vlenb
-; CHECK-RV64V-NEXT:    slli a3, a3, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    slli a3, a3, 1
-; CHECK-RV64V-NEXT:    add a3, a3, a4
-; CHECK-RV64V-NEXT:    add a3, sp, a3
-; CHECK-RV64V-NEXT:    addi a3, a3, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, a1, .LBB913_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv s0, a1
-; CHECK-RV64V-NEXT:  .LBB913_12:
-; CHECK-RV64V-NEXT:    sub a0, s0, s1
-; CHECK-RV64V-NEXT:    sltu a1, s0, a0
-; CHECK-RV64V-NEXT:    addi a1, a1, -1
-; CHECK-RV64V-NEXT:    and a0, a1, a0
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, s1, .LBB913_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv s0, s1
-; CHECK-RV64V-NEXT:  .LBB913_14:
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64V-NEXT:	mv	s0, a6
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	s1, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, s1, 3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 4
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	addi	a0, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s1, 2
+; CHECK-RV64V-NEXT:	sub	a1, s0, a2
+; CHECK-RV64V-NEXT:	sltu	a3, s0, a1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a3, a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, s1, 1
+; CHECK-RV64V-NEXT:	sub	a4, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a5, a3, a4
+; CHECK-RV64V-NEXT:	addi	a5, a5, -1
+; CHECK-RV64V-NEXT:	and	a6, a5, a4
+; CHECK-RV64V-NEXT:	sub	a4, a6, s1
+; CHECK-RV64V-NEXT:	mv	a5, a6
+; CHECK-RV64V-NEXT:	bltu	a6, s1, .LBB913_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a5, s1
+; CHECK-RV64V-NEXT:.LBB913_2:
+; CHECK-RV64V-NEXT:	sltu	a7, a6, a4
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB913_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:.LBB913_4:
+; CHECK-RV64V-NEXT:	add	a6, s2, a0
+; CHECK-RV64V-NEXT:	addi	a0, a7, -1
+; CHECK-RV64V-NEXT:	sub	a7, a3, s1
+; CHECK-RV64V-NEXT:	sltu	t0, a3, a7
+; CHECK-RV64V-NEXT:	addi	t0, t0, -1
+; CHECK-RV64V-NEXT:	and	a7, t0, a7
+; CHECK-RV64V-NEXT:	bltu	a3, s1, .LBB913_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:.LBB913_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a6)
+; CHECK-RV64V-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a7, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 3
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64V-NEXT:	and	a0, a0, a4
+; CHECK-RV64V-NEXT:	bltu	s0, a2, .LBB913_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	s0, a2
+; CHECK-RV64V-NEXT:.LBB913_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64V-NEXT:	sub	a0, s0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	and	a0, a2, a0
+; CHECK-RV64V-NEXT:	sub	a2, a0, s1
+; CHECK-RV64V-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a2, a3, a2
+; CHECK-RV64V-NEXT:	bltu	a0, s1, .LBB913_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:.LBB913_10:
+; CHECK-RV64V-NEXT:	csrr	a3, vlenb
+; CHECK-RV64V-NEXT:	slli	a3, a3, 4
+; CHECK-RV64V-NEXT:	add	a3, sp, a3
+; CHECK-RV64V-NEXT:	addi	a3, a3, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, a1, .LBB913_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	s0, a1
+; CHECK-RV64V-NEXT:.LBB913_12:
+; CHECK-RV64V-NEXT:	sub	a0, s0, s1
+; CHECK-RV64V-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64V-NEXT:	addi	a1, a1, -1
+; CHECK-RV64V-NEXT:	and	a0, a1, a0
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 5
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, s1, .LBB913_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	s0, s1
+; CHECK-RV64V-NEXT:.LBB913_14:
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv64i8_ALL:
 ; CHECK-RV32V:       # %bb.0:
@@ -36389,213 +36277,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_ALL(<vscale x 64 x
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv64i8_ALL:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64VC-NEXT:    mv s0, a6
-; CHECK-RV64VC-NEXT:    mv s2, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s1, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, s1, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a7, s1, 2
-; CHECK-RV64VC-NEXT:    sub a1, s0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a3, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, s1, 1
-; CHECK-RV64VC-NEXT:    sub a2, a3, a1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    sub t0, a2, s1
-; CHECK-RV64VC-NEXT:    mv a5, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s1, .LBB913_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a5, s1
-; CHECK-RV64VC-NEXT:  .LBB913_2:
-; CHECK-RV64VC-NEXT:    sltu a6, a2, t0
-; CHECK-RV64VC-NEXT:    bltu a3, a1, .LBB913_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a3, a1
-; CHECK-RV64VC-NEXT:  .LBB913_4:
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    addi a6, a6, -1
-; CHECK-RV64VC-NEXT:    sub a2, a3, s1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    bltu a3, s1, .LBB913_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a3, s1
-; CHECK-RV64VC-NEXT:  .LBB913_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64VC-NEXT:    and a0, a6, t0
-; CHECK-RV64VC-NEXT:    bltu s0, a7, .LBB913_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv s0, a7
-; CHECK-RV64VC-NEXT:  .LBB913_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64VC-NEXT:    sub a0, s0, a1
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a0
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a2
-; CHECK-RV64VC-NEXT:    sub a2, a0, s1
-; CHECK-RV64VC-NEXT:    sltu a3, a0, a2
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a3
-; CHECK-RV64VC-NEXT:    bltu a0, s1, .LBB913_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:  .LBB913_10:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    slli a3, a3, 1
-; CHECK-RV64VC-NEXT:    add a3, a3, a4
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, a1, .LBB913_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv s0, a1
-; CHECK-RV64VC-NEXT:  .LBB913_12:
-; CHECK-RV64VC-NEXT:    sub a0, s0, s1
-; CHECK-RV64VC-NEXT:    sltu a1, s0, a0
-; CHECK-RV64VC-NEXT:    addi a1, a1, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, s1, .LBB913_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv s0, s1
-; CHECK-RV64VC-NEXT:  .LBB913_14:
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s0, a6
+; CHECK-RV64VC-NEXT:	mv	s2, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	s1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a7, s1, 2
+; CHECK-RV64VC-NEXT:	sub	a1, s0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a3, a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, s1, 1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, a1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	sub	t0, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a5, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s1, .LBB913_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a5, s1
+; CHECK-RV64VC-NEXT:.LBB913_2:
+; CHECK-RV64VC-NEXT:	sltu	a6, a2, t0
+; CHECK-RV64VC-NEXT:	bltu	a3, a1, .LBB913_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a3, a1
+; CHECK-RV64VC-NEXT:.LBB913_4:
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	addi	a6, a6, -1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, s1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	bltu	a3, s1, .LBB913_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a3, s1
+; CHECK-RV64VC-NEXT:.LBB913_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64VC-NEXT:	and	a0, a6, t0
+; CHECK-RV64VC-NEXT:	bltu	s0, a7, .LBB913_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	s0, a7
+; CHECK-RV64VC-NEXT:.LBB913_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64VC-NEXT:	sub	a0, s0, a1
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a2
+; CHECK-RV64VC-NEXT:	sub	a2, a0, s1
+; CHECK-RV64VC-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a3
+; CHECK-RV64VC-NEXT:	bltu	a0, s1, .LBB913_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:.LBB913_10:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 4
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, a1, .LBB913_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	s0, a1
+; CHECK-RV64VC-NEXT:.LBB913_12:
+; CHECK-RV64VC-NEXT:	sub	a0, s0, s1
+; CHECK-RV64VC-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a1, a1, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 5
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, s1, .LBB913_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	s0, s1
+; CHECK-RV64VC-NEXT:.LBB913_14:
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv64i8_ALL:
 ; CHECK-RV32VC:       # %bb.0:
@@ -36667,213 +36539,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_ALL(<vscale x 64 x
 define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_DEFAULT(<vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_gather_nxv64i8_DEFAULT:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 4
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64V-NEXT:    mv s0, a6
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s1, vlenb
-; CHECK-RV64V-NEXT:    slli a0, s1, 3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 4
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s1, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    addi a0, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s1, 2
-; CHECK-RV64V-NEXT:    sub a1, s0, a2
-; CHECK-RV64V-NEXT:    sltu a3, s0, a1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a3, a3, a1
-; CHECK-RV64V-NEXT:    slli a1, s1, 1
-; CHECK-RV64V-NEXT:    sub a4, a3, a1
-; CHECK-RV64V-NEXT:    sltu a5, a3, a4
-; CHECK-RV64V-NEXT:    addi a5, a5, -1
-; CHECK-RV64V-NEXT:    and a6, a5, a4
-; CHECK-RV64V-NEXT:    sub a4, a6, s1
-; CHECK-RV64V-NEXT:    mv a5, a6
-; CHECK-RV64V-NEXT:    bltu a6, s1, .LBB914_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a5, s1
-; CHECK-RV64V-NEXT:  .LBB914_2:
-; CHECK-RV64V-NEXT:    sltu a7, a6, a4
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB914_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:  .LBB914_4:
-; CHECK-RV64V-NEXT:    add a6, s2, a0
-; CHECK-RV64V-NEXT:    addi a0, a7, -1
-; CHECK-RV64V-NEXT:    sub a7, a3, s1
-; CHECK-RV64V-NEXT:    sltu t0, a3, a7
-; CHECK-RV64V-NEXT:    addi t0, t0, -1
-; CHECK-RV64V-NEXT:    and a7, t0, a7
-; CHECK-RV64V-NEXT:    bltu a3, s1, .LBB914_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:  .LBB914_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a6)
-; CHECK-RV64V-NEXT:    addi a6, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 3
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a7, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64V-NEXT:    and a0, a0, a4
-; CHECK-RV64V-NEXT:    bltu s0, a2, .LBB914_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv s0, a2
-; CHECK-RV64V-NEXT:  .LBB914_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64V-NEXT:    sub a0, s0, a1
-; CHECK-RV64V-NEXT:    sltu a2, s0, a0
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    and a0, a2, a0
-; CHECK-RV64V-NEXT:    sub a2, a0, s1
-; CHECK-RV64V-NEXT:    sltu a3, a0, a2
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a2, a3, a2
-; CHECK-RV64V-NEXT:    bltu a0, s1, .LBB914_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a0, s1
-; CHECK-RV64V-NEXT:  .LBB914_10:
-; CHECK-RV64V-NEXT:    csrr a3, vlenb
-; CHECK-RV64V-NEXT:    slli a3, a3, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    slli a3, a3, 1
-; CHECK-RV64V-NEXT:    add a3, a3, a4
-; CHECK-RV64V-NEXT:    add a3, sp, a3
-; CHECK-RV64V-NEXT:    addi a3, a3, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, a1, .LBB914_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv s0, a1
-; CHECK-RV64V-NEXT:  .LBB914_12:
-; CHECK-RV64V-NEXT:    sub a0, s0, s1
-; CHECK-RV64V-NEXT:    sltu a1, s0, a0
-; CHECK-RV64V-NEXT:    addi a1, a1, -1
-; CHECK-RV64V-NEXT:    and a0, a1, a0
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64V-NEXT:    bltu s0, s1, .LBB914_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv s0, s1
-; CHECK-RV64V-NEXT:  .LBB914_14:
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64V-NEXT:	mv	s0, a6
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	s1, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, s1, 3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 4
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	addi	a0, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s1, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s1, 2
+; CHECK-RV64V-NEXT:	sub	a1, s0, a2
+; CHECK-RV64V-NEXT:	sltu	a3, s0, a1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a3, a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, s1, 1
+; CHECK-RV64V-NEXT:	sub	a4, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a5, a3, a4
+; CHECK-RV64V-NEXT:	addi	a5, a5, -1
+; CHECK-RV64V-NEXT:	and	a6, a5, a4
+; CHECK-RV64V-NEXT:	sub	a4, a6, s1
+; CHECK-RV64V-NEXT:	mv	a5, a6
+; CHECK-RV64V-NEXT:	bltu	a6, s1, .LBB914_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a5, s1
+; CHECK-RV64V-NEXT:.LBB914_2:
+; CHECK-RV64V-NEXT:	sltu	a7, a6, a4
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB914_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:.LBB914_4:
+; CHECK-RV64V-NEXT:	add	a6, s2, a0
+; CHECK-RV64V-NEXT:	addi	a0, a7, -1
+; CHECK-RV64V-NEXT:	sub	a7, a3, s1
+; CHECK-RV64V-NEXT:	sltu	t0, a3, a7
+; CHECK-RV64V-NEXT:	addi	t0, t0, -1
+; CHECK-RV64V-NEXT:	and	a7, t0, a7
+; CHECK-RV64V-NEXT:	bltu	a3, s1, .LBB914_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:.LBB914_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (a6)
+; CHECK-RV64V-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a7, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 3
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64V-NEXT:	and	a0, a0, a4
+; CHECK-RV64V-NEXT:	bltu	s0, a2, .LBB914_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	s0, a2
+; CHECK-RV64V-NEXT:.LBB914_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64V-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64V-NEXT:	sub	a0, s0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	and	a0, a2, a0
+; CHECK-RV64V-NEXT:	sub	a2, a0, s1
+; CHECK-RV64V-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a2, a3, a2
+; CHECK-RV64V-NEXT:	bltu	a0, s1, .LBB914_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a0, s1
+; CHECK-RV64V-NEXT:.LBB914_10:
+; CHECK-RV64V-NEXT:	csrr	a3, vlenb
+; CHECK-RV64V-NEXT:	slli	a3, a3, 4
+; CHECK-RV64V-NEXT:	add	a3, sp, a3
+; CHECK-RV64V-NEXT:	addi	a3, a3, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, a1, .LBB914_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	s0, a1
+; CHECK-RV64V-NEXT:.LBB914_12:
+; CHECK-RV64V-NEXT:	sub	a0, s0, s1
+; CHECK-RV64V-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64V-NEXT:	addi	a1, a1, -1
+; CHECK-RV64V-NEXT:	and	a0, a1, a0
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 5
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64V-NEXT:	bltu	s0, s1, .LBB914_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	s0, s1
+; CHECK-RV64V-NEXT:.LBB914_14:
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv64i8_DEFAULT:
 ; CHECK-RV32V:       # %bb.0:
@@ -36941,213 +36797,197 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_DEFAULT(<vscale x 
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv64i8_DEFAULT:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
-; CHECK-RV64VC-NEXT:    mv s0, a6
-; CHECK-RV64VC-NEXT:    mv s2, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s1, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, s1, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s1, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a7, s1, 2
-; CHECK-RV64VC-NEXT:    sub a1, s0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a3, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, s1, 1
-; CHECK-RV64VC-NEXT:    sub a2, a3, a1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    sub t0, a2, s1
-; CHECK-RV64VC-NEXT:    mv a5, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s1, .LBB914_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a5, s1
-; CHECK-RV64VC-NEXT:  .LBB914_2:
-; CHECK-RV64VC-NEXT:    sltu a6, a2, t0
-; CHECK-RV64VC-NEXT:    bltu a3, a1, .LBB914_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a3, a1
-; CHECK-RV64VC-NEXT:  .LBB914_4:
-; CHECK-RV64VC-NEXT:    add a0, a0, s2
-; CHECK-RV64VC-NEXT:    addi a6, a6, -1
-; CHECK-RV64VC-NEXT:    sub a2, a3, s1
-; CHECK-RV64VC-NEXT:    sltu a4, a3, a2
-; CHECK-RV64VC-NEXT:    addi a4, a4, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a4
-; CHECK-RV64VC-NEXT:    bltu a3, s1, .LBB914_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a3, s1
-; CHECK-RV64VC-NEXT:  .LBB914_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a0)
-; CHECK-RV64VC-NEXT:    addi a0, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a5, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v14, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v13, (zero), v24
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v24
-; CHECK-RV64VC-NEXT:    and a0, a6, t0
-; CHECK-RV64VC-NEXT:    bltu s0, a7, .LBB914_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv s0, a7
-; CHECK-RV64VC-NEXT:  .LBB914_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v15, (zero), v16
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (s2)
-; CHECK-RV64VC-NEXT:    sub a0, s0, a1
-; CHECK-RV64VC-NEXT:    sltu a2, s0, a0
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a2
-; CHECK-RV64VC-NEXT:    sub a2, a0, s1
-; CHECK-RV64VC-NEXT:    sltu a3, a0, a2
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a3
-; CHECK-RV64VC-NEXT:    bltu a0, s1, .LBB914_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a0, s1
-; CHECK-RV64VC-NEXT:  .LBB914_10:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    slli a3, a3, 1
-; CHECK-RV64VC-NEXT:    add a3, a3, a4
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v11, (zero), v24
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, a1, .LBB914_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv s0, a1
-; CHECK-RV64VC-NEXT:  .LBB914_12:
-; CHECK-RV64VC-NEXT:    sub a0, s0, s1
-; CHECK-RV64VC-NEXT:    sltu a1, s0, a0
-; CHECK-RV64VC-NEXT:    addi a1, a1, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v16
-; CHECK-RV64VC-NEXT:    bltu s0, s1, .LBB914_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv s0, s1
-; CHECK-RV64VC-NEXT:  .LBB914_14:
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, s0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v16
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x28, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 40 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s0, a6
+; CHECK-RV64VC-NEXT:	mv	s2, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	s1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s1, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	vl8re64.v	v24, (a0)
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a7, s1, 2
+; CHECK-RV64VC-NEXT:	sub	a1, s0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a3, a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, s1, 1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, a1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	sub	t0, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a5, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s1, .LBB914_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a5, s1
+; CHECK-RV64VC-NEXT:.LBB914_2:
+; CHECK-RV64VC-NEXT:	sltu	a6, a2, t0
+; CHECK-RV64VC-NEXT:	bltu	a3, a1, .LBB914_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a3, a1
+; CHECK-RV64VC-NEXT:.LBB914_4:
+; CHECK-RV64VC-NEXT:	add	a0, a0, s2
+; CHECK-RV64VC-NEXT:	addi	a6, a6, -1
+; CHECK-RV64VC-NEXT:	sub	a2, a3, s1
+; CHECK-RV64VC-NEXT:	sltu	a4, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a4, a4, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a4
+; CHECK-RV64VC-NEXT:	bltu	a3, s1, .LBB914_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a3, s1
+; CHECK-RV64VC-NEXT:.LBB914_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (a0)
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a5, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v14, (zero), v24
+; CHECK-RV64VC-NEXT:	addi	a0, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v13, (zero), v24
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v12, (zero), v24
+; CHECK-RV64VC-NEXT:	and	a0, a6, t0
+; CHECK-RV64VC-NEXT:	bltu	s0, a7, .LBB914_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	s0, a7
+; CHECK-RV64VC-NEXT:.LBB914_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v15, (zero), v16
+; CHECK-RV64VC-NEXT:	vl8re64.v	v16, (s2)
+; CHECK-RV64VC-NEXT:	sub	a0, s0, a1
+; CHECK-RV64VC-NEXT:	sltu	a2, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a2
+; CHECK-RV64VC-NEXT:	sub	a2, a0, s1
+; CHECK-RV64VC-NEXT:	sltu	a3, a0, a2
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a3
+; CHECK-RV64VC-NEXT:	bltu	a0, s1, .LBB914_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a0, s1
+; CHECK-RV64VC-NEXT:.LBB914_10:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 4
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v24, (a3)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v11, (zero), v24
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v10, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, a1, .LBB914_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	s0, a1
+; CHECK-RV64VC-NEXT:.LBB914_12:
+; CHECK-RV64VC-NEXT:	sub	a0, s0, s1
+; CHECK-RV64VC-NEXT:	sltu	a1, s0, a0
+; CHECK-RV64VC-NEXT:	addi	a1, a1, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 5
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v9, (zero), v16
+; CHECK-RV64VC-NEXT:	bltu	s0, s1, .LBB914_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	s0, s1
+; CHECK-RV64VC-NEXT:.LBB914_14:
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a0)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, s0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vluxei64.v	v8, (zero), v16
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv64i8_DEFAULT:
 ; CHECK-RV32VC:       # %bb.0:
@@ -37220,244 +37060,226 @@ define <vscale x 64 x i8> @test_nontemporal_vp_gather_nxv64i8_DEFAULT(<vscale x 
 define void @test_nontemporal_vp_scatter_nxv64i8_P1(<vscale x 64 x i8> %val, <vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_scatter_nxv64i8_P1:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a2, a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64V-NEXT:    mv s1, a7
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s0, vlenb
-; CHECK-RV64V-NEXT:    li a1, 48
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s0, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s0, 2
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:    bltu s1, a2, .LBB915_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:  .LBB915_2:
-; CHECK-RV64V-NEXT:    slli a5, s0, 4
-; CHECK-RV64V-NEXT:    slli a1, s0, 1
-; CHECK-RV64V-NEXT:    slli a6, s0, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB915_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a4, a1
-; CHECK-RV64V-NEXT:  .LBB915_4:
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (s2)
-; CHECK-RV64V-NEXT:    add a7, s2, a0
-; CHECK-RV64V-NEXT:    add a5, s2, a5
-; CHECK-RV64V-NEXT:    add a6, s2, a6
-; CHECK-RV64V-NEXT:    mv a0, a4
-; CHECK-RV64V-NEXT:    bltu a4, s0, .LBB915_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:  .LBB915_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a7)
-; CHECK-RV64V-NEXT:    csrr a7, vlenb
-; CHECK-RV64V-NEXT:    slli a7, a7, 3
-; CHECK-RV64V-NEXT:    add a7, sp, a7
-; CHECK-RV64V-NEXT:    addi a7, a7, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a7) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64V-NEXT:    addi a5, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v0, (a6)
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    mv a6, a5
-; CHECK-RV64V-NEXT:    slli a5, a5, 1
-; CHECK-RV64V-NEXT:    add a5, a5, a6
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64V-NEXT:    sub a0, a4, s0
-; CHECK-RV64V-NEXT:    sub a5, a3, a1
-; CHECK-RV64V-NEXT:    sltu a4, a4, a0
-; CHECK-RV64V-NEXT:    sltu a3, a3, a5
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a4, a4, a0
-; CHECK-RV64V-NEXT:    and a0, a3, a5
-; CHECK-RV64V-NEXT:    vsetvli zero, a4, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64V-NEXT:    mv a3, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB915_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB915_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64V-NEXT:    sub a3, a0, s0
-; CHECK-RV64V-NEXT:    sub a2, s1, a2
-; CHECK-RV64V-NEXT:    sltu a0, a0, a3
-; CHECK-RV64V-NEXT:    sltu a4, s1, a2
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    and a3, a0, a3
-; CHECK-RV64V-NEXT:    and a0, a4, a2
-; CHECK-RV64V-NEXT:    addi a2, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64V-NEXT:    mv a2, a0
-; CHECK-RV64V-NEXT:    bltu a0, a1, .LBB915_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:  .LBB915_10:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:    bltu a2, s0, .LBB915_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB915_12:
-; CHECK-RV64V-NEXT:    csrr a4, vlenb
-; CHECK-RV64V-NEXT:    slli a4, a4, 3
-; CHECK-RV64V-NEXT:    add a4, sp, a4
-; CHECK-RV64V-NEXT:    addi a4, a4, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a4) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64V-NEXT:    sub a3, a2, s0
-; CHECK-RV64V-NEXT:    sub a1, a0, a1
-; CHECK-RV64V-NEXT:    sltu a2, a2, a3
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a2, a2, a3
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a3
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB915_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv a1, s0
-; CHECK-RV64V-NEXT:  .LBB915_14:
-; CHECK-RV64V-NEXT:    csrr a2, vlenb
-; CHECK-RV64V-NEXT:    slli a2, a2, 5
-; CHECK-RV64V-NEXT:    add a2, sp, a2
-; CHECK-RV64V-NEXT:    addi a2, a2, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64V-NEXT:    sub a1, a0, s0
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 4
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64V-NEXT:	mv	s1, a7
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64V-NEXT:	csrr	s0, vlenb
+; CHECK-RV64V-NEXT:	li	a1, 48
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s0, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s0, 2
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:	bltu	s1, a2, .LBB915_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:.LBB915_2:
+; CHECK-RV64V-NEXT:	slli	a5, s0, 4
+; CHECK-RV64V-NEXT:	slli	a1, s0, 1
+; CHECK-RV64V-NEXT:	slli	a6, s0, 3
+; CHECK-RV64V-NEXT:	mv	a4, a3
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB915_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a4, a1
+; CHECK-RV64V-NEXT:.LBB915_4:
+; CHECK-RV64V-NEXT:	vl8re64.v	v0, (s2)
+; CHECK-RV64V-NEXT:	add	a7, s2, a0
+; CHECK-RV64V-NEXT:	add	a5, s2, a5
+; CHECK-RV64V-NEXT:	add	a6, s2, a6
+; CHECK-RV64V-NEXT:	mv	a0, a4
+; CHECK-RV64V-NEXT:	bltu	a4, s0, .LBB915_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:.LBB915_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a7)
+; CHECK-RV64V-NEXT:	csrr	a7, vlenb
+; CHECK-RV64V-NEXT:	slli	a7, a7, 3
+; CHECK-RV64V-NEXT:	add	a7, sp, a7
+; CHECK-RV64V-NEXT:	addi	a7, a7, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a7)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a6)
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 4
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64V-NEXT:	sub	a0, a4, s0
+; CHECK-RV64V-NEXT:	sub	a5, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a4, a4, a0
+; CHECK-RV64V-NEXT:	sltu	a3, a3, a5
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a4, a4, a0
+; CHECK-RV64V-NEXT:	and	a0, a3, a5
+; CHECK-RV64V-NEXT:	vsetvli	zero, a4, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64V-NEXT:	mv	a3, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB915_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB915_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a0, s0
+; CHECK-RV64V-NEXT:	sub	a2, s1, a2
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64V-NEXT:	sltu	a4, s1, a2
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	and	a3, a0, a3
+; CHECK-RV64V-NEXT:	and	a0, a4, a2
+; CHECK-RV64V-NEXT:	addi	a2, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a2, a0
+; CHECK-RV64V-NEXT:	bltu	a0, a1, .LBB915_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:.LBB915_10:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:	bltu	a2, s0, .LBB915_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB915_12:
+; CHECK-RV64V-NEXT:	csrr	a4, vlenb
+; CHECK-RV64V-NEXT:	slli	a4, a4, 3
+; CHECK-RV64V-NEXT:	add	a4, sp, a4
+; CHECK-RV64V-NEXT:	addi	a4, a4, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a4)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a2, s0
+; CHECK-RV64V-NEXT:	sub	a1, a0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, a2, a3
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a2, a2, a3
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a3
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB915_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	a1, s0
+; CHECK-RV64V-NEXT:.LBB915_14:
+; CHECK-RV64V-NEXT:	csrr	a2, vlenb
+; CHECK-RV64V-NEXT:	slli	a2, a2, 5
+; CHECK-RV64V-NEXT:	add	a2, sp, a2
+; CHECK-RV64V-NEXT:	addi	a2, a2, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a1, a0, s0
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.p1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_scatter_nxv64i8_P1:
 ; CHECK-RV32V:       # %bb.0:
@@ -37530,244 +37352,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_P1(<vscale x 64 x i8> %val, <vs
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_P1:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64VC-NEXT:    mv s2, a7
-; CHECK-RV64VC-NEXT:    mv s1, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s0, vlenb
-; CHECK-RV64VC-NEXT:    li a1, 48
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a6, s0, 2
-; CHECK-RV64VC-NEXT:    mv a3, s2
-; CHECK-RV64VC-NEXT:    bltu s2, a6, .LBB915_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a3, a6
-; CHECK-RV64VC-NEXT:  .LBB915_2:
-; CHECK-RV64VC-NEXT:    slli a5, s0, 4
-; CHECK-RV64VC-NEXT:    slli a7, s0, 1
-; CHECK-RV64VC-NEXT:    slli a2, s0, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    bltu a3, a7, .LBB915_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a4, a7
-; CHECK-RV64VC-NEXT:  .LBB915_4:
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (s1)
-; CHECK-RV64VC-NEXT:    add a1, s1, a0
-; CHECK-RV64VC-NEXT:    add a5, a5, s1
-; CHECK-RV64VC-NEXT:    add a2, a2, s1
-; CHECK-RV64VC-NEXT:    mv a0, a4
-; CHECK-RV64VC-NEXT:    bltu a4, s0, .LBB915_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:  .LBB915_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a1)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64VC-NEXT:    addi a1, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v0, (a2)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64VC-NEXT:    sub a0, a4, s0
-; CHECK-RV64VC-NEXT:    sub a1, a3, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a4, a0
-; CHECK-RV64VC-NEXT:    sltu a3, a3, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a1
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB915_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB915_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sub a2, s2, a6
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    sltu a3, s2, a2
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a2
-; CHECK-RV64VC-NEXT:    addi a2, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a2, a0
-; CHECK-RV64VC-NEXT:    bltu a0, a7, .LBB915_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a2, a7
-; CHECK-RV64VC-NEXT:  .LBB915_10:
-; CHECK-RV64VC-NEXT:    mv a1, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s0, .LBB915_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB915_12:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a2, s0
-; CHECK-RV64VC-NEXT:    sub a3, a0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a2, a1
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a3
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a2
-; CHECK-RV64VC-NEXT:    and a0, a0, a3
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 3
-; CHECK-RV64VC-NEXT:    mv a3, a2
-; CHECK-RV64VC-NEXT:    slli a2, a2, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a3
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB915_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB915_14:
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 5
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 1
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s2, a7
+; CHECK-RV64VC-NEXT:	mv	s1, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64VC-NEXT:	csrr	s0, vlenb
+; CHECK-RV64VC-NEXT:	li	a1, 48
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a6, s0, 2
+; CHECK-RV64VC-NEXT:	mv	a3, s2
+; CHECK-RV64VC-NEXT:	bltu	s2, a6, .LBB915_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a3, a6
+; CHECK-RV64VC-NEXT:.LBB915_2:
+; CHECK-RV64VC-NEXT:	slli	a5, s0, 4
+; CHECK-RV64VC-NEXT:	slli	a7, s0, 1
+; CHECK-RV64VC-NEXT:	slli	a2, s0, 3
+; CHECK-RV64VC-NEXT:	mv	a4, a3
+; CHECK-RV64VC-NEXT:	bltu	a3, a7, .LBB915_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a4, a7
+; CHECK-RV64VC-NEXT:.LBB915_4:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v0, (s1)
+; CHECK-RV64VC-NEXT:	add	a1, s1, a0
+; CHECK-RV64VC-NEXT:	add	a5, a5, s1
+; CHECK-RV64VC-NEXT:	add	a2, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a0, a4
+; CHECK-RV64VC-NEXT:	bltu	a4, s0, .LBB915_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:.LBB915_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a1)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64VC-NEXT:	addi	a1, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a2)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64VC-NEXT:	sub	a0, a4, s0
+; CHECK-RV64VC-NEXT:	sub	a1, a3, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a4, a0
+; CHECK-RV64VC-NEXT:	sltu	a3, a3, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a1
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB915_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB915_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sub	a2, s2, a6
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	sltu	a3, s2, a2
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a2, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a2, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, a7, .LBB915_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a2, a7
+; CHECK-RV64VC-NEXT:.LBB915_10:
+; CHECK-RV64VC-NEXT:	mv	a1, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s0, .LBB915_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB915_12:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 3
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a3)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a2, s0
+; CHECK-RV64VC-NEXT:	sub	a3, a0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a2, a1
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a2
+; CHECK-RV64VC-NEXT:	and	a0, a0, a3
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 3
+; CHECK-RV64VC-NEXT:	mv	a3, a2
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 1
+; CHECK-RV64VC-NEXT:	add	a2, a2, a3
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB915_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB915_14:
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 5
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.p1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_P1:
 ; CHECK-RV32VC:       # %bb.0:
@@ -37845,244 +37649,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_P1(<vscale x 64 x i8> %val, <vs
 define void @test_nontemporal_vp_scatter_nxv64i8_PALL(<vscale x 64 x i8> %val, <vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_scatter_nxv64i8_PALL:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a2, a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64V-NEXT:    mv s1, a7
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s0, vlenb
-; CHECK-RV64V-NEXT:    li a1, 48
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s0, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s0, 2
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:    bltu s1, a2, .LBB916_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:  .LBB916_2:
-; CHECK-RV64V-NEXT:    slli a5, s0, 4
-; CHECK-RV64V-NEXT:    slli a1, s0, 1
-; CHECK-RV64V-NEXT:    slli a6, s0, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB916_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a4, a1
-; CHECK-RV64V-NEXT:  .LBB916_4:
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (s2)
-; CHECK-RV64V-NEXT:    add a7, s2, a0
-; CHECK-RV64V-NEXT:    add a5, s2, a5
-; CHECK-RV64V-NEXT:    add a6, s2, a6
-; CHECK-RV64V-NEXT:    mv a0, a4
-; CHECK-RV64V-NEXT:    bltu a4, s0, .LBB916_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:  .LBB916_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a7)
-; CHECK-RV64V-NEXT:    csrr a7, vlenb
-; CHECK-RV64V-NEXT:    slli a7, a7, 3
-; CHECK-RV64V-NEXT:    add a7, sp, a7
-; CHECK-RV64V-NEXT:    addi a7, a7, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a7) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64V-NEXT:    addi a5, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v0, (a6)
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    mv a6, a5
-; CHECK-RV64V-NEXT:    slli a5, a5, 1
-; CHECK-RV64V-NEXT:    add a5, a5, a6
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64V-NEXT:    sub a0, a4, s0
-; CHECK-RV64V-NEXT:    sub a5, a3, a1
-; CHECK-RV64V-NEXT:    sltu a4, a4, a0
-; CHECK-RV64V-NEXT:    sltu a3, a3, a5
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a4, a4, a0
-; CHECK-RV64V-NEXT:    and a0, a3, a5
-; CHECK-RV64V-NEXT:    vsetvli zero, a4, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64V-NEXT:    mv a3, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB916_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB916_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64V-NEXT:    sub a3, a0, s0
-; CHECK-RV64V-NEXT:    sub a2, s1, a2
-; CHECK-RV64V-NEXT:    sltu a0, a0, a3
-; CHECK-RV64V-NEXT:    sltu a4, s1, a2
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    and a3, a0, a3
-; CHECK-RV64V-NEXT:    and a0, a4, a2
-; CHECK-RV64V-NEXT:    addi a2, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64V-NEXT:    mv a2, a0
-; CHECK-RV64V-NEXT:    bltu a0, a1, .LBB916_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:  .LBB916_10:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:    bltu a2, s0, .LBB916_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB916_12:
-; CHECK-RV64V-NEXT:    csrr a4, vlenb
-; CHECK-RV64V-NEXT:    slli a4, a4, 3
-; CHECK-RV64V-NEXT:    add a4, sp, a4
-; CHECK-RV64V-NEXT:    addi a4, a4, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a4) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64V-NEXT:    sub a3, a2, s0
-; CHECK-RV64V-NEXT:    sub a1, a0, a1
-; CHECK-RV64V-NEXT:    sltu a2, a2, a3
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a2, a2, a3
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a3
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB916_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv a1, s0
-; CHECK-RV64V-NEXT:  .LBB916_14:
-; CHECK-RV64V-NEXT:    csrr a2, vlenb
-; CHECK-RV64V-NEXT:    slli a2, a2, 5
-; CHECK-RV64V-NEXT:    add a2, sp, a2
-; CHECK-RV64V-NEXT:    addi a2, a2, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64V-NEXT:    sub a1, a0, s0
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 4
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64V-NEXT:	mv	s1, a7
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64V-NEXT:	csrr	s0, vlenb
+; CHECK-RV64V-NEXT:	li	a1, 48
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s0, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s0, 2
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:	bltu	s1, a2, .LBB916_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:.LBB916_2:
+; CHECK-RV64V-NEXT:	slli	a5, s0, 4
+; CHECK-RV64V-NEXT:	slli	a1, s0, 1
+; CHECK-RV64V-NEXT:	slli	a6, s0, 3
+; CHECK-RV64V-NEXT:	mv	a4, a3
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB916_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a4, a1
+; CHECK-RV64V-NEXT:.LBB916_4:
+; CHECK-RV64V-NEXT:	vl8re64.v	v0, (s2)
+; CHECK-RV64V-NEXT:	add	a7, s2, a0
+; CHECK-RV64V-NEXT:	add	a5, s2, a5
+; CHECK-RV64V-NEXT:	add	a6, s2, a6
+; CHECK-RV64V-NEXT:	mv	a0, a4
+; CHECK-RV64V-NEXT:	bltu	a4, s0, .LBB916_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:.LBB916_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a7)
+; CHECK-RV64V-NEXT:	csrr	a7, vlenb
+; CHECK-RV64V-NEXT:	slli	a7, a7, 3
+; CHECK-RV64V-NEXT:	add	a7, sp, a7
+; CHECK-RV64V-NEXT:	addi	a7, a7, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a7)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a6)
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 4
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64V-NEXT:	sub	a0, a4, s0
+; CHECK-RV64V-NEXT:	sub	a5, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a4, a4, a0
+; CHECK-RV64V-NEXT:	sltu	a3, a3, a5
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a4, a4, a0
+; CHECK-RV64V-NEXT:	and	a0, a3, a5
+; CHECK-RV64V-NEXT:	vsetvli	zero, a4, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64V-NEXT:	mv	a3, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB916_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB916_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a0, s0
+; CHECK-RV64V-NEXT:	sub	a2, s1, a2
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64V-NEXT:	sltu	a4, s1, a2
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	and	a3, a0, a3
+; CHECK-RV64V-NEXT:	and	a0, a4, a2
+; CHECK-RV64V-NEXT:	addi	a2, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a2, a0
+; CHECK-RV64V-NEXT:	bltu	a0, a1, .LBB916_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:.LBB916_10:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:	bltu	a2, s0, .LBB916_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB916_12:
+; CHECK-RV64V-NEXT:	csrr	a4, vlenb
+; CHECK-RV64V-NEXT:	slli	a4, a4, 3
+; CHECK-RV64V-NEXT:	add	a4, sp, a4
+; CHECK-RV64V-NEXT:	addi	a4, a4, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a4)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a2, s0
+; CHECK-RV64V-NEXT:	sub	a1, a0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, a2, a3
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a2, a2, a3
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a3
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB916_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	a1, s0
+; CHECK-RV64V-NEXT:.LBB916_14:
+; CHECK-RV64V-NEXT:	csrr	a2, vlenb
+; CHECK-RV64V-NEXT:	slli	a2, a2, 5
+; CHECK-RV64V-NEXT:	add	a2, sp, a2
+; CHECK-RV64V-NEXT:	addi	a2, a2, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a1, a0, s0
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.pall
+; CHECK-RV64V-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_scatter_nxv64i8_PALL:
 ; CHECK-RV32V:       # %bb.0:
@@ -38155,244 +37941,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_PALL(<vscale x 64 x i8> %val, <
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_PALL:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64VC-NEXT:    mv s2, a7
-; CHECK-RV64VC-NEXT:    mv s1, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s0, vlenb
-; CHECK-RV64VC-NEXT:    li a1, 48
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a6, s0, 2
-; CHECK-RV64VC-NEXT:    mv a3, s2
-; CHECK-RV64VC-NEXT:    bltu s2, a6, .LBB916_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a3, a6
-; CHECK-RV64VC-NEXT:  .LBB916_2:
-; CHECK-RV64VC-NEXT:    slli a5, s0, 4
-; CHECK-RV64VC-NEXT:    slli a7, s0, 1
-; CHECK-RV64VC-NEXT:    slli a2, s0, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    bltu a3, a7, .LBB916_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a4, a7
-; CHECK-RV64VC-NEXT:  .LBB916_4:
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (s1)
-; CHECK-RV64VC-NEXT:    add a1, s1, a0
-; CHECK-RV64VC-NEXT:    add a5, a5, s1
-; CHECK-RV64VC-NEXT:    add a2, a2, s1
-; CHECK-RV64VC-NEXT:    mv a0, a4
-; CHECK-RV64VC-NEXT:    bltu a4, s0, .LBB916_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:  .LBB916_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a1)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64VC-NEXT:    addi a1, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v0, (a2)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64VC-NEXT:    sub a0, a4, s0
-; CHECK-RV64VC-NEXT:    sub a1, a3, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a4, a0
-; CHECK-RV64VC-NEXT:    sltu a3, a3, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a1
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB916_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB916_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sub a2, s2, a6
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    sltu a3, s2, a2
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a2
-; CHECK-RV64VC-NEXT:    addi a2, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a2, a0
-; CHECK-RV64VC-NEXT:    bltu a0, a7, .LBB916_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a2, a7
-; CHECK-RV64VC-NEXT:  .LBB916_10:
-; CHECK-RV64VC-NEXT:    mv a1, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s0, .LBB916_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB916_12:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a2, s0
-; CHECK-RV64VC-NEXT:    sub a3, a0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a2, a1
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a3
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a2
-; CHECK-RV64VC-NEXT:    and a0, a0, a3
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 3
-; CHECK-RV64VC-NEXT:    mv a3, a2
-; CHECK-RV64VC-NEXT:    slli a2, a2, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a3
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB916_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB916_14:
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 5
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 1
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s2, a7
+; CHECK-RV64VC-NEXT:	mv	s1, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64VC-NEXT:	csrr	s0, vlenb
+; CHECK-RV64VC-NEXT:	li	a1, 48
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a6, s0, 2
+; CHECK-RV64VC-NEXT:	mv	a3, s2
+; CHECK-RV64VC-NEXT:	bltu	s2, a6, .LBB916_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a3, a6
+; CHECK-RV64VC-NEXT:.LBB916_2:
+; CHECK-RV64VC-NEXT:	slli	a5, s0, 4
+; CHECK-RV64VC-NEXT:	slli	a7, s0, 1
+; CHECK-RV64VC-NEXT:	slli	a2, s0, 3
+; CHECK-RV64VC-NEXT:	mv	a4, a3
+; CHECK-RV64VC-NEXT:	bltu	a3, a7, .LBB916_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a4, a7
+; CHECK-RV64VC-NEXT:.LBB916_4:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v0, (s1)
+; CHECK-RV64VC-NEXT:	add	a1, s1, a0
+; CHECK-RV64VC-NEXT:	add	a5, a5, s1
+; CHECK-RV64VC-NEXT:	add	a2, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a0, a4
+; CHECK-RV64VC-NEXT:	bltu	a4, s0, .LBB916_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:.LBB916_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a1)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64VC-NEXT:	addi	a1, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a2)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64VC-NEXT:	sub	a0, a4, s0
+; CHECK-RV64VC-NEXT:	sub	a1, a3, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a4, a0
+; CHECK-RV64VC-NEXT:	sltu	a3, a3, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a1
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB916_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB916_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sub	a2, s2, a6
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	sltu	a3, s2, a2
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a2, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a2, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, a7, .LBB916_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a2, a7
+; CHECK-RV64VC-NEXT:.LBB916_10:
+; CHECK-RV64VC-NEXT:	mv	a1, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s0, .LBB916_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB916_12:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 3
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a3)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a2, s0
+; CHECK-RV64VC-NEXT:	sub	a3, a0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a2, a1
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a2
+; CHECK-RV64VC-NEXT:	and	a0, a0, a3
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 3
+; CHECK-RV64VC-NEXT:	mv	a3, a2
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 1
+; CHECK-RV64VC-NEXT:	add	a2, a2, a3
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB916_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB916_14:
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 5
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.pall
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_PALL:
 ; CHECK-RV32VC:       # %bb.0:
@@ -38470,244 +38238,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_PALL(<vscale x 64 x i8> %val, <
 define void @test_nontemporal_vp_scatter_nxv64i8_S1(<vscale x 64 x i8> %val, <vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_scatter_nxv64i8_S1:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a2, a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64V-NEXT:    mv s1, a7
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s0, vlenb
-; CHECK-RV64V-NEXT:    li a1, 48
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s0, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s0, 2
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:    bltu s1, a2, .LBB917_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:  .LBB917_2:
-; CHECK-RV64V-NEXT:    slli a5, s0, 4
-; CHECK-RV64V-NEXT:    slli a1, s0, 1
-; CHECK-RV64V-NEXT:    slli a6, s0, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB917_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a4, a1
-; CHECK-RV64V-NEXT:  .LBB917_4:
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (s2)
-; CHECK-RV64V-NEXT:    add a7, s2, a0
-; CHECK-RV64V-NEXT:    add a5, s2, a5
-; CHECK-RV64V-NEXT:    add a6, s2, a6
-; CHECK-RV64V-NEXT:    mv a0, a4
-; CHECK-RV64V-NEXT:    bltu a4, s0, .LBB917_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:  .LBB917_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a7)
-; CHECK-RV64V-NEXT:    csrr a7, vlenb
-; CHECK-RV64V-NEXT:    slli a7, a7, 3
-; CHECK-RV64V-NEXT:    add a7, sp, a7
-; CHECK-RV64V-NEXT:    addi a7, a7, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a7) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64V-NEXT:    addi a5, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v0, (a6)
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    mv a6, a5
-; CHECK-RV64V-NEXT:    slli a5, a5, 1
-; CHECK-RV64V-NEXT:    add a5, a5, a6
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64V-NEXT:    sub a0, a4, s0
-; CHECK-RV64V-NEXT:    sub a5, a3, a1
-; CHECK-RV64V-NEXT:    sltu a4, a4, a0
-; CHECK-RV64V-NEXT:    sltu a3, a3, a5
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a4, a4, a0
-; CHECK-RV64V-NEXT:    and a0, a3, a5
-; CHECK-RV64V-NEXT:    vsetvli zero, a4, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64V-NEXT:    mv a3, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB917_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB917_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64V-NEXT:    sub a3, a0, s0
-; CHECK-RV64V-NEXT:    sub a2, s1, a2
-; CHECK-RV64V-NEXT:    sltu a0, a0, a3
-; CHECK-RV64V-NEXT:    sltu a4, s1, a2
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    and a3, a0, a3
-; CHECK-RV64V-NEXT:    and a0, a4, a2
-; CHECK-RV64V-NEXT:    addi a2, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64V-NEXT:    mv a2, a0
-; CHECK-RV64V-NEXT:    bltu a0, a1, .LBB917_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:  .LBB917_10:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:    bltu a2, s0, .LBB917_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB917_12:
-; CHECK-RV64V-NEXT:    csrr a4, vlenb
-; CHECK-RV64V-NEXT:    slli a4, a4, 3
-; CHECK-RV64V-NEXT:    add a4, sp, a4
-; CHECK-RV64V-NEXT:    addi a4, a4, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a4) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64V-NEXT:    sub a3, a2, s0
-; CHECK-RV64V-NEXT:    sub a1, a0, a1
-; CHECK-RV64V-NEXT:    sltu a2, a2, a3
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a2, a2, a3
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a3
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB917_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv a1, s0
-; CHECK-RV64V-NEXT:  .LBB917_14:
-; CHECK-RV64V-NEXT:    csrr a2, vlenb
-; CHECK-RV64V-NEXT:    slli a2, a2, 5
-; CHECK-RV64V-NEXT:    add a2, sp, a2
-; CHECK-RV64V-NEXT:    addi a2, a2, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64V-NEXT:    sub a1, a0, s0
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 4
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64V-NEXT:	mv	s1, a7
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64V-NEXT:	csrr	s0, vlenb
+; CHECK-RV64V-NEXT:	li	a1, 48
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s0, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s0, 2
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:	bltu	s1, a2, .LBB917_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:.LBB917_2:
+; CHECK-RV64V-NEXT:	slli	a5, s0, 4
+; CHECK-RV64V-NEXT:	slli	a1, s0, 1
+; CHECK-RV64V-NEXT:	slli	a6, s0, 3
+; CHECK-RV64V-NEXT:	mv	a4, a3
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB917_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a4, a1
+; CHECK-RV64V-NEXT:.LBB917_4:
+; CHECK-RV64V-NEXT:	vl8re64.v	v0, (s2)
+; CHECK-RV64V-NEXT:	add	a7, s2, a0
+; CHECK-RV64V-NEXT:	add	a5, s2, a5
+; CHECK-RV64V-NEXT:	add	a6, s2, a6
+; CHECK-RV64V-NEXT:	mv	a0, a4
+; CHECK-RV64V-NEXT:	bltu	a4, s0, .LBB917_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:.LBB917_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a7)
+; CHECK-RV64V-NEXT:	csrr	a7, vlenb
+; CHECK-RV64V-NEXT:	slli	a7, a7, 3
+; CHECK-RV64V-NEXT:	add	a7, sp, a7
+; CHECK-RV64V-NEXT:	addi	a7, a7, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a7)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a6)
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 4
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64V-NEXT:	sub	a0, a4, s0
+; CHECK-RV64V-NEXT:	sub	a5, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a4, a4, a0
+; CHECK-RV64V-NEXT:	sltu	a3, a3, a5
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a4, a4, a0
+; CHECK-RV64V-NEXT:	and	a0, a3, a5
+; CHECK-RV64V-NEXT:	vsetvli	zero, a4, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64V-NEXT:	mv	a3, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB917_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB917_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a0, s0
+; CHECK-RV64V-NEXT:	sub	a2, s1, a2
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64V-NEXT:	sltu	a4, s1, a2
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	and	a3, a0, a3
+; CHECK-RV64V-NEXT:	and	a0, a4, a2
+; CHECK-RV64V-NEXT:	addi	a2, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a2, a0
+; CHECK-RV64V-NEXT:	bltu	a0, a1, .LBB917_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:.LBB917_10:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:	bltu	a2, s0, .LBB917_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB917_12:
+; CHECK-RV64V-NEXT:	csrr	a4, vlenb
+; CHECK-RV64V-NEXT:	slli	a4, a4, 3
+; CHECK-RV64V-NEXT:	add	a4, sp, a4
+; CHECK-RV64V-NEXT:	addi	a4, a4, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a4)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a2, s0
+; CHECK-RV64V-NEXT:	sub	a1, a0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, a2, a3
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a2, a2, a3
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a3
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB917_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	a1, s0
+; CHECK-RV64V-NEXT:.LBB917_14:
+; CHECK-RV64V-NEXT:	csrr	a2, vlenb
+; CHECK-RV64V-NEXT:	slli	a2, a2, 5
+; CHECK-RV64V-NEXT:	add	a2, sp, a2
+; CHECK-RV64V-NEXT:	addi	a2, a2, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a1, a0, s0
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.s1
+; CHECK-RV64V-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_scatter_nxv64i8_S1:
 ; CHECK-RV32V:       # %bb.0:
@@ -38780,244 +38530,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_S1(<vscale x 64 x i8> %val, <vs
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_S1:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64VC-NEXT:    mv s2, a7
-; CHECK-RV64VC-NEXT:    mv s1, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s0, vlenb
-; CHECK-RV64VC-NEXT:    li a1, 48
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a6, s0, 2
-; CHECK-RV64VC-NEXT:    mv a3, s2
-; CHECK-RV64VC-NEXT:    bltu s2, a6, .LBB917_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a3, a6
-; CHECK-RV64VC-NEXT:  .LBB917_2:
-; CHECK-RV64VC-NEXT:    slli a5, s0, 4
-; CHECK-RV64VC-NEXT:    slli a7, s0, 1
-; CHECK-RV64VC-NEXT:    slli a2, s0, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    bltu a3, a7, .LBB917_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a4, a7
-; CHECK-RV64VC-NEXT:  .LBB917_4:
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (s1)
-; CHECK-RV64VC-NEXT:    add a1, s1, a0
-; CHECK-RV64VC-NEXT:    add a5, a5, s1
-; CHECK-RV64VC-NEXT:    add a2, a2, s1
-; CHECK-RV64VC-NEXT:    mv a0, a4
-; CHECK-RV64VC-NEXT:    bltu a4, s0, .LBB917_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:  .LBB917_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a1)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64VC-NEXT:    addi a1, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v0, (a2)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64VC-NEXT:    sub a0, a4, s0
-; CHECK-RV64VC-NEXT:    sub a1, a3, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a4, a0
-; CHECK-RV64VC-NEXT:    sltu a3, a3, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a1
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB917_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB917_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sub a2, s2, a6
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    sltu a3, s2, a2
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a2
-; CHECK-RV64VC-NEXT:    addi a2, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a2, a0
-; CHECK-RV64VC-NEXT:    bltu a0, a7, .LBB917_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a2, a7
-; CHECK-RV64VC-NEXT:  .LBB917_10:
-; CHECK-RV64VC-NEXT:    mv a1, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s0, .LBB917_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB917_12:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a2, s0
-; CHECK-RV64VC-NEXT:    sub a3, a0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a2, a1
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a3
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a2
-; CHECK-RV64VC-NEXT:    and a0, a0, a3
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 3
-; CHECK-RV64VC-NEXT:    mv a3, a2
-; CHECK-RV64VC-NEXT:    slli a2, a2, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a3
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB917_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB917_14:
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 5
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 1
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s2, a7
+; CHECK-RV64VC-NEXT:	mv	s1, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64VC-NEXT:	csrr	s0, vlenb
+; CHECK-RV64VC-NEXT:	li	a1, 48
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a6, s0, 2
+; CHECK-RV64VC-NEXT:	mv	a3, s2
+; CHECK-RV64VC-NEXT:	bltu	s2, a6, .LBB917_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a3, a6
+; CHECK-RV64VC-NEXT:.LBB917_2:
+; CHECK-RV64VC-NEXT:	slli	a5, s0, 4
+; CHECK-RV64VC-NEXT:	slli	a7, s0, 1
+; CHECK-RV64VC-NEXT:	slli	a2, s0, 3
+; CHECK-RV64VC-NEXT:	mv	a4, a3
+; CHECK-RV64VC-NEXT:	bltu	a3, a7, .LBB917_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a4, a7
+; CHECK-RV64VC-NEXT:.LBB917_4:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v0, (s1)
+; CHECK-RV64VC-NEXT:	add	a1, s1, a0
+; CHECK-RV64VC-NEXT:	add	a5, a5, s1
+; CHECK-RV64VC-NEXT:	add	a2, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a0, a4
+; CHECK-RV64VC-NEXT:	bltu	a4, s0, .LBB917_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:.LBB917_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a1)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64VC-NEXT:	addi	a1, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a2)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64VC-NEXT:	sub	a0, a4, s0
+; CHECK-RV64VC-NEXT:	sub	a1, a3, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a4, a0
+; CHECK-RV64VC-NEXT:	sltu	a3, a3, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a1
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB917_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB917_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sub	a2, s2, a6
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	sltu	a3, s2, a2
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a2, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a2, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, a7, .LBB917_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a2, a7
+; CHECK-RV64VC-NEXT:.LBB917_10:
+; CHECK-RV64VC-NEXT:	mv	a1, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s0, .LBB917_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB917_12:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 3
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a3)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a2, s0
+; CHECK-RV64VC-NEXT:	sub	a3, a0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a2, a1
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a2
+; CHECK-RV64VC-NEXT:	and	a0, a0, a3
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 3
+; CHECK-RV64VC-NEXT:	mv	a3, a2
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 1
+; CHECK-RV64VC-NEXT:	add	a2, a2, a3
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB917_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB917_14:
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 5
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.s1
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_S1:
 ; CHECK-RV32VC:       # %bb.0:
@@ -39095,244 +38827,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_S1(<vscale x 64 x i8> %val, <vs
 define void @test_nontemporal_vp_scatter_nxv64i8_ALL(<vscale x 64 x i8> %val, <vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_scatter_nxv64i8_ALL:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a2, a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64V-NEXT:    mv s1, a7
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s0, vlenb
-; CHECK-RV64V-NEXT:    li a1, 48
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s0, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s0, 2
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:    bltu s1, a2, .LBB918_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:  .LBB918_2:
-; CHECK-RV64V-NEXT:    slli a5, s0, 4
-; CHECK-RV64V-NEXT:    slli a1, s0, 1
-; CHECK-RV64V-NEXT:    slli a6, s0, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB918_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a4, a1
-; CHECK-RV64V-NEXT:  .LBB918_4:
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (s2)
-; CHECK-RV64V-NEXT:    add a7, s2, a0
-; CHECK-RV64V-NEXT:    add a5, s2, a5
-; CHECK-RV64V-NEXT:    add a6, s2, a6
-; CHECK-RV64V-NEXT:    mv a0, a4
-; CHECK-RV64V-NEXT:    bltu a4, s0, .LBB918_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:  .LBB918_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a7)
-; CHECK-RV64V-NEXT:    csrr a7, vlenb
-; CHECK-RV64V-NEXT:    slli a7, a7, 3
-; CHECK-RV64V-NEXT:    add a7, sp, a7
-; CHECK-RV64V-NEXT:    addi a7, a7, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a7) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64V-NEXT:    addi a5, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v0, (a6)
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    mv a6, a5
-; CHECK-RV64V-NEXT:    slli a5, a5, 1
-; CHECK-RV64V-NEXT:    add a5, a5, a6
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64V-NEXT:    sub a0, a4, s0
-; CHECK-RV64V-NEXT:    sub a5, a3, a1
-; CHECK-RV64V-NEXT:    sltu a4, a4, a0
-; CHECK-RV64V-NEXT:    sltu a3, a3, a5
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a4, a4, a0
-; CHECK-RV64V-NEXT:    and a0, a3, a5
-; CHECK-RV64V-NEXT:    vsetvli zero, a4, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64V-NEXT:    mv a3, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB918_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB918_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64V-NEXT:    sub a3, a0, s0
-; CHECK-RV64V-NEXT:    sub a2, s1, a2
-; CHECK-RV64V-NEXT:    sltu a0, a0, a3
-; CHECK-RV64V-NEXT:    sltu a4, s1, a2
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    and a3, a0, a3
-; CHECK-RV64V-NEXT:    and a0, a4, a2
-; CHECK-RV64V-NEXT:    addi a2, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64V-NEXT:    mv a2, a0
-; CHECK-RV64V-NEXT:    bltu a0, a1, .LBB918_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:  .LBB918_10:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:    bltu a2, s0, .LBB918_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB918_12:
-; CHECK-RV64V-NEXT:    csrr a4, vlenb
-; CHECK-RV64V-NEXT:    slli a4, a4, 3
-; CHECK-RV64V-NEXT:    add a4, sp, a4
-; CHECK-RV64V-NEXT:    addi a4, a4, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a4) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64V-NEXT:    sub a3, a2, s0
-; CHECK-RV64V-NEXT:    sub a1, a0, a1
-; CHECK-RV64V-NEXT:    sltu a2, a2, a3
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a2, a2, a3
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a3
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB918_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv a1, s0
-; CHECK-RV64V-NEXT:  .LBB918_14:
-; CHECK-RV64V-NEXT:    csrr a2, vlenb
-; CHECK-RV64V-NEXT:    slli a2, a2, 5
-; CHECK-RV64V-NEXT:    add a2, sp, a2
-; CHECK-RV64V-NEXT:    addi a2, a2, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64V-NEXT:    sub a1, a0, s0
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 4
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64V-NEXT:	mv	s1, a7
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64V-NEXT:	csrr	s0, vlenb
+; CHECK-RV64V-NEXT:	li	a1, 48
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s0, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s0, 2
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:	bltu	s1, a2, .LBB918_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:.LBB918_2:
+; CHECK-RV64V-NEXT:	slli	a5, s0, 4
+; CHECK-RV64V-NEXT:	slli	a1, s0, 1
+; CHECK-RV64V-NEXT:	slli	a6, s0, 3
+; CHECK-RV64V-NEXT:	mv	a4, a3
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB918_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a4, a1
+; CHECK-RV64V-NEXT:.LBB918_4:
+; CHECK-RV64V-NEXT:	vl8re64.v	v0, (s2)
+; CHECK-RV64V-NEXT:	add	a7, s2, a0
+; CHECK-RV64V-NEXT:	add	a5, s2, a5
+; CHECK-RV64V-NEXT:	add	a6, s2, a6
+; CHECK-RV64V-NEXT:	mv	a0, a4
+; CHECK-RV64V-NEXT:	bltu	a4, s0, .LBB918_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:.LBB918_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a7)
+; CHECK-RV64V-NEXT:	csrr	a7, vlenb
+; CHECK-RV64V-NEXT:	slli	a7, a7, 3
+; CHECK-RV64V-NEXT:	add	a7, sp, a7
+; CHECK-RV64V-NEXT:	addi	a7, a7, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a7)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a6)
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 4
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64V-NEXT:	sub	a0, a4, s0
+; CHECK-RV64V-NEXT:	sub	a5, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a4, a4, a0
+; CHECK-RV64V-NEXT:	sltu	a3, a3, a5
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a4, a4, a0
+; CHECK-RV64V-NEXT:	and	a0, a3, a5
+; CHECK-RV64V-NEXT:	vsetvli	zero, a4, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64V-NEXT:	mv	a3, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB918_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB918_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a0, s0
+; CHECK-RV64V-NEXT:	sub	a2, s1, a2
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64V-NEXT:	sltu	a4, s1, a2
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	and	a3, a0, a3
+; CHECK-RV64V-NEXT:	and	a0, a4, a2
+; CHECK-RV64V-NEXT:	addi	a2, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a2, a0
+; CHECK-RV64V-NEXT:	bltu	a0, a1, .LBB918_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:.LBB918_10:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:	bltu	a2, s0, .LBB918_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB918_12:
+; CHECK-RV64V-NEXT:	csrr	a4, vlenb
+; CHECK-RV64V-NEXT:	slli	a4, a4, 3
+; CHECK-RV64V-NEXT:	add	a4, sp, a4
+; CHECK-RV64V-NEXT:	addi	a4, a4, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a4)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a2, s0
+; CHECK-RV64V-NEXT:	sub	a1, a0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, a2, a3
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a2, a2, a3
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a3
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB918_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	a1, s0
+; CHECK-RV64V-NEXT:.LBB918_14:
+; CHECK-RV64V-NEXT:	csrr	a2, vlenb
+; CHECK-RV64V-NEXT:	slli	a2, a2, 5
+; CHECK-RV64V-NEXT:	add	a2, sp, a2
+; CHECK-RV64V-NEXT:	addi	a2, a2, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a1, a0, s0
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_scatter_nxv64i8_ALL:
 ; CHECK-RV32V:       # %bb.0:
@@ -39405,244 +39119,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_ALL(<vscale x 64 x i8> %val, <v
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_ALL:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64VC-NEXT:    mv s2, a7
-; CHECK-RV64VC-NEXT:    mv s1, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s0, vlenb
-; CHECK-RV64VC-NEXT:    li a1, 48
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a6, s0, 2
-; CHECK-RV64VC-NEXT:    mv a3, s2
-; CHECK-RV64VC-NEXT:    bltu s2, a6, .LBB918_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a3, a6
-; CHECK-RV64VC-NEXT:  .LBB918_2:
-; CHECK-RV64VC-NEXT:    slli a5, s0, 4
-; CHECK-RV64VC-NEXT:    slli a7, s0, 1
-; CHECK-RV64VC-NEXT:    slli a2, s0, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    bltu a3, a7, .LBB918_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a4, a7
-; CHECK-RV64VC-NEXT:  .LBB918_4:
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (s1)
-; CHECK-RV64VC-NEXT:    add a1, s1, a0
-; CHECK-RV64VC-NEXT:    add a5, a5, s1
-; CHECK-RV64VC-NEXT:    add a2, a2, s1
-; CHECK-RV64VC-NEXT:    mv a0, a4
-; CHECK-RV64VC-NEXT:    bltu a4, s0, .LBB918_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:  .LBB918_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a1)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64VC-NEXT:    addi a1, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v0, (a2)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64VC-NEXT:    sub a0, a4, s0
-; CHECK-RV64VC-NEXT:    sub a1, a3, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a4, a0
-; CHECK-RV64VC-NEXT:    sltu a3, a3, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a1
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB918_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB918_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sub a2, s2, a6
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    sltu a3, s2, a2
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a2
-; CHECK-RV64VC-NEXT:    addi a2, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a2, a0
-; CHECK-RV64VC-NEXT:    bltu a0, a7, .LBB918_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a2, a7
-; CHECK-RV64VC-NEXT:  .LBB918_10:
-; CHECK-RV64VC-NEXT:    mv a1, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s0, .LBB918_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB918_12:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a2, s0
-; CHECK-RV64VC-NEXT:    sub a3, a0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a2, a1
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a3
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a2
-; CHECK-RV64VC-NEXT:    and a0, a0, a3
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 3
-; CHECK-RV64VC-NEXT:    mv a3, a2
-; CHECK-RV64VC-NEXT:    slli a2, a2, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a3
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB918_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB918_14:
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 5
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 1
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s2, a7
+; CHECK-RV64VC-NEXT:	mv	s1, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64VC-NEXT:	csrr	s0, vlenb
+; CHECK-RV64VC-NEXT:	li	a1, 48
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a6, s0, 2
+; CHECK-RV64VC-NEXT:	mv	a3, s2
+; CHECK-RV64VC-NEXT:	bltu	s2, a6, .LBB918_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a3, a6
+; CHECK-RV64VC-NEXT:.LBB918_2:
+; CHECK-RV64VC-NEXT:	slli	a5, s0, 4
+; CHECK-RV64VC-NEXT:	slli	a7, s0, 1
+; CHECK-RV64VC-NEXT:	slli	a2, s0, 3
+; CHECK-RV64VC-NEXT:	mv	a4, a3
+; CHECK-RV64VC-NEXT:	bltu	a3, a7, .LBB918_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a4, a7
+; CHECK-RV64VC-NEXT:.LBB918_4:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v0, (s1)
+; CHECK-RV64VC-NEXT:	add	a1, s1, a0
+; CHECK-RV64VC-NEXT:	add	a5, a5, s1
+; CHECK-RV64VC-NEXT:	add	a2, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a0, a4
+; CHECK-RV64VC-NEXT:	bltu	a4, s0, .LBB918_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:.LBB918_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a1)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64VC-NEXT:	addi	a1, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a2)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64VC-NEXT:	sub	a0, a4, s0
+; CHECK-RV64VC-NEXT:	sub	a1, a3, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a4, a0
+; CHECK-RV64VC-NEXT:	sltu	a3, a3, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a1
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB918_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB918_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sub	a2, s2, a6
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	sltu	a3, s2, a2
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a2, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a2, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, a7, .LBB918_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a2, a7
+; CHECK-RV64VC-NEXT:.LBB918_10:
+; CHECK-RV64VC-NEXT:	mv	a1, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s0, .LBB918_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB918_12:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 3
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a3)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a2, s0
+; CHECK-RV64VC-NEXT:	sub	a3, a0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a2, a1
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a2
+; CHECK-RV64VC-NEXT:	and	a0, a0, a3
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 3
+; CHECK-RV64VC-NEXT:	mv	a3, a2
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 1
+; CHECK-RV64VC-NEXT:	add	a2, a2, a3
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB918_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB918_14:
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 5
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_ALL:
 ; CHECK-RV32VC:       # %bb.0:
@@ -39719,244 +39415,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_ALL(<vscale x 64 x i8> %val, <v
 define void @test_nontemporal_vp_scatter_nxv64i8_DEFAULT(<vscale x 64 x i8> %val, <vscale x 64 x ptr> %ptrs, i32 zeroext %vl) {
 ; CHECK-RV64V-LABEL: test_nontemporal_vp_scatter_nxv64i8_DEFAULT:
 ; CHECK-RV64V:       # %bb.0:
-; CHECK-RV64V-NEXT:    addi sp, sp, -48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64V-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64V-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64V-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64V-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64V-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a2, a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    sub sp, sp, a1
-; CHECK-RV64V-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64V-NEXT:    mv s1, a7
-; CHECK-RV64V-NEXT:    mv s2, a0
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 4
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    csrr s0, vlenb
-; CHECK-RV64V-NEXT:    li a1, 48
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 2
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 40
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 5
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    slli a0, s0, 5
-; CHECK-RV64V-NEXT:    add a0, s2, a0
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add a0, sp, a0
-; CHECK-RV64V-NEXT:    addi a0, a0, 16
-; CHECK-RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    li a1, 24
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:    call __muldi3
-; CHECK-RV64V-NEXT:    slli a2, s0, 2
-; CHECK-RV64V-NEXT:    mv a3, s1
-; CHECK-RV64V-NEXT:    bltu s1, a2, .LBB919_2
-; CHECK-RV64V-NEXT:  # %bb.1:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:  .LBB919_2:
-; CHECK-RV64V-NEXT:    slli a5, s0, 4
-; CHECK-RV64V-NEXT:    slli a1, s0, 1
-; CHECK-RV64V-NEXT:    slli a6, s0, 3
-; CHECK-RV64V-NEXT:    mv a4, a3
-; CHECK-RV64V-NEXT:    bltu a3, a1, .LBB919_4
-; CHECK-RV64V-NEXT:  # %bb.3:
-; CHECK-RV64V-NEXT:    mv a4, a1
-; CHECK-RV64V-NEXT:  .LBB919_4:
-; CHECK-RV64V-NEXT:    vl8re64.v v8, (s2)
-; CHECK-RV64V-NEXT:    add a7, s2, a0
-; CHECK-RV64V-NEXT:    add a5, s2, a5
-; CHECK-RV64V-NEXT:    add a6, s2, a6
-; CHECK-RV64V-NEXT:    mv a0, a4
-; CHECK-RV64V-NEXT:    bltu a4, s0, .LBB919_6
-; CHECK-RV64V-NEXT:  # %bb.5:
-; CHECK-RV64V-NEXT:    mv a0, s0
-; CHECK-RV64V-NEXT:  .LBB919_6:
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a7)
-; CHECK-RV64V-NEXT:    csrr a7, vlenb
-; CHECK-RV64V-NEXT:    slli a7, a7, 3
-; CHECK-RV64V-NEXT:    add a7, sp, a7
-; CHECK-RV64V-NEXT:    addi a7, a7, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a7) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64V-NEXT:    addi a5, sp, 16
-; CHECK-RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
-; CHECK-RV64V-NEXT:    vl8re64.v v0, (a6)
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    mv a6, a5
-; CHECK-RV64V-NEXT:    slli a5, a5, 1
-; CHECK-RV64V-NEXT:    add a5, a5, a6
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    csrr a5, vlenb
-; CHECK-RV64V-NEXT:    slli a5, a5, 4
-; CHECK-RV64V-NEXT:    add a5, sp, a5
-; CHECK-RV64V-NEXT:    addi a5, a5, 16
-; CHECK-RV64V-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64V-NEXT:    sub a0, a4, s0
-; CHECK-RV64V-NEXT:    sub a5, a3, a1
-; CHECK-RV64V-NEXT:    sltu a4, a4, a0
-; CHECK-RV64V-NEXT:    sltu a3, a3, a5
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    addi a3, a3, -1
-; CHECK-RV64V-NEXT:    and a4, a4, a0
-; CHECK-RV64V-NEXT:    and a0, a3, a5
-; CHECK-RV64V-NEXT:    vsetvli zero, a4, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64V-NEXT:    mv a3, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB919_8
-; CHECK-RV64V-NEXT:  # %bb.7:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB919_8:
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64V-NEXT:    sub a3, a0, s0
-; CHECK-RV64V-NEXT:    sub a2, s1, a2
-; CHECK-RV64V-NEXT:    sltu a0, a0, a3
-; CHECK-RV64V-NEXT:    sltu a4, s1, a2
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    addi a4, a4, -1
-; CHECK-RV64V-NEXT:    and a3, a0, a3
-; CHECK-RV64V-NEXT:    and a0, a4, a2
-; CHECK-RV64V-NEXT:    addi a2, sp, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64V-NEXT:    mv a2, a0
-; CHECK-RV64V-NEXT:    bltu a0, a1, .LBB919_10
-; CHECK-RV64V-NEXT:  # %bb.9:
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:  .LBB919_10:
-; CHECK-RV64V-NEXT:    mv a3, a2
-; CHECK-RV64V-NEXT:    bltu a2, s0, .LBB919_12
-; CHECK-RV64V-NEXT:  # %bb.11:
-; CHECK-RV64V-NEXT:    mv a3, s0
-; CHECK-RV64V-NEXT:  .LBB919_12:
-; CHECK-RV64V-NEXT:    csrr a4, vlenb
-; CHECK-RV64V-NEXT:    slli a4, a4, 3
-; CHECK-RV64V-NEXT:    add a4, sp, a4
-; CHECK-RV64V-NEXT:    addi a4, a4, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a4) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64V-NEXT:    sub a3, a2, s0
-; CHECK-RV64V-NEXT:    sub a1, a0, a1
-; CHECK-RV64V-NEXT:    sltu a2, a2, a3
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a2, a2, -1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a2, a2, a3
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a3, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a3
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    bltu a0, s0, .LBB919_14
-; CHECK-RV64V-NEXT:  # %bb.13:
-; CHECK-RV64V-NEXT:    mv a1, s0
-; CHECK-RV64V-NEXT:  .LBB919_14:
-; CHECK-RV64V-NEXT:    csrr a2, vlenb
-; CHECK-RV64V-NEXT:    slli a2, a2, 5
-; CHECK-RV64V-NEXT:    add a2, sp, a2
-; CHECK-RV64V-NEXT:    addi a2, a2, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64V-NEXT:    sub a1, a0, s0
-; CHECK-RV64V-NEXT:    sltu a0, a0, a1
-; CHECK-RV64V-NEXT:    addi a0, a0, -1
-; CHECK-RV64V-NEXT:    and a0, a0, a1
-; CHECK-RV64V-NEXT:    csrr a1, vlenb
-; CHECK-RV64V-NEXT:    slli a1, a1, 3
-; CHECK-RV64V-NEXT:    mv a2, a1
-; CHECK-RV64V-NEXT:    slli a1, a1, 2
-; CHECK-RV64V-NEXT:    add a1, a1, a2
-; CHECK-RV64V-NEXT:    add a1, sp, a1
-; CHECK-RV64V-NEXT:    addi a1, a1, 16
-; CHECK-RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64V-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64V-NEXT:    csrr a0, vlenb
-; CHECK-RV64V-NEXT:    slli a0, a0, 3
-; CHECK-RV64V-NEXT:    mv a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a1, a1, a0
-; CHECK-RV64V-NEXT:    slli a0, a0, 1
-; CHECK-RV64V-NEXT:    add a0, a0, a1
-; CHECK-RV64V-NEXT:    add sp, sp, a0
-; CHECK-RV64V-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64V-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64V-NEXT:    .cfi_restore ra
-; CHECK-RV64V-NEXT:    .cfi_restore s0
-; CHECK-RV64V-NEXT:    .cfi_restore s1
-; CHECK-RV64V-NEXT:    .cfi_restore s2
-; CHECK-RV64V-NEXT:    addi sp, sp, 48
-; CHECK-RV64V-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64V-NEXT:    ret
+; CHECK-RV64V-NEXT:	addi	sp, sp, -48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64V-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64V-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64V-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64V-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64V-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 4
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	sub	sp, sp, a1
+; CHECK-RV64V-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64V-NEXT:	mv	s1, a7
+; CHECK-RV64V-NEXT:	mv	s2, a0
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64V-NEXT:	csrr	s0, vlenb
+; CHECK-RV64V-NEXT:	li	a1, 48
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 2
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 40
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 5
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	slli	a0, s0, 5
+; CHECK-RV64V-NEXT:	add	a0, s2, a0
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 3
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	a0, sp, a0
+; CHECK-RV64V-NEXT:	addi	a0, a0, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	li	a1, 24
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:	call	__muldi3
+; CHECK-RV64V-NEXT:	slli	a2, s0, 2
+; CHECK-RV64V-NEXT:	mv	a3, s1
+; CHECK-RV64V-NEXT:	bltu	s1, a2, .LBB919_2
+; CHECK-RV64V-NEXT:# %bb.1:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:.LBB919_2:
+; CHECK-RV64V-NEXT:	slli	a5, s0, 4
+; CHECK-RV64V-NEXT:	slli	a1, s0, 1
+; CHECK-RV64V-NEXT:	slli	a6, s0, 3
+; CHECK-RV64V-NEXT:	mv	a4, a3
+; CHECK-RV64V-NEXT:	bltu	a3, a1, .LBB919_4
+; CHECK-RV64V-NEXT:# %bb.3:
+; CHECK-RV64V-NEXT:	mv	a4, a1
+; CHECK-RV64V-NEXT:.LBB919_4:
+; CHECK-RV64V-NEXT:	vl8re64.v	v0, (s2)
+; CHECK-RV64V-NEXT:	add	a7, s2, a0
+; CHECK-RV64V-NEXT:	add	a5, s2, a5
+; CHECK-RV64V-NEXT:	add	a6, s2, a6
+; CHECK-RV64V-NEXT:	mv	a0, a4
+; CHECK-RV64V-NEXT:	bltu	a4, s0, .LBB919_6
+; CHECK-RV64V-NEXT:# %bb.5:
+; CHECK-RV64V-NEXT:	mv	a0, s0
+; CHECK-RV64V-NEXT:.LBB919_6:
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a7)
+; CHECK-RV64V-NEXT:	csrr	a7, vlenb
+; CHECK-RV64V-NEXT:	slli	a7, a7, 3
+; CHECK-RV64V-NEXT:	add	a7, sp, a7
+; CHECK-RV64V-NEXT:	addi	a7, a7, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a7)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64V-NEXT:	addi	a5, sp, 16
+; CHECK-RV64V-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64V-NEXT:	vl8re64.v	v8, (a6)
+; CHECK-RV64V-NEXT:	csrr	a5, vlenb
+; CHECK-RV64V-NEXT:	slli	a5, a5, 4
+; CHECK-RV64V-NEXT:	add	a5, sp, a5
+; CHECK-RV64V-NEXT:	addi	a5, a5, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64V-NEXT:	sub	a0, a4, s0
+; CHECK-RV64V-NEXT:	sub	a5, a3, a1
+; CHECK-RV64V-NEXT:	sltu	a4, a4, a0
+; CHECK-RV64V-NEXT:	sltu	a3, a3, a5
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	addi	a3, a3, -1
+; CHECK-RV64V-NEXT:	and	a4, a4, a0
+; CHECK-RV64V-NEXT:	and	a0, a3, a5
+; CHECK-RV64V-NEXT:	vsetvli	zero, a4, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64V-NEXT:	mv	a3, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB919_8
+; CHECK-RV64V-NEXT:# %bb.7:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB919_8:
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a0, s0
+; CHECK-RV64V-NEXT:	sub	a2, s1, a2
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64V-NEXT:	sltu	a4, s1, a2
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	addi	a4, a4, -1
+; CHECK-RV64V-NEXT:	and	a3, a0, a3
+; CHECK-RV64V-NEXT:	and	a0, a4, a2
+; CHECK-RV64V-NEXT:	addi	a2, sp, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a2, a0
+; CHECK-RV64V-NEXT:	bltu	a0, a1, .LBB919_10
+; CHECK-RV64V-NEXT:# %bb.9:
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:.LBB919_10:
+; CHECK-RV64V-NEXT:	mv	a3, a2
+; CHECK-RV64V-NEXT:	bltu	a2, s0, .LBB919_12
+; CHECK-RV64V-NEXT:# %bb.11:
+; CHECK-RV64V-NEXT:	mv	a3, s0
+; CHECK-RV64V-NEXT:.LBB919_12:
+; CHECK-RV64V-NEXT:	csrr	a4, vlenb
+; CHECK-RV64V-NEXT:	slli	a4, a4, 3
+; CHECK-RV64V-NEXT:	add	a4, sp, a4
+; CHECK-RV64V-NEXT:	addi	a4, a4, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a4)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a3, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a3, a2, s0
+; CHECK-RV64V-NEXT:	sub	a1, a0, a1
+; CHECK-RV64V-NEXT:	sltu	a2, a2, a3
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a2, a2, -1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a2, a2, a3
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a3, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 1
+; CHECK-RV64V-NEXT:	add	a1, a1, a3
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	bltu	a0, s0, .LBB919_14
+; CHECK-RV64V-NEXT:# %bb.13:
+; CHECK-RV64V-NEXT:	mv	a1, s0
+; CHECK-RV64V-NEXT:.LBB919_14:
+; CHECK-RV64V-NEXT:	csrr	a2, vlenb
+; CHECK-RV64V-NEXT:	slli	a2, a2, 5
+; CHECK-RV64V-NEXT:	add	a2, sp, a2
+; CHECK-RV64V-NEXT:	addi	a2, a2, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64V-NEXT:	sub	a1, a0, s0
+; CHECK-RV64V-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64V-NEXT:	addi	a0, a0, -1
+; CHECK-RV64V-NEXT:	and	a0, a0, a1
+; CHECK-RV64V-NEXT:	csrr	a1, vlenb
+; CHECK-RV64V-NEXT:	slli	a1, a1, 3
+; CHECK-RV64V-NEXT:	mv	a2, a1
+; CHECK-RV64V-NEXT:	slli	a1, a1, 2
+; CHECK-RV64V-NEXT:	add	a1, a1, a2
+; CHECK-RV64V-NEXT:	add	a1, sp, a1
+; CHECK-RV64V-NEXT:	addi	a1, a1, 16
+; CHECK-RV64V-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64V-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64V-NEXT:	ntl.all
+; CHECK-RV64V-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64V-NEXT:	csrr	a0, vlenb
+; CHECK-RV64V-NEXT:	slli	a0, a0, 4
+; CHECK-RV64V-NEXT:	mv	a1, a0
+; CHECK-RV64V-NEXT:	slli	a0, a0, 1
+; CHECK-RV64V-NEXT:	add	a0, a0, a1
+; CHECK-RV64V-NEXT:	add	sp, sp, a0
+; CHECK-RV64V-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64V-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64V-NEXT:	.cfi_restore ra
+; CHECK-RV64V-NEXT:	.cfi_restore s0
+; CHECK-RV64V-NEXT:	.cfi_restore s1
+; CHECK-RV64V-NEXT:	.cfi_restore s2
+; CHECK-RV64V-NEXT:	addi	sp, sp, 48
+; CHECK-RV64V-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64V-NEXT:	ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_scatter_nxv64i8_DEFAULT:
 ; CHECK-RV32V:       # %bb.0:
@@ -40029,244 +39707,226 @@ define void @test_nontemporal_vp_scatter_nxv64i8_DEFAULT(<vscale x 64 x i8> %val
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_DEFAULT:
 ; CHECK-RV64VC:       # %bb.0:
-; CHECK-RV64VC-NEXT:    addi sp, sp, -48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-RV64VC-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-RV64VC-NEXT:    .cfi_offset ra, -8
-; CHECK-RV64VC-NEXT:    .cfi_offset s0, -16
-; CHECK-RV64VC-NEXT:    .cfi_offset s1, -24
-; CHECK-RV64VC-NEXT:    .cfi_offset s2, -32
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    sub sp, sp, a1
-; CHECK-RV64VC-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x38, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 56 * vlenb
-; CHECK-RV64VC-NEXT:    mv s2, a7
-; CHECK-RV64VC-NEXT:    mv s1, a0
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 4
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    csrr s0, vlenb
-; CHECK-RV64VC-NEXT:    li a1, 48
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 2
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 40
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    slli a0, s0, 5
-; CHECK-RV64VC-NEXT:    add a0, a0, s1
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (a0)
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add a0, a0, sp
-; CHECK-RV64VC-NEXT:    addi a0, a0, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    li a1, 24
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:    call __muldi3
-; CHECK-RV64VC-NEXT:    slli a6, s0, 2
-; CHECK-RV64VC-NEXT:    mv a3, s2
-; CHECK-RV64VC-NEXT:    bltu s2, a6, .LBB919_2
-; CHECK-RV64VC-NEXT:  # %bb.1:
-; CHECK-RV64VC-NEXT:    mv a3, a6
-; CHECK-RV64VC-NEXT:  .LBB919_2:
-; CHECK-RV64VC-NEXT:    slli a5, s0, 4
-; CHECK-RV64VC-NEXT:    slli a7, s0, 1
-; CHECK-RV64VC-NEXT:    slli a2, s0, 3
-; CHECK-RV64VC-NEXT:    mv a4, a3
-; CHECK-RV64VC-NEXT:    bltu a3, a7, .LBB919_4
-; CHECK-RV64VC-NEXT:  # %bb.3:
-; CHECK-RV64VC-NEXT:    mv a4, a7
-; CHECK-RV64VC-NEXT:  .LBB919_4:
-; CHECK-RV64VC-NEXT:    vl8re64.v v8, (s1)
-; CHECK-RV64VC-NEXT:    add a1, s1, a0
-; CHECK-RV64VC-NEXT:    add a5, a5, s1
-; CHECK-RV64VC-NEXT:    add a2, a2, s1
-; CHECK-RV64VC-NEXT:    mv a0, a4
-; CHECK-RV64VC-NEXT:    bltu a4, s0, .LBB919_6
-; CHECK-RV64VC-NEXT:  # %bb.5:
-; CHECK-RV64VC-NEXT:    mv a0, s0
-; CHECK-RV64VC-NEXT:  .LBB919_6:
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a1)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v16, (a5)
-; CHECK-RV64VC-NEXT:    addi a1, sp, 16
-; CHECK-RV64VC-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-RV64VC-NEXT:    vl8re64.v v0, (a2)
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 4
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v24, (zero), v16
-; CHECK-RV64VC-NEXT:    sub a0, a4, s0
-; CHECK-RV64VC-NEXT:    sub a1, a3, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a4, a0
-; CHECK-RV64VC-NEXT:    sltu a3, a3, a1
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a2, a2, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a1
-; CHECK-RV64VC-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v25, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB919_8
-; CHECK-RV64VC-NEXT:  # %bb.7:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB919_8:
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v26, (zero), v0
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sub a2, s2, a6
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    sltu a3, s2, a2
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    addi a3, a3, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a0
-; CHECK-RV64VC-NEXT:    and a0, a3, a2
-; CHECK-RV64VC-NEXT:    addi a2, sp, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v27, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a2, a0
-; CHECK-RV64VC-NEXT:    bltu a0, a7, .LBB919_10
-; CHECK-RV64VC-NEXT:  # %bb.9:
-; CHECK-RV64VC-NEXT:    mv a2, a7
-; CHECK-RV64VC-NEXT:  .LBB919_10:
-; CHECK-RV64VC-NEXT:    mv a1, a2
-; CHECK-RV64VC-NEXT:    bltu a2, s0, .LBB919_12
-; CHECK-RV64VC-NEXT:  # %bb.11:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB919_12:
-; CHECK-RV64VC-NEXT:    csrr a3, vlenb
-; CHECK-RV64VC-NEXT:    slli a3, a3, 3
-; CHECK-RV64VC-NEXT:    add a3, a3, sp
-; CHECK-RV64VC-NEXT:    addi a3, a3, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v28, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a2, s0
-; CHECK-RV64VC-NEXT:    sub a3, a0, a7
-; CHECK-RV64VC-NEXT:    sltu a2, a2, a1
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a3
-; CHECK-RV64VC-NEXT:    addi a2, a2, -1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a1, a1, a2
-; CHECK-RV64VC-NEXT:    and a0, a0, a3
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 3
-; CHECK-RV64VC-NEXT:    mv a3, a2
-; CHECK-RV64VC-NEXT:    slli a2, a2, 1
-; CHECK-RV64VC-NEXT:    add a2, a2, a3
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v29, (zero), v8
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    bltu a0, s0, .LBB919_14
-; CHECK-RV64VC-NEXT:  # %bb.13:
-; CHECK-RV64VC-NEXT:    mv a1, s0
-; CHECK-RV64VC-NEXT:  .LBB919_14:
-; CHECK-RV64VC-NEXT:    csrr a2, vlenb
-; CHECK-RV64VC-NEXT:    slli a2, a2, 5
-; CHECK-RV64VC-NEXT:    add a2, a2, sp
-; CHECK-RV64VC-NEXT:    addi a2, a2, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a2) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v30, (zero), v8
-; CHECK-RV64VC-NEXT:    sub a1, a0, s0
-; CHECK-RV64VC-NEXT:    sltu a0, a0, a1
-; CHECK-RV64VC-NEXT:    addi a0, a0, -1
-; CHECK-RV64VC-NEXT:    and a0, a0, a1
-; CHECK-RV64VC-NEXT:    csrr a1, vlenb
-; CHECK-RV64VC-NEXT:    slli a1, a1, 3
-; CHECK-RV64VC-NEXT:    mv a2, a1
-; CHECK-RV64VC-NEXT:    slli a1, a1, 2
-; CHECK-RV64VC-NEXT:    add a1, a1, a2
-; CHECK-RV64VC-NEXT:    add a1, a1, sp
-; CHECK-RV64VC-NEXT:    addi a1, a1, 16
-; CHECK-RV64VC-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vsoxei64.v v31, (zero), v8
-; CHECK-RV64VC-NEXT:    csrr a0, vlenb
-; CHECK-RV64VC-NEXT:    slli a0, a0, 3
-; CHECK-RV64VC-NEXT:    mv a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a1, a1, a0
-; CHECK-RV64VC-NEXT:    slli a0, a0, 1
-; CHECK-RV64VC-NEXT:    add a0, a0, a1
-; CHECK-RV64VC-NEXT:    add sp, sp, a0
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa sp, 48
-; CHECK-RV64VC-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-RV64VC-NEXT:    .cfi_restore ra
-; CHECK-RV64VC-NEXT:    .cfi_restore s0
-; CHECK-RV64VC-NEXT:    .cfi_restore s1
-; CHECK-RV64VC-NEXT:    .cfi_restore s2
-; CHECK-RV64VC-NEXT:    addi sp, sp, 48
-; CHECK-RV64VC-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-RV64VC-NEXT:    ret
+; CHECK-RV64VC-NEXT:	addi	sp, sp, -48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 48
+; CHECK-RV64VC-NEXT:	sd	ra, 40(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s0, 32(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s1, 24(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	sd	s2, 16(sp)                      # 8-byte Folded Spill
+; CHECK-RV64VC-NEXT:	.cfi_offset ra, -8
+; CHECK-RV64VC-NEXT:	.cfi_offset s0, -16
+; CHECK-RV64VC-NEXT:	.cfi_offset s1, -24
+; CHECK-RV64VC-NEXT:	.cfi_offset s2, -32
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 1
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	sub	sp, sp, a1
+; CHECK-RV64VC-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x30, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 48 * vlenb
+; CHECK-RV64VC-NEXT:	mv	s2, a7
+; CHECK-RV64VC-NEXT:	mv	s1, a0
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v16, (a0)                       # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	vmv8r.v	v24, v8
+; CHECK-RV64VC-NEXT:	csrr	s0, vlenb
+; CHECK-RV64VC-NEXT:	li	a1, 48
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 2
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 40
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	slli	a0, s0, 5
+; CHECK-RV64VC-NEXT:	add	a0, a0, s1
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a0)
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 3
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	a0, a0, sp
+; CHECK-RV64VC-NEXT:	addi	a0, a0, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	li	a1, 24
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:	call	__muldi3
+; CHECK-RV64VC-NEXT:	slli	a6, s0, 2
+; CHECK-RV64VC-NEXT:	mv	a3, s2
+; CHECK-RV64VC-NEXT:	bltu	s2, a6, .LBB919_2
+; CHECK-RV64VC-NEXT:# %bb.1:
+; CHECK-RV64VC-NEXT:	mv	a3, a6
+; CHECK-RV64VC-NEXT:.LBB919_2:
+; CHECK-RV64VC-NEXT:	slli	a5, s0, 4
+; CHECK-RV64VC-NEXT:	slli	a7, s0, 1
+; CHECK-RV64VC-NEXT:	slli	a2, s0, 3
+; CHECK-RV64VC-NEXT:	mv	a4, a3
+; CHECK-RV64VC-NEXT:	bltu	a3, a7, .LBB919_4
+; CHECK-RV64VC-NEXT:# %bb.3:
+; CHECK-RV64VC-NEXT:	mv	a4, a7
+; CHECK-RV64VC-NEXT:.LBB919_4:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v0, (s1)
+; CHECK-RV64VC-NEXT:	add	a1, s1, a0
+; CHECK-RV64VC-NEXT:	add	a5, a5, s1
+; CHECK-RV64VC-NEXT:	add	a2, a2, s1
+; CHECK-RV64VC-NEXT:	mv	a0, a4
+; CHECK-RV64VC-NEXT:	bltu	a4, s0, .LBB919_6
+; CHECK-RV64VC-NEXT:# %bb.5:
+; CHECK-RV64VC-NEXT:	mv	a0, s0
+; CHECK-RV64VC-NEXT:.LBB919_6:
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a1)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a5)
+; CHECK-RV64VC-NEXT:	addi	a1, sp, 16
+; CHECK-RV64VC-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; CHECK-RV64VC-NEXT:	vl8re64.v	v8, (a2)
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 4
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v24, (zero), v16
+; CHECK-RV64VC-NEXT:	sub	a0, a4, s0
+; CHECK-RV64VC-NEXT:	sub	a1, a3, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a4, a0
+; CHECK-RV64VC-NEXT:	sltu	a3, a3, a1
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a2, a2, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a1
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a2, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v25, (zero), v0
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB919_8
+; CHECK-RV64VC-NEXT:# %bb.7:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB919_8:
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v26, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sub	a2, s2, a6
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	sltu	a3, s2, a2
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	addi	a3, a3, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a0
+; CHECK-RV64VC-NEXT:	and	a0, a3, a2
+; CHECK-RV64VC-NEXT:	addi	a2, sp, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v27, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a2, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, a7, .LBB919_10
+; CHECK-RV64VC-NEXT:# %bb.9:
+; CHECK-RV64VC-NEXT:	mv	a2, a7
+; CHECK-RV64VC-NEXT:.LBB919_10:
+; CHECK-RV64VC-NEXT:	mv	a1, a2
+; CHECK-RV64VC-NEXT:	bltu	a2, s0, .LBB919_12
+; CHECK-RV64VC-NEXT:# %bb.11:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB919_12:
+; CHECK-RV64VC-NEXT:	csrr	a3, vlenb
+; CHECK-RV64VC-NEXT:	slli	a3, a3, 3
+; CHECK-RV64VC-NEXT:	add	a3, a3, sp
+; CHECK-RV64VC-NEXT:	addi	a3, a3, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a3)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v28, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a2, s0
+; CHECK-RV64VC-NEXT:	sub	a3, a0, a7
+; CHECK-RV64VC-NEXT:	sltu	a2, a2, a1
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a3
+; CHECK-RV64VC-NEXT:	addi	a2, a2, -1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a1, a1, a2
+; CHECK-RV64VC-NEXT:	and	a0, a0, a3
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 3
+; CHECK-RV64VC-NEXT:	mv	a3, a2
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 1
+; CHECK-RV64VC-NEXT:	add	a2, a2, a3
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v29, (zero), v8
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	bltu	a0, s0, .LBB919_14
+; CHECK-RV64VC-NEXT:# %bb.13:
+; CHECK-RV64VC-NEXT:	mv	a1, s0
+; CHECK-RV64VC-NEXT:.LBB919_14:
+; CHECK-RV64VC-NEXT:	csrr	a2, vlenb
+; CHECK-RV64VC-NEXT:	slli	a2, a2, 5
+; CHECK-RV64VC-NEXT:	add	a2, a2, sp
+; CHECK-RV64VC-NEXT:	addi	a2, a2, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a2)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a1, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v30, (zero), v8
+; CHECK-RV64VC-NEXT:	sub	a1, a0, s0
+; CHECK-RV64VC-NEXT:	sltu	a0, a0, a1
+; CHECK-RV64VC-NEXT:	addi	a0, a0, -1
+; CHECK-RV64VC-NEXT:	and	a0, a0, a1
+; CHECK-RV64VC-NEXT:	csrr	a1, vlenb
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 3
+; CHECK-RV64VC-NEXT:	mv	a2, a1
+; CHECK-RV64VC-NEXT:	slli	a1, a1, 2
+; CHECK-RV64VC-NEXT:	add	a1, a1, a2
+; CHECK-RV64VC-NEXT:	add	a1, a1, sp
+; CHECK-RV64VC-NEXT:	addi	a1, a1, 16
+; CHECK-RV64VC-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; CHECK-RV64VC-NEXT:	vsetvli	zero, a0, e8, m1, ta, ma
+; CHECK-RV64VC-NEXT:	c.ntl.all
+; CHECK-RV64VC-NEXT:	vsoxei64.v	v31, (zero), v8
+; CHECK-RV64VC-NEXT:	csrr	a0, vlenb
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 4
+; CHECK-RV64VC-NEXT:	mv	a1, a0
+; CHECK-RV64VC-NEXT:	slli	a0, a0, 1
+; CHECK-RV64VC-NEXT:	add	a0, a0, a1
+; CHECK-RV64VC-NEXT:	add	sp, sp, a0
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa sp, 48
+; CHECK-RV64VC-NEXT:	ld	ra, 40(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s0, 32(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s1, 24(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	ld	s2, 16(sp)                      # 8-byte Folded Reload
+; CHECK-RV64VC-NEXT:	.cfi_restore ra
+; CHECK-RV64VC-NEXT:	.cfi_restore s0
+; CHECK-RV64VC-NEXT:	.cfi_restore s1
+; CHECK-RV64VC-NEXT:	.cfi_restore s2
+; CHECK-RV64VC-NEXT:	addi	sp, sp, 48
+; CHECK-RV64VC-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-RV64VC-NEXT:	ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_scatter_nxv64i8_DEFAULT:
 ; CHECK-RV32VC:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rvv/pr63596.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/pr63596.ll
@@ -4,65 +4,43 @@
 define <4 x float> @foo(ptr %0) nounwind {
 ; CHECK-LABEL: foo:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -48
-; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 32(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    lhu s0, 0(a0)
-; CHECK-NEXT:    lhu s1, 2(a0)
-; CHECK-NEXT:    lhu s2, 4(a0)
-; CHECK-NEXT:    lhu a0, 6(a0)
-; CHECK-NEXT:    fmv.w.x fa0, a0
-; CHECK-NEXT:    call __extendhfsf2
-; CHECK-NEXT:    fmv.w.x fa5, s2
-; CHECK-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-NEXT:    vfmv.s.f v8, fa0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    fmv.s fa0, fa5
-; CHECK-NEXT:    call __extendhfsf2
-; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-NEXT:    vfmv.s.f v8, fa0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add a0, sp, a0
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    fmv.w.x fa0, s1
-; CHECK-NEXT:    call __extendhfsf2
-; CHECK-NEXT:    fmv.w.x fa5, s0
-; CHECK-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; CHECK-NEXT:    vfmv.s.f v8, fa0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    fmv.s fa0, fa5
-; CHECK-NEXT:    call __extendhfsf2
-; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-NEXT:    vfmv.s.f v8, fa0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vslideup.vi v8, v9, 1
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add a0, sp, a0
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 32(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s1, 24(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s2, 16(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 48
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -32
+; CHECK-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s2, 0(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	lhu	s0, 0(a0)
+; CHECK-NEXT:	lhu	s1, 2(a0)
+; CHECK-NEXT:	lhu	s2, 4(a0)
+; CHECK-NEXT:	lhu	a0, 6(a0)
+; CHECK-NEXT:	fmv.w.x	fa0, a0
+; CHECK-NEXT:	call	__extendhfsf2
+; CHECK-NEXT:	fmv.w.x	fa5, s2
+; CHECK-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-NEXT:	vfmv.s.f	v24, fa0
+; CHECK-NEXT:	fmv.s	fa0, fa5
+; CHECK-NEXT:	call	__extendhfsf2
+; CHECK-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:	vfmv.s.f	v25, fa0
+; CHECK-NEXT:	vslideup.vi	v25, v24, 1
+; CHECK-NEXT:	fmv.w.x	fa0, s1
+; CHECK-NEXT:	call	__extendhfsf2
+; CHECK-NEXT:	fmv.w.x	fa5, s0
+; CHECK-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; CHECK-NEXT:	vfmv.s.f	v24, fa0
+; CHECK-NEXT:	fmv.s	fa0, fa5
+; CHECK-NEXT:	call	__extendhfsf2
+; CHECK-NEXT:	vsetivli	zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:	vfmv.s.f	v8, fa0
+; CHECK-NEXT:	vslideup.vi	v8, v24, 1
+; CHECK-NEXT:	vsetivli	zero, 4, e32, m1, ta, ma
+; CHECK-NEXT:	vslideup.vi	v8, v25, 2
+; CHECK-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s2, 0(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 32
+; CHECK-NEXT:	ret
   %2 = load <4 x half>, ptr %0, align 2
   %3 = fpext <4 x half> %2 to <4 x float>
   ret <4 x float> %3

--- a/llvm/test/CodeGen/RISCV/rvv/reg-alloc-reserve-bp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/reg-alloc-reserve-bp.ll
@@ -5,60 +5,53 @@
 define void @foo(ptr nocapture noundef %p1) {
 ; CHECK-LABEL: foo:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -192
-; CHECK-NEXT:    .cfi_def_cfa_offset 192
-; CHECK-NEXT:    sd ra, 184(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 176(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s1, 168(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s2, 160(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    .cfi_offset ra, -8
-; CHECK-NEXT:    .cfi_offset s0, -16
-; CHECK-NEXT:    .cfi_offset s1, -24
-; CHECK-NEXT:    .cfi_offset s2, -32
-; CHECK-NEXT:    addi s0, sp, 192
-; CHECK-NEXT:    .cfi_def_cfa s0, 0
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    andi sp, sp, -64
-; CHECK-NEXT:    mv s1, sp
-; CHECK-NEXT:    mv s2, a0
-; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-NEXT:    vle32.v v8, (a0)
-; CHECK-NEXT:    addi a0, s1, 160
-; CHECK-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    addi t0, s1, 64
-; CHECK-NEXT:    li a0, 1
-; CHECK-NEXT:    li a1, 2
-; CHECK-NEXT:    li a2, 3
-; CHECK-NEXT:    li a3, 4
-; CHECK-NEXT:    li a4, 5
-; CHECK-NEXT:    li a5, 6
-; CHECK-NEXT:    li a6, 7
-; CHECK-NEXT:    li a7, 8
-; CHECK-NEXT:    sd t0, 0(sp)
-; CHECK-NEXT:    call bar
-; CHECK-NEXT:    addi sp, sp, 16
-; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-NEXT:    vle32.v v8, (s2)
-; CHECK-NEXT:    addi a0, s1, 160
-; CHECK-NEXT:    vl2r.v v10, (a0) # vscale x 16-byte Folded Reload
-; CHECK-NEXT:    vfadd.vv v8, v10, v8
-; CHECK-NEXT:    vse32.v v8, (s2)
-; CHECK-NEXT:    addi sp, s0, -192
-; CHECK-NEXT:    .cfi_def_cfa sp, 192
-; CHECK-NEXT:    ld ra, 184(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 176(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s1, 168(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s2, 160(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    .cfi_restore ra
-; CHECK-NEXT:    .cfi_restore s0
-; CHECK-NEXT:    .cfi_restore s1
-; CHECK-NEXT:    .cfi_restore s2
-; CHECK-NEXT:    addi sp, sp, 192
-; CHECK-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -128
+; CHECK-NEXT:	.cfi_def_cfa_offset 128
+; CHECK-NEXT:	sd	ra, 120(sp)                     # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 112(sp)                     # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s1, 104(sp)                     # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s2, 96(sp)                      # 8-byte Folded Spill
+; CHECK-NEXT:	.cfi_offset ra, -8
+; CHECK-NEXT:	.cfi_offset s0, -16
+; CHECK-NEXT:	.cfi_offset s1, -24
+; CHECK-NEXT:	.cfi_offset s2, -32
+; CHECK-NEXT:	addi	s0, sp, 128
+; CHECK-NEXT:	.cfi_def_cfa s0, 0
+; CHECK-NEXT:	andi	sp, sp, -64
+; CHECK-NEXT:	mv	s1, sp
+; CHECK-NEXT:	mv	s2, a0
+; CHECK-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-NEXT:	vle32.v	v24, (a0)
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	mv	t0, s1
+; CHECK-NEXT:	li	a0, 1
+; CHECK-NEXT:	li	a1, 2
+; CHECK-NEXT:	li	a2, 3
+; CHECK-NEXT:	li	a3, 4
+; CHECK-NEXT:	li	a4, 5
+; CHECK-NEXT:	li	a5, 6
+; CHECK-NEXT:	li	a6, 7
+; CHECK-NEXT:	li	a7, 8
+; CHECK-NEXT:	sd	t0, 0(sp)
+; CHECK-NEXT:	call	bar
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; CHECK-NEXT:	vle32.v	v8, (s2)
+; CHECK-NEXT:	vfadd.vv	v8, v24, v8
+; CHECK-NEXT:	vse32.v	v8, (s2)
+; CHECK-NEXT:	addi	sp, s0, -128
+; CHECK-NEXT:	.cfi_def_cfa sp, 128
+; CHECK-NEXT:	ld	ra, 120(sp)                     # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 112(sp)                     # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s1, 104(sp)                     # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s2, 96(sp)                      # 8-byte Folded Reload
+; CHECK-NEXT:	.cfi_restore ra
+; CHECK-NEXT:	.cfi_restore s0
+; CHECK-NEXT:	.cfi_restore s1
+; CHECK-NEXT:	.cfi_restore s2
+; CHECK-NEXT:	addi	sp, sp, 128
+; CHECK-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-NEXT:	ret
 entry:
   %vla = alloca [10 x i32], align 64
   call void @llvm.lifetime.start.p0(i64 40, ptr nonnull %vla)

--- a/llvm/test/CodeGen/RISCV/rvv/rv32-spill-vector-csr.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rv32-spill-vector-csr.ll
@@ -64,83 +64,45 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ;
 ; SPILL-O2-LABEL: foo:
 ; SPILL-O2:       # %bb.0:
-; SPILL-O2-NEXT:    addi sp, sp, -32
-; SPILL-O2-NEXT:    .cfi_def_cfa_offset 32
-; SPILL-O2-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; SPILL-O2-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; SPILL-O2-NEXT:    .cfi_offset ra, -4
-; SPILL-O2-NEXT:    .cfi_offset s0, -8
-; SPILL-O2-NEXT:    csrr a1, vlenb
-; SPILL-O2-NEXT:    slli a1, a1, 1
-; SPILL-O2-NEXT:    sub sp, sp, a1
-; SPILL-O2-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 2 * vlenb
-; SPILL-O2-NEXT:    mv s0, a0
-; SPILL-O2-NEXT:    addi a1, sp, 16
-; SPILL-O2-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-NEXT:    csrr a0, vlenb
-; SPILL-O2-NEXT:    add a0, sp, a0
-; SPILL-O2-NEXT:    addi a0, a0, 16
-; SPILL-O2-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-NEXT:    call puts
-; SPILL-O2-NEXT:    csrr a0, vlenb
-; SPILL-O2-NEXT:    add a0, sp, a0
-; SPILL-O2-NEXT:    addi a0, a0, 16
-; SPILL-O2-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-NEXT:    addi a0, sp, 16
-; SPILL-O2-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-NEXT:    csrr a0, vlenb
-; SPILL-O2-NEXT:    slli a0, a0, 1
-; SPILL-O2-NEXT:    add sp, sp, a0
-; SPILL-O2-NEXT:    .cfi_def_cfa sp, 32
-; SPILL-O2-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; SPILL-O2-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; SPILL-O2-NEXT:    .cfi_restore ra
-; SPILL-O2-NEXT:    .cfi_restore s0
-; SPILL-O2-NEXT:    addi sp, sp, 32
-; SPILL-O2-NEXT:    .cfi_def_cfa_offset 0
-; SPILL-O2-NEXT:    ret
+; SPILL-O2-NEXT:	addi	sp, sp, -16
+; SPILL-O2-NEXT:	.cfi_def_cfa_offset 16
+; SPILL-O2-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; SPILL-O2-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; SPILL-O2-NEXT:	.cfi_offset ra, -4
+; SPILL-O2-NEXT:	.cfi_offset s0, -8
+; SPILL-O2-NEXT:	mv	s0, a0
+; SPILL-O2-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-NEXT:	call	puts
+; SPILL-O2-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; SPILL-O2-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; SPILL-O2-NEXT:	.cfi_restore ra
+; SPILL-O2-NEXT:	.cfi_restore s0
+; SPILL-O2-NEXT:	addi	sp, sp, 16
+; SPILL-O2-NEXT:	.cfi_def_cfa_offset 0
+; SPILL-O2-NEXT:	ret
 ;
 ; SPILL-O2-ZCMP-LABEL: foo:
 ; SPILL-O2-ZCMP:       # %bb.0:
-; SPILL-O2-ZCMP-NEXT:    cm.push {ra, s0}, -32
-; SPILL-O2-ZCMP-NEXT:    .cfi_def_cfa_offset 32
-; SPILL-O2-ZCMP-NEXT:    .cfi_offset ra, -8
-; SPILL-O2-ZCMP-NEXT:    .cfi_offset s0, -4
-; SPILL-O2-ZCMP-NEXT:    csrr a1, vlenb
-; SPILL-O2-ZCMP-NEXT:    slli a1, a1, 1
-; SPILL-O2-ZCMP-NEXT:    sub sp, sp, a1
-; SPILL-O2-ZCMP-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 2 * vlenb
-; SPILL-O2-ZCMP-NEXT:    mv s0, a0
-; SPILL-O2-ZCMP-NEXT:    addi a1, sp, 16
-; SPILL-O2-ZCMP-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-ZCMP-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-ZCMP-NEXT:    call puts
-; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-NEXT:    addi a0, sp, 16
-; SPILL-O2-ZCMP-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-NEXT:    slli a0, a0, 1
-; SPILL-O2-ZCMP-NEXT:    add sp, sp, a0
-; SPILL-O2-ZCMP-NEXT:    .cfi_def_cfa sp, 32
-; SPILL-O2-ZCMP-NEXT:    cm.popret {ra, s0}, 32
+; SPILL-O2-ZCMP-NEXT:	cm.push	{ra, s0}, -16
+; SPILL-O2-ZCMP-NEXT:	.cfi_def_cfa_offset 16
+; SPILL-O2-ZCMP-NEXT:	.cfi_offset ra, -8
+; SPILL-O2-ZCMP-NEXT:	.cfi_offset s0, -4
+; SPILL-O2-ZCMP-NEXT:	mv	s0, a0
+; SPILL-O2-ZCMP-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-ZCMP-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-ZCMP-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-ZCMP-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-ZCMP-NEXT:	call	puts
+; SPILL-O2-ZCMP-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-ZCMP-NEXT:	cm.popret	{ra, s0}, 16
 ;
 ; SPILL-O0-VSETVLI-LABEL: foo:
 ; SPILL-O0-VSETVLI:       # %bb.0:
@@ -189,79 +151,45 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ;
 ; SPILL-O2-VSETVLI-LABEL: foo:
 ; SPILL-O2-VSETVLI:       # %bb.0:
-; SPILL-O2-VSETVLI-NEXT:    addi sp, sp, -32
-; SPILL-O2-VSETVLI-NEXT:    .cfi_def_cfa_offset 32
-; SPILL-O2-VSETVLI-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    .cfi_offset ra, -4
-; SPILL-O2-VSETVLI-NEXT:    .cfi_offset s0, -8
-; SPILL-O2-VSETVLI-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    sub sp, sp, a1
-; SPILL-O2-VSETVLI-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 2 * vlenb
-; SPILL-O2-VSETVLI-NEXT:    mv s0, a0
-; SPILL-O2-VSETVLI-NEXT:    addi a1, sp, 16
-; SPILL-O2-VSETVLI-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-VSETVLI-NEXT:    add a0, sp, a0
-; SPILL-O2-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-VSETVLI-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-VSETVLI-NEXT:    call puts
-; SPILL-O2-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-VSETVLI-NEXT:    add a0, sp, a0
-; SPILL-O2-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-VSETVLI-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    addi a0, sp, 16
-; SPILL-O2-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-VSETVLI-NEXT:    vsetvli a0, zero, e8, m2, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    add sp, sp, a0
-; SPILL-O2-VSETVLI-NEXT:    .cfi_def_cfa sp, 32
-; SPILL-O2-VSETVLI-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    .cfi_restore ra
-; SPILL-O2-VSETVLI-NEXT:    .cfi_restore s0
-; SPILL-O2-VSETVLI-NEXT:    addi sp, sp, 32
-; SPILL-O2-VSETVLI-NEXT:    .cfi_def_cfa_offset 0
-; SPILL-O2-VSETVLI-NEXT:    ret
+; SPILL-O2-VSETVLI-NEXT:	addi	sp, sp, -16
+; SPILL-O2-VSETVLI-NEXT:	.cfi_def_cfa_offset 16
+; SPILL-O2-VSETVLI-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; SPILL-O2-VSETVLI-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; SPILL-O2-VSETVLI-NEXT:	.cfi_offset ra, -4
+; SPILL-O2-VSETVLI-NEXT:	.cfi_offset s0, -8
+; SPILL-O2-VSETVLI-NEXT:	mv	s0, a0
+; SPILL-O2-VSETVLI-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-VSETVLI-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-VSETVLI-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-VSETVLI-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-VSETVLI-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-VSETVLI-NEXT:	call	puts
+; SPILL-O2-VSETVLI-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-VSETVLI-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-VSETVLI-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; SPILL-O2-VSETVLI-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; SPILL-O2-VSETVLI-NEXT:	.cfi_restore ra
+; SPILL-O2-VSETVLI-NEXT:	.cfi_restore s0
+; SPILL-O2-VSETVLI-NEXT:	addi	sp, sp, 16
+; SPILL-O2-VSETVLI-NEXT:	.cfi_def_cfa_offset 0
+; SPILL-O2-VSETVLI-NEXT:	ret
 ;
 ; SPILL-O2-ZCMP-VSETVLI-LABEL: foo:
 ; SPILL-O2-ZCMP-VSETVLI:       # %bb.0:
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.push {ra, s0}, -32
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_def_cfa_offset 32
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_offset ra, -8
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_offset s0, -4
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    sub sp, sp, a1
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 2 * vlenb
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    mv s0, a0
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a1, sp, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    call puts
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, sp, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli a0, zero, e8, m2, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    add sp, sp, a0
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_def_cfa sp, 32
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.popret {ra, s0}, 32
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	cm.push	{ra, s0}, -16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	.cfi_def_cfa_offset 16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	.cfi_offset ra, -8
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	.cfi_offset s0, -4
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	mv	s0, a0
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	call	puts
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	cm.popret	{ra, s0}, 16
 {
    %x = call <vscale x 1 x double> @llvm.riscv.vfadd.nxv1f64.nxv1f64(<vscale x 1 x double> poison, <vscale x 1 x double> %a, <vscale x 1 x double> %b, i32 7, i32 %gvl)
    %call = call signext i32 @puts(ptr @.str)

--- a/llvm/test/CodeGen/RISCV/rvv/rv64-spill-vector-csr.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rv64-spill-vector-csr.ll
@@ -61,98 +61,55 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ;
 ; SPILL-O2-LABEL: foo:
 ; SPILL-O2:       # %bb.0:
-; SPILL-O2-NEXT:    addi sp, sp, -32
-; SPILL-O2-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; SPILL-O2-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; SPILL-O2-NEXT:    csrr a1, vlenb
-; SPILL-O2-NEXT:    slli a1, a1, 1
-; SPILL-O2-NEXT:    sub sp, sp, a1
-; SPILL-O2-NEXT:    mv s0, a0
-; SPILL-O2-NEXT:    addi a1, sp, 16
-; SPILL-O2-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-NEXT:    csrr a0, vlenb
-; SPILL-O2-NEXT:    add a0, sp, a0
-; SPILL-O2-NEXT:    addi a0, a0, 16
-; SPILL-O2-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-NEXT:    call puts
-; SPILL-O2-NEXT:    csrr a0, vlenb
-; SPILL-O2-NEXT:    add a0, sp, a0
-; SPILL-O2-NEXT:    addi a0, a0, 16
-; SPILL-O2-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-NEXT:    addi a0, sp, 16
-; SPILL-O2-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-NEXT:    csrr a0, vlenb
-; SPILL-O2-NEXT:    slli a0, a0, 1
-; SPILL-O2-NEXT:    add sp, sp, a0
-; SPILL-O2-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; SPILL-O2-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; SPILL-O2-NEXT:    addi sp, sp, 32
-; SPILL-O2-NEXT:    ret
+; SPILL-O2-NEXT:	addi	sp, sp, -16
+; SPILL-O2-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; SPILL-O2-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; SPILL-O2-NEXT:	mv	s0, a0
+; SPILL-O2-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-NEXT:	call	puts
+; SPILL-O2-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; SPILL-O2-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; SPILL-O2-NEXT:	addi	sp, sp, 16
+; SPILL-O2-NEXT:	ret
 ;
 ; SPILL-O2-VLEN128-LABEL: foo:
 ; SPILL-O2-VLEN128:       # %bb.0:
-; SPILL-O2-VLEN128-NEXT:    addi sp, sp, -32
-; SPILL-O2-VLEN128-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; SPILL-O2-VLEN128-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; SPILL-O2-VLEN128-NEXT:    addi sp, sp, -32
-; SPILL-O2-VLEN128-NEXT:    mv s0, a0
-; SPILL-O2-VLEN128-NEXT:    addi a1, sp, 16
-; SPILL-O2-VLEN128-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-VLEN128-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-VLEN128-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-VLEN128-NEXT:    addi a0, sp, 32
-; SPILL-O2-VLEN128-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-VLEN128-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-VLEN128-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-VLEN128-NEXT:    call puts
-; SPILL-O2-VLEN128-NEXT:    addi a0, sp, 32
-; SPILL-O2-VLEN128-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-VLEN128-NEXT:    addi a0, sp, 16
-; SPILL-O2-VLEN128-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-VLEN128-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-VLEN128-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-VLEN128-NEXT:    addi sp, sp, 32
-; SPILL-O2-VLEN128-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; SPILL-O2-VLEN128-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; SPILL-O2-VLEN128-NEXT:    addi sp, sp, 32
-; SPILL-O2-VLEN128-NEXT:    ret
+; SPILL-O2-VLEN128-NEXT:	addi	sp, sp, -16
+; SPILL-O2-VLEN128-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; SPILL-O2-VLEN128-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; SPILL-O2-VLEN128-NEXT:	mv	s0, a0
+; SPILL-O2-VLEN128-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-VLEN128-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-VLEN128-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-VLEN128-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-VLEN128-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-VLEN128-NEXT:	call	puts
+; SPILL-O2-VLEN128-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-VLEN128-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-VLEN128-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; SPILL-O2-VLEN128-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; SPILL-O2-VLEN128-NEXT:	addi	sp, sp, 16
+; SPILL-O2-VLEN128-NEXT:	ret
 ;
 ; SPILL-O2-ZCMP-LABEL: foo:
 ; SPILL-O2-ZCMP:       # %bb.0:
-; SPILL-O2-ZCMP-NEXT:    cm.push {ra, s0}, -32
-; SPILL-O2-ZCMP-NEXT:    csrr a1, vlenb
-; SPILL-O2-ZCMP-NEXT:    slli a1, a1, 1
-; SPILL-O2-ZCMP-NEXT:    sub sp, sp, a1
-; SPILL-O2-ZCMP-NEXT:    mv s0, a0
-; SPILL-O2-ZCMP-NEXT:    addi a1, sp, 16
-; SPILL-O2-ZCMP-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-ZCMP-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-ZCMP-NEXT:    call puts
-; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-NEXT:    addi a0, sp, 16
-; SPILL-O2-ZCMP-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-NEXT:    slli a0, a0, 1
-; SPILL-O2-ZCMP-NEXT:    add sp, sp, a0
-; SPILL-O2-ZCMP-NEXT:    cm.popret {ra, s0}, 32
+; SPILL-O2-ZCMP-NEXT:	cm.push	{ra, s0}, -16
+; SPILL-O2-ZCMP-NEXT:	mv	s0, a0
+; SPILL-O2-ZCMP-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-ZCMP-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-ZCMP-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-ZCMP-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-ZCMP-NEXT:	call	puts
+; SPILL-O2-ZCMP-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-ZCMP-NEXT:	cm.popret	{ra, s0}, 16
 ;
 ; SPILL-O0-VSETVLI-LABEL: foo:
 ; SPILL-O0-VSETVLI:       # %bb.0:
@@ -195,66 +152,36 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ;
 ; SPILL-O2-VSETVLI-LABEL: foo:
 ; SPILL-O2-VSETVLI:       # %bb.0:
-; SPILL-O2-VSETVLI-NEXT:    addi sp, sp, -32
-; SPILL-O2-VSETVLI-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    sub sp, sp, a1
-; SPILL-O2-VSETVLI-NEXT:    mv s0, a0
-; SPILL-O2-VSETVLI-NEXT:    addi a1, sp, 16
-; SPILL-O2-VSETVLI-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-VSETVLI-NEXT:    add a0, sp, a0
-; SPILL-O2-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-VSETVLI-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-VSETVLI-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-VSETVLI-NEXT:    call puts
-; SPILL-O2-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-VSETVLI-NEXT:    add a0, sp, a0
-; SPILL-O2-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-VSETVLI-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    addi a0, sp, 16
-; SPILL-O2-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-VSETVLI-NEXT:    vsetvli a0, zero, e8, m2, ta, ma
-; SPILL-O2-VSETVLI-NEXT:    add sp, sp, a0
-; SPILL-O2-VSETVLI-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; SPILL-O2-VSETVLI-NEXT:    addi sp, sp, 32
-; SPILL-O2-VSETVLI-NEXT:    ret
+; SPILL-O2-VSETVLI-NEXT:	addi	sp, sp, -16
+; SPILL-O2-VSETVLI-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; SPILL-O2-VSETVLI-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; SPILL-O2-VSETVLI-NEXT:	mv	s0, a0
+; SPILL-O2-VSETVLI-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-VSETVLI-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-VSETVLI-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-VSETVLI-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-VSETVLI-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-VSETVLI-NEXT:	call	puts
+; SPILL-O2-VSETVLI-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-VSETVLI-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-VSETVLI-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; SPILL-O2-VSETVLI-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; SPILL-O2-VSETVLI-NEXT:	addi	sp, sp, 16
+; SPILL-O2-VSETVLI-NEXT:	ret
 ;
 ; SPILL-O2-ZCMP-VSETVLI-LABEL: foo:
 ; SPILL-O2-ZCMP-VSETVLI:       # %bb.0:
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.push {ra, s0}, -32
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    sub sp, sp, a1
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    mv s0, a0
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a1, sp, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vfadd.vv v9, v8, v9
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    lui a0, %hi(.L.str)
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    call puts
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    csrr a0, vlenb
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    add a0, a0, sp
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, sp, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vfadd.vv v8, v9, v8
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli a0, zero, e8, m2, ta, ma
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    add sp, sp, a0
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.popret {ra, s0}, 32
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	cm.push	{ra, s0}, -16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	mv	s0, a0
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vmv1r.v	v24, v8
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vfadd.vv	v25, v8, v9
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	lui	a0, %hi(.L.str)
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	addi	a0, a0, %lo(.L.str)
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	call	puts
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	vfadd.vv	v8, v24, v25
+; SPILL-O2-ZCMP-VSETVLI-NEXT:	cm.popret	{ra, s0}, 16
 {
    %x = call <vscale x 1 x double> @llvm.riscv.vfadd.nxv1f64.nxv1f64(<vscale x 1 x double> poison, <vscale x 1 x double> %a, <vscale x 1 x double> %b, i64 7, i64 %gvl)
    %call = call signext i32 @puts(ptr @.str)

--- a/llvm/test/CodeGen/RISCV/rvv/setcc-fp-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/setcc-fp-vp.ll
@@ -4822,425 +4822,265 @@ declare <vscale x 32 x i1> @llvm.vp.fcmp.nxv32f64(<vscale x 32 x double>, <vscal
 define <vscale x 32 x i1> @fcmp_oeq_vv_nxv32f64(<vscale x 32 x double> %va, <vscale x 32 x double> %vb, <vscale x 32 x i1> %m, i32 zeroext %evl) {
 ; CHECK32-LABEL: fcmp_oeq_vv_nxv32f64:
 ; CHECK32:       # %bb.0:
-; CHECK32-NEXT:    addi sp, sp, -48
-; CHECK32-NEXT:    .cfi_def_cfa_offset 48
-; CHECK32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; CHECK32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
-; CHECK32-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
-; CHECK32-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
-; CHECK32-NEXT:    sw s3, 28(sp) # 4-byte Folded Spill
-; CHECK32-NEXT:    sw s4, 24(sp) # 4-byte Folded Spill
-; CHECK32-NEXT:    .cfi_offset ra, -4
-; CHECK32-NEXT:    .cfi_offset s0, -8
-; CHECK32-NEXT:    .cfi_offset s1, -12
-; CHECK32-NEXT:    .cfi_offset s2, -16
-; CHECK32-NEXT:    .cfi_offset s3, -20
-; CHECK32-NEXT:    .cfi_offset s4, -24
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    slli a1, a1, 1
-; CHECK32-NEXT:    mv a3, a1
-; CHECK32-NEXT:    slli a1, a1, 2
-; CHECK32-NEXT:    add a3, a3, a1
-; CHECK32-NEXT:    slli a1, a1, 1
-; CHECK32-NEXT:    add a1, a1, a3
-; CHECK32-NEXT:    sub sp, sp, a1
-; CHECK32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x1a, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 26 * vlenb
-; CHECK32-NEXT:    mv s1, a6
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    add a1, sp, a1
-; CHECK32-NEXT:    addi a1, a1, 16
-; CHECK32-NEXT:    vs1r.v v0, (a1) # vscale x 8-byte Folded Spill
-; CHECK32-NEXT:    mv s3, a2
-; CHECK32-NEXT:    mv s2, a0
-; CHECK32-NEXT:    csrr a0, vlenb
-; CHECK32-NEXT:    slli a1, a0, 3
-; CHECK32-NEXT:    add a0, a1, a0
-; CHECK32-NEXT:    add a0, sp, a0
-; CHECK32-NEXT:    addi a0, a0, 16
-; CHECK32-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK32-NEXT:    csrr a0, vlenb
-; CHECK32-NEXT:    slli a0, a0, 1
-; CHECK32-NEXT:    mv a1, a0
-; CHECK32-NEXT:    slli a0, a0, 3
-; CHECK32-NEXT:    add a0, a0, a1
-; CHECK32-NEXT:    add a0, sp, a0
-; CHECK32-NEXT:    addi a0, a0, 16
-; CHECK32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK32-NEXT:    csrr s0, vlenb
-; CHECK32-NEXT:    li a1, 24
-; CHECK32-NEXT:    mv a0, s0
-; CHECK32-NEXT:    call __mulsi3
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    add a1, sp, a1
-; CHECK32-NEXT:    addi a1, a1, 16
-; CHECK32-NEXT:    vl1r.v v6, (a1) # vscale x 8-byte Folded Reload
-; CHECK32-NEXT:    mv a1, a0
-; CHECK32-NEXT:    slli a4, s0, 3
-; CHECK32-NEXT:    srli s4, s0, 2
-; CHECK32-NEXT:    srli a0, s0, 3
-; CHECK32-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
-; CHECK32-NEXT:    vslidedown.vx v7, v6, s4
-; CHECK32-NEXT:    add a2, s3, a4
-; CHECK32-NEXT:    vl8re64.v v16, (a2)
-; CHECK32-NEXT:    slli a6, s0, 4
-; CHECK32-NEXT:    slli a2, s0, 1
-; CHECK32-NEXT:    vsetvli a3, zero, e8, mf4, ta, ma
-; CHECK32-NEXT:    vslidedown.vx v0, v6, a0
-; CHECK32-NEXT:    mv a3, s1
-; CHECK32-NEXT:    bltu s1, a2, .LBB257_2
-; CHECK32-NEXT:  # %bb.1:
-; CHECK32-NEXT:    mv a3, a2
-; CHECK32-NEXT:  .LBB257_2:
-; CHECK32-NEXT:    add a5, s3, a1
-; CHECK32-NEXT:    add a1, s2, a4
-; CHECK32-NEXT:    vslidedown.vx v9, v7, a0
-; CHECK32-NEXT:    csrr a4, vlenb
-; CHECK32-NEXT:    slli a7, a4, 4
-; CHECK32-NEXT:    add a4, a7, a4
-; CHECK32-NEXT:    add a4, sp, a4
-; CHECK32-NEXT:    addi a4, a4, 16
-; CHECK32-NEXT:    vs1r.v v9, (a4) # vscale x 8-byte Folded Spill
-; CHECK32-NEXT:    add a4, s3, a6
-; CHECK32-NEXT:    vl8re64.v v24, (s3)
-; CHECK32-NEXT:    sub a6, a3, s0
-; CHECK32-NEXT:    sltu a7, a3, a6
-; CHECK32-NEXT:    addi a7, a7, -1
-; CHECK32-NEXT:    and a6, a7, a6
-; CHECK32-NEXT:    csrr a7, vlenb
-; CHECK32-NEXT:    slli t0, a7, 3
-; CHECK32-NEXT:    add a7, t0, a7
-; CHECK32-NEXT:    add a7, sp, a7
-; CHECK32-NEXT:    addi a7, a7, 16
-; CHECK32-NEXT:    vl8r.v v8, (a7) # vscale x 64-byte Folded Reload
-; CHECK32-NEXT:    vsetvli zero, a6, e64, m8, ta, ma
-; CHECK32-NEXT:    vmfeq.vv v5, v8, v16, v0.t
-; CHECK32-NEXT:    bltu a3, s0, .LBB257_4
-; CHECK32-NEXT:  # %bb.3:
-; CHECK32-NEXT:    mv a3, s0
-; CHECK32-NEXT:  .LBB257_4:
-; CHECK32-NEXT:    vmv1r.v v0, v6
-; CHECK32-NEXT:    vl8re64.v v8, (a5)
-; CHECK32-NEXT:    csrr a5, vlenb
-; CHECK32-NEXT:    slli a6, a5, 3
-; CHECK32-NEXT:    add a5, a6, a5
-; CHECK32-NEXT:    add a5, sp, a5
-; CHECK32-NEXT:    addi a5, a5, 16
-; CHECK32-NEXT:    vs8r.v v8, (a5) # vscale x 64-byte Folded Spill
-; CHECK32-NEXT:    csrr a5, vlenb
-; CHECK32-NEXT:    slli a5, a5, 1
-; CHECK32-NEXT:    mv a6, a5
-; CHECK32-NEXT:    slli a5, a5, 3
-; CHECK32-NEXT:    add a5, a5, a6
-; CHECK32-NEXT:    add a5, sp, a5
-; CHECK32-NEXT:    addi a5, a5, 16
-; CHECK32-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK32-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; CHECK32-NEXT:    vmfeq.vv v8, v16, v24, v0.t
-; CHECK32-NEXT:    vl8re64.v v16, (a1)
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    add a1, sp, a1
-; CHECK32-NEXT:    addi a1, a1, 16
-; CHECK32-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK32-NEXT:    vl8re64.v v16, (a4)
-; CHECK32-NEXT:    sub a1, s1, a2
-; CHECK32-NEXT:    sltu a2, s1, a1
-; CHECK32-NEXT:    vl8re64.v v24, (s2)
-; CHECK32-NEXT:    addi a2, a2, -1
-; CHECK32-NEXT:    and s1, a2, a1
-; CHECK32-NEXT:    vsetvli zero, s4, e8, mf2, tu, ma
-; CHECK32-NEXT:    vslideup.vx v8, v5, a0
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    slli a1, a1, 1
-; CHECK32-NEXT:    mv a2, a1
-; CHECK32-NEXT:    slli a1, a1, 3
-; CHECK32-NEXT:    add a1, a1, a2
-; CHECK32-NEXT:    add a1, sp, a1
-; CHECK32-NEXT:    addi a1, a1, 16
-; CHECK32-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; CHECK32-NEXT:    mv a1, s1
-; CHECK32-NEXT:    bltu s1, s0, .LBB257_6
-; CHECK32-NEXT:  # %bb.5:
-; CHECK32-NEXT:    mv a1, s0
-; CHECK32-NEXT:  .LBB257_6:
-; CHECK32-NEXT:    vmv1r.v v0, v7
-; CHECK32-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK32-NEXT:    vmfeq.vv v8, v24, v16, v0.t
-; CHECK32-NEXT:    addi a1, sp, 16
-; CHECK32-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; CHECK32-NEXT:    li a1, 3
-; CHECK32-NEXT:    call __mulsi3
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    slli a2, a1, 4
-; CHECK32-NEXT:    add a1, a2, a1
-; CHECK32-NEXT:    add a1, sp, a1
-; CHECK32-NEXT:    addi a1, a1, 16
-; CHECK32-NEXT:    vl1r.v v0, (a1) # vscale x 8-byte Folded Reload
-; CHECK32-NEXT:    csrr a1, vlenb
-; CHECK32-NEXT:    slli a1, a1, 1
-; CHECK32-NEXT:    mv a2, a1
-; CHECK32-NEXT:    slli a1, a1, 3
-; CHECK32-NEXT:    add a1, a1, a2
-; CHECK32-NEXT:    add a1, sp, a1
-; CHECK32-NEXT:    addi a1, a1, 16
-; CHECK32-NEXT:    vl1r.v v9, (a1) # vscale x 8-byte Folded Reload
-; CHECK32-NEXT:    addi a1, sp, 16
-; CHECK32-NEXT:    vl1r.v v8, (a1) # vscale x 8-byte Folded Reload
-; CHECK32-NEXT:    vsetvli zero, a0, e8, mf2, tu, ma
-; CHECK32-NEXT:    vslideup.vx v9, v8, s4
-; CHECK32-NEXT:    sub a1, s1, s0
-; CHECK32-NEXT:    sltu a2, s1, a1
-; CHECK32-NEXT:    addi a2, a2, -1
-; CHECK32-NEXT:    and a1, a2, a1
-; CHECK32-NEXT:    csrr a2, vlenb
-; CHECK32-NEXT:    slli a3, a2, 3
-; CHECK32-NEXT:    add a2, a3, a2
-; CHECK32-NEXT:    add a2, sp, a2
-; CHECK32-NEXT:    addi a2, a2, 16
-; CHECK32-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; CHECK32-NEXT:    csrr a2, vlenb
-; CHECK32-NEXT:    add a2, sp, a2
-; CHECK32-NEXT:    addi a2, a2, 16
-; CHECK32-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; CHECK32-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK32-NEXT:    vmfeq.vv v8, v24, v16, v0.t
-; CHECK32-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; CHECK32-NEXT:    vslideup.vx v9, v8, a0
-; CHECK32-NEXT:    vmv1r.v v0, v9
-; CHECK32-NEXT:    csrr a0, vlenb
-; CHECK32-NEXT:    slli a0, a0, 1
-; CHECK32-NEXT:    mv a1, a0
-; CHECK32-NEXT:    slli a0, a0, 2
-; CHECK32-NEXT:    add a1, a1, a0
-; CHECK32-NEXT:    slli a0, a0, 1
-; CHECK32-NEXT:    add a0, a0, a1
-; CHECK32-NEXT:    add sp, sp, a0
-; CHECK32-NEXT:    .cfi_def_cfa sp, 48
-; CHECK32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; CHECK32-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
-; CHECK32-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
-; CHECK32-NEXT:    lw s2, 32(sp) # 4-byte Folded Reload
-; CHECK32-NEXT:    lw s3, 28(sp) # 4-byte Folded Reload
-; CHECK32-NEXT:    lw s4, 24(sp) # 4-byte Folded Reload
-; CHECK32-NEXT:    .cfi_restore ra
-; CHECK32-NEXT:    .cfi_restore s0
-; CHECK32-NEXT:    .cfi_restore s1
-; CHECK32-NEXT:    .cfi_restore s2
-; CHECK32-NEXT:    .cfi_restore s3
-; CHECK32-NEXT:    .cfi_restore s4
-; CHECK32-NEXT:    addi sp, sp, 48
-; CHECK32-NEXT:    .cfi_def_cfa_offset 0
-; CHECK32-NEXT:    ret
+; CHECK32-NEXT:	addi	sp, sp, -48
+; CHECK32-NEXT:	.cfi_def_cfa_offset 48
+; CHECK32-NEXT:	sw	ra, 44(sp)                      # 4-byte Folded Spill
+; CHECK32-NEXT:	sw	s0, 40(sp)                      # 4-byte Folded Spill
+; CHECK32-NEXT:	sw	s1, 36(sp)                      # 4-byte Folded Spill
+; CHECK32-NEXT:	sw	s2, 32(sp)                      # 4-byte Folded Spill
+; CHECK32-NEXT:	sw	s3, 28(sp)                      # 4-byte Folded Spill
+; CHECK32-NEXT:	sw	s4, 24(sp)                      # 4-byte Folded Spill
+; CHECK32-NEXT:	.cfi_offset ra, -4
+; CHECK32-NEXT:	.cfi_offset s0, -8
+; CHECK32-NEXT:	.cfi_offset s1, -12
+; CHECK32-NEXT:	.cfi_offset s2, -16
+; CHECK32-NEXT:	.cfi_offset s3, -20
+; CHECK32-NEXT:	.cfi_offset s4, -24
+; CHECK32-NEXT:	csrr	a1, vlenb
+; CHECK32-NEXT:	slli	a1, a1, 4
+; CHECK32-NEXT:	sub	sp, sp, a1
+; CHECK32-NEXT:	.cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x10, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 16 * vlenb
+; CHECK32-NEXT:	mv	s1, a6
+; CHECK32-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK32-NEXT:	vmv1r.v	v7, v0
+; CHECK32-NEXT:	mv	s3, a2
+; CHECK32-NEXT:	mv	s2, a0
+; CHECK32-NEXT:	vmv8r.v	v24, v16
+; CHECK32-NEXT:	csrr	a0, vlenb
+; CHECK32-NEXT:	slli	a0, a0, 3
+; CHECK32-NEXT:	add	a0, sp, a0
+; CHECK32-NEXT:	addi	a0, a0, 16
+; CHECK32-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK32-NEXT:	csrr	s0, vlenb
+; CHECK32-NEXT:	li	a1, 24
+; CHECK32-NEXT:	mv	a0, s0
+; CHECK32-NEXT:	call	__mulsi3
+; CHECK32-NEXT:	mv	a1, a0
+; CHECK32-NEXT:	slli	a4, s0, 3
+; CHECK32-NEXT:	srli	s4, s0, 2
+; CHECK32-NEXT:	srli	a0, s0, 3
+; CHECK32-NEXT:	vsetvli	a2, zero, e8, mf2, ta, ma
+; CHECK32-NEXT:	vslidedown.vx	v5, v7, s4
+; CHECK32-NEXT:	add	a2, s3, a4
+; CHECK32-NEXT:	vl8re64.v	v16, (a2)
+; CHECK32-NEXT:	slli	a6, s0, 4
+; CHECK32-NEXT:	slli	a2, s0, 1
+; CHECK32-NEXT:	vsetvli	a3, zero, e8, mf4, ta, ma
+; CHECK32-NEXT:	vslidedown.vx	v0, v7, a0
+; CHECK32-NEXT:	mv	a3, s1
+; CHECK32-NEXT:	bltu	s1, a2, .LBB257_2
+; CHECK32-NEXT:# %bb.1:
+; CHECK32-NEXT:	mv	a3, a2
+; CHECK32-NEXT:.LBB257_2:
+; CHECK32-NEXT:	add	a5, s3, a1
+; CHECK32-NEXT:	add	a1, s2, a4
+; CHECK32-NEXT:	vslidedown.vx	v6, v5, a0
+; CHECK32-NEXT:	add	a4, s3, a6
+; CHECK32-NEXT:	vl8re64.v	v8, (s3)
+; CHECK32-NEXT:	sub	a6, a3, s0
+; CHECK32-NEXT:	sltu	a7, a3, a6
+; CHECK32-NEXT:	addi	a7, a7, -1
+; CHECK32-NEXT:	and	a6, a7, a6
+; CHECK32-NEXT:	vsetvli	zero, a6, e64, m8, ta, ma
+; CHECK32-NEXT:	vmfeq.vv	v4, v24, v16, v0.t
+; CHECK32-NEXT:	bltu	a3, s0, .LBB257_4
+; CHECK32-NEXT:# %bb.3:
+; CHECK32-NEXT:	mv	a3, s0
+; CHECK32-NEXT:.LBB257_4:
+; CHECK32-NEXT:	vmv1r.v	v0, v7
+; CHECK32-NEXT:	vl8re64.v	v16, (a5)
+; CHECK32-NEXT:	addi	a5, sp, 16
+; CHECK32-NEXT:	vs8r.v	v16, (a5)                       # vscale x 64-byte Folded Spill
+; CHECK32-NEXT:	csrr	a5, vlenb
+; CHECK32-NEXT:	slli	a5, a5, 3
+; CHECK32-NEXT:	add	a5, sp, a5
+; CHECK32-NEXT:	addi	a5, a5, 16
+; CHECK32-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK32-NEXT:	vsetvli	zero, a3, e64, m8, ta, ma
+; CHECK32-NEXT:	vmfeq.vv	v7, v16, v8, v0.t
+; CHECK32-NEXT:	vl8re64.v	v24, (a1)
+; CHECK32-NEXT:	vl8re64.v	v8, (a4)
+; CHECK32-NEXT:	sub	a1, s1, a2
+; CHECK32-NEXT:	sltu	a2, s1, a1
+; CHECK32-NEXT:	vl8re64.v	v16, (s2)
+; CHECK32-NEXT:	addi	a2, a2, -1
+; CHECK32-NEXT:	and	s1, a2, a1
+; CHECK32-NEXT:	vsetvli	zero, s4, e8, mf2, tu, ma
+; CHECK32-NEXT:	vslideup.vx	v7, v4, a0
+; CHECK32-NEXT:	mv	a1, s1
+; CHECK32-NEXT:	bltu	s1, s0, .LBB257_6
+; CHECK32-NEXT:# %bb.5:
+; CHECK32-NEXT:	mv	a1, s0
+; CHECK32-NEXT:.LBB257_6:
+; CHECK32-NEXT:	vmv1r.v	v0, v5
+; CHECK32-NEXT:	vsetvli	zero, a1, e64, m8, ta, ma
+; CHECK32-NEXT:	vmfeq.vv	v5, v16, v8, v0.t
+; CHECK32-NEXT:	li	a1, 3
+; CHECK32-NEXT:	call	__mulsi3
+; CHECK32-NEXT:	vsetvli	zero, a0, e8, mf2, tu, ma
+; CHECK32-NEXT:	vmv1r.v	v0, v6
+; CHECK32-NEXT:	vslideup.vx	v7, v5, s4
+; CHECK32-NEXT:	sub	a1, s1, s0
+; CHECK32-NEXT:	sltu	a2, s1, a1
+; CHECK32-NEXT:	addi	a2, a2, -1
+; CHECK32-NEXT:	and	a1, a2, a1
+; CHECK32-NEXT:	addi	a2, sp, 16
+; CHECK32-NEXT:	vl8r.v	v16, (a2)                       # vscale x 64-byte Folded Reload
+; CHECK32-NEXT:	vsetvli	zero, a1, e64, m8, ta, ma
+; CHECK32-NEXT:	vmfeq.vv	v8, v24, v16, v0.t
+; CHECK32-NEXT:	vsetvli	a1, zero, e8, mf2, ta, ma
+; CHECK32-NEXT:	vslideup.vx	v7, v8, a0
+; CHECK32-NEXT:	vmv1r.v	v0, v7
+; CHECK32-NEXT:	csrr	a0, vlenb
+; CHECK32-NEXT:	slli	a0, a0, 4
+; CHECK32-NEXT:	add	sp, sp, a0
+; CHECK32-NEXT:	.cfi_def_cfa sp, 48
+; CHECK32-NEXT:	lw	ra, 44(sp)                      # 4-byte Folded Reload
+; CHECK32-NEXT:	lw	s0, 40(sp)                      # 4-byte Folded Reload
+; CHECK32-NEXT:	lw	s1, 36(sp)                      # 4-byte Folded Reload
+; CHECK32-NEXT:	lw	s2, 32(sp)                      # 4-byte Folded Reload
+; CHECK32-NEXT:	lw	s3, 28(sp)                      # 4-byte Folded Reload
+; CHECK32-NEXT:	lw	s4, 24(sp)                      # 4-byte Folded Reload
+; CHECK32-NEXT:	.cfi_restore ra
+; CHECK32-NEXT:	.cfi_restore s0
+; CHECK32-NEXT:	.cfi_restore s1
+; CHECK32-NEXT:	.cfi_restore s2
+; CHECK32-NEXT:	.cfi_restore s3
+; CHECK32-NEXT:	.cfi_restore s4
+; CHECK32-NEXT:	addi	sp, sp, 48
+; CHECK32-NEXT:	.cfi_def_cfa_offset 0
+; CHECK32-NEXT:	ret
 ;
 ; CHECK64-LABEL: fcmp_oeq_vv_nxv32f64:
 ; CHECK64:       # %bb.0:
-; CHECK64-NEXT:    addi sp, sp, -64
-; CHECK64-NEXT:    .cfi_def_cfa_offset 64
-; CHECK64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK64-NEXT:    sd s2, 32(sp) # 8-byte Folded Spill
-; CHECK64-NEXT:    sd s3, 24(sp) # 8-byte Folded Spill
-; CHECK64-NEXT:    sd s4, 16(sp) # 8-byte Folded Spill
-; CHECK64-NEXT:    .cfi_offset ra, -8
-; CHECK64-NEXT:    .cfi_offset s0, -16
-; CHECK64-NEXT:    .cfi_offset s1, -24
-; CHECK64-NEXT:    .cfi_offset s2, -32
-; CHECK64-NEXT:    .cfi_offset s3, -40
-; CHECK64-NEXT:    .cfi_offset s4, -48
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    slli a1, a1, 1
-; CHECK64-NEXT:    mv a3, a1
-; CHECK64-NEXT:    slli a1, a1, 2
-; CHECK64-NEXT:    add a3, a3, a1
-; CHECK64-NEXT:    slli a1, a1, 1
-; CHECK64-NEXT:    add a1, a1, a3
-; CHECK64-NEXT:    sub sp, sp, a1
-; CHECK64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x1a, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 26 * vlenb
-; CHECK64-NEXT:    mv s1, a6
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    add a1, sp, a1
-; CHECK64-NEXT:    addi a1, a1, 16
-; CHECK64-NEXT:    vs1r.v v0, (a1) # vscale x 8-byte Folded Spill
-; CHECK64-NEXT:    mv s3, a2
-; CHECK64-NEXT:    mv s2, a0
-; CHECK64-NEXT:    csrr a0, vlenb
-; CHECK64-NEXT:    slli a1, a0, 3
-; CHECK64-NEXT:    add a0, a1, a0
-; CHECK64-NEXT:    add a0, sp, a0
-; CHECK64-NEXT:    addi a0, a0, 16
-; CHECK64-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
-; CHECK64-NEXT:    csrr a0, vlenb
-; CHECK64-NEXT:    slli a0, a0, 1
-; CHECK64-NEXT:    mv a1, a0
-; CHECK64-NEXT:    slli a0, a0, 3
-; CHECK64-NEXT:    add a0, a0, a1
-; CHECK64-NEXT:    add a0, sp, a0
-; CHECK64-NEXT:    addi a0, a0, 16
-; CHECK64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK64-NEXT:    csrr s0, vlenb
-; CHECK64-NEXT:    li a1, 24
-; CHECK64-NEXT:    mv a0, s0
-; CHECK64-NEXT:    call __muldi3
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    add a1, sp, a1
-; CHECK64-NEXT:    addi a1, a1, 16
-; CHECK64-NEXT:    vl1r.v v6, (a1) # vscale x 8-byte Folded Reload
-; CHECK64-NEXT:    mv a1, a0
-; CHECK64-NEXT:    slli a4, s0, 3
-; CHECK64-NEXT:    srli s4, s0, 2
-; CHECK64-NEXT:    srli a0, s0, 3
-; CHECK64-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
-; CHECK64-NEXT:    vslidedown.vx v7, v6, s4
-; CHECK64-NEXT:    add a2, s3, a4
-; CHECK64-NEXT:    vl8re64.v v16, (a2)
-; CHECK64-NEXT:    slli a6, s0, 4
-; CHECK64-NEXT:    slli a2, s0, 1
-; CHECK64-NEXT:    vsetvli a3, zero, e8, mf4, ta, ma
-; CHECK64-NEXT:    vslidedown.vx v0, v6, a0
-; CHECK64-NEXT:    mv a3, s1
-; CHECK64-NEXT:    bltu s1, a2, .LBB257_2
-; CHECK64-NEXT:  # %bb.1:
-; CHECK64-NEXT:    mv a3, a2
-; CHECK64-NEXT:  .LBB257_2:
-; CHECK64-NEXT:    add a5, s3, a1
-; CHECK64-NEXT:    add a1, s2, a4
-; CHECK64-NEXT:    vslidedown.vx v9, v7, a0
-; CHECK64-NEXT:    csrr a4, vlenb
-; CHECK64-NEXT:    slli a7, a4, 4
-; CHECK64-NEXT:    add a4, a7, a4
-; CHECK64-NEXT:    add a4, sp, a4
-; CHECK64-NEXT:    addi a4, a4, 16
-; CHECK64-NEXT:    vs1r.v v9, (a4) # vscale x 8-byte Folded Spill
-; CHECK64-NEXT:    add a4, s3, a6
-; CHECK64-NEXT:    vl8re64.v v24, (s3)
-; CHECK64-NEXT:    sub a6, a3, s0
-; CHECK64-NEXT:    sltu a7, a3, a6
-; CHECK64-NEXT:    addi a7, a7, -1
-; CHECK64-NEXT:    and a6, a7, a6
-; CHECK64-NEXT:    csrr a7, vlenb
-; CHECK64-NEXT:    slli t0, a7, 3
-; CHECK64-NEXT:    add a7, t0, a7
-; CHECK64-NEXT:    add a7, sp, a7
-; CHECK64-NEXT:    addi a7, a7, 16
-; CHECK64-NEXT:    vl8r.v v8, (a7) # vscale x 64-byte Folded Reload
-; CHECK64-NEXT:    vsetvli zero, a6, e64, m8, ta, ma
-; CHECK64-NEXT:    vmfeq.vv v5, v8, v16, v0.t
-; CHECK64-NEXT:    bltu a3, s0, .LBB257_4
-; CHECK64-NEXT:  # %bb.3:
-; CHECK64-NEXT:    mv a3, s0
-; CHECK64-NEXT:  .LBB257_4:
-; CHECK64-NEXT:    vmv1r.v v0, v6
-; CHECK64-NEXT:    vl8re64.v v8, (a5)
-; CHECK64-NEXT:    csrr a5, vlenb
-; CHECK64-NEXT:    slli a6, a5, 3
-; CHECK64-NEXT:    add a5, a6, a5
-; CHECK64-NEXT:    add a5, sp, a5
-; CHECK64-NEXT:    addi a5, a5, 16
-; CHECK64-NEXT:    vs8r.v v8, (a5) # vscale x 64-byte Folded Spill
-; CHECK64-NEXT:    csrr a5, vlenb
-; CHECK64-NEXT:    slli a5, a5, 1
-; CHECK64-NEXT:    mv a6, a5
-; CHECK64-NEXT:    slli a5, a5, 3
-; CHECK64-NEXT:    add a5, a5, a6
-; CHECK64-NEXT:    add a5, sp, a5
-; CHECK64-NEXT:    addi a5, a5, 16
-; CHECK64-NEXT:    vl8r.v v16, (a5) # vscale x 64-byte Folded Reload
-; CHECK64-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; CHECK64-NEXT:    vmfeq.vv v8, v16, v24, v0.t
-; CHECK64-NEXT:    vl8re64.v v16, (a1)
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    add a1, sp, a1
-; CHECK64-NEXT:    addi a1, a1, 16
-; CHECK64-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK64-NEXT:    vl8re64.v v16, (a4)
-; CHECK64-NEXT:    sub a1, s1, a2
-; CHECK64-NEXT:    sltu a2, s1, a1
-; CHECK64-NEXT:    vl8re64.v v24, (s2)
-; CHECK64-NEXT:    addi a2, a2, -1
-; CHECK64-NEXT:    and s1, a2, a1
-; CHECK64-NEXT:    vsetvli zero, s4, e8, mf2, tu, ma
-; CHECK64-NEXT:    vslideup.vx v8, v5, a0
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    slli a1, a1, 1
-; CHECK64-NEXT:    mv a2, a1
-; CHECK64-NEXT:    slli a1, a1, 3
-; CHECK64-NEXT:    add a1, a1, a2
-; CHECK64-NEXT:    add a1, sp, a1
-; CHECK64-NEXT:    addi a1, a1, 16
-; CHECK64-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; CHECK64-NEXT:    mv a1, s1
-; CHECK64-NEXT:    bltu s1, s0, .LBB257_6
-; CHECK64-NEXT:  # %bb.5:
-; CHECK64-NEXT:    mv a1, s0
-; CHECK64-NEXT:  .LBB257_6:
-; CHECK64-NEXT:    vmv1r.v v0, v7
-; CHECK64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK64-NEXT:    vmfeq.vv v8, v24, v16, v0.t
-; CHECK64-NEXT:    addi a1, sp, 16
-; CHECK64-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
-; CHECK64-NEXT:    li a1, 3
-; CHECK64-NEXT:    call __muldi3
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    slli a2, a1, 4
-; CHECK64-NEXT:    add a1, a2, a1
-; CHECK64-NEXT:    add a1, sp, a1
-; CHECK64-NEXT:    addi a1, a1, 16
-; CHECK64-NEXT:    vl1r.v v0, (a1) # vscale x 8-byte Folded Reload
-; CHECK64-NEXT:    csrr a1, vlenb
-; CHECK64-NEXT:    slli a1, a1, 1
-; CHECK64-NEXT:    mv a2, a1
-; CHECK64-NEXT:    slli a1, a1, 3
-; CHECK64-NEXT:    add a1, a1, a2
-; CHECK64-NEXT:    add a1, sp, a1
-; CHECK64-NEXT:    addi a1, a1, 16
-; CHECK64-NEXT:    vl1r.v v9, (a1) # vscale x 8-byte Folded Reload
-; CHECK64-NEXT:    addi a1, sp, 16
-; CHECK64-NEXT:    vl1r.v v8, (a1) # vscale x 8-byte Folded Reload
-; CHECK64-NEXT:    vsetvli zero, a0, e8, mf2, tu, ma
-; CHECK64-NEXT:    vslideup.vx v9, v8, s4
-; CHECK64-NEXT:    sub a1, s1, s0
-; CHECK64-NEXT:    sltu a2, s1, a1
-; CHECK64-NEXT:    addi a2, a2, -1
-; CHECK64-NEXT:    and a1, a2, a1
-; CHECK64-NEXT:    csrr a2, vlenb
-; CHECK64-NEXT:    slli a3, a2, 3
-; CHECK64-NEXT:    add a2, a3, a2
-; CHECK64-NEXT:    add a2, sp, a2
-; CHECK64-NEXT:    addi a2, a2, 16
-; CHECK64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; CHECK64-NEXT:    csrr a2, vlenb
-; CHECK64-NEXT:    add a2, sp, a2
-; CHECK64-NEXT:    addi a2, a2, 16
-; CHECK64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; CHECK64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK64-NEXT:    vmfeq.vv v8, v24, v16, v0.t
-; CHECK64-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; CHECK64-NEXT:    vslideup.vx v9, v8, a0
-; CHECK64-NEXT:    vmv1r.v v0, v9
-; CHECK64-NEXT:    csrr a0, vlenb
-; CHECK64-NEXT:    slli a0, a0, 1
-; CHECK64-NEXT:    mv a1, a0
-; CHECK64-NEXT:    slli a0, a0, 2
-; CHECK64-NEXT:    add a1, a1, a0
-; CHECK64-NEXT:    slli a0, a0, 1
-; CHECK64-NEXT:    add a0, a0, a1
-; CHECK64-NEXT:    add sp, sp, a0
-; CHECK64-NEXT:    .cfi_def_cfa sp, 64
-; CHECK64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK64-NEXT:    ld s2, 32(sp) # 8-byte Folded Reload
-; CHECK64-NEXT:    ld s3, 24(sp) # 8-byte Folded Reload
-; CHECK64-NEXT:    ld s4, 16(sp) # 8-byte Folded Reload
-; CHECK64-NEXT:    .cfi_restore ra
-; CHECK64-NEXT:    .cfi_restore s0
-; CHECK64-NEXT:    .cfi_restore s1
-; CHECK64-NEXT:    .cfi_restore s2
-; CHECK64-NEXT:    .cfi_restore s3
-; CHECK64-NEXT:    .cfi_restore s4
-; CHECK64-NEXT:    addi sp, sp, 64
-; CHECK64-NEXT:    .cfi_def_cfa_offset 0
-; CHECK64-NEXT:    ret
+; CHECK64-NEXT:addi	sp, sp, -64
+; CHECK64-NEXT:	.cfi_def_cfa_offset 64
+; CHECK64-NEXT:	sd	ra, 56(sp)                      # 8-byte Folded Spill
+; CHECK64-NEXT:	sd	s0, 48(sp)                      # 8-byte Folded Spill
+; CHECK64-NEXT:	sd	s1, 40(sp)                      # 8-byte Folded Spill
+; CHECK64-NEXT:	sd	s2, 32(sp)                      # 8-byte Folded Spill
+; CHECK64-NEXT:	sd	s3, 24(sp)                      # 8-byte Folded Spill
+; CHECK64-NEXT:	sd	s4, 16(sp)                      # 8-byte Folded Spill
+; CHECK64-NEXT:	.cfi_offset ra, -8
+; CHECK64-NEXT:	.cfi_offset s0, -16
+; CHECK64-NEXT:	.cfi_offset s1, -24
+; CHECK64-NEXT:	.cfi_offset s2, -32
+; CHECK64-NEXT:	.cfi_offset s3, -40
+; CHECK64-NEXT:	.cfi_offset s4, -48
+; CHECK64-NEXT:	csrr	a1, vlenb
+; CHECK64-NEXT:	slli	a1, a1, 4
+; CHECK64-NEXT:	sub	sp, sp, a1
+; CHECK64-NEXT:	.cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x10, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 16 * vlenb
+; CHECK64-NEXT:	mv	s1, a6
+; CHECK64-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK64-NEXT:	vmv1r.v	v7, v0
+; CHECK64-NEXT:	mv	s3, a2
+; CHECK64-NEXT:	mv	s2, a0
+; CHECK64-NEXT:	vmv8r.v	v24, v16
+; CHECK64-NEXT:	csrr	a0, vlenb
+; CHECK64-NEXT:	slli	a0, a0, 3
+; CHECK64-NEXT:	add	a0, sp, a0
+; CHECK64-NEXT:	addi	a0, a0, 16
+; CHECK64-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; CHECK64-NEXT:	csrr	s0, vlenb
+; CHECK64-NEXT:	li	a1, 24
+; CHECK64-NEXT:	mv	a0, s0
+; CHECK64-NEXT:	call	__muldi3
+; CHECK64-NEXT:	mv	a1, a0
+; CHECK64-NEXT:	slli	a4, s0, 3
+; CHECK64-NEXT:	srli	s4, s0, 2
+; CHECK64-NEXT:	srli	a0, s0, 3
+; CHECK64-NEXT:	vsetvli	a2, zero, e8, mf2, ta, ma
+; CHECK64-NEXT:	vslidedown.vx	v5, v7, s4
+; CHECK64-NEXT:	add	a2, s3, a4
+; CHECK64-NEXT:	vl8re64.v	v16, (a2)
+; CHECK64-NEXT:	slli	a6, s0, 4
+; CHECK64-NEXT:	slli	a2, s0, 1
+; CHECK64-NEXT:	vsetvli	a3, zero, e8, mf4, ta, ma
+; CHECK64-NEXT:	vslidedown.vx	v0, v7, a0
+; CHECK64-NEXT:	mv	a3, s1
+; CHECK64-NEXT:	bltu	s1, a2, .LBB257_2
+; CHECK64-NEXT:# %bb.1:
+; CHECK64-NEXT:	mv	a3, a2
+; CHECK64-NEXT:.LBB257_2:
+; CHECK64-NEXT:	add	a5, s3, a1
+; CHECK64-NEXT:	add	a1, s2, a4
+; CHECK64-NEXT:	vslidedown.vx	v6, v5, a0
+; CHECK64-NEXT:	add	a4, s3, a6
+; CHECK64-NEXT:	vl8re64.v	v8, (s3)
+; CHECK64-NEXT:	sub	a6, a3, s0
+; CHECK64-NEXT:	sltu	a7, a3, a6
+; CHECK64-NEXT:	addi	a7, a7, -1
+; CHECK64-NEXT:	and	a6, a7, a6
+; CHECK64-NEXT:	vsetvli	zero, a6, e64, m8, ta, ma
+; CHECK64-NEXT:	vmfeq.vv	v4, v24, v16, v0.t
+; CHECK64-NEXT:	bltu	a3, s0, .LBB257_4
+; CHECK64-NEXT:# %bb.3:
+; CHECK64-NEXT:	mv	a3, s0
+; CHECK64-NEXT:.LBB257_4:
+; CHECK64-NEXT:	vmv1r.v	v0, v7
+; CHECK64-NEXT:	vl8re64.v	v16, (a5)
+; CHECK64-NEXT:	addi	a5, sp, 16
+; CHECK64-NEXT:	vs8r.v	v16, (a5)                       # vscale x 64-byte Folded Spill
+; CHECK64-NEXT:	csrr	a5, vlenb
+; CHECK64-NEXT:	slli	a5, a5, 3
+; CHECK64-NEXT:	add	a5, sp, a5
+; CHECK64-NEXT:	addi	a5, a5, 16
+; CHECK64-NEXT:	vl8r.v	v16, (a5)                       # vscale x 64-byte Folded Reload
+; CHECK64-NEXT:	vsetvli	zero, a3, e64, m8, ta, ma
+; CHECK64-NEXT:	vmfeq.vv	v7, v16, v8, v0.t
+; CHECK64-NEXT:	vl8re64.v	v24, (a1)
+; CHECK64-NEXT:	vl8re64.v	v8, (a4)
+; CHECK64-NEXT:	sub	a1, s1, a2
+; CHECK64-NEXT:	sltu	a2, s1, a1
+; CHECK64-NEXT:	vl8re64.v	v16, (s2)
+; CHECK64-NEXT:	addi	a2, a2, -1
+; CHECK64-NEXT:	and	s1, a2, a1
+; CHECK64-NEXT:	vsetvli	zero, s4, e8, mf2, tu, ma
+; CHECK64-NEXT:	vslideup.vx	v7, v4, a0
+; CHECK64-NEXT:	mv	a1, s1
+; CHECK64-NEXT:	bltu	s1, s0, .LBB257_6
+; CHECK64-NEXT:# %bb.5:
+; CHECK64-NEXT:	mv	a1, s0
+; CHECK64-NEXT:.LBB257_6:
+; CHECK64-NEXT:	vmv1r.v	v0, v5
+; CHECK64-NEXT:	vsetvli	zero, a1, e64, m8, ta, ma
+; CHECK64-NEXT:	vmfeq.vv	v5, v16, v8, v0.t
+; CHECK64-NEXT:	li	a1, 3
+; CHECK64-NEXT:	call	__muldi3
+; CHECK64-NEXT:	vsetvli	zero, a0, e8, mf2, tu, ma
+; CHECK64-NEXT:	vmv1r.v	v0, v6
+; CHECK64-NEXT:	vslideup.vx	v7, v5, s4
+; CHECK64-NEXT:	sub	a1, s1, s0
+; CHECK64-NEXT:	sltu	a2, s1, a1
+; CHECK64-NEXT:	addi	a2, a2, -1
+; CHECK64-NEXT:	and	a1, a2, a1
+; CHECK64-NEXT:	addi	a2, sp, 16
+; CHECK64-NEXT:	vl8r.v	v16, (a2)                       # vscale x 64-byte Folded Reload
+; CHECK64-NEXT:	vsetvli	zero, a1, e64, m8, ta, ma
+; CHECK64-NEXT:	vmfeq.vv	v8, v24, v16, v0.t
+; CHECK64-NEXT:	vsetvli	a1, zero, e8, mf2, ta, ma
+; CHECK64-NEXT:	vslideup.vx	v7, v8, a0
+; CHECK64-NEXT:	vmv1r.v	v0, v7
+; CHECK64-NEXT:	csrr	a0, vlenb
+; CHECK64-NEXT:	slli	a0, a0, 4
+; CHECK64-NEXT:	add	sp, sp, a0
+; CHECK64-NEXT:	.cfi_def_cfa sp, 64
+; CHECK64-NEXT:	ld	ra, 56(sp)                      # 8-byte Folded Reload
+; CHECK64-NEXT:	ld	s0, 48(sp)                      # 8-byte Folded Reload
+; CHECK64-NEXT:	ld	s1, 40(sp)                      # 8-byte Folded Reload
+; CHECK64-NEXT:	ld	s2, 32(sp)                      # 8-byte Folded Reload
+; CHECK64-NEXT:	ld	s3, 24(sp)                      # 8-byte Folded Reload
+; CHECK64-NEXT:	ld	s4, 16(sp)                      # 8-byte Folded Reload
+; CHECK64-NEXT:	.cfi_restore ra
+; CHECK64-NEXT:	.cfi_restore s0
+; CHECK64-NEXT:	.cfi_restore s1
+; CHECK64-NEXT:	.cfi_restore s2
+; CHECK64-NEXT:	.cfi_restore s3
+; CHECK64-NEXT:	.cfi_restore s4
+; CHECK64-NEXT:	addi	sp, sp, 64
+; CHECK64-NEXT:	.cfi_def_cfa_offset 0
+; CHECK64-NEXT:	ret
   %v = call <vscale x 32 x i1> @llvm.vp.fcmp.nxv32f64(<vscale x 32 x double> %va, <vscale x 32 x double> %vb, metadata !"oeq", <vscale x 32 x i1> %m, i32 %evl)
   ret <vscale x 32 x i1> %v
 }

--- a/llvm/test/CodeGen/RISCV/rvv/stack-slot-coloring.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/stack-slot-coloring.ll
@@ -7,85 +7,59 @@ declare void @foo()
 define void @test_m1(ptr %p, ptr %p2) {
 ; RV32-LABEL: test_m1:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -48
-; RV32-NEXT:    .cfi_def_cfa_offset 48
-; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    .cfi_offset s0, -8
-; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    sub sp, sp, a2
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 1 * vlenb
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    vl1r.v v8, (a0)
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    mv s1, a1
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vs1r.v v8, (s0)
-; RV32-NEXT:    vl1r.v v8, (s1)
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vs1r.v v8, (s1)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    .cfi_def_cfa sp, 48
-; RV32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    .cfi_restore s0
-; RV32-NEXT:    .cfi_restore s1
-; RV32-NEXT:    addi sp, sp, 48
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	.cfi_def_cfa_offset 16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	sw	s1, 4(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	.cfi_offset s0, -8
+; RV32-NEXT:	.cfi_offset s1, -12
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vl1r.v	v24, (a0)
+; RV32-NEXT:	mv	s1, a1
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs1r.v	v24, (s0)
+; RV32-NEXT:	vl1r.v	v24, (s1)
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs1r.v	v24, (s1)
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	lw	s1, 4(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	.cfi_restore s0
+; RV32-NEXT:	.cfi_restore s1
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: test_m1:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s1, -24
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    sub sp, sp, a2
-; RV64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 1 * vlenb
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    vl1r.v v8, (a0)
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    mv s1, a1
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vs1r.v v8, (s0)
-; RV64-NEXT:    vl1r.v v8, (s1)
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vs1r.v v8, (s1)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    .cfi_restore ra
-; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s1
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	.cfi_def_cfa_offset 32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; RV64-NEXT:	.cfi_offset ra, -8
+; RV64-NEXT:	.cfi_offset s0, -16
+; RV64-NEXT:	.cfi_offset s1, -24
+; RV64-NEXT:	mv	s0, a0
+; RV64-NEXT:	vl1r.v	v24, (a0)
+; RV64-NEXT:	mv	s1, a1
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs1r.v	v24, (s0)
+; RV64-NEXT:	vl1r.v	v24, (s1)
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs1r.v	v24, (s1)
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; RV64-NEXT:	.cfi_restore ra
+; RV64-NEXT:	.cfi_restore s0
+; RV64-NEXT:	.cfi_restore s1
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-NEXT:	ret
   %v1 = load <vscale x 8 x i8>, ptr %p
   call void @foo();
   store <vscale x 8 x i8> %v1, ptr %p
@@ -98,89 +72,59 @@ define void @test_m1(ptr %p, ptr %p2) {
 define void @test_m2(ptr %p, ptr %p2) {
 ; RV32-LABEL: test_m2:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -48
-; RV32-NEXT:    .cfi_def_cfa_offset 48
-; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    .cfi_offset s0, -8
-; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 1
-; RV32-NEXT:    sub sp, sp, a2
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 2 * vlenb
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    vl2r.v v8, (a0)
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    mv s1, a1
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vs2r.v v8, (s0)
-; RV32-NEXT:    vl2r.v v8, (s1)
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vs2r.v v8, (s1)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    .cfi_def_cfa sp, 48
-; RV32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    .cfi_restore s0
-; RV32-NEXT:    .cfi_restore s1
-; RV32-NEXT:    addi sp, sp, 48
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	.cfi_def_cfa_offset 16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	sw	s1, 4(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	.cfi_offset s0, -8
+; RV32-NEXT:	.cfi_offset s1, -12
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vl2r.v	v24, (a0)
+; RV32-NEXT:	mv	s1, a1
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs2r.v	v24, (s0)
+; RV32-NEXT:	vl2r.v	v24, (s1)
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs2r.v	v24, (s1)
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	lw	s1, 4(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	.cfi_restore s0
+; RV32-NEXT:	.cfi_restore s1
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: test_m2:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s1, -24
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 1
-; RV64-NEXT:    sub sp, sp, a2
-; RV64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 2 * vlenb
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    vl2r.v v8, (a0)
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    mv s1, a1
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vs2r.v v8, (s0)
-; RV64-NEXT:    vl2r.v v8, (s1)
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vs2r.v v8, (s1)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    .cfi_restore ra
-; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s1
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	.cfi_def_cfa_offset 32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; RV64-NEXT:	.cfi_offset ra, -8
+; RV64-NEXT:	.cfi_offset s0, -16
+; RV64-NEXT:	.cfi_offset s1, -24
+; RV64-NEXT:	mv	s0, a0
+; RV64-NEXT:	vl2r.v	v24, (a0)
+; RV64-NEXT:	mv	s1, a1
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs2r.v	v24, (s0)
+; RV64-NEXT:	vl2r.v	v24, (s1)
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs2r.v	v24, (s1)
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; RV64-NEXT:	.cfi_restore ra
+; RV64-NEXT:	.cfi_restore s0
+; RV64-NEXT:	.cfi_restore s1
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-NEXT:	ret
   %v1 = load <vscale x 16 x i8>, ptr %p
   call void @foo();
   store <vscale x 16 x i8> %v1, ptr %p
@@ -193,89 +137,59 @@ define void @test_m2(ptr %p, ptr %p2) {
 define void @test_m8(ptr %p, ptr %p2) {
 ; RV32-LABEL: test_m8:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -48
-; RV32-NEXT:    .cfi_def_cfa_offset 48
-; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    .cfi_offset s0, -8
-; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 3
-; RV32-NEXT:    sub sp, sp, a2
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x08, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 8 * vlenb
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    vl8r.v v8, (a0)
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    mv s1, a1
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v8, (s0)
-; RV32-NEXT:    vl8r.v v8, (s1)
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v8, (s1)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    .cfi_def_cfa sp, 48
-; RV32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    .cfi_restore s0
-; RV32-NEXT:    .cfi_restore s1
-; RV32-NEXT:    addi sp, sp, 48
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	.cfi_def_cfa_offset 16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	sw	s1, 4(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	.cfi_offset s0, -8
+; RV32-NEXT:	.cfi_offset s1, -12
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vl8r.v	v24, (a0)
+; RV32-NEXT:	mv	s1, a1
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs8r.v	v24, (s0)
+; RV32-NEXT:	vl8r.v	v24, (s1)
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs8r.v	v24, (s1)
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	lw	s1, 4(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	.cfi_restore s0
+; RV32-NEXT:	.cfi_restore s1
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: test_m8:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s1, -24
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 3
-; RV64-NEXT:    sub sp, sp, a2
-; RV64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x08, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 8 * vlenb
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    vl8r.v v8, (a0)
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    mv s1, a1
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v8, (s0)
-; RV64-NEXT:    vl8r.v v8, (s1)
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v8, (s1)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    .cfi_restore ra
-; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s1
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	.cfi_def_cfa_offset 32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; RV64-NEXT:	.cfi_offset ra, -8
+; RV64-NEXT:	.cfi_offset s0, -16
+; RV64-NEXT:	.cfi_offset s1, -24
+; RV64-NEXT:	mv	s0, a0
+; RV64-NEXT:	vl8r.v	v24, (a0)
+; RV64-NEXT:	mv	s1, a1
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs8r.v	v24, (s0)
+; RV64-NEXT:	vl8r.v	v24, (s1)
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs8r.v	v24, (s1)
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; RV64-NEXT:	.cfi_restore ra
+; RV64-NEXT:	.cfi_restore s0
+; RV64-NEXT:	.cfi_restore s1
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-NEXT:	ret
   %v1 = load <vscale x 64 x i8>, ptr %p
   call void @foo();
   store <vscale x 64 x i8> %v1, ptr %p
@@ -288,89 +202,59 @@ define void @test_m8(ptr %p, ptr %p2) {
 define void @test_m1_then_m1(ptr %p, ptr %p2) {
 ; RV32-LABEL: test_m1_then_m1:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -48
-; RV32-NEXT:    .cfi_def_cfa_offset 48
-; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    .cfi_offset s0, -8
-; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 1
-; RV32-NEXT:    sub sp, sp, a2
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 2 * vlenb
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    vl2r.v v8, (a0)
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    mv s1, a1
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vs2r.v v8, (s0)
-; RV32-NEXT:    vl1r.v v8, (s1)
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vs1r.v v8, (s1)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    .cfi_def_cfa sp, 48
-; RV32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    .cfi_restore s0
-; RV32-NEXT:    .cfi_restore s1
-; RV32-NEXT:    addi sp, sp, 48
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	.cfi_def_cfa_offset 16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	sw	s1, 4(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	.cfi_offset s0, -8
+; RV32-NEXT:	.cfi_offset s1, -12
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vl2r.v	v24, (a0)
+; RV32-NEXT:	mv	s1, a1
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs2r.v	v24, (s0)
+; RV32-NEXT:	vl1r.v	v24, (s1)
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs1r.v	v24, (s1)
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	lw	s1, 4(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	.cfi_restore s0
+; RV32-NEXT:	.cfi_restore s1
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: test_m1_then_m1:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s1, -24
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 1
-; RV64-NEXT:    sub sp, sp, a2
-; RV64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 2 * vlenb
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    vl2r.v v8, (a0)
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    mv s1, a1
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vs2r.v v8, (s0)
-; RV64-NEXT:    vl1r.v v8, (s1)
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vs1r.v v8, (s1)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    .cfi_restore ra
-; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s1
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	.cfi_def_cfa_offset 32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; RV64-NEXT:	.cfi_offset ra, -8
+; RV64-NEXT:	.cfi_offset s0, -16
+; RV64-NEXT:	.cfi_offset s1, -24
+; RV64-NEXT:	mv	s0, a0
+; RV64-NEXT:	vl2r.v	v24, (a0)
+; RV64-NEXT:	mv	s1, a1
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs2r.v	v24, (s0)
+; RV64-NEXT:	vl1r.v	v24, (s1)
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs1r.v	v24, (s1)
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; RV64-NEXT:	.cfi_restore ra
+; RV64-NEXT:	.cfi_restore s0
+; RV64-NEXT:	.cfi_restore s1
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-NEXT:	ret
   %v1 = load <vscale x 16 x i8>, ptr %p
   call void @foo();
   store <vscale x 16 x i8> %v1, ptr %p
@@ -383,89 +267,59 @@ define void @test_m1_then_m1(ptr %p, ptr %p2) {
 define void @test_m1_then_m2(ptr %p, ptr %p2) {
 ; RV32-LABEL: test_m1_then_m2:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -48
-; RV32-NEXT:    .cfi_def_cfa_offset 48
-; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    .cfi_offset s0, -8
-; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 1
-; RV32-NEXT:    sub sp, sp, a2
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x30, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 48 + 2 * vlenb
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    vl1r.v v8, (a0)
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    mv s1, a1
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vs1r.v v8, (s0)
-; RV32-NEXT:    vl2r.v v8, (s1)
-; RV32-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32-NEXT:    call foo
-; RV32-NEXT:    addi a0, sp, 32
-; RV32-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV32-NEXT:    vs2r.v v8, (s1)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    .cfi_def_cfa sp, 48
-; RV32-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    .cfi_restore s0
-; RV32-NEXT:    .cfi_restore s1
-; RV32-NEXT:    addi sp, sp, 48
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:	addi	sp, sp, -16
+; RV32-NEXT:	.cfi_def_cfa_offset 16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	sw	s1, 4(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	.cfi_offset s0, -8
+; RV32-NEXT:	.cfi_offset s1, -12
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vl1r.v	v24, (a0)
+; RV32-NEXT:	mv	s1, a1
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs1r.v	v24, (s0)
+; RV32-NEXT:	vl2r.v	v24, (s1)
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	vs2r.v	v24, (s1)
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	lw	s1, 4(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	.cfi_restore s0
+; RV32-NEXT:	.cfi_restore s1
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: test_m1_then_m2:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -64
-; RV64-NEXT:    .cfi_def_cfa_offset 64
-; RV64-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s1, -24
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 1
-; RV64-NEXT:    sub sp, sp, a2
-; RV64-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 2 * vlenb
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    vl1r.v v8, (a0)
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    mv s1, a1
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vs1r.v v8, (s0)
-; RV64-NEXT:    vl2r.v v8, (s1)
-; RV64-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV64-NEXT:    call foo
-; RV64-NEXT:    addi a0, sp, 32
-; RV64-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; RV64-NEXT:    vs2r.v v8, (s1)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    .cfi_def_cfa sp, 64
-; RV64-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    .cfi_restore ra
-; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s1
-; RV64-NEXT:    addi sp, sp, 64
-; RV64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -32
+; RV64-NEXT:	.cfi_def_cfa_offset 32
+; RV64-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; RV64-NEXT:	.cfi_offset ra, -8
+; RV64-NEXT:	.cfi_offset s0, -16
+; RV64-NEXT:	.cfi_offset s1, -24
+; RV64-NEXT:	mv	s0, a0
+; RV64-NEXT:	vl1r.v	v24, (a0)
+; RV64-NEXT:	mv	s1, a1
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs1r.v	v24, (s0)
+; RV64-NEXT:	vl2r.v	v24, (s1)
+; RV64-NEXT:	call	foo
+; RV64-NEXT:	vs2r.v	v24, (s1)
+; RV64-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; RV64-NEXT:	.cfi_restore ra
+; RV64-NEXT:	.cfi_restore s0
+; RV64-NEXT:	.cfi_restore s1
+; RV64-NEXT:	addi	sp, sp, 32
+; RV64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-NEXT:	ret
   %v1 = load <vscale x 8 x i8>, ptr %p
   call void @foo();
   store <vscale x 8 x i8> %v1, ptr %p

--- a/llvm/test/CodeGen/RISCV/rvv/stores-of-loads-merging.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/stores-of-loads-merging.ll
@@ -344,35 +344,25 @@ define void @i32_i64_rotate(ptr %p, ptr %q) {
 define void @v2i8_v4i8(ptr %p, ptr %q) {
 ; CHECK-LABEL: v2i8_v4i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -32
-; CHECK-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    .cfi_offset ra, -8
-; CHECK-NEXT:    .cfi_offset s0, -16
-; CHECK-NEXT:    csrr a2, vlenb
-; CHECK-NEXT:    sub sp, sp, a2
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 1 * vlenb
-; CHECK-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; CHECK-NEXT:    vle8.v v8, (a0)
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    mv s0, a1
-; CHECK-NEXT:    call g
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; CHECK-NEXT:    vse8.v v8, (s0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 32
-; CHECK-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    .cfi_restore ra
-; CHECK-NEXT:    .cfi_restore s0
-; CHECK-NEXT:    addi sp, sp, 32
-; CHECK-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	.cfi_def_cfa_offset 16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	.cfi_offset ra, -8
+; CHECK-NEXT:	.cfi_offset s0, -16
+; CHECK-NEXT:	vsetivli	zero, 4, e8, mf4, ta, ma
+; CHECK-NEXT:	vle8.v	v24, (a0)
+; CHECK-NEXT:	mv	s0, a1
+; CHECK-NEXT:	call	g
+; CHECK-NEXT:	vsetivli	zero, 4, e8, mf4, ta, ma
+; CHECK-NEXT:	vse8.v	v24, (s0)
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	.cfi_restore ra
+; CHECK-NEXT:	.cfi_restore s0
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-NEXT:	ret
   %p0 = getelementptr i8, ptr %p, i64 0
   %p1 = getelementptr i8, ptr %p, i64 2
   %x0 = load <2 x i8>, ptr %p0, align 2
@@ -391,41 +381,30 @@ define void @v2i8_v4i8(ptr %p, ptr %q) {
 define void @v16i8_v32i8(ptr %p, ptr %q) {
 ; CHECK-LABEL: v16i8_v32i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -64
-; CHECK-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-NEXT:    sd ra, 56(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s1, 40(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    .cfi_offset ra, -8
-; CHECK-NEXT:    .cfi_offset s0, -16
-; CHECK-NEXT:    .cfi_offset s1, -24
-; CHECK-NEXT:    csrr a2, vlenb
-; CHECK-NEXT:    slli a2, a2, 1
-; CHECK-NEXT:    sub sp, sp, a2
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0xc0, 0x00, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 64 + 2 * vlenb
-; CHECK-NEXT:    li s1, 32
-; CHECK-NEXT:    vsetvli zero, s1, e8, m2, ta, ma
-; CHECK-NEXT:    vle8.v v8, (a0)
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; CHECK-NEXT:    mv s0, a1
-; CHECK-NEXT:    call g
-; CHECK-NEXT:    addi a0, sp, 32
-; CHECK-NEXT:    vl2r.v v8, (a0) # vscale x 16-byte Folded Reload
-; CHECK-NEXT:    vsetvli zero, s1, e8, m2, ta, ma
-; CHECK-NEXT:    vse8.v v8, (s0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    sh1add sp, a0, sp
-; CHECK-NEXT:    .cfi_def_cfa sp, 64
-; CHECK-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s1, 40(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    .cfi_restore ra
-; CHECK-NEXT:    .cfi_restore s0
-; CHECK-NEXT:    .cfi_restore s1
-; CHECK-NEXT:    addi sp, sp, 64
-; CHECK-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -32
+; CHECK-NEXT:	.cfi_def_cfa_offset 32
+; CHECK-NEXT:	sd	ra, 24(sp)                      # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 16(sp)                      # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s1, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	.cfi_offset ra, -8
+; CHECK-NEXT:	.cfi_offset s0, -16
+; CHECK-NEXT:	.cfi_offset s1, -24
+; CHECK-NEXT:	li	s1, 32
+; CHECK-NEXT:	vsetvli	zero, s1, e8, m2, ta, ma
+; CHECK-NEXT:	vle8.v	v24, (a0)
+; CHECK-NEXT:	mv	s0, a1
+; CHECK-NEXT:	call	g
+; CHECK-NEXT:	vsetvli	zero, s1, e8, m2, ta, ma
+; CHECK-NEXT:	vse8.v	v24, (s0)
+; CHECK-NEXT:	ld	ra, 24(sp)                      # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 16(sp)                      # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s1, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	.cfi_restore ra
+; CHECK-NEXT:	.cfi_restore s0
+; CHECK-NEXT:	.cfi_restore s1
+; CHECK-NEXT:	addi	sp, sp, 32
+; CHECK-NEXT:	.cfi_def_cfa_offset 0
+; CHECK-NEXT:	ret
   %p0 = getelementptr i8, ptr %p, i64 0
   %p1 = getelementptr i8, ptr %p, i64 16
   %x0 = load <16 x i8>, ptr %p0, align 2

--- a/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-crossbb.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-crossbb.ll
@@ -322,41 +322,26 @@ declare void @foo()
 define <vscale x 1 x double> @test8(i64 %avl, i8 zeroext %cond, <vscale x 1 x double> %a, <vscale x 1 x double> %b) nounwind {
 ; CHECK-LABEL: test8:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; CHECK-NEXT:    beqz a1, .LBB6_2
-; CHECK-NEXT:  # %bb.1: # %if.then
-; CHECK-NEXT:    vfadd.vv v8, v8, v9
-; CHECK-NEXT:    ret
-; CHECK-NEXT:  .LBB6_2: # %if.else
-; CHECK-NEXT:    addi sp, sp, -32
-; CHECK-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    sub sp, sp, a1
-; CHECK-NEXT:    mv s0, a0
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add a0, a0, sp
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add a0, a0, sp
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; CHECK-NEXT:    vfsub.vv v8, v9, v8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 32
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v24, v9
+; CHECK-NEXT:	vmv1r.v	v25, v8
+; CHECK-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; CHECK-NEXT:	beqz	a1, .LBB6_2
+; CHECK-NEXT:# %bb.1:                                # %if.then
+; CHECK-NEXT:	vfadd.vv	v8, v25, v24
+; CHECK-NEXT:	ret
+; CHECK-NEXT:.LBB6_2:                                # %if.else
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	mv	s0, a0
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; CHECK-NEXT:	vfsub.vv	v8, v25, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 entry:
   %0 = tail call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 0)
   %tobool = icmp eq i8 %cond, 0
@@ -381,43 +366,27 @@ if.end:                                           ; preds = %if.else, %if.then
 define <vscale x 1 x double> @test9(i64 %avl, i8 zeroext %cond, <vscale x 1 x double> %a, <vscale x 1 x double> %b) nounwind {
 ; CHECK-LABEL: test9:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -32
-; CHECK-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a2, vlenb
-; CHECK-NEXT:    slli a2, a2, 1
-; CHECK-NEXT:    sub sp, sp, a2
-; CHECK-NEXT:    mv s0, a0
-; CHECK-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; CHECK-NEXT:    beqz a1, .LBB7_2
-; CHECK-NEXT:  # %bb.1: # %if.then
-; CHECK-NEXT:    vfadd.vv v9, v8, v9
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add a0, a0, sp
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
-; CHECK-NEXT:    call foo
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add a0, a0, sp
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    j .LBB7_3
-; CHECK-NEXT:  .LBB7_2: # %if.else
-; CHECK-NEXT:    vfsub.vv v9, v8, v9
-; CHECK-NEXT:  .LBB7_3: # %if.end
-; CHECK-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
-; CHECK-NEXT:    vfmul.vv v8, v9, v8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 32
-; CHECK-NEXT:    ret
+; CHECK-NEXT:	addi	sp, sp, -16
+; CHECK-NEXT:	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT:	vsetivli	zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:	vmv1r.v	v24, v8
+; CHECK-NEXT:	mv	s0, a0
+; CHECK-NEXT:	vsetvli	zero, a0, e64, m1, ta, ma
+; CHECK-NEXT:	beqz	a1, .LBB7_2
+; CHECK-NEXT:# %bb.1:                                # %if.then
+; CHECK-NEXT:	vfadd.vv	v25, v24, v9
+; CHECK-NEXT:	call	foo
+; CHECK-NEXT:	j	.LBB7_3
+; CHECK-NEXT:.LBB7_2:                                # %if.else
+; CHECK-NEXT:	vfsub.vv	v25, v24, v9
+; CHECK-NEXT:.LBB7_3:                                # %if.end
+; CHECK-NEXT:	vsetvli	zero, s0, e64, m1, ta, ma
+; CHECK-NEXT:	vfmul.vv	v8, v25, v24
+; CHECK-NEXT:	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT:	addi	sp, sp, 16
+; CHECK-NEXT:	ret
 entry:
   %0 = tail call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 0)
   %tobool = icmp eq i8 %cond, 0

--- a/llvm/test/CodeGen/RISCV/rvv/vsub-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsub-sdnode.ll
@@ -927,795 +927,775 @@ define <vscale x 8 x i32> @vsub_vi_mask_nxv8i32(<vscale x 8 x i32> %va, <vscale 
 define <vscale x 64 x i64> @vsub_vv_nxv64i64(<vscale x 64 x i64> %va, <vscale x 64 x i64> %vb) {
 ; RV32-LABEL: vsub_vv_nxv64i64:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -80
-; RV32-NEXT:    .cfi_def_cfa_offset 80
-; RV32-NEXT:    sw ra, 76(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 72(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s1, 68(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s2, 64(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s3, 60(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s4, 56(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s5, 52(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s6, 48(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s7, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s8, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s9, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    .cfi_offset s0, -8
-; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    .cfi_offset s2, -16
-; RV32-NEXT:    .cfi_offset s3, -20
-; RV32-NEXT:    .cfi_offset s4, -24
-; RV32-NEXT:    .cfi_offset s5, -28
-; RV32-NEXT:    .cfi_offset s6, -32
-; RV32-NEXT:    .cfi_offset s7, -36
-; RV32-NEXT:    .cfi_offset s8, -40
-; RV32-NEXT:    .cfi_offset s9, -44
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 3
-; RV32-NEXT:    mv a3, a2
-; RV32-NEXT:    slli a2, a2, 1
-; RV32-NEXT:    add a3, a3, a2
-; RV32-NEXT:    slli a2, a2, 2
-; RV32-NEXT:    add a2, a2, a3
-; RV32-NEXT:    sub sp, sp, a2
-; RV32-NEXT:    .cfi_escape 0x0f, 0x0f, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0xd8, 0x00, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 88 * vlenb
-; RV32-NEXT:    mv s2, a7
-; RV32-NEXT:    mv s3, a1
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 6
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    csrr s6, vlenb
-; RV32-NEXT:    slli s7, s6, 4
-; RV32-NEXT:    slli s8, s6, 3
-; RV32-NEXT:    add a1, a7, s7
-; RV32-NEXT:    vl8re64.v v8, (a1)
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    add a1, a7, s8
-; RV32-NEXT:    vl8re64.v v8, (a1)
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    li a1, 56
-; RV32-NEXT:    mv a0, s6
-; RV32-NEXT:    call __mulsi3
-; RV32-NEXT:    mv s1, a0
-; RV32-NEXT:    add a0, s2, a0
-; RV32-NEXT:    vl8re64.v v8, (a0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 5
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    li a1, 40
-; RV32-NEXT:    mv a0, s6
-; RV32-NEXT:    call __mulsi3
-; RV32-NEXT:    mv s4, a0
-; RV32-NEXT:    add a0, s3, a0
-; RV32-NEXT:    vl8re64.v v8, (a0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    mv a1, a0
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    li a1, 48
-; RV32-NEXT:    mv a0, s6
-; RV32-NEXT:    call __mulsi3
-; RV32-NEXT:    mv s5, a0
-; RV32-NEXT:    add a0, s2, a0
-; RV32-NEXT:    slli s9, s6, 5
-; RV32-NEXT:    vl8re64.v v8, (a0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    mv a1, a0
-; RV32-NEXT:    slli a0, a0, 2
-; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    add a0, s3, s9
-; RV32-NEXT:    vl8re64.v v8, (a0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 4
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    add a0, s2, s4
-; RV32-NEXT:    vl8re64.v v8, (a0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    mv a1, a0
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a1, a1, a0
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    li a1, 24
-; RV32-NEXT:    mv a0, s6
-; RV32-NEXT:    call __mulsi3
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsetvli a1, zero, e64, m8, ta, ma
-; RV32-NEXT:    vsub.vv v8, v16, v8
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 5
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v8, v16, v8
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 5
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 6
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v8, v8, v16
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 6
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    vl8re64.v v8, (s3)
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v8, v8, v16
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    add a1, s3, a0
-; RV32-NEXT:    add a2, s2, s9
-; RV32-NEXT:    add a3, s3, s7
-; RV32-NEXT:    add a4, s2, a0
-; RV32-NEXT:    add s3, s3, s8
-; RV32-NEXT:    vl8re64.v v8, (s2)
-; RV32-NEXT:    csrr a5, vlenb
-; RV32-NEXT:    slli a5, a5, 3
-; RV32-NEXT:    mv a6, a5
-; RV32-NEXT:    slli a5, a5, 1
-; RV32-NEXT:    add a5, a5, a6
-; RV32-NEXT:    add a5, sp, a5
-; RV32-NEXT:    addi a5, a5, 32
-; RV32-NEXT:    vs8r.v v8, (a5) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    vl8re64.v v8, (a2)
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 4
-; RV32-NEXT:    mv a5, a2
-; RV32-NEXT:    slli a2, a2, 1
-; RV32-NEXT:    add a2, a2, a5
-; RV32-NEXT:    add a2, sp, a2
-; RV32-NEXT:    addi a2, a2, 32
-; RV32-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    vl8re64.v v8, (a4)
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 4
-; RV32-NEXT:    add a2, sp, a2
-; RV32-NEXT:    addi a2, a2, 32
-; RV32-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    vl8re64.v v8, (s3)
-; RV32-NEXT:    csrr a2, vlenb
-; RV32-NEXT:    slli a2, a2, 3
-; RV32-NEXT:    add a2, sp, a2
-; RV32-NEXT:    addi a2, a2, 32
-; RV32-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    vl8re64.v v8, (a3)
-; RV32-NEXT:    addi a2, sp, 32
-; RV32-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    vl8re64.v v24, (a1)
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v0, v0, v8
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v8, v16, v8
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    addi a1, sp, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v8, v16, v8
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a2, a2, a1
-; RV32-NEXT:    slli a1, a1, 1
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vsub.vv v16, v24, v16
-; RV32-NEXT:    vs8r.v v0, (s0)
-; RV32-NEXT:    add s1, s0, s1
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 5
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v24, (s1)
-; RV32-NEXT:    add s5, s0, s5
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v24, (s5)
-; RV32-NEXT:    add s4, s0, s4
-; RV32-NEXT:    vs8r.v v16, (s4)
-; RV32-NEXT:    add s9, s0, s9
-; RV32-NEXT:    add a0, s0, a0
-; RV32-NEXT:    add s7, s0, s7
-; RV32-NEXT:    add s0, s0, s8
-; RV32-NEXT:    vs8r.v v8, (s9)
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    mv a2, a1
-; RV32-NEXT:    slli a1, a1, 2
-; RV32-NEXT:    add a1, a1, a2
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 32
-; RV32-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v8, (a0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    mv a1, a0
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v8, (s7)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 6
-; RV32-NEXT:    add a0, sp, a0
-; RV32-NEXT:    addi a0, a0, 32
-; RV32-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32-NEXT:    vs8r.v v8, (s0)
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    slli a0, a0, 3
-; RV32-NEXT:    mv a1, a0
-; RV32-NEXT:    slli a0, a0, 1
-; RV32-NEXT:    add a1, a1, a0
-; RV32-NEXT:    slli a0, a0, 2
-; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    .cfi_def_cfa sp, 80
-; RV32-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 72(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 68(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s2, 64(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s3, 60(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s4, 56(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s5, 52(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s6, 48(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s7, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s8, 40(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s9, 36(sp) # 4-byte Folded Reload
-; RV32-NEXT:    .cfi_restore ra
-; RV32-NEXT:    .cfi_restore s0
-; RV32-NEXT:    .cfi_restore s1
-; RV32-NEXT:    .cfi_restore s2
-; RV32-NEXT:    .cfi_restore s3
-; RV32-NEXT:    .cfi_restore s4
-; RV32-NEXT:    .cfi_restore s5
-; RV32-NEXT:    .cfi_restore s6
-; RV32-NEXT:    .cfi_restore s7
-; RV32-NEXT:    .cfi_restore s8
-; RV32-NEXT:    .cfi_restore s9
-; RV32-NEXT:    addi sp, sp, 80
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
+; RV32-NEXT:addi	sp, sp, -80
+; RV32-NEXT:	.cfi_def_cfa_offset 80
+; RV32-NEXT:	sw	ra, 76(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 72(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s1, 68(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s2, 64(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s3, 60(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s4, 56(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s5, 52(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s6, 48(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s7, 44(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s8, 40(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s9, 36(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	.cfi_offset ra, -4
+; RV32-NEXT:	.cfi_offset s0, -8
+; RV32-NEXT:	.cfi_offset s1, -12
+; RV32-NEXT:	.cfi_offset s2, -16
+; RV32-NEXT:	.cfi_offset s3, -20
+; RV32-NEXT:	.cfi_offset s4, -24
+; RV32-NEXT:	.cfi_offset s5, -28
+; RV32-NEXT:	.cfi_offset s6, -32
+; RV32-NEXT:	.cfi_offset s7, -36
+; RV32-NEXT:	.cfi_offset s8, -40
+; RV32-NEXT:	.cfi_offset s9, -44
+; RV32-NEXT:	csrr	a2, vlenb
+; RV32-NEXT:	slli	a2, a2, 3
+; RV32-NEXT:	mv	a3, a2
+; RV32-NEXT:	slli	a2, a2, 1
+; RV32-NEXT:	add	a3, a3, a2
+; RV32-NEXT:	slli	a2, a2, 2
+; RV32-NEXT:	add	a2, a2, a3
+; RV32-NEXT:	sub	sp, sp, a2
+; RV32-NEXT:	.cfi_escape 0x0f, 0x0f, 0x72, 0x00, 0x11, 0xd0, 0x00, 0x22, 0x11, 0xd8, 0x00, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 80 + 88 * vlenb
+; RV32-NEXT:	mv	s2, a7
+; RV32-NEXT:	mv	s3, a1
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 6
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v16, (a1)                       # vscale x 64-byte Folded Spill
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	csrr	s6, vlenb
+; RV32-NEXT:	slli	s7, s6, 4
+; RV32-NEXT:	slli	s8, s6, 3
+; RV32-NEXT:	add	a1, a7, s7
+; RV32-NEXT:	vl8re64.v	v8, (a1)
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	add	a1, a7, s8
+; RV32-NEXT:	vl8re64.v	v8, (a1)
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	li	a1, 56
+; RV32-NEXT:	mv	a0, s6
+; RV32-NEXT:	call	__mulsi3
+; RV32-NEXT:	mv	s1, a0
+; RV32-NEXT:	add	a0, s2, a0
+; RV32-NEXT:	vl8re64.v	v8, (a0)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 5
+; RV32-NEXT:	add	a0, sp, a0
+; RV32-NEXT:	addi	a0, a0, 32
+; RV32-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	li	a1, 40
+; RV32-NEXT:	mv	a0, s6
+; RV32-NEXT:	call	__mulsi3
+; RV32-NEXT:	mv	s4, a0
+; RV32-NEXT:	add	a0, s3, a0
+; RV32-NEXT:	vl8re64.v	v8, (a0)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 3
+; RV32-NEXT:	mv	a1, a0
+; RV32-NEXT:	slli	a0, a0, 1
+; RV32-NEXT:	add	a0, a0, a1
+; RV32-NEXT:	add	a0, sp, a0
+; RV32-NEXT:	addi	a0, a0, 32
+; RV32-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	li	a1, 48
+; RV32-NEXT:	mv	a0, s6
+; RV32-NEXT:	call	__mulsi3
+; RV32-NEXT:	mv	s5, a0
+; RV32-NEXT:	add	a0, s2, a0
+; RV32-NEXT:	slli	s9, s6, 5
+; RV32-NEXT:	vl8re64.v	v8, (a0)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 3
+; RV32-NEXT:	mv	a1, a0
+; RV32-NEXT:	slli	a0, a0, 2
+; RV32-NEXT:	add	a0, a0, a1
+; RV32-NEXT:	add	a0, sp, a0
+; RV32-NEXT:	addi	a0, a0, 32
+; RV32-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	add	a0, s3, s9
+; RV32-NEXT:	vl8re64.v	v24, (a0)
+; RV32-NEXT:	add	a0, s2, s4
+; RV32-NEXT:	vl8re64.v	v8, (a0)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 3
+; RV32-NEXT:	mv	a1, a0
+; RV32-NEXT:	slli	a0, a0, 1
+; RV32-NEXT:	add	a1, a1, a0
+; RV32-NEXT:	slli	a0, a0, 1
+; RV32-NEXT:	add	a0, a0, a1
+; RV32-NEXT:	add	a0, sp, a0
+; RV32-NEXT:	addi	a0, a0, 32
+; RV32-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	li	a1, 24
+; RV32-NEXT:	mv	a0, s6
+; RV32-NEXT:	call	__mulsi3
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsetvli	a1, zero, e64, m8, ta, ma
+; RV32-NEXT:	vsub.vv	v8, v24, v8
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 5
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v8, v16, v8
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 5
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 6
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v8, v8, v16
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 6
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	vl8re64.v	v8, (s3)
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v8, v8, v16
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	add	a1, s3, a0
+; RV32-NEXT:	add	a2, s2, s9
+; RV32-NEXT:	add	a3, s3, s7
+; RV32-NEXT:	add	a4, s2, a0
+; RV32-NEXT:	add	s3, s3, s8
+; RV32-NEXT:	vl8re64.v	v8, (s2)
+; RV32-NEXT:	csrr	a5, vlenb
+; RV32-NEXT:	slli	a5, a5, 3
+; RV32-NEXT:	mv	a6, a5
+; RV32-NEXT:	slli	a5, a5, 1
+; RV32-NEXT:	add	a5, a5, a6
+; RV32-NEXT:	add	a5, sp, a5
+; RV32-NEXT:	addi	a5, a5, 32
+; RV32-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	vl8re64.v	v8, (a2)
+; RV32-NEXT:	csrr	a2, vlenb
+; RV32-NEXT:	slli	a2, a2, 4
+; RV32-NEXT:	mv	a5, a2
+; RV32-NEXT:	slli	a2, a2, 1
+; RV32-NEXT:	add	a2, a2, a5
+; RV32-NEXT:	add	a2, sp, a2
+; RV32-NEXT:	addi	a2, a2, 32
+; RV32-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	vl8re64.v	v8, (a4)
+; RV32-NEXT:	csrr	a2, vlenb
+; RV32-NEXT:	slli	a2, a2, 4
+; RV32-NEXT:	add	a2, sp, a2
+; RV32-NEXT:	addi	a2, a2, 32
+; RV32-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	vl8re64.v	v8, (s3)
+; RV32-NEXT:	csrr	a2, vlenb
+; RV32-NEXT:	slli	a2, a2, 3
+; RV32-NEXT:	add	a2, sp, a2
+; RV32-NEXT:	addi	a2, a2, 32
+; RV32-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	vl8re64.v	v8, (a3)
+; RV32-NEXT:	addi	a2, sp, 32
+; RV32-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	vl8re64.v	v24, (a1)
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v0, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v0, v0, v8
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v8, v16, v8
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	addi	a1, sp, 32
+; RV32-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v8, v16, v8
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a2, a2, a1
+; RV32-NEXT:	slli	a1, a1, 1
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vsub.vv	v16, v24, v16
+; RV32-NEXT:	vs8r.v	v0, (s0)
+; RV32-NEXT:	add	s1, s0, s1
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 5
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v24, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vs8r.v	v24, (s1)
+; RV32-NEXT:	add	s5, s0, s5
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 3
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v24, (a1)                       # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vs8r.v	v24, (s5)
+; RV32-NEXT:	add	s4, s0, s4
+; RV32-NEXT:	vs8r.v	v16, (s4)
+; RV32-NEXT:	add	s9, s0, s9
+; RV32-NEXT:	add	a0, s0, a0
+; RV32-NEXT:	add	s7, s0, s7
+; RV32-NEXT:	add	s0, s0, s8
+; RV32-NEXT:	vs8r.v	v8, (s9)
+; RV32-NEXT:	csrr	a1, vlenb
+; RV32-NEXT:	slli	a1, a1, 4
+; RV32-NEXT:	mv	a2, a1
+; RV32-NEXT:	slli	a1, a1, 2
+; RV32-NEXT:	add	a1, a1, a2
+; RV32-NEXT:	add	a1, sp, a1
+; RV32-NEXT:	addi	a1, a1, 32
+; RV32-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vs8r.v	v8, (a0)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 3
+; RV32-NEXT:	mv	a1, a0
+; RV32-NEXT:	slli	a0, a0, 3
+; RV32-NEXT:	add	a0, a0, a1
+; RV32-NEXT:	add	a0, sp, a0
+; RV32-NEXT:	addi	a0, a0, 32
+; RV32-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vs8r.v	v8, (s7)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 6
+; RV32-NEXT:	add	a0, sp, a0
+; RV32-NEXT:	addi	a0, a0, 32
+; RV32-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV32-NEXT:	vs8r.v	v8, (s0)
+; RV32-NEXT:	csrr	a0, vlenb
+; RV32-NEXT:	slli	a0, a0, 3
+; RV32-NEXT:	mv	a1, a0
+; RV32-NEXT:	slli	a0, a0, 1
+; RV32-NEXT:	add	a1, a1, a0
+; RV32-NEXT:	slli	a0, a0, 2
+; RV32-NEXT:	add	a0, a0, a1
+; RV32-NEXT:	add	sp, sp, a0
+; RV32-NEXT:	.cfi_def_cfa sp, 80
+; RV32-NEXT:	lw	ra, 76(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 72(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s1, 68(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s2, 64(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s3, 60(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s4, 56(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s5, 52(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s6, 48(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s7, 44(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s8, 40(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s9, 36(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	.cfi_restore ra
+; RV32-NEXT:	.cfi_restore s0
+; RV32-NEXT:	.cfi_restore s1
+; RV32-NEXT:	.cfi_restore s2
+; RV32-NEXT:	.cfi_restore s3
+; RV32-NEXT:	.cfi_restore s4
+; RV32-NEXT:	.cfi_restore s5
+; RV32-NEXT:	.cfi_restore s6
+; RV32-NEXT:	.cfi_restore s7
+; RV32-NEXT:	.cfi_restore s8
+; RV32-NEXT:	.cfi_restore s9
+; RV32-NEXT:	addi	sp, sp, 80
+; RV32-NEXT:	.cfi_def_cfa_offset 0
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: vsub_vv_nxv64i64:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -128
-; RV64-NEXT:    .cfi_def_cfa_offset 128
-; RV64-NEXT:    sd ra, 120(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 112(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s1, 104(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s2, 96(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s3, 88(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s4, 80(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s5, 72(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s6, 64(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s7, 56(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s8, 48(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s9, 40(sp) # 8-byte Folded Spill
-; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s1, -24
-; RV64-NEXT:    .cfi_offset s2, -32
-; RV64-NEXT:    .cfi_offset s3, -40
-; RV64-NEXT:    .cfi_offset s4, -48
-; RV64-NEXT:    .cfi_offset s5, -56
-; RV64-NEXT:    .cfi_offset s6, -64
-; RV64-NEXT:    .cfi_offset s7, -72
-; RV64-NEXT:    .cfi_offset s8, -80
-; RV64-NEXT:    .cfi_offset s9, -88
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 3
-; RV64-NEXT:    mv a3, a2
-; RV64-NEXT:    slli a2, a2, 1
-; RV64-NEXT:    add a3, a3, a2
-; RV64-NEXT:    slli a2, a2, 2
-; RV64-NEXT:    add a2, a2, a3
-; RV64-NEXT:    sub sp, sp, a2
-; RV64-NEXT:    .cfi_escape 0x0f, 0x0f, 0x72, 0x00, 0x11, 0x80, 0x01, 0x22, 0x11, 0xd8, 0x00, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 128 + 88 * vlenb
-; RV64-NEXT:    mv s2, a7
-; RV64-NEXT:    mv s3, a1
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 6
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    csrr s6, vlenb
-; RV64-NEXT:    slli s7, s6, 4
-; RV64-NEXT:    slli s8, s6, 3
-; RV64-NEXT:    add a1, a7, s7
-; RV64-NEXT:    vl8re64.v v8, (a1)
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    add a1, a7, s8
-; RV64-NEXT:    vl8re64.v v8, (a1)
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    li a1, 56
-; RV64-NEXT:    mv a0, s6
-; RV64-NEXT:    call __muldi3
-; RV64-NEXT:    mv s1, a0
-; RV64-NEXT:    add a0, s2, a0
-; RV64-NEXT:    vl8re64.v v8, (a0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 5
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    li a1, 40
-; RV64-NEXT:    mv a0, s6
-; RV64-NEXT:    call __muldi3
-; RV64-NEXT:    mv s4, a0
-; RV64-NEXT:    add a0, s3, a0
-; RV64-NEXT:    vl8re64.v v8, (a0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    mv a1, a0
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, a0, a1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    li a1, 48
-; RV64-NEXT:    mv a0, s6
-; RV64-NEXT:    call __muldi3
-; RV64-NEXT:    mv s5, a0
-; RV64-NEXT:    add a0, s2, a0
-; RV64-NEXT:    slli s9, s6, 5
-; RV64-NEXT:    vl8re64.v v8, (a0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    mv a1, a0
-; RV64-NEXT:    slli a0, a0, 2
-; RV64-NEXT:    add a0, a0, a1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    add a0, s3, s9
-; RV64-NEXT:    vl8re64.v v8, (a0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 4
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    add a0, s2, s4
-; RV64-NEXT:    vl8re64.v v8, (a0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    mv a1, a0
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a1, a1, a0
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a0, a0, a1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    li a1, 24
-; RV64-NEXT:    mv a0, s6
-; RV64-NEXT:    call __muldi3
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsetvli a1, zero, e64, m8, ta, ma
-; RV64-NEXT:    vsub.vv v8, v16, v8
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 5
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v8, v16, v8
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 5
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 6
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v8, v8, v16
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 6
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    vl8re64.v v8, (s3)
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v8, v8, v16
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    add a1, s3, a0
-; RV64-NEXT:    add a2, s2, s9
-; RV64-NEXT:    add a3, s3, s7
-; RV64-NEXT:    add a4, s2, a0
-; RV64-NEXT:    add s3, s3, s8
-; RV64-NEXT:    vl8re64.v v8, (s2)
-; RV64-NEXT:    csrr a5, vlenb
-; RV64-NEXT:    slli a5, a5, 3
-; RV64-NEXT:    mv a6, a5
-; RV64-NEXT:    slli a5, a5, 1
-; RV64-NEXT:    add a5, a5, a6
-; RV64-NEXT:    add a5, sp, a5
-; RV64-NEXT:    addi a5, a5, 32
-; RV64-NEXT:    vs8r.v v8, (a5) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    vl8re64.v v8, (a2)
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 4
-; RV64-NEXT:    mv a5, a2
-; RV64-NEXT:    slli a2, a2, 1
-; RV64-NEXT:    add a2, a2, a5
-; RV64-NEXT:    add a2, sp, a2
-; RV64-NEXT:    addi a2, a2, 32
-; RV64-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    vl8re64.v v8, (a4)
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 4
-; RV64-NEXT:    add a2, sp, a2
-; RV64-NEXT:    addi a2, a2, 32
-; RV64-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    vl8re64.v v8, (s3)
-; RV64-NEXT:    csrr a2, vlenb
-; RV64-NEXT:    slli a2, a2, 3
-; RV64-NEXT:    add a2, sp, a2
-; RV64-NEXT:    addi a2, a2, 32
-; RV64-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    vl8re64.v v8, (a3)
-; RV64-NEXT:    addi a2, sp, 32
-; RV64-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    vl8re64.v v24, (a1)
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v0, v0, v8
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v8, v16, v8
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    addi a1, sp, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v8, v16, v8
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a2, a2, a1
-; RV64-NEXT:    slli a1, a1, 1
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v16, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vsub.vv v16, v24, v16
-; RV64-NEXT:    vs8r.v v0, (s0)
-; RV64-NEXT:    add s1, s0, s1
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 5
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v24, (s1)
-; RV64-NEXT:    add s5, s0, s5
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v24, (s5)
-; RV64-NEXT:    add s4, s0, s4
-; RV64-NEXT:    vs8r.v v16, (s4)
-; RV64-NEXT:    add s9, s0, s9
-; RV64-NEXT:    add a0, s0, a0
-; RV64-NEXT:    add s7, s0, s7
-; RV64-NEXT:    add s0, s0, s8
-; RV64-NEXT:    vs8r.v v8, (s9)
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    mv a2, a1
-; RV64-NEXT:    slli a1, a1, 2
-; RV64-NEXT:    add a1, a1, a2
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 32
-; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v8, (a0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    mv a1, a0
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    add a0, a0, a1
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v8, (s7)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 6
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a0, a0, 32
-; RV64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64-NEXT:    vs8r.v v8, (s0)
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    slli a0, a0, 3
-; RV64-NEXT:    mv a1, a0
-; RV64-NEXT:    slli a0, a0, 1
-; RV64-NEXT:    add a1, a1, a0
-; RV64-NEXT:    slli a0, a0, 2
-; RV64-NEXT:    add a0, a0, a1
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    .cfi_def_cfa sp, 128
-; RV64-NEXT:    ld ra, 120(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 112(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s1, 104(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s2, 96(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s3, 88(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s4, 80(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s5, 72(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s6, 64(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s7, 56(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s8, 48(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s9, 40(sp) # 8-byte Folded Reload
-; RV64-NEXT:    .cfi_restore ra
-; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s1
-; RV64-NEXT:    .cfi_restore s2
-; RV64-NEXT:    .cfi_restore s3
-; RV64-NEXT:    .cfi_restore s4
-; RV64-NEXT:    .cfi_restore s5
-; RV64-NEXT:    .cfi_restore s6
-; RV64-NEXT:    .cfi_restore s7
-; RV64-NEXT:    .cfi_restore s8
-; RV64-NEXT:    .cfi_restore s9
-; RV64-NEXT:    addi sp, sp, 128
-; RV64-NEXT:    .cfi_def_cfa_offset 0
-; RV64-NEXT:    ret
+; RV64-NEXT:	addi	sp, sp, -128
+; RV64-NEXT:	.cfi_def_cfa_offset 128
+; RV64-NEXT:	sd	ra, 120(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s0, 112(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s1, 104(sp)                     # 8-byte Folded Spill
+; RV64-NEXT:	sd	s2, 96(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s3, 88(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s4, 80(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s5, 72(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s6, 64(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s7, 56(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s8, 48(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	sd	s9, 40(sp)                      # 8-byte Folded Spill
+; RV64-NEXT:	.cfi_offset ra, -8
+; RV64-NEXT:	.cfi_offset s0, -16
+; RV64-NEXT:	.cfi_offset s1, -24
+; RV64-NEXT:	.cfi_offset s2, -32
+; RV64-NEXT:	.cfi_offset s3, -40
+; RV64-NEXT:	.cfi_offset s4, -48
+; RV64-NEXT:	.cfi_offset s5, -56
+; RV64-NEXT:	.cfi_offset s6, -64
+; RV64-NEXT:	.cfi_offset s7, -72
+; RV64-NEXT:	.cfi_offset s8, -80
+; RV64-NEXT:	.cfi_offset s9, -88
+; RV64-NEXT:	csrr	a2, vlenb
+; RV64-NEXT:	slli	a2, a2, 3
+; RV64-NEXT:	mv	a3, a2
+; RV64-NEXT:	slli	a2, a2, 1
+; RV64-NEXT:	add	a3, a3, a2
+; RV64-NEXT:	slli	a2, a2, 2
+; RV64-NEXT:	add	a2, a2, a3
+; RV64-NEXT:	sub	sp, sp, a2
+; RV64-NEXT:	.cfi_escape 0x0f, 0x0f, 0x72, 0x00, 0x11, 0x80, 0x01, 0x22, 0x11, 0xd8, 0x00, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 128 + 88 * vlenb
+; RV64-NEXT:	mv	s2, a7
+; RV64-NEXT:	mv	s3, a1
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 6
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v16, (a1)                       # vscale x 64-byte Folded Spill
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	csrr	s6, vlenb
+; RV64-NEXT:	slli	s7, s6, 4
+; RV64-NEXT:	slli	s8, s6, 3
+; RV64-NEXT:	add	a1, a7, s7
+; RV64-NEXT:	vl8re64.v	v8, (a1)
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	add	a1, a7, s8
+; RV64-NEXT:	vl8re64.v	v8, (a1)
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	mv	s0, a0
+; RV64-NEXT:	li	a1, 56
+; RV64-NEXT:	mv	a0, s6
+; RV64-NEXT:	call	__muldi3
+; RV64-NEXT:	mv	s1, a0
+; RV64-NEXT:	add	a0, s2, a0
+; RV64-NEXT:	vl8re64.v	v8, (a0)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 5
+; RV64-NEXT:	add	a0, sp, a0
+; RV64-NEXT:	addi	a0, a0, 32
+; RV64-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	li	a1, 40
+; RV64-NEXT:	mv	a0, s6
+; RV64-NEXT:	call	__muldi3
+; RV64-NEXT:	mv	s4, a0
+; RV64-NEXT:	add	a0, s3, a0
+; RV64-NEXT:	vl8re64.v	v8, (a0)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 3
+; RV64-NEXT:	mv	a1, a0
+; RV64-NEXT:	slli	a0, a0, 1
+; RV64-NEXT:	add	a0, a0, a1
+; RV64-NEXT:	add	a0, sp, a0
+; RV64-NEXT:	addi	a0, a0, 32
+; RV64-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	li	a1, 48
+; RV64-NEXT:	mv	a0, s6
+; RV64-NEXT:	call	__muldi3
+; RV64-NEXT:	mv	s5, a0
+; RV64-NEXT:	add	a0, s2, a0
+; RV64-NEXT:	slli	s9, s6, 5
+; RV64-NEXT:	vl8re64.v	v8, (a0)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 3
+; RV64-NEXT:	mv	a1, a0
+; RV64-NEXT:	slli	a0, a0, 2
+; RV64-NEXT:	add	a0, a0, a1
+; RV64-NEXT:	add	a0, sp, a0
+; RV64-NEXT:	addi	a0, a0, 32
+; RV64-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	add	a0, s3, s9
+; RV64-NEXT:	vl8re64.v	v24, (a0)
+; RV64-NEXT:	add	a0, s2, s4
+; RV64-NEXT:	vl8re64.v	v8, (a0)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 3
+; RV64-NEXT:	mv	a1, a0
+; RV64-NEXT:	slli	a0, a0, 1
+; RV64-NEXT:	add	a1, a1, a0
+; RV64-NEXT:	slli	a0, a0, 1
+; RV64-NEXT:	add	a0, a0, a1
+; RV64-NEXT:	add	a0, sp, a0
+; RV64-NEXT:	addi	a0, a0, 32
+; RV64-NEXT:	vs8r.v	v8, (a0)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	li	a1, 24
+; RV64-NEXT:	mv	a0, s6
+; RV64-NEXT:	call	__muldi3
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsetvli	a1, zero, e64, m8, ta, ma
+; RV64-NEXT:	vsub.vv	v8, v24, v8
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 5
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v8, v16, v8
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 5
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 6
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v8, v8, v16
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 6
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	vl8re64.v	v8, (s3)
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v8, v8, v16
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	add	a1, s3, a0
+; RV64-NEXT:	add	a2, s2, s9
+; RV64-NEXT:	add	a3, s3, s7
+; RV64-NEXT:	add	a4, s2, a0
+; RV64-NEXT:	add	s3, s3, s8
+; RV64-NEXT:	vl8re64.v	v8, (s2)
+; RV64-NEXT:	csrr	a5, vlenb
+; RV64-NEXT:	slli	a5, a5, 3
+; RV64-NEXT:	mv	a6, a5
+; RV64-NEXT:	slli	a5, a5, 1
+; RV64-NEXT:	add	a5, a5, a6
+; RV64-NEXT:	add	a5, sp, a5
+; RV64-NEXT:	addi	a5, a5, 32
+; RV64-NEXT:	vs8r.v	v8, (a5)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	vl8re64.v	v8, (a2)
+; RV64-NEXT:	csrr	a2, vlenb
+; RV64-NEXT:	slli	a2, a2, 4
+; RV64-NEXT:	mv	a5, a2
+; RV64-NEXT:	slli	a2, a2, 1
+; RV64-NEXT:	add	a2, a2, a5
+; RV64-NEXT:	add	a2, sp, a2
+; RV64-NEXT:	addi	a2, a2, 32
+; RV64-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	vl8re64.v	v8, (a4)
+; RV64-NEXT:	csrr	a2, vlenb
+; RV64-NEXT:	slli	a2, a2, 4
+; RV64-NEXT:	add	a2, sp, a2
+; RV64-NEXT:	addi	a2, a2, 32
+; RV64-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	vl8re64.v	v8, (s3)
+; RV64-NEXT:	csrr	a2, vlenb
+; RV64-NEXT:	slli	a2, a2, 3
+; RV64-NEXT:	add	a2, sp, a2
+; RV64-NEXT:	addi	a2, a2, 32
+; RV64-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	vl8re64.v	v8, (a3)
+; RV64-NEXT:	addi	a2, sp, 32
+; RV64-NEXT:	vs8r.v	v8, (a2)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	vl8re64.v	v24, (a1)
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v0, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v0, v0, v8
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v8, v16, v8
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vs8r.v	v8, (a1)                        # vscale x 64-byte Folded Spill
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	addi	a1, sp, 32
+; RV64-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v8, v16, v8
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a2, a2, a1
+; RV64-NEXT:	slli	a1, a1, 1
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v16, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vsub.vv	v16, v24, v16
+; RV64-NEXT:	vs8r.v	v0, (s0)
+; RV64-NEXT:	add	s1, s0, s1
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 5
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v24, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vs8r.v	v24, (s1)
+; RV64-NEXT:	add	s5, s0, s5
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 3
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v24, (a1)                       # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vs8r.v	v24, (s5)
+; RV64-NEXT:	add	s4, s0, s4
+; RV64-NEXT:	vs8r.v	v16, (s4)
+; RV64-NEXT:	add	s9, s0, s9
+; RV64-NEXT:	add	a0, s0, a0
+; RV64-NEXT:	add	s7, s0, s7
+; RV64-NEXT:	add	s0, s0, s8
+; RV64-NEXT:	vs8r.v	v8, (s9)
+; RV64-NEXT:	csrr	a1, vlenb
+; RV64-NEXT:	slli	a1, a1, 4
+; RV64-NEXT:	mv	a2, a1
+; RV64-NEXT:	slli	a1, a1, 2
+; RV64-NEXT:	add	a1, a1, a2
+; RV64-NEXT:	add	a1, sp, a1
+; RV64-NEXT:	addi	a1, a1, 32
+; RV64-NEXT:	vl8r.v	v8, (a1)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vs8r.v	v8, (a0)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 3
+; RV64-NEXT:	mv	a1, a0
+; RV64-NEXT:	slli	a0, a0, 3
+; RV64-NEXT:	add	a0, a0, a1
+; RV64-NEXT:	add	a0, sp, a0
+; RV64-NEXT:	addi	a0, a0, 32
+; RV64-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vs8r.v	v8, (s7)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 6
+; RV64-NEXT:	add	a0, sp, a0
+; RV64-NEXT:	addi	a0, a0, 32
+; RV64-NEXT:	vl8r.v	v8, (a0)                        # vscale x 64-byte Folded Reload
+; RV64-NEXT:	vs8r.v	v8, (s0)
+; RV64-NEXT:	csrr	a0, vlenb
+; RV64-NEXT:	slli	a0, a0, 3
+; RV64-NEXT:	mv	a1, a0
+; RV64-NEXT:	slli	a0, a0, 1
+; RV64-NEXT:	add	a1, a1, a0
+; RV64-NEXT:	slli	a0, a0, 2
+; RV64-NEXT:	add	a0, a0, a1
+; RV64-NEXT:	add	sp, sp, a0
+; RV64-NEXT:	.cfi_def_cfa sp, 128
+; RV64-NEXT:	ld	ra, 120(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s0, 112(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s1, 104(sp)                     # 8-byte Folded Reload
+; RV64-NEXT:	ld	s2, 96(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s3, 88(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s4, 80(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s5, 72(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s6, 64(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s7, 56(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s8, 48(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	ld	s9, 40(sp)                      # 8-byte Folded Reload
+; RV64-NEXT:	.cfi_restore ra
+; RV64-NEXT:	.cfi_restore s0
+; RV64-NEXT:	.cfi_restore s1
+; RV64-NEXT:	.cfi_restore s2
+; RV64-NEXT:	.cfi_restore s3
+; RV64-NEXT:	.cfi_restore s4
+; RV64-NEXT:	.cfi_restore s5
+; RV64-NEXT:	.cfi_restore s6
+; RV64-NEXT:	.cfi_restore s7
+; RV64-NEXT:	.cfi_restore s8
+; RV64-NEXT:	.cfi_restore s9
+; RV64-NEXT:	addi	sp, sp, 128
+; RV64-NEXT:	.cfi_def_cfa_offset 0
+; RV64-NEXT:	ret
   %vc = sub <vscale x 64 x i64> %va, %vb
   ret <vscale x 64 x i64> %vc
 }

--- a/llvm/test/CodeGen/RISCV/rvv/vxrm-insert.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vxrm-insert.ll
@@ -71,55 +71,41 @@ declare <vscale x 1 x i8> @foo(<vscale x 1 x i8>)
 define <vscale x 1 x i8> @test3(<vscale x 1 x i8> %0, <vscale x 1 x i8> %1, <vscale x 1 x i8> %2, iXLen %3) nounwind {
 ; RV32-LABEL: test3:
 ; RV32:       # %bb.0: # %entry
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    sub sp, sp, a1
-; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    addi a1, sp, 16
-; RV32-NEXT:    vs1r.v v10, (a1) # vscale x 8-byte Folded Spill
-; RV32-NEXT:    csrwi vxrm, 0
-; RV32-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; RV32-NEXT:    vaadd.vv v8, v8, v9
-; RV32-NEXT:    call foo
-; RV32-NEXT:    csrwi vxrm, 0
-; RV32-NEXT:    addi a0, sp, 16
-; RV32-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; RV32-NEXT:    vsetvli zero, s0, e8, mf8, ta, ma
-; RV32-NEXT:    vaadd.vv v8, v8, v9
-; RV32-NEXT:    csrr a0, vlenb
-; RV32-NEXT:    add sp, sp, a0
-; RV32-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    ret
+; RV32-NEXT:addi	sp, sp, -16
+; RV32-NEXT:	sw	ra, 12(sp)                      # 4-byte Folded Spill
+; RV32-NEXT:	sw	s0, 8(sp)                       # 4-byte Folded Spill
+; RV32-NEXT:	mv	s0, a0
+; RV32-NEXT:	vsetvli	zero, a0, e8, mf8, ta, ma
+; RV32-NEXT:	vmv1r.v	v24, v10
+; RV32-NEXT:	csrwi	vxrm, 0
+; RV32-NEXT:	vaadd.vv	v8, v8, v9
+; RV32-NEXT:	call	foo
+; RV32-NEXT:	csrwi	vxrm, 0
+; RV32-NEXT:	vsetvli	zero, s0, e8, mf8, ta, ma
+; RV32-NEXT:	vaadd.vv	v8, v8, v24
+; RV32-NEXT:	lw	ra, 12(sp)                      # 4-byte Folded Reload
+; RV32-NEXT:	lw	s0, 8(sp)                       # 4-byte Folded Reload
+; RV32-NEXT:	addi	sp, sp, 16
+; RV32-NEXT:	ret
 ;
 ; RV64-LABEL: test3:
 ; RV64:       # %bb.0: # %entry
-; RV64-NEXT:    addi sp, sp, -32
-; RV64-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    sub sp, sp, a1
-; RV64-NEXT:    mv s0, a0
-; RV64-NEXT:    addi a1, sp, 16
-; RV64-NEXT:    vs1r.v v10, (a1) # vscale x 8-byte Folded Spill
-; RV64-NEXT:    csrwi vxrm, 0
-; RV64-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; RV64-NEXT:    vaadd.vv v8, v8, v9
-; RV64-NEXT:    call foo
-; RV64-NEXT:    csrwi vxrm, 0
-; RV64-NEXT:    addi a0, sp, 16
-; RV64-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
-; RV64-NEXT:    vsetvli zero, s0, e8, mf8, ta, ma
-; RV64-NEXT:    vaadd.vv v8, v8, v9
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    add sp, sp, a0
-; RV64-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 32
-; RV64-NEXT:    ret
+; RV64-NEXT: 	addi	sp, sp, -16
+; RV64-NEXT: 	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; RV64-NEXT: 	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; RV64-NEXT: 	mv	s0, a0
+; RV64-NEXT: 	vsetvli	zero, a0, e8, mf8, ta, ma
+; RV64-NEXT: 	vmv1r.v	v24, v10
+; RV64-NEXT: 	csrwi	vxrm, 0
+; RV64-NEXT: 	vaadd.vv	v8, v8, v9
+; RV64-NEXT: 	call	foo
+; RV64-NEXT: 	csrwi	vxrm, 0
+; RV64-NEXT: 	vsetvli	zero, s0, e8, mf8, ta, ma
+; RV64-NEXT: 	vaadd.vv	v8, v8, v24
+; RV64-NEXT: 	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; RV64-NEXT: 	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; RV64-NEXT: 	addi	sp, sp, 16
+; RV64-NEXT: 	ret
 entry:
   %a = call <vscale x 1 x i8> @llvm.riscv.vaadd.nxv1i8.nxv1i8(
     <vscale x 1 x i8> poison,

--- a/llvm/test/CodeGen/RISCV/srem-seteq-illegal-types.ll
+++ b/llvm/test/CodeGen/RISCV/srem-seteq-illegal-types.ll
@@ -674,121 +674,107 @@ define void @test_srem_vec(ptr %X) nounwind {
 ;
 ; RV32MV-LABEL: test_srem_vec:
 ; RV32MV:       # %bb.0:
-; RV32MV-NEXT:    addi sp, sp, -64
-; RV32MV-NEXT:    sw ra, 60(sp) # 4-byte Folded Spill
-; RV32MV-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
-; RV32MV-NEXT:    sw s1, 52(sp) # 4-byte Folded Spill
-; RV32MV-NEXT:    sw s2, 48(sp) # 4-byte Folded Spill
-; RV32MV-NEXT:    sw s3, 44(sp) # 4-byte Folded Spill
-; RV32MV-NEXT:    sw s4, 40(sp) # 4-byte Folded Spill
-; RV32MV-NEXT:    csrr a1, vlenb
-; RV32MV-NEXT:    slli a1, a1, 1
-; RV32MV-NEXT:    sub sp, sp, a1
-; RV32MV-NEXT:    mv s0, a0
-; RV32MV-NEXT:    lw a1, 8(a0)
-; RV32MV-NEXT:    lbu a2, 12(a0)
-; RV32MV-NEXT:    lw a3, 4(a0)
-; RV32MV-NEXT:    lw a0, 0(a0)
-; RV32MV-NEXT:    li a4, 1
-; RV32MV-NEXT:    slli a5, a2, 30
-; RV32MV-NEXT:    srli s1, a1, 2
-; RV32MV-NEXT:    slli a6, a1, 31
-; RV32MV-NEXT:    or s1, s1, a5
-; RV32MV-NEXT:    srli a5, a3, 1
-; RV32MV-NEXT:    or s2, a5, a6
-; RV32MV-NEXT:    li a5, -1
-; RV32MV-NEXT:    srli a2, a2, 2
-; RV32MV-NEXT:    srli a1, a1, 1
-; RV32MV-NEXT:    slli a3, a3, 31
-; RV32MV-NEXT:    slli a2, a2, 31
-; RV32MV-NEXT:    slli a6, a1, 31
-; RV32MV-NEXT:    srai a1, a3, 31
-; RV32MV-NEXT:    srai s3, a2, 31
-; RV32MV-NEXT:    srai s4, a6, 31
-; RV32MV-NEXT:    sw a5, 16(sp)
-; RV32MV-NEXT:    sw a4, 20(sp)
-; RV32MV-NEXT:    li a2, 6
-; RV32MV-NEXT:    li a3, 0
-; RV32MV-NEXT:    call __moddi3
-; RV32MV-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32MV-NEXT:    vmv.v.x v8, a0
-; RV32MV-NEXT:    vslide1down.vx v8, v8, a1
-; RV32MV-NEXT:    addi a0, sp, 32
-; RV32MV-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32MV-NEXT:    li a2, 7
-; RV32MV-NEXT:    mv a0, s2
-; RV32MV-NEXT:    mv a1, s4
-; RV32MV-NEXT:    li a3, 0
-; RV32MV-NEXT:    call __moddi3
-; RV32MV-NEXT:    addi a2, sp, 32
-; RV32MV-NEXT:    vl2r.v v8, (a2) # vscale x 16-byte Folded Reload
-; RV32MV-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32MV-NEXT:    vslide1down.vx v8, v8, a0
-; RV32MV-NEXT:    vslide1down.vx v8, v8, a1
-; RV32MV-NEXT:    addi a0, sp, 32
-; RV32MV-NEXT:    vs2r.v v8, (a0) # vscale x 16-byte Folded Spill
-; RV32MV-NEXT:    li a2, -5
-; RV32MV-NEXT:    li a3, -1
-; RV32MV-NEXT:    mv a0, s1
-; RV32MV-NEXT:    mv a1, s3
-; RV32MV-NEXT:    call __moddi3
-; RV32MV-NEXT:    addi a2, sp, 32
-; RV32MV-NEXT:    vl2r.v v8, (a2) # vscale x 16-byte Folded Reload
-; RV32MV-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32MV-NEXT:    vslide1down.vx v8, v8, a0
-; RV32MV-NEXT:    addi a0, sp, 16
-; RV32MV-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV32MV-NEXT:    vlse64.v v10, (a0), zero
-; RV32MV-NEXT:    vid.v v12
-; RV32MV-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32MV-NEXT:    vslide1down.vx v8, v8, a1
-; RV32MV-NEXT:    vslidedown.vi v8, v8, 2
-; RV32MV-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV32MV-NEXT:    vand.vv v8, v8, v10
-; RV32MV-NEXT:    vand.vv v10, v12, v10
-; RV32MV-NEXT:    vmsne.vv v0, v8, v10
-; RV32MV-NEXT:    vmv.v.i v8, 0
-; RV32MV-NEXT:    vmerge.vim v8, v8, -1, v0
-; RV32MV-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; RV32MV-NEXT:    vslidedown.vi v12, v8, 1
-; RV32MV-NEXT:    vslidedown.vi v13, v8, 2
-; RV32MV-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; RV32MV-NEXT:    vslidedown.vi v10, v8, 4
-; RV32MV-NEXT:    vmv.x.s a0, v12
-; RV32MV-NEXT:    vmv.x.s a1, v13
-; RV32MV-NEXT:    vslidedown.vi v12, v8, 5
-; RV32MV-NEXT:    vmv.x.s a2, v10
-; RV32MV-NEXT:    vmv.x.s a3, v12
-; RV32MV-NEXT:    slli a4, a1, 1
-; RV32MV-NEXT:    sub a4, a4, a0
-; RV32MV-NEXT:    srli a0, a2, 30
-; RV32MV-NEXT:    slli a3, a3, 2
-; RV32MV-NEXT:    or a0, a3, a0
-; RV32MV-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
-; RV32MV-NEXT:    vse32.v v8, (s0)
-; RV32MV-NEXT:    vslidedown.vi v8, v8, 3
-; RV32MV-NEXT:    srli a1, a1, 31
-; RV32MV-NEXT:    slli a2, a2, 2
-; RV32MV-NEXT:    or a1, a1, a2
-; RV32MV-NEXT:    vmv.x.s a2, v8
-; RV32MV-NEXT:    andi a2, a2, 1
-; RV32MV-NEXT:    slli a2, a2, 1
-; RV32MV-NEXT:    andi a0, a0, 7
-; RV32MV-NEXT:    or a1, a1, a2
-; RV32MV-NEXT:    sw a4, 4(s0)
-; RV32MV-NEXT:    sw a1, 8(s0)
-; RV32MV-NEXT:    sb a0, 12(s0)
-; RV32MV-NEXT:    csrr a0, vlenb
-; RV32MV-NEXT:    slli a0, a0, 1
-; RV32MV-NEXT:    add sp, sp, a0
-; RV32MV-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
-; RV32MV-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
-; RV32MV-NEXT:    lw s1, 52(sp) # 4-byte Folded Reload
-; RV32MV-NEXT:    lw s2, 48(sp) # 4-byte Folded Reload
-; RV32MV-NEXT:    lw s3, 44(sp) # 4-byte Folded Reload
-; RV32MV-NEXT:    lw s4, 40(sp) # 4-byte Folded Reload
-; RV32MV-NEXT:    addi sp, sp, 64
-; RV32MV-NEXT:    ret
+; RV32MV-NEXT:	addi	sp, sp, -32
+; RV32MV-NEXT:	sw	ra, 28(sp)                      # 4-byte Folded Spill
+; RV32MV-NEXT:	sw	s0, 24(sp)                      # 4-byte Folded Spill
+; RV32MV-NEXT:	sw	s1, 20(sp)                      # 4-byte Folded Spill
+; RV32MV-NEXT:	sw	s2, 16(sp)                      # 4-byte Folded Spill
+; RV32MV-NEXT:	sw	s3, 12(sp)                      # 4-byte Folded Spill
+; RV32MV-NEXT:	sw	s4, 8(sp)                       # 4-byte Folded Spill
+; RV32MV-NEXT:	mv	s0, a0
+; RV32MV-NEXT:	lw	a1, 8(a0)
+; RV32MV-NEXT:	lbu	a2, 12(a0)
+; RV32MV-NEXT:	lw	a3, 4(a0)
+; RV32MV-NEXT:	lw	a0, 0(a0)
+; RV32MV-NEXT:	li	a4, 1
+; RV32MV-NEXT:	slli	a5, a2, 30
+; RV32MV-NEXT:	srli	s1, a1, 2
+; RV32MV-NEXT:	slli	a6, a1, 31
+; RV32MV-NEXT:	or	s1, s1, a5
+; RV32MV-NEXT:	srli	a5, a3, 1
+; RV32MV-NEXT:	or	s2, a5, a6
+; RV32MV-NEXT:	li	a5, -1
+; RV32MV-NEXT:	srli	a2, a2, 2
+; RV32MV-NEXT:	srli	a1, a1, 1
+; RV32MV-NEXT:	slli	a3, a3, 31
+; RV32MV-NEXT:	slli	a2, a2, 31
+; RV32MV-NEXT:	slli	a6, a1, 31
+; RV32MV-NEXT:	srai	a1, a3, 31
+; RV32MV-NEXT:	srai	s3, a2, 31
+; RV32MV-NEXT:	srai	s4, a6, 31
+; RV32MV-NEXT:	sw	a5, 0(sp)
+; RV32MV-NEXT:	sw	a4, 4(sp)
+; RV32MV-NEXT:	li	a2, 6
+; RV32MV-NEXT:	li	a3, 0
+; RV32MV-NEXT:	call	__moddi3
+; RV32MV-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32MV-NEXT:	vmv.v.x	v8, a0
+; RV32MV-NEXT:	vslide1down.vx	v24, v8, a1
+; RV32MV-NEXT:	li	a2, 7
+; RV32MV-NEXT:	mv	a0, s2
+; RV32MV-NEXT:	mv	a1, s4
+; RV32MV-NEXT:	li	a3, 0
+; RV32MV-NEXT:	call	__moddi3
+; RV32MV-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32MV-NEXT:	vslide1down.vx	v8, v24, a0
+; RV32MV-NEXT:	vslide1down.vx	v24, v8, a1
+; RV32MV-NEXT:	li	a2, -5
+; RV32MV-NEXT:	li	a3, -1
+; RV32MV-NEXT:	mv	a0, s1
+; RV32MV-NEXT:	mv	a1, s3
+; RV32MV-NEXT:	call	__moddi3
+; RV32MV-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32MV-NEXT:	vslide1down.vx	v8, v24, a0
+; RV32MV-NEXT:	mv	a0, sp
+; RV32MV-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV32MV-NEXT:	vlse64.v	v10, (a0), zero
+; RV32MV-NEXT:	vid.v	v12
+; RV32MV-NEXT:	vsetivli	zero, 8, e32, m2, ta, ma
+; RV32MV-NEXT:	vslide1down.vx	v8, v8, a1
+; RV32MV-NEXT:	vslidedown.vi	v8, v8, 2
+; RV32MV-NEXT:	vsetivli	zero, 4, e64, m2, ta, ma
+; RV32MV-NEXT:	vand.vv	v8, v8, v10
+; RV32MV-NEXT:	vand.vv	v10, v12, v10
+; RV32MV-NEXT:	vmsne.vv	v0, v8, v10
+; RV32MV-NEXT:	vmv.v.i	v8, 0
+; RV32MV-NEXT:	vmerge.vim	v8, v8, -1, v0
+; RV32MV-NEXT:	vsetvli	zero, zero, e32, m1, ta, ma
+; RV32MV-NEXT:	vslidedown.vi	v12, v8, 1
+; RV32MV-NEXT:	vslidedown.vi	v13, v8, 2
+; RV32MV-NEXT:	vsetivli	zero, 1, e32, m2, ta, ma
+; RV32MV-NEXT:	vslidedown.vi	v10, v8, 4
+; RV32MV-NEXT:	vmv.x.s	a0, v12
+; RV32MV-NEXT:	vmv.x.s	a1, v13
+; RV32MV-NEXT:	vslidedown.vi	v12, v8, 5
+; RV32MV-NEXT:	vmv.x.s	a2, v10
+; RV32MV-NEXT:	vmv.x.s	a3, v12
+; RV32MV-NEXT:	slli	a4, a1, 1
+; RV32MV-NEXT:	sub	a4, a4, a0
+; RV32MV-NEXT:	srli	a0, a2, 30
+; RV32MV-NEXT:	slli	a3, a3, 2
+; RV32MV-NEXT:	or	a0, a3, a0
+; RV32MV-NEXT:	vsetivli	zero, 1, e32, m1, ta, ma
+; RV32MV-NEXT:	vse32.v	v8, (s0)
+; RV32MV-NEXT:	vslidedown.vi	v8, v8, 3
+; RV32MV-NEXT:	srli	a1, a1, 31
+; RV32MV-NEXT:	slli	a2, a2, 2
+; RV32MV-NEXT:	or	a1, a1, a2
+; RV32MV-NEXT:	vmv.x.s	a2, v8
+; RV32MV-NEXT:	andi	a2, a2, 1
+; RV32MV-NEXT:	slli	a2, a2, 1
+; RV32MV-NEXT:	andi	a0, a0, 7
+; RV32MV-NEXT:	or	a1, a1, a2
+; RV32MV-NEXT:	sw	a4, 4(s0)
+; RV32MV-NEXT:	sw	a1, 8(s0)
+; RV32MV-NEXT:	sb	a0, 12(s0)
+; RV32MV-NEXT:	lw	ra, 28(sp)                      # 4-byte Folded Reload
+; RV32MV-NEXT:	lw	s0, 24(sp)                      # 4-byte Folded Reload
+; RV32MV-NEXT:	lw	s1, 20(sp)                      # 4-byte Folded Reload
+; RV32MV-NEXT:	lw	s2, 16(sp)                      # 4-byte Folded Reload
+; RV32MV-NEXT:	lw	s3, 12(sp)                      # 4-byte Folded Reload
+; RV32MV-NEXT:	lw	s4, 8(sp)                       # 4-byte Folded Reload
+; RV32MV-NEXT:	addi	sp, sp, 32
+; RV32MV-NEXT:	ret
 ;
 ; RV64MV-LABEL: test_srem_vec:
 ; RV64MV:       # %bb.0:


### PR DESCRIPTION


In LLVM  21.1.0, the **RegMask of scalar library functions on RISC-V does not include available vector registers**. This behavior may **increase the likelihood of register spills**, especially in functions that frequently invoke scalar library calls within vectorized loops.

For the following C code:

```C++
1 void vector_silu(float *input, float *output, int *shape, int num_dims) {
2    int total_elements = 1;
3    for (int i = 0; i < num_dims; ++i) {
4        total_elements *= shape[i];
5    }
6    for (int i = 0; i < total_elements; ++i) {
7        float x = input[i];
8        output[i] = x / (1.0 + expf(-x));
9    }
10 }
```

the corresponding RISC-V assembly for line 8 (`output[i] = x / (1.0 + expf(-x));`)is as follows. The reason for the v8 spill that `expf` (a scalar library function) does not have vector registers available in its RegMask.

```
        vsetivli        zero, 4, e32, m1, ta, ma
        vfslide1down.vf v8, v8, fa0
        csrr    a0, vlenb
        sh1add  a0, a0, sp
        addi    a0, a0, 32
        vs1r.v  v8, (a0)					# Spill
        csrr    a0, vlenb
        sh2add  a0, a0, a0
        add     a0, a0, sp
        addi    a0, a0, 32
        vl1r.v  v8, (a0)					# Reload
        vslidedown.vi   v8, v8, 3
        vfmv.f.s        fa0, v8
        call    expf
```
 See the online code at https://godbolt.org/z/T7f7PxYor

**RISCVRegisterInfo::getCallPreservedMask** function implements the setting of the library function's **regmask**. When we modify it to CSR_ILP32D_LP64D_V_RegMask when the architecture supports the V extension, the regmask setting for the library function returns a V-inclusive regmaskt, spill was successfully eliminated.

We modified and tested only the **RISCVABI::ABI_ILP32D** and **ABI_LP64D** cases, but we **recommend** modifying the remaining cases too. We performed correctness testing on **Spec06** and encountered no problems.

The [XSCC compiler team](https://github.com/orgs/OpenXiangShan/teams/xscc) developed this implementation.

