### PR TITLE
[libc][stdlib][annex_k] Add ignore_handler_s.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1081,6 +1081,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.atexit
     libc.src.stdlib.exit
     libc.src.stdlib.getenv
+    libc.src.stdlib.ignore_handler_s
     libc.src.stdlib.quick_exit
 
     # signal.h entrypoints

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1209,6 +1209,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.atexit
     libc.src.stdlib.exit
     libc.src.stdlib.getenv
+    libc.src.stdlib.ignore_handler_s
     libc.src.stdlib.quick_exit
 
     # signal.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1248,6 +1248,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.atexit
     libc.src.stdlib.exit
     libc.src.stdlib.getenv
+    libc.src.stdlib.ignore_handler_s
     libc.src.stdlib.quick_exit
 
     # signal.h entrypoints

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -360,6 +360,7 @@ add_header_macro(
   ../libc/include/stdlib.yaml
   stdlib.h
   DEPENDS
+    .llvm-libc-macros.annex_k_macros
     .llvm-libc-macros.null_macro
     .llvm-libc-macros.stdlib_macros
     .llvm-libc-types.__atexithandler_t

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -113,6 +113,15 @@ functions:
     return_type: char *
     arguments:
       - type: const char *
+  - name: ignore_handler_s
+    standards:
+      - stdc
+    return_type: void
+    arguments:
+      - type: const char *__restrict
+      - type: void *__restrict
+      - type: errno_t
+    guard: 'LIBC_HAS_ANNEX_K'
   - name: labs
     standards:
       - stdc

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -663,3 +663,16 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.system
 )
+
+add_entrypoint_object(
+  ignore_handler_s
+  HDRS
+    ignore_handler_s.h
+  SRCS
+    ignore_handler_s.cpp
+  DEPENDS
+    libc.hdr.types.errno_t
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
+    libc.src.__support.macros.attributes
+)

--- a/libc/src/stdlib/ignore_handler_s.cpp
+++ b/libc/src/stdlib/ignore_handler_s.cpp
@@ -1,0 +1,16 @@
+//===-- Implementation header for ignore_handler_s --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdlib/ignore_handler_s.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, ignore_handler_s,
+                   (const char *__restrict, void *__restrict, errno_t)) {}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/ignore_handler_s.h
+++ b/libc/src/stdlib/ignore_handler_s.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for ignore_handler_s --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDLIB_IGNORE_HANDLER_S_H
+#define LLVM_LIBC_SRC_STDLIB_IGNORE_HANDLER_S_H
+
+#include "hdr/types/errno_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void ignore_handler_s(const char *__restrict msg, void *__restrict ptr,
+                      errno_t error);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_IGNORE_HANDLER_S_H


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add `ignore_handler_s` required by Annex K interface in LLVM libc.