### PR TITLE
Add support for ref.func to AsmParser/MC

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrRef.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrRef.td
@@ -41,6 +41,11 @@ defm REF_TEST_FUNCREF : I<(outs I32:$res), (ins TypeIndex:$type, FUNCREF:$ref),
                           "ref.test\t$type, $ref", "ref.test $type", 0xfb14>,
                         Requires<[HasGC]>;
 
+defm REF_FUNC : I<(outs FUNCREF:$res), (ins function32_op:$func),
+                    (outs), (ins function32_op:$func), [],
+                    "ref.func\t$func", "ref.func $func", 0xd2>,
+                Requires<[HasReferenceTypes]>;
+
 defm "" : REF_I<FUNCREF, funcref, "func">;
 defm "" : REF_I<EXTERNREF, externref, "extern">;
 defm "" : REF_I<EXNREF, exnref, "exn">;

--- a/llvm/test/MC/WebAssembly/reference-types.s
+++ b/llvm/test/MC/WebAssembly/reference-types.s
@@ -105,3 +105,12 @@ ref_block_test:
   end_block
   drop
   end_function
+
+# CHECK-LABEL: ref_func_test:
+# CHECK-NEXT:  .functype ref_func_test () -> (funcref)
+# CHECK-NEXT:  ref.func ref_func_test # encoding: [0xd2,0x80'A',0x80'A',0x80'A',0x80'A',A]
+# CHECK-NEXT:  # fixup A - offset: 1, value: ref_func_test, kind: fixup_uleb128_i32
+ref_func_test:
+  .functype ref_func_test () -> (funcref)
+  ref.func ref_func_test
+  end_function


### PR DESCRIPTION
This is step 1 of exposing WASM `ref.func` to LLVM.

This PR only handles creating the instruction and a test for assembling it.