### PR TITLE
[X86] Add baseline test for X86 conditional load/store optimization bug

### DIFF
--- a/llvm/test/CodeGen/X86/apx/cf.ll
+++ b/llvm/test/CodeGen/X86/apx/cf.ll
@@ -232,19 +232,18 @@ entry:
 
 define void @and_cond(i32 %a, i1 %b) {
 ; CHECK-LABEL: and_cond:
-; CHECK:       # %bb.0: # %entry
+; CHECK:       # %bb.0:
 ; CHECK-NEXT:    testl %edi, %edi
 ; CHECK-NEXT:    setg %al
 ; CHECK-NEXT:    xorl %ecx, %ecx
 ; CHECK-NEXT:    testb %al, %sil
 ; CHECK-NEXT:    cfcmovel %ecx, 0
 ; CHECK-NEXT:    retq
-entry:
-  %0 = icmp sgt i32 %a, 0
-  %1 = xor i1 %b, true
-  %3 = and i1 %1, %0
-  %4 = insertelement <1 x i1> zeroinitializer, i1 %3, i64 0
-  call void @llvm.masked.store.v1i32.p0(<1 x i32> zeroinitializer, ptr null, i32 1, <1 x i1> %4)
+  %is_pos = icmp sgt i32 %a, 0
+  %not_b = xor i1 %b, true
+  %cond = and i1 %not_b, %is_pos
+  %mask = insertelement <1 x i1> zeroinitializer, i1 %cond, i64 0
+  call void @llvm.masked.store.v1i32.p0(<1 x i32> zeroinitializer, ptr null, i32 1, <1 x i1> %mask)
   ret void
 }
 

--- a/llvm/test/CodeGen/X86/apx/cf.ll
+++ b/llvm/test/CodeGen/X86/apx/cf.ll
@@ -230,6 +230,24 @@ entry:
   ret void
 }
 
+define void @and_cond(i32 %a, i1 %b) {
+; CHECK-LABEL: and_cond:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    testl %edi, %edi
+; CHECK-NEXT:    setg %al
+; CHECK-NEXT:    xorl %ecx, %ecx
+; CHECK-NEXT:    testb %al, %sil
+; CHECK-NEXT:    cfcmovel %ecx, 0
+; CHECK-NEXT:    retq
+entry:
+  %0 = icmp sgt i32 %a, 0
+  %1 = xor i1 %b, true
+  %3 = and i1 %1, %0
+  %4 = insertelement <1 x i1> zeroinitializer, i1 %3, i64 0
+  call void @llvm.masked.store.v1i32.p0(<1 x i32> zeroinitializer, ptr null, i32 1, <1 x i1> %4)
+  ret void
+}
+
 define i64 @redundant_test(i64 %num, ptr %p1, i64 %in) {
 ; CHECK-LABEL: redundant_test:
 ; CHECK:       # %bb.0:


### PR DESCRIPTION
This PR adds a baseline test that exposes a bug in the current `combineX86CloadCstore` optimization. The generated assembly demonstrates incorrect behavior when the optimization is applied without proper constraints.

Without any assumptions about `X` this transformation is only valid when `Y` is a non zero power of two/single-bit mask.
```cpp
      // res, flags2 = sub 0, (and (xor X, -1), Y)
      // cload/cstore ..., cond_ne, flag2
      // ->
      // res, flags2 = sub 0, (and X, Y)
      // cload/cstore ..., cond_e, flag2
```

In the provided test case, the value in `%al` is unknown at compile time. If `%al` contains `0`, the optimization cannot be applied, because `(and (xor X, -1), 0)` is not equal to `(and X, 0)`.

Fix: https://github.com/llvm/llvm-project/pull/163353