### PR TITLE
[libc++][C++03] Introduce LIBCPP_{,NON_}FROZEN_ASSERT

### DIFF
--- a/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/assign_copy.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/assign_copy.pass.cpp
@@ -14,8 +14,6 @@
 
 // unordered_map& operator=(const unordered_map& u);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
@@ -270,7 +268,7 @@ void test_alloc(const Alloc& lhs_alloc                   = Alloc(),
       V rhs_arr[] = {V(10, 4), V(13, 5), V(12, 324), V(0, 54), V(50, 5), V(2, 5)};
       Map copy(begin(rhs_arr), end(rhs_arr), 0, std::hash<int>(), std::equal_to<int>(), rhs_alloc);
       copy = orig;
-      LIBCPP_ASSERT(copy.bucket_count() == 5);
+      LIBCPP_NON_FROZEN_ASSERT(copy.bucket_count() == 5);
       assert(copy.size() == 4);
       assert(copy.at(1) == 1);
       assert(copy.at(2) == 3);

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/assign_copy.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/assign_copy.pass.cpp
@@ -14,8 +14,6 @@
 
 // unordered_multimap& operator=(const unordered_multimap& u);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
@@ -289,7 +287,7 @@ void test_alloc(const Alloc& lhs_alloc                   = Alloc(),
       V rhs_arr[] = {V(10, 4), V(13, 5), V(12, 324), V(0, 54), V(50, 5), V(2, 5)};
       Map copy(begin(rhs_arr), end(rhs_arr), 0, std::hash<int>(), std::equal_to<int>(), rhs_alloc);
       copy = orig;
-      LIBCPP_ASSERT(copy.bucket_count() == 5);
+      LIBCPP_NON_FROZEN_ASSERT(copy.bucket_count() == 5);
       assert(copy.size() == 4);
       assert(copy.find(1)->second == 1);
       assert(copy.find(2)->second == 3);

--- a/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/assign_copy.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/assign_copy.pass.cpp
@@ -14,8 +14,6 @@
 
 // unordered_multiset& operator=(const unordered_multiset& u);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
@@ -259,7 +257,7 @@ void test_alloc(const Alloc& lhs_alloc                   = Alloc(),
       int rhs_arr[] = {10, 13, 12, 0, 50, 2};
       Set copy(std::begin(rhs_arr), std::end(rhs_arr), 0, std::hash<int>(), std::equal_to<int>(), rhs_alloc);
       copy = orig;
-      LIBCPP_ASSERT(copy.bucket_count() == 5);
+      LIBCPP_NON_FROZEN_ASSERT(copy.bucket_count() == 5);
       assert(copy.size() == 4);
       assert(copy.count(1) == 1);
       assert(copy.count(2) == 1);

--- a/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/assign_copy.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/assign_copy.pass.cpp
@@ -14,8 +14,6 @@
 
 // unordered_set& operator=(const unordered_set& u);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
@@ -262,7 +260,7 @@ void test_alloc(const Alloc& lhs_alloc                   = Alloc(),
       int rhs_arr[] = {10, 13, 12, 0, 50, 2};
       Set copy(std::begin(rhs_arr), std::end(rhs_arr), 0, std::hash<int>(), std::equal_to<int>(), rhs_alloc);
       copy = orig;
-      LIBCPP_ASSERT(copy.bucket_count() == 5);
+      LIBCPP_NON_FROZEN_ASSERT(copy.bucket_count() == 5);
       assert(copy.size() == 4);
       assert(copy.count(1) == 1);
       assert(copy.count(2) == 1);

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_pointer.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_pointer.pass.cpp
@@ -12,8 +12,6 @@
 
 // iter_type put(iter_type s, ios_base& iob, char_type fill, void* v) const;
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <cassert>
 #include <ios>
 #include <locale>
@@ -36,7 +34,7 @@ int main(int, char**) {
     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
     std::string ex(str, base(iter));
     assert(!ex.empty());
-    LIBCPP_ASSERT(ex == "0");
+    LIBCPP_NON_FROZEN_ASSERT(ex == "0");
   }
 
   return 0;

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -264,6 +264,12 @@
 #define LIBCPP_ONLY(...) static_assert(true, "")
 #endif
 
+#ifdef _LIBCPP_USE_FROZEN_CXX03_HEADERS
+#  define LIBCPP_NON_FROZEN_ASSERT(...) static_assert(true, "")
+#else
+#  define LIBCPP_NON_FROZEN_ASSERT(...) LIBCPP_ASSERT(__VA_ARGS__)
+#endif
+
 #if __has_cpp_attribute(nodiscard)
 #  define TEST_NODISCARD [[nodiscard]]
 #else


### PR DESCRIPTION
There are a few cases where test only fail with the C++03 frozen headers because some implementation details are asserted. This patch introduces new assertion macros to differentiate between frozen and non-frozen headers.
