### PR TITLE
[OpenACC][NFC] Simplify Reduction Recipe Storage

### DIFF
--- a/clang/lib/AST/OpenACCClause.cpp
+++ b/clang/lib/AST/OpenACCClause.cpp
@@ -509,7 +509,7 @@ OpenACCReductionClause *OpenACCReductionClause::Create(
     ArrayRef<OpenACCReductionRecipeWithStorage> Recipes,
     SourceLocation EndLoc) {
   size_t NumCombiners = llvm::accumulate(
-      Recipes, 0, [](size_t Num, const OpenACCReductionRecipe &R) {
+      Recipes, 0, [](size_t Num, const OpenACCReductionRecipeWithStorage &R) {
         return Num + R.CombinerRecipes.size();
       });
 


### PR DESCRIPTION
The inheritence link between the Reduction Recipe and the version with storage made it overly complicated of an implementation for near zero gain.  This patch removes that link, and uses the private constructor of the non-storage version to ensure only the 'right' ones get created in the right place.