### PR TITLE
[TSan] Fix warning when compiling with -Wmissing-designated-field-initializers

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp
@@ -259,7 +259,9 @@ void InitializePlatform() {
 
   ThreadEventCallbacks callbacks = {
       .create = ThreadCreateCallback,
+      .start = nullptr,
       .terminate = ThreadTerminateCallback,
+      .destroy = nullptr,
   };
   InstallPthreadIntrospectionHook(callbacks);
 #endif


### PR DESCRIPTION
Currently we receive a warning when initializing a ThreadEventCallbacks when compiling with this flag:
```
llvm-project/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp:252:3: warning: missing field 'start' initializer [-Wmissing-designated-field-initializers]
  252 |   };
      |   ^
```

This patch explicitly initializes the missing fields to null, fixing the warning.

rdar://162074310