### PR TITLE
[CodeGen] Introduce MachineLaneSSAUpdater for SSA Repair in Machine IR

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineLaneSSAUpdater.h
+++ b/llvm/include/llvm/CodeGen/MachineLaneSSAUpdater.h
@@ -186,7 +186,8 @@ private:
   // Helper: Create PHI in a specific block with per-edge lane analysis
   Register createPHIInBlock(MachineBasicBlock &JoinMBB,
                            Register OrigVReg,
-                           Register NewVReg);
+                           Register NewVReg,
+                           LaneBitmask DefMask);
 
   // Rewrite dominated uses of OrigVReg to NewSSA according to the
   // exact/subset/super policy; create REG_SEQUENCE only when needed.

--- a/llvm/include/llvm/CodeGen/MachineLaneSSAUpdater.h
+++ b/llvm/include/llvm/CodeGen/MachineLaneSSAUpdater.h
@@ -1,0 +1,217 @@
+//===- MachineLaneSSAUpdater.h - SSA repair for Machine IR (lane-aware) -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// === MachineLaneSSAUpdater Design Notes ===
+//
+
+#ifndef LLVM_CODEGEN_MACHINELANESSAUPDATER_H
+#define LLVM_CODEGEN_MACHINELANESSAUPDATER_H
+
+#include "llvm/MC/LaneBitmask.h"        // LaneBitmask
+#include "llvm/ADT/SmallVector.h"        // SmallVector
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/CodeGen/Register.h"       // Register
+#include "llvm/CodeGen/SlotIndexes.h"    // SlotIndex
+#include "llvm/CodeGen/LiveInterval.h"    // LiveRange
+
+namespace llvm {
+
+// Forward declarations to avoid heavy includes in the header.
+class MachineFunction;
+class MachineBasicBlock;
+class MachineInstr;
+class LiveIntervals;
+class LiveRange;
+class MachineDominatorTree;
+class TargetRegisterInfo;
+class MachinePostDominatorTree; // optional if you choose to use it
+
+//===----------------------------------------------------------------------===//
+// CutEndPoints: Opaque token representing a spill-time cut of a value.
+// Constructed only by SpillCutCollector and consumed by the updater in
+// addDefAndRepairAfterSpill().
+//===----------------------------------------------------------------------===//
+class CutEndPoints {
+public:
+  CutEndPoints() = delete;
+
+  Register getOrigVReg() const { return OrigVReg; }
+  SlotIndex getCutIdx() const { return CutIdx; }
+  const SmallVector<LaneBitmask, 4> &getTouchedLaneMasks() const { return TouchedLaneMasks; }
+  
+  // Access to captured endpoint data for extendToIndices()
+  const SmallVector<SlotIndex, 8> &getMainEndPoints() const { return MainEndPoints; }
+  const DenseMap<LaneBitmask, SmallVector<SlotIndex, 8>> &getSubrangeEndPoints() const { 
+    return SubrangeEndPoints; 
+  }
+
+  // Optional: debugging aids (not required for functionality).
+  const SmallVector<LiveRange::Segment, 4> &getDebugSegsBefore() const { return SegsBefore; }
+
+private:
+  friend class SpillCutCollector; // only the collector can create valid tokens
+
+  // Private constructor used by the collector.
+  CutEndPoints(Register VReg,
+               SlotIndex Cut,
+               SmallVector<LaneBitmask, 4> Lanes,
+               SmallVector<SlotIndex, 8> MainEP,
+               DenseMap<LaneBitmask, SmallVector<SlotIndex, 8>> SubEP,
+               SmallVector<LiveRange::Segment, 4> Before)
+      : OrigVReg(VReg), CutIdx(Cut),
+        TouchedLaneMasks(std::move(Lanes)), 
+        MainEndPoints(std::move(MainEP)),
+        SubrangeEndPoints(std::move(SubEP)),
+        SegsBefore(std::move(Before)) {}
+
+  Register OrigVReg;
+  SlotIndex CutIdx;
+  SmallVector<LaneBitmask, 4> TouchedLaneMasks; // main + touched subranges
+  
+  // Captured endpoint data for extendToIndices()
+  SmallVector<SlotIndex, 8> MainEndPoints;
+  DenseMap<LaneBitmask, SmallVector<SlotIndex, 8>> SubrangeEndPoints;
+
+  // Optional diagnostics: segments before pruning (for asserts/debug dumps).
+  SmallVector<LiveRange::Segment, 4> SegsBefore;
+};
+
+//===----------------------------------------------------------------------===//
+// SpillCutCollector: captures EndPoints at spill-time by calling pruneValue()
+// on the main live range and the touched subranges. The opaque CutEndPoints
+// are later consumed by the updater.
+//===----------------------------------------------------------------------===//
+class SpillCutCollector {
+public:
+  explicit SpillCutCollector(LiveIntervals &LIS, MachineRegisterInfo &MRI) 
+      : LIS(LIS), MRI(MRI) {}
+
+  // Decide a cut at CutIdx for OrigVReg (lane-aware). This should:
+  //  - call pruneValue() on main + subranges as needed,
+  //  - stash the returned endpoints needed by extendToIndices(),
+  //  - return an opaque token capturing OrigVReg, CutIdx, and masks.
+  CutEndPoints cut(Register OrigVReg, SlotIndex CutIdx, LaneBitmask LanesToCut);
+
+private:
+  LiveIntervals &LIS;
+  MachineRegisterInfo &MRI;
+};
+
+//===----------------------------------------------------------------------===//
+// MachineLaneSSAUpdater: universal SSA repair for Machine IR (lane-aware)
+//   * addDefAndRepairNewDef   : for plain new defs (no prior pruneValue)
+//   * addDefAndRepairAfterSpill: for reloads (must consume CutEndPoints)
+//===----------------------------------------------------------------------===//
+class MachineLaneSSAUpdater {
+public:
+  MachineLaneSSAUpdater(MachineFunction &MF,
+                        LiveIntervals &LIS,
+                        MachineDominatorTree &MDT,
+                        const TargetRegisterInfo &TRI)
+      : MF(MF), LIS(LIS), MDT(MDT), TRI(TRI) {}
+
+  // Plain new-def path (no EndPoints required). The updater derives any
+  // necessary data from the intact LIS.
+  Register addDefAndRepairNewDef(MachineInstr &NewDefMI,
+                                 Register OrigVReg,
+                                 LaneBitmask DefMask);
+
+  // Reload-after-spill path (requires spill-time EndPoints). Will assert
+  // if the token does not match the OrigVReg or if indices are inconsistent.
+  Register addDefAndRepairAfterSpill(MachineInstr &ReloadMI,
+                                     Register OrigVReg,
+                                     LaneBitmask DefMask,
+                                     const CutEndPoints &EP);
+
+private:
+  // Common SSA repair logic used by both entry points
+  void performSSARepair(Register NewVReg, Register OrigVReg, 
+                        LaneBitmask DefMask, MachineBasicBlock *DefBB);
+
+  // Optional knobs (fluent style); no-ops until implemented in .cpp.
+  MachineLaneSSAUpdater &setUndefEdgePolicy(bool MaterializeImplicitDef) {
+    UndefEdgeAsImplicitDef = MaterializeImplicitDef; return *this; }
+  MachineLaneSSAUpdater &setVerifyOnExit(bool Enable) {
+    VerifyOnExit = Enable; return *this; }
+
+private:
+  // --- Internal helpers (declarations only; implement in .cpp) ---
+
+  // Index MI in SlotIndexes / LIS maps immediately after insertion.
+  // Returns the SlotIndex assigned to the instruction.
+  SlotIndex indexNewInstr(MachineInstr &MI);
+
+  // Extend the main live range and the specific subranges at MI's index
+  // for the lanes actually used/defined.
+  void extendPreciselyAt(const Register VReg,
+                         const SmallVector<LaneBitmask, 4> &LaneMasks,
+                         const MachineInstr &AtMI);
+
+  // Compute pruned IDF for a set of definition blocks (usually {block(NewDef)}),
+  // intersected with blocks where OrigVReg lanes specified by DefMask are live-in.
+  void computePrunedIDF(Register OrigVReg,
+                        LaneBitmask DefMask,
+                        ArrayRef<MachineBasicBlock *> NewDefBlocks,
+                        SmallVectorImpl<MachineBasicBlock *> &OutIDFBlocks);
+
+  // Insert lane-aware Machine PHIs with iterative worklist processing.
+  // Seeds with InitialVReg definition, computes IDF, places PHIs, repeats until convergence.
+  // Returns all PHI result registers created during the iteration.
+  SmallVector<Register> insertLaneAwarePHI(Register InitialVReg,
+                                            Register OrigVReg,
+                                            LaneBitmask DefMask,
+                                            MachineBasicBlock *InitialDefBB);
+
+  // Helper: Create PHI in a specific block with per-edge lane analysis
+  SmallVector<Register> createPHIInBlock(MachineBasicBlock &JoinMBB,
+                                          Register OrigVReg,
+                                          Register NewVReg,
+                                          LaneBitmask ResultMask);
+
+  // Rewrite dominated uses of OrigVReg to NewSSA according to the
+  // exact/subset/super policy; create REG_SEQUENCE only when needed.
+  void rewriteDominatedUses(Register OrigVReg,
+                            Register NewSSA,
+                            LaneBitmask MaskToRewrite);
+
+  // --- Data members ---
+  MachineFunction &MF;
+  LiveIntervals &LIS;
+  MachineDominatorTree &MDT;
+  const TargetRegisterInfo &TRI;
+
+  bool UndefEdgeAsImplicitDef = true; // policy hook
+  bool VerifyOnExit = true;           // run MF.verify()/LI.verify() at end
+};
+
+// DenseMapInfo specialization for LaneBitmask
+template<>
+struct DenseMapInfo<LaneBitmask> {
+  static inline LaneBitmask getEmptyKey() {
+    // Use a specific bit pattern for empty key
+    return LaneBitmask(~0U - 1);
+  }
+  
+  static inline LaneBitmask getTombstoneKey() {
+    // Use a different bit pattern for tombstone  
+    return LaneBitmask(~0U);
+  }
+  
+  static unsigned getHashValue(const LaneBitmask &Val) {
+    return (unsigned)Val.getAsInteger();
+  }
+  
+  static bool isEqual(const LaneBitmask &LHS, const LaneBitmask &RHS) {
+    return LHS == RHS;
+  }
+};
+
+} // end namespace llvm
+
+#endif // LLVM_CODEGEN_MACHINELANESSAUPDATER_H

--- a/llvm/include/llvm/CodeGen/MachineLaneSSAUpdater.h
+++ b/llvm/include/llvm/CodeGen/MachineLaneSSAUpdater.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"        // SmallVector
 #include "llvm/CodeGen/LiveInterval.h"    // LiveRange
+#include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/Register.h"       // Register
 #include "llvm/CodeGen/SlotIndexes.h"    // SlotIndex
 #include "llvm/CodeGen/TargetRegisterInfo.h" // For inline function
@@ -58,33 +59,118 @@ public:
       : MF(MF), LIS(LIS), MDT(MDT), TRI(TRI) {}
 
   // Repair SSA for a new definition that violates SSA form
-  // 
-  // Parameters:
-  //   NewDefMI: Instruction with a def operand that currently defines OrigVReg (violating SSA)
-  //   OrigVReg: The virtual register being redefined
-  //   NewVReg:  (Optional) Pre-allocated virtual register to use instead of auto-creating one
   //
+  // Parameters:
+  //   NewDefMI: Instruction with a def operand that currently defines OrigVReg
+  //   (violating SSA) 
+  //   OrigVReg: The virtual register being redefined
+  //   PHIRegDefOps: A vector of def operands for the PHI registers that were
+  //   created
   // This function will:
   //   1. Find the def operand in NewDefMI that defines OrigVReg
   //   2. Derive the lane mask from the operand's subreg index (if any)
-  //   3. Use NewVReg if provided, or create a new virtual register with appropriate class
-  //   4. Replace the operand in NewDefMI to define the new vreg
+  //   3. Create a new virtual register with same class as OrigVReg
+  //   4. Replace the operand in NewDefMI to define the new vreg (preserving
+  //   subreg index)
   //   5. Perform SSA repair (insert PHIs, rewrite uses)
   //
-  // When to provide NewVReg:
-  //   - Leave it empty (default) for most cases - automatic class selection works well
-  //   - Provide it when you need precise control over register class selection
-  //   - Common use case: subregister spill/reload where target-specific constraints apply
-  //   - Example: Reloading a 96-bit subregister requires vreg_96 class (not vreg_128)
-  //
-  // Returns: The SSA-repaired virtual register (either NewVReg or auto-created)
+  // Returns: The newly created SSA-repaired virtual register
   Register repairSSAForNewDef(MachineInstr &NewDefMI, Register OrigVReg,
-                             Register NewVReg = Register());
+                              SmallVectorImpl<MachineOperand *> &PHIRegDefOps);
+
+  /// Check if a use is reachable from a definition using IDF analysis.
+  /// 
+  /// Fast paths:
+  /// - Same block: check instruction order
+  /// - Non-PHI uses: check block dominance
+  /// - PHI with dominated predecessor: return true
+  ///
+  /// \param DefMI - The instruction that defines/uses the register
+  /// \param UseMI - The instruction that uses the register
+  /// \param OrigVReg - The original register being analyzed
+  /// \param DefMask - The lane mask for the definition (used for IDF analysis)
+  /// \returns true if UseMI is reachable from DefMI
+  // TODO: Make VRegMaskPair.h public and change signature to use VRegMaskPair
+  // instead of Register and LaneBitmask separately
+  bool isUseReachableFromDef(MachineInstr *DefMI, MachineInstr *UseMI,
+                             Register OrigVReg, LaneBitmask DefMask);
+
+  /// Check if a use is reachable from a definition.
+  /// Fast path (dominated use): Simple dominance check
+  /// Slow path (PHI with non-dominated predecessor):
+  /// Uses pruned IDF to determine reachability
+  ///
+  /// \param DefOp - The definition operand (provides DefMI, block, mask)
+  /// \param UseOp - The use operand (provides UseMI)
+  /// \param OrigVReg - The original register being analyzed
+  /// \returns true if UseOp is reachable from DefOp
+  bool isUseReachableFromDef(MachineOperand &DefOp,
+                             MachineOperand &UseOp,
+                             Register OrigVReg);
+
+  /// Get pruned IDF blocks for a definition (with caching).
+  /// 
+  /// Computes the Iterated Dominance Frontier (IDF) for DefBlock, pruned by
+  /// LiveInterval analysis (only includes blocks where OrigVReg lanes are live-in).
+  /// Results are cached to avoid redundant computation.
+  ///
+  /// \param OrigVReg - The register to analyze
+  /// \param DefMask - Lane mask of the definition
+  /// \param DefBlock - The definition block
+  /// \param OutIDFBlocks - Output vector of IDF blocks
+  void getPrunedIDF(Register OrigVReg,
+                    LaneBitmask DefMask,
+                    MachineBasicBlock *DefBlock,
+                    SmallVectorImpl<MachineBasicBlock *> &OutIDFBlocks);
+
+  /// Clear the IDF cache. Call this if the CFG is modified.
+  void clearIDFCache() { IDFCache.clear(); }
+
+  /// Insert a PHI at a join block with explicit incoming values.
+  ///
+  /// \param JoinBB - The block where the PHI will be inserted
+  /// \param OrigVReg - The original register being tracked
+  /// \param IncomingValues - Map from predecessor to incoming register
+  /// \param SpilledMask - Lane mask of the spilled register
+  /// \returns Pointer to the PHI result operand
+  MachineOperand *insertPHIAtBlock(MachineBasicBlock *JoinBB,
+                                   Register OrigVReg,
+                                   const DenseMap<MachineBasicBlock *, Register> &IncomingValues,
+                                   LaneBitmask SpilledMask);
+
+  // Public cache key structure for DenseMapInfo specialization
+  struct IDFCacheKey {
+    Register VReg;
+    LaneBitmask Mask;
+    unsigned DefBlockNum;
+    
+    bool operator==(const IDFCacheKey &Other) const {
+      return VReg == Other.VReg && Mask == Other.Mask && DefBlockNum == Other.DefBlockNum;
+    }
+  };
+
+  /// Rewrite dominated uses of OrigVReg to NewSSA according to the
+  /// exact/subset/super policy; create REG_SEQUENCE only when needed.
+  void rewriteDominatedUses(Register OrigVReg,
+                            Register NewSSA,
+                            LaneBitmask MaskToRewrite);
+
+  /// Repair SSA for a reload instruction that already defines a new register.
+  /// This inserts PHIs at IDF blocks and rewrites dominated uses.
+  /// Use this when you've already created a reload that defines NewVReg.
+  /// Returns PHI def operands created during repair.
+  SmallVector<MachineOperand *, 4> repairSSAForReload(Register NewVReg,
+                                                       Register OrigVReg,
+                                                       LaneBitmask DefMask,
+                                                       MachineBasicBlock *DefBB);
 
 private:
   // Common SSA repair logic
-  void performSSARepair(Register NewVReg, Register OrigVReg, 
-                        LaneBitmask DefMask, MachineBasicBlock *DefBB);
+  // Returns a vector of MachineOperand pointers to the PHI result registers
+  SmallVector<MachineOperand *> performSSARepair(Register NewVReg,
+                                                     Register OrigVReg,
+                                                     LaneBitmask DefMask,
+                                                     MachineBasicBlock *DefBB);
 
   // Optional knobs (fluent style); no-ops until implemented in .cpp.
   MachineLaneSSAUpdater &setUndefEdgePolicy(bool MaterializeImplicitDef) {
@@ -114,26 +200,24 @@ private:
   // Insert lane-aware Machine PHIs with iterative worklist processing.
   // Seeds with InitialVReg definition, computes IDF, places PHIs, repeats until convergence.
   // Returns all PHI result registers created during the iteration.
-  SmallVector<Register> insertLaneAwarePHI(Register InitialVReg,
+  SmallVector<MachineOperand*> insertLaneAwarePHI(Register InitialVReg,
                                             Register OrigVReg,
                                             LaneBitmask DefMask,
                                             MachineBasicBlock *InitialDefBB);
 
   // Helper: Create PHI in a specific block with per-edge lane analysis
-  Register createPHIInBlock(MachineBasicBlock &JoinMBB,
+  MachineOperand* createPHIInBlock(MachineBasicBlock &JoinMBB,
                            Register OrigVReg,
                            Register NewVReg,
                            LaneBitmask DefMask);
 
-  // Rewrite dominated uses of OrigVReg to NewSSA according to the
-  // exact/subset/super policy; create REG_SEQUENCE only when needed.
-  void rewriteDominatedUses(Register OrigVReg,
-                            Register NewSSA,
-                            LaneBitmask MaskToRewrite);
+  // Cache for IDF computations to avoid redundant calculations
+  DenseMap<IDFCacheKey, SmallVector<MachineBasicBlock *, 4>> IDFCache;
 
   // Internal helper methods for use rewriting
   VNInfo *incomingOnEdge(LiveInterval &LI, MachineInstr *Phi, MachineOperand &PhiOp);
-  bool defReachesUse(MachineInstr *DefMI, MachineInstr *UseMI, MachineOperand &UseOp);
+  bool defDominatesUse(MachineInstr *DefMI, MachineInstr *UseMI, MachineOperand &UseOp);
+  bool defReachesUse(MachineInstr *DefMI, Register NewSSA, MachineInstr *UseMI, MachineOperand &UseOp);
   LaneBitmask operandLaneMask(const MachineOperand &MO);
   Register buildRSForSuperUse(MachineInstr *UseMI, MachineOperand &MO,
                              Register OldVR, Register NewVR, LaneBitmask MaskToRewrite,
@@ -151,26 +235,6 @@ private:
   bool UndefEdgeAsImplicitDef = true; // policy hook
   bool VerifyOnExit = true;           // run MF.verify()/LI.verify() at end
 };
-
-/// Get the subregister index that corresponds to the given lane mask.
-/// \param Mask The lane mask to convert to a subregister index
-/// \param TRI The target register info (provides target-specific subregister mapping)
-/// \return The subregister index, or 0 if no single subregister matches
-inline unsigned getSubRegIndexForLaneMask(LaneBitmask Mask, const TargetRegisterInfo *TRI) {
-  if (Mask.none())
-    return 0; // No subregister
-  
-  // Iterate through all subregister indices to find a match
-  for (unsigned SubIdx = 1; SubIdx < TRI->getNumSubRegIndices(); ++SubIdx) {
-    LaneBitmask SubMask = TRI->getSubRegIndexLaneMask(SubIdx);
-    if (SubMask == Mask) {
-      return SubIdx;
-    }
-  }
-  
-  // No exact match found - this might be a composite mask requiring REG_SEQUENCE
-  return 0;
-}
 
 // DenseMapInfo specialization for LaneBitmask
 template<>
@@ -190,6 +254,28 @@ struct DenseMapInfo<LaneBitmask> {
   }
   
   static bool isEqual(const LaneBitmask &LHS, const LaneBitmask &RHS) {
+    return LHS == RHS;
+  }
+};
+
+// DenseMapInfo specialization for MachineLaneSSAUpdater::IDFCacheKey
+template <>
+struct DenseMapInfo<MachineLaneSSAUpdater::IDFCacheKey> {
+  using Key = MachineLaneSSAUpdater::IDFCacheKey;
+  
+  static inline Key getEmptyKey() {
+    return Key{Register(), LaneBitmask::getAll(), ~0U};
+  }
+  
+  static inline Key getTombstoneKey() {
+    return Key{Register(), LaneBitmask::getNone(), ~0U - 1};
+  }
+  
+  static unsigned getHashValue(const Key &K) {
+    return hash_combine(K.VReg.id(), K.Mask.getAsInteger(), K.DefBlockNum);
+  }
+  
+  static bool isEqual(const Key &LHS, const Key &RHS) {
     return LHS == RHS;
   }
 };

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -434,6 +434,17 @@ public:
     return SubRegIndexLaneMasks[SubIdx];
   }
 
+  /// Return the subreg index whose LaneMask exactly equals \p Mask, or 0 if
+  /// no such subreg index exists.
+  unsigned getSubRegIndexForLaneMask(LaneBitmask Mask) const {
+    if (Mask.none())
+      return 0;
+    for (unsigned Idx = 1, E = getNumSubRegIndices(); Idx < E; ++Idx)
+      if (getSubRegIndexLaneMask(Idx) == Mask)
+        return Idx;
+    return 0;
+  }
+
   /// Try to find one or more subregister indexes to cover \p LaneMask.
   ///
   /// If this is possible, returns true and appends the best matching set of

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -150,6 +150,7 @@ add_llvm_component_library(LLVMCodeGen
   MachineSizeOpts.cpp
   MachineSSAContext.cpp
   MachineSSAUpdater.cpp
+  MachineLaneSSAUpdater.cpp
   MachineStripDebug.cpp
   MachineTraceMetrics.cpp
   MachineUniformityAnalysis.cpp

--- a/llvm/lib/CodeGen/MachineLaneSSAUpdater.cpp
+++ b/llvm/lib/CodeGen/MachineLaneSSAUpdater.cpp
@@ -1,0 +1,775 @@
+//===- MachineLaneSSAUpdater.cpp - SSA repair for Machine IR (lane-aware) ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of the MachineLaneSSAUpdater - a universal SSA repair utility
+// for Machine IR that handles both regular new definitions and reload-after-
+// spill scenarios with full subregister lane awareness.
+//
+// Key features:
+//  - Two explicit entry points: addDefAndRepairNewDef and addDefAndRepairAfterSpill
+//  - Lane-aware PHI insertion with per-edge masks
+//  - Pruned IDF computation (NewDefBlocks ∩ LiveIn(OldVR))
+//  - Precise LiveInterval extension using captured EndPoints
+//  - REG_SEQUENCE insertion only when necessary
+//  - Preservation of undef/dead flags on partial definitions
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/MachineLaneSSAUpdater.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/SlotIndexes.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/GenericIteratedDominanceFrontier.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "machine-lane-ssa-updater"
+
+using namespace llvm;
+
+//===----------------------------------------------------------------------===//
+// SpillCutCollector Implementation
+//===----------------------------------------------------------------------===//
+
+CutEndPoints SpillCutCollector::cut(Register OrigVReg, SlotIndex CutIdx, 
+                                    LaneBitmask LanesToCut) {
+  LLVM_DEBUG(dbgs() << "SpillCutCollector::cut VReg=" << OrigVReg 
+                    << " at " << CutIdx << " lanes=" << PrintLaneMask(LanesToCut) << "\n");
+  
+  assert(OrigVReg.isVirtual() && "Only virtual registers can be cut for spilling");
+  
+  LiveInterval &LI = LIS.getInterval(OrigVReg);
+  SmallVector<LaneBitmask, 4> TouchedLanes;
+  SmallVector<LiveRange::Segment, 4> DebugSegsBefore;
+  SmallVector<SlotIndex, 8> MainEndPoints;
+  DenseMap<LaneBitmask, SmallVector<SlotIndex, 8>> SubrangeEndPoints;
+  
+  // Store debug information before pruning
+  for (const LiveRange::Segment &S : LI.segments) {
+    DebugSegsBefore.push_back(S);
+  }
+  
+  // Use MRI to get the accurate full mask for this register class
+  LaneBitmask RegClassFullMask = MRI.getMaxLaneMaskForVReg(OrigVReg);
+  bool HasSubranges = !LI.subranges().empty();
+  bool IsFullRegSpill = (LanesToCut == RegClassFullMask) || (!HasSubranges && MRI.shouldTrackSubRegLiveness(OrigVReg));
+  
+  LLVM_DEBUG(dbgs() << "  HasSubranges=" << HasSubranges 
+                    << " RegClassFullMask=" << PrintLaneMask(RegClassFullMask)
+                    << " shouldTrackSubRegLiveness=" << MRI.shouldTrackSubRegLiveness(OrigVReg)
+                    << " IsFullRegSpill=" << IsFullRegSpill << "\n");
+  
+  if (IsFullRegSpill) {
+    // Whole-register spill: prune main range only
+  if (LI.liveAt(CutIdx)) {
+      TouchedLanes.push_back(LanesToCut);
+    LIS.pruneValue(LI, CutIdx, &MainEndPoints);
+      LLVM_DEBUG(dbgs() << "  Pruned main range (whole-reg) with " << MainEndPoints.size() 
+                      << " endpoints\n");
+  }
+  } else {
+    // Partial-lane spill: refine-then-operate on subranges
+    LLVM_DEBUG(dbgs() << "  Partial-lane spill: refining subranges for " 
+                      << PrintLaneMask(LanesToCut) << "\n");
+    
+    // Step 1: Collect subranges that need refinement
+    SmallVector<LiveInterval::SubRange *, 4> SubrangesToRefine;
+    SmallVector<LiveInterval::SubRange *, 4> PreciseMatches;
+    
+  for (LiveInterval::SubRange &SR : LI.subranges()) {
+      LaneBitmask Overlap = SR.LaneMask & LanesToCut;
+      if (Overlap.none()) {
+        continue; // No intersection, skip
+      }
+      
+      if (Overlap == SR.LaneMask) {
+        // SR is completely contained in LanesToCut
+        PreciseMatches.push_back(&SR);
+        LLVM_DEBUG(dbgs() << "    Found " << (SR.LaneMask == LanesToCut ? "precise" : "subset") 
+                          << " match: " << PrintLaneMask(SR.LaneMask) << "\n");
+      } else {
+        // Partial overlap: need to refine this subrange
+        SubrangesToRefine.push_back(&SR);
+        LLVM_DEBUG(dbgs() << "    Need to refine: " << PrintLaneMask(SR.LaneMask) 
+                          << " (overlap=" << PrintLaneMask(Overlap) << ")\n");
+      }
+    }
+    
+    // Step 2: Refine overlapping subranges into disjoint ones
+    for (LiveInterval::SubRange *SR : SubrangesToRefine) {
+      LaneBitmask OrigMask = SR->LaneMask;
+      LaneBitmask SpillMask = OrigMask & LanesToCut;
+      LaneBitmask KeepMask = OrigMask & ~LanesToCut;
+      
+      LLVM_DEBUG(dbgs() << "    Refining " << PrintLaneMask(OrigMask) 
+                        << " into Spill=" << PrintLaneMask(SpillMask) 
+                        << " Keep=" << PrintLaneMask(KeepMask) << "\n");
+      
+      // Create new subrange for spilled portion (SpillMask is always non-empty here)
+      LiveInterval::SubRange *SpillSR = LI.createSubRange(LIS.getVNInfoAllocator(), SpillMask);
+      // Copy liveness from original subrange
+      SpillSR->assign(*SR, LIS.getVNInfoAllocator());
+      PreciseMatches.push_back(SpillSR);
+      LLVM_DEBUG(dbgs() << "      Created spill subrange: " << PrintLaneMask(SpillMask) << "\n");
+      
+      // Update original subrange to keep-only portion (KeepMask is always non-empty here)
+      SR->LaneMask = KeepMask;
+      LLVM_DEBUG(dbgs() << "      Updated original to keep: " << PrintLaneMask(KeepMask) << "\n");
+    }
+    
+    // Step 3: Prune only the precise matches for LanesToCut
+    for (LiveInterval::SubRange *SR : PreciseMatches) {
+      if (SR->liveAt(CutIdx) && (SR->LaneMask & LanesToCut).any()) {
+        TouchedLanes.push_back(SR->LaneMask);
+        SmallVector<SlotIndex, 8> SubEndPoints;
+        LIS.pruneValue(*SR, CutIdx, &SubEndPoints);
+        SubrangeEndPoints[SR->LaneMask] = std::move(SubEndPoints);
+        LLVM_DEBUG(dbgs() << "    Pruned subrange " << PrintLaneMask(SR->LaneMask)
+                          << " with " << SubrangeEndPoints[SR->LaneMask].size() << " endpoints\n");
+      }
+    }
+    
+    // Note: Do NOT prune main range for partial spills - subranges are authoritative
+  }
+  
+  LLVM_DEBUG(dbgs() << "  Cut complete: " << TouchedLanes.size() 
+                    << " touched lane masks\n");
+  
+  return CutEndPoints(OrigVReg, CutIdx, std::move(TouchedLanes), 
+                      std::move(MainEndPoints), std::move(SubrangeEndPoints),
+                      std::move(DebugSegsBefore));
+}
+
+//===----------------------------------------------------------------------===//
+// MachineLaneSSAUpdater Implementation
+//===----------------------------------------------------------------------===//
+
+Register MachineLaneSSAUpdater::addDefAndRepairNewDef(MachineInstr &NewDefMI,
+                                                       Register OrigVReg,
+                                                       LaneBitmask DefMask) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::addDefAndRepairNewDef VReg=" << OrigVReg
+                    << " DefMask=" << PrintLaneMask(DefMask) << "\n");
+  
+  // Step 1: Index the new instruction in SlotIndexes/LIS
+  indexNewInstr(NewDefMI);
+  
+  // Step 2: Extract the new SSA register from the definition instruction
+  Register NewSSAVReg = NewDefMI.defs().begin()->getReg();
+  assert(NewSSAVReg.isValid() && NewSSAVReg.isVirtual() &&
+         "NewDefMI should define a valid virtual register");
+  
+  // Step 3: Derive necessary data from intact LiveIntervals
+  // The LiveInterval should already exist and be properly computed
+  if (!LIS.hasInterval(NewSSAVReg)) {
+    LIS.createAndComputeVirtRegInterval(NewSSAVReg);
+  }
+  
+  // Step 4: Perform common SSA repair (PHI placement + use rewriting)
+  performSSARepair(NewSSAVReg, OrigVReg, DefMask, NewDefMI.getParent());
+  
+  LLVM_DEBUG(dbgs() << "  New def SSA repair complete, returning " << NewSSAVReg << "\n");
+  return NewSSAVReg;
+}
+
+Register MachineLaneSSAUpdater::addDefAndRepairAfterSpill(MachineInstr &ReloadMI,
+                                                           Register OrigVReg,
+                                                           LaneBitmask DefMask,
+                                                           const CutEndPoints &EP) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::addDefAndRepairAfterSpill VReg=" << OrigVReg
+                    << " DefMask=" << PrintLaneMask(DefMask) << "\n");
+  
+  // Safety checks as specified in the design
+  assert(EP.getOrigVReg() == OrigVReg && 
+         "CutEndPoints OrigVReg mismatch");
+  
+  // Validate that DefMask is a subset of the lanes that were actually spilled
+  // This allows partial reloads (e.g., reload 32-bit subreg from 64-bit spill)
+  LaneBitmask SpilledLanes = LaneBitmask::getNone();
+  for (LaneBitmask TouchedMask : EP.getTouchedLaneMasks()) {
+    SpilledLanes |= TouchedMask;
+  }
+  assert((DefMask & SpilledLanes) == DefMask && 
+         "DefMask must be a subset of the lanes that were spilled");
+  
+  LLVM_DEBUG(dbgs() << "  DefMask=" << PrintLaneMask(DefMask) 
+                    << " is subset of SpilledLanes=" << PrintLaneMask(SpilledLanes) << "\n");
+  
+  // Step 1: Index the reload instruction and get its SlotIndex
+  SlotIndex ReloadIdx = indexNewInstr(ReloadMI);
+  assert(ReloadIdx >= EP.getCutIdx() && 
+         "Reload index must be >= cut index");
+  
+  // Step 2: Extract the new SSA register from the reload instruction
+  // The caller should have already created NewVReg and built ReloadMI with it
+  Register NewSSAVReg = ReloadMI.defs().begin()->getReg();
+  assert(NewSSAVReg.isValid() && NewSSAVReg.isVirtual() &&
+         "ReloadMI should define a valid virtual register");
+  
+  // Step 3: Create and extend NewSSAVReg's LiveInterval using captured EndPoints
+  // The endpoints capture where the original register was live after the spill point
+  // We need to reconstruct this liveness for the new SSA register
+  LiveInterval &NewLI = LIS.createAndComputeVirtRegInterval(NewSSAVReg);
+  
+  // Extend main live range using the captured endpoints
+  if (!EP.getMainEndPoints().empty()) {
+    LIS.extendToIndices(NewLI, EP.getMainEndPoints());
+    LLVM_DEBUG(dbgs() << "  Extended NewSSA main range with " << EP.getMainEndPoints().size() 
+                      << " endpoints\n");
+  }
+  
+  // Extend subranges for lane-aware liveness reconstruction
+  // Create subranges on-demand for each LaneMask that was captured during spill
+  for (const auto &[LaneMask, EndPoints] : EP.getSubrangeEndPoints()) {
+    if (!EndPoints.empty()) {
+      // Always create a new subrange since NewLI.subranges() is initially empty
+      LiveInterval::SubRange *NewSR = NewLI.createSubRange(LIS.getVNInfoAllocator(), LaneMask);
+      
+      LIS.extendToIndices(*NewSR, EndPoints);
+      LLVM_DEBUG(dbgs() << "  Created and extended NewSSA subrange " << PrintLaneMask(LaneMask)
+                        << " with " << EndPoints.size() << " endpoints\n");
+    }
+  }
+  
+  // Step 4: Perform common SSA repair (PHI placement + use rewriting)
+  performSSARepair(NewSSAVReg, OrigVReg, DefMask, ReloadMI.getParent());
+  
+  LLVM_DEBUG(dbgs() << "  SSA repair complete, returning " << NewSSAVReg << "\n");
+  return NewSSAVReg;
+}
+
+//===----------------------------------------------------------------------===//
+// Common SSA Repair Logic
+//===----------------------------------------------------------------------===//
+
+void MachineLaneSSAUpdater::performSSARepair(Register NewVReg, Register OrigVReg, 
+                                              LaneBitmask DefMask, MachineBasicBlock *DefBB) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::performSSARepair NewVReg=" << NewVReg
+                    << " OrigVReg=" << OrigVReg << " DefMask=" << PrintLaneMask(DefMask) << "\n");
+  
+  // Step 1: Use worklist-driven PHI placement
+  SmallVector<Register> AllPHIVRegs = insertLaneAwarePHI(NewVReg, OrigVReg, DefMask, DefBB);
+  
+  // Step 2: Rewrite dominated uses once for each new register
+  rewriteDominatedUses(OrigVReg, NewVReg, DefMask);
+  for (Register PHIVReg : AllPHIVRegs) {
+    rewriteDominatedUses(OrigVReg, PHIVReg, DefMask);
+  }
+  
+  // Step 3: Renumber values if needed
+  LiveInterval &NewLI = LIS.getInterval(NewVReg);
+  NewLI.RenumberValues();
+  
+  // Also renumber PHI intervals
+  for (Register PHIVReg : AllPHIVRegs) {
+    if (LIS.hasInterval(PHIVReg)) {
+      LiveInterval &PHILI = LIS.getInterval(PHIVReg);
+      PHILI.RenumberValues();
+    }
+  }
+  
+  // Also renumber original interval if it was modified
+  LiveInterval &OrigLI = LIS.getInterval(OrigVReg);
+  OrigLI.RenumberValues();
+  
+  // Step 4: Verification if enabled
+  if (VerifyOnExit) {
+    LLVM_DEBUG(dbgs() << "  Verifying after SSA repair...\n");
+    // TODO: Add verification calls
+  }
+  
+  LLVM_DEBUG(dbgs() << "  performSSARepair complete\n");
+}
+
+//===----------------------------------------------------------------------===//
+// Internal Helper Methods (Stubs)
+//===----------------------------------------------------------------------===//
+
+SlotIndex MachineLaneSSAUpdater::indexNewInstr(MachineInstr &MI) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::indexNewInstr: " << MI);
+  
+  // Register the instruction in SlotIndexes and LiveIntervals
+  // This is typically done automatically when instructions are inserted,
+  // but we need to ensure it's properly indexed
+  SlotIndexes *SI = LIS.getSlotIndexes();
+  
+  // Check if instruction is already indexed
+  if (SI->hasIndex(MI)) {
+    SlotIndex Idx = SI->getInstructionIndex(MI);
+    LLVM_DEBUG(dbgs() << "  Already indexed at " << Idx << "\n");
+    return Idx;
+  }
+  
+  // Insert the instruction in maps - this should be done by the caller
+  // before calling our SSA repair methods, but we can verify
+  LIS.InsertMachineInstrInMaps(MI);
+  
+  SlotIndex Idx = SI->getInstructionIndex(MI);
+  LLVM_DEBUG(dbgs() << "  Indexed at " << Idx << "\n");
+  return Idx;
+}
+
+void MachineLaneSSAUpdater::extendPreciselyAt(const Register VReg,
+                                              const SmallVector<LaneBitmask, 4> &LaneMasks,
+                                              const MachineInstr &AtMI) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::extendPreciselyAt VReg=" << VReg 
+                    << " at " << LIS.getInstructionIndex(AtMI) << "\n");
+  
+  if (!VReg.isVirtual()) {
+    return; // Only handle virtual registers
+  }
+  
+  SlotIndex DefIdx = LIS.getInstructionIndex(AtMI).getRegSlot();
+  
+  // Create or get the LiveInterval for this register
+  LiveInterval &LI = LIS.getInterval(VReg);
+  
+  // Extend the main live range to include the definition point
+  SmallVector<SlotIndex, 2> DefPoint = { DefIdx };
+  LIS.extendToIndices(LI, DefPoint);
+  
+  // For each lane mask, ensure appropriate subranges exist and are extended
+  // For now, assume all lanes are valid - we'll refine this later based on register class
+  LaneBitmask RegCoverageMask = MF.getRegInfo().getMaxLaneMaskForVReg(VReg);
+  
+  for (LaneBitmask LaneMask : LaneMasks) {
+    if (LaneMask == MF.getRegInfo().getMaxLaneMaskForVReg(VReg) || LaneMask == LaneBitmask::getNone()) {
+      continue; // Main range handles getAll(), skip getNone()
+    }
+    
+    // Only process lanes that are valid for this register class
+    LaneBitmask ValidLanes = LaneMask & RegCoverageMask;
+    if (ValidLanes.none()) {
+      continue;
+    }
+    
+    // Find or create the appropriate subrange
+    LiveInterval::SubRange *SR = nullptr;
+    for (LiveInterval::SubRange &Sub : LI.subranges()) {
+      if (Sub.LaneMask == ValidLanes) {
+        SR = &Sub;
+        break;
+      }
+    }
+    if (!SR) {
+      SR = LI.createSubRange(LIS.getVNInfoAllocator(), ValidLanes);
+    }
+    
+    // Extend this subrange to include the definition point
+    LIS.extendToIndices(*SR, DefPoint);
+    
+    LLVM_DEBUG(dbgs() << "  Extended subrange " << PrintLaneMask(ValidLanes) << "\n");
+  }
+  
+  LLVM_DEBUG(dbgs() << "  LiveInterval extension complete\n");
+}
+
+void MachineLaneSSAUpdater::computePrunedIDF(Register OrigVReg,
+                                              LaneBitmask DefMask,
+                                              ArrayRef<MachineBasicBlock *> NewDefBlocks,
+                                              SmallVectorImpl<MachineBasicBlock *> &OutIDFBlocks) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::computePrunedIDF VReg=" << OrigVReg 
+                    << " DefMask=" << PrintLaneMask(DefMask)
+                    << " with " << NewDefBlocks.size() << " new def blocks\n");
+  
+  // Clear output vector at entry
+  OutIDFBlocks.clear();
+  
+  // Early bail-out checks for robustness
+  if (!OrigVReg.isVirtual()) {
+    LLVM_DEBUG(dbgs() << "  Skipping non-virtual register\n");
+    return;
+  }
+  
+  if (!LIS.hasInterval(OrigVReg)) {
+    LLVM_DEBUG(dbgs() << "  OrigVReg not tracked by LiveIntervals, bailing out\n");
+    return;
+  }
+  
+  // Get the main LiveInterval for OrigVReg
+  LiveInterval &LI = LIS.getInterval(OrigVReg);
+  
+  // Build prune set: blocks where specified lanes (DefMask) are live-in at entry
+  SmallPtrSet<MachineBasicBlock *, 32> LiveIn;
+  for (MachineBasicBlock &BB : MF) {
+    SlotIndex Start = LIS.getMBBStartIdx(&BB);
+    
+    // Collect live lanes at block entry
+    LaneBitmask LiveLanes = LaneBitmask::getNone();
+    
+    if (DefMask == MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg)) {
+      // For full register (e.g., reload case), check main interval
+      if (LI.liveAt(Start)) {
+        LiveLanes = MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg);
+      }
+    } else {
+      // For specific lanes, check subranges
+      for (LiveInterval::SubRange &S : LI.subranges()) {
+        if (S.liveAt(Start)) {
+          LiveLanes |= S.LaneMask;
+        }
+      }
+      
+      // If no subranges found but main interval is live,
+      // assume all lanes are covered by the main interval
+      if (LiveLanes == LaneBitmask::getNone() && LI.liveAt(Start)) {
+        LiveLanes = MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg);
+      }
+    }
+    
+    // Check if any of the requested lanes (DefMask) are live
+    if ((LiveLanes & DefMask).any()) {
+      LiveIn.insert(&BB);
+    }
+  }
+  
+  // Seed set: the blocks where new defs exist (e.g., reload or prior PHIs)
+  SmallPtrSet<MachineBasicBlock *, 8> DefBlocks;
+  for (MachineBasicBlock *B : NewDefBlocks) {
+    if (B) { // Robust to null entries
+      DefBlocks.insert(B);
+    }
+  }
+  
+  // Early exit if either set is empty
+  if (DefBlocks.empty() || LiveIn.empty()) {
+    LLVM_DEBUG(dbgs() << "  DefBlocks=" << DefBlocks.size() << " LiveIn=" << LiveIn.size() 
+                      << ", early exit\n");
+    return;
+  }
+  
+  LLVM_DEBUG(dbgs() << "  DefBlocks=" << DefBlocks.size() << " LiveIn=" << LiveIn.size() << "\n");
+  
+  // Use LLVM's IDFCalculatorBase for MachineBasicBlock with forward dominance
+  using NodeTy = MachineBasicBlock;
+  
+  // Access the underlying DomTreeBase from MachineDominatorTree
+  // MachineDominatorTree inherits from DomTreeBase<MachineBasicBlock>
+  DomTreeBase<NodeTy> &DT = MDT;
+  
+  // Compute pruned IDF (forward dominance, IsPostDom=false)
+  llvm::IDFCalculatorBase<NodeTy, /*IsPostDom=*/false> IDF(DT);
+  IDF.setDefiningBlocks(DefBlocks);
+  IDF.setLiveInBlocks(LiveIn);
+  IDF.calculate(OutIDFBlocks);
+  
+  LLVM_DEBUG(dbgs() << "  Computed " << OutIDFBlocks.size() << " IDF blocks\n");
+  
+  // Note: We do not place PHIs here; this function only computes candidate 
+  // join blocks. The IDFCalculator handles deduplication automatically.
+}
+
+SmallVector<Register> MachineLaneSSAUpdater::insertLaneAwarePHI(Register InitialVReg,
+                                                                Register OrigVReg,
+                                                                LaneBitmask DefMask,
+                                                                MachineBasicBlock *InitialDefBB) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::insertLaneAwarePHI InitialVReg=" << InitialVReg
+                    << " OrigVReg=" << OrigVReg << " DefMask=" << PrintLaneMask(DefMask) << "\n");
+  
+  // Worklist item: (VReg, DefBB) pairs that need PHI placement
+  struct WorkItem {
+    Register VReg;
+    MachineBasicBlock *DefBB;
+    WorkItem(Register V, MachineBasicBlock *BB) : VReg(V), DefBB(BB) {}
+  };
+  
+  SmallVector<Register> AllCreatedPHIs;
+  SmallVector<WorkItem> Worklist;
+  DenseSet<MachineBasicBlock *> ProcessedBlocks; // Avoid duplicate PHIs in same block
+  
+  // Seed worklist with initial definition
+  Worklist.emplace_back(InitialVReg, InitialDefBB);
+  
+  LLVM_DEBUG(dbgs() << "  Starting worklist processing...\n");
+  
+  while (!Worklist.empty()) {
+    WorkItem Item = Worklist.pop_back_val();
+    
+    LLVM_DEBUG(dbgs() << "  Processing VReg=" << Item.VReg 
+                      << " DefBB=#" << Item.DefBB->getNumber() << "\n");
+    
+    // Step 1: Compute pruned IDF for this definition
+    SmallVector<MachineBasicBlock *> DefBlocks = {Item.DefBB};
+    SmallVector<MachineBasicBlock *> IDFBlocks;
+    computePrunedIDF(OrigVReg, DefMask, DefBlocks, IDFBlocks);
+    
+    LLVM_DEBUG(dbgs() << "    Found " << IDFBlocks.size() << " IDF blocks\n");
+    
+    // Step 2: Create PHIs in each IDF block
+    for (MachineBasicBlock *JoinMBB : IDFBlocks) {
+      // Skip if we already processed this join block (avoid duplicate PHIs)
+      if (ProcessedBlocks.contains(JoinMBB)) {
+        LLVM_DEBUG(dbgs() << "    Skipping already processed BB#" << JoinMBB->getNumber() << "\n");
+        continue;
+      }
+      ProcessedBlocks.insert(JoinMBB);
+      
+      LLVM_DEBUG(dbgs() << "    Creating PHI in BB#" << JoinMBB->getNumber() << "\n");
+      
+      // Create PHI using the original per-edge analysis logic
+      SmallVector<Register> PHIResults = createPHIInBlock(*JoinMBB, OrigVReg, Item.VReg, DefMask);
+      
+      // Add PHI results to worklist for further processing and to result collection
+      for (Register PHIVReg : PHIResults) {
+        if (PHIVReg.isValid()) {
+          Worklist.emplace_back(PHIVReg, JoinMBB);
+          AllCreatedPHIs.push_back(PHIVReg);
+          LLVM_DEBUG(dbgs() << "      Created PHI result VReg=" << PHIVReg 
+                            << ", added to worklist\n");
+        }
+      }
+    }
+  }
+  
+  LLVM_DEBUG(dbgs() << "  Worklist processing complete. Created " 
+                    << AllCreatedPHIs.size() << " PHI registers total.\n");
+  
+  return AllCreatedPHIs;
+}
+
+// Helper: Create PHI in a specific block (extracted from previous implementation)
+SmallVector<Register> MachineLaneSSAUpdater::createPHIInBlock(MachineBasicBlock &JoinMBB,
+                                                    Register OrigVReg,
+                                                               Register NewVReg,
+                                                    LaneBitmask ResultMask) {
+  LLVM_DEBUG(dbgs() << "    createPHIInBlock in BB#" << JoinMBB.getNumber()
+                    << " OrigVReg=" << OrigVReg << " NewVReg=" << NewVReg 
+                    << " ResultMask=" << PrintLaneMask(ResultMask) << "\n");
+  
+  // Get the LiveIntervals for both old and new registers
+  LiveInterval &OldLI = LIS.getInterval(OrigVReg);
+  LiveInterval &NewLI = LIS.getInterval(NewVReg);
+  
+  const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+  const LaneBitmask FullMask = MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg);
+  const LaneBitmask NonReloadedMask = FullMask & ~ResultMask;
+  const unsigned NoRegister = 0; // Target-independent equivalent to AMDGPU::NoRegister
+  
+  // Analyze each predecessor edge to determine operand sources
+  SmallVector<MachineOperand> NewVRegOps;  // Operands for NewVReg PHI
+  SmallVector<MachineOperand> OldVRegOps;  // Operands for OrigVReg PHI
+  
+  LaneBitmask NewCommonMask = MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg); // intersection across preds
+  LaneBitmask NewUnionMask = LaneBitmask::getNone();  // union across preds
+  LaneBitmask OldCommonMask = MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg);
+  LaneBitmask OldUnionMask = LaneBitmask::getNone();
+  
+  LLVM_DEBUG(dbgs() << "      Analyzing " << JoinMBB.pred_size() << " predecessors:\n");
+  
+  for (MachineBasicBlock *PredMBB : JoinMBB.predecessors()) {
+    SlotIndex PredEndIdx = LIS.getMBBEndIdx(PredMBB);
+    
+    // Analyze NewVReg lanes on this edge
+    LaneBitmask NewEdgeMask = LaneBitmask::getNone();
+    if (VNInfo *NewVN = NewLI.getVNInfoBefore(PredEndIdx)) {
+      // Check which lanes of NewVReg are live-out via subrange analysis
+      for (const LiveInterval::SubRange &SR : NewLI.subranges()) {
+        if (SR.getVNInfoBefore(PredEndIdx)) {
+          NewEdgeMask |= SR.LaneMask;
+        }
+      }
+      
+      // If no subranges but main range is live, assume all reloaded lanes
+      if (NewEdgeMask.none()) {
+        NewEdgeMask = ResultMask;
+      }
+      
+      // NewVReg can only contribute reloaded lanes
+      NewEdgeMask &= ResultMask;
+      
+      LLVM_DEBUG(dbgs() << "        Pred BB#" << PredMBB->getNumber() 
+                        << " NewVReg lanes: " << PrintLaneMask(NewEdgeMask)
+                        << " (VN=" << NewVN->id << ")\n");
+    }
+    
+    // Analyze OrigVReg lanes on this edge  
+    LaneBitmask OldEdgeMask = LaneBitmask::getNone();
+    if (VNInfo *OldVN = OldLI.getVNInfoBefore(PredEndIdx)) {
+      // Check which lanes of OrigVReg are live-out via subrange analysis
+      for (const LiveInterval::SubRange &SR : OldLI.subranges()) {
+        if (SR.getVNInfoBefore(PredEndIdx)) {
+          OldEdgeMask |= SR.LaneMask;
+        }
+      }
+      
+      // If no subranges but main range is live, assume all non-reloaded lanes
+      if (OldEdgeMask.none()) {
+        OldEdgeMask = NonReloadedMask;
+      }
+      
+      // OrigVReg can only contribute non-reloaded lanes
+      OldEdgeMask &= NonReloadedMask;
+      
+      LLVM_DEBUG(dbgs() << "        Pred BB#" << PredMBB->getNumber() 
+                        << " OrigVReg lanes: " << PrintLaneMask(OldEdgeMask)
+                        << " (VN=" << OldVN->id << ")\n");
+    }
+    
+    // Update mask statistics
+    NewCommonMask &= NewEdgeMask;
+    NewUnionMask |= NewEdgeMask;
+    OldCommonMask &= OldEdgeMask;
+    OldUnionMask |= OldEdgeMask;
+    
+    // Create operands for NewVReg PHI if this edge contributes
+    if (NewEdgeMask.any()) {
+      unsigned SubIdx = NoRegister;
+      if ((ResultMask & ~NewEdgeMask).any()) { // partial register incoming
+        // TODO: Implement getSubRegIndexForLaneMask or equivalent
+        // SubIdx = getSubRegIndexForLaneMask(NewEdgeMask, &TRI);
+      }
+      
+      NewVRegOps.push_back(MachineOperand::CreateReg(NewVReg, /*isDef*/ false,
+                                                     /*isImp*/ false, /*isKill*/ false,
+                                                     /*isDead*/ false, /*isUndef*/ false,
+                                                     /*isEarlyClobber*/ false, SubIdx));
+      NewVRegOps.push_back(MachineOperand::CreateMBB(PredMBB));
+    }
+    
+    // Create operands for OrigVReg PHI if this edge contributes  
+    if (OldEdgeMask.any()) {
+      unsigned SubIdx = NoRegister;
+      if ((NonReloadedMask & ~OldEdgeMask).any()) { // partial register incoming
+        // TODO: Implement getSubRegIndexForLaneMask or equivalent
+        // SubIdx = getSubRegIndexForLaneMask(OldEdgeMask, &TRI);
+      }
+      
+      OldVRegOps.push_back(MachineOperand::CreateReg(OrigVReg, /*isDef*/ false,
+                                                     /*isImp*/ false, /*isKill*/ false,
+                                                     /*isDead*/ false, /*isUndef*/ false,
+                                                     /*isEarlyClobber*/ false, SubIdx));
+      OldVRegOps.push_back(MachineOperand::CreateMBB(PredMBB));
+    }
+  }
+  
+  // Decide PHI mask strategies using CommonMask/UnionMask logic
+  LaneBitmask NewPhiMask = (NewCommonMask.none() ? NewUnionMask : NewCommonMask);
+  LaneBitmask OldPhiMask = (OldCommonMask.none() ? OldUnionMask : OldCommonMask);
+  
+  if (NewPhiMask.none()) NewPhiMask = ResultMask;
+  if (OldPhiMask.none()) OldPhiMask = NonReloadedMask;
+  
+  LLVM_DEBUG(dbgs() << "      Analysis: NewPhiMask=" << PrintLaneMask(NewPhiMask)
+                    << " OldPhiMask=" << PrintLaneMask(OldPhiMask) << "\n");
+                    
+  SmallVector<Register> ResultVRegs;
+  
+  // Create PHI(s) based on what we need
+  if (NewUnionMask.any() && OldUnionMask.any()) {
+    LLVM_DEBUG(dbgs() << "      Complex case: Creating separate PHIs for NewVReg and OrigVReg\n");
+    
+    // Create PHI for NewVReg lanes
+    if (!NewVRegOps.empty()) {
+      const TargetRegisterClass *RC = MF.getRegInfo().getRegClass(NewVReg);
+      Register NewPHIVReg = MF.getRegInfo().createVirtualRegister(RC);
+      
+      auto NewPHINode = BuildMI(JoinMBB, JoinMBB.begin(), DebugLoc(),
+                               TII->get(TargetOpcode::PHI), NewPHIVReg);
+      for (const MachineOperand &Op : NewVRegOps) {
+        NewPHINode.add(Op);
+      }
+      
+      MachineInstr *NewPHI = NewPHINode.getInstr();
+      LIS.InsertMachineInstrInMaps(*NewPHI);
+      LIS.createAndComputeVirtRegInterval(NewPHIVReg);
+      
+      ResultVRegs.push_back(NewPHIVReg);
+      LLVM_DEBUG(dbgs() << "      Created NewVReg PHI: ");
+      LLVM_DEBUG(NewPHI->print(dbgs()));
+    }
+    
+    // Create PHI for OrigVReg lanes
+    if (!OldVRegOps.empty()) {
+      const TargetRegisterClass *RC = MF.getRegInfo().getRegClass(OrigVReg);
+      Register OldPHIVReg = MF.getRegInfo().createVirtualRegister(RC);
+      
+      auto OldPHINode = BuildMI(JoinMBB, JoinMBB.begin(), DebugLoc(),
+                               TII->get(TargetOpcode::PHI), OldPHIVReg);
+      for (const MachineOperand &Op : OldVRegOps) {
+        OldPHINode.add(Op);
+      }
+      
+      MachineInstr *OldPHI = OldPHINode.getInstr();
+      LIS.InsertMachineInstrInMaps(*OldPHI);
+      LIS.createAndComputeVirtRegInterval(OldPHIVReg);
+      
+      ResultVRegs.push_back(OldPHIVReg);
+      LLVM_DEBUG(dbgs() << "      Created OrigVReg PHI: ");
+      LLVM_DEBUG(OldPHI->print(dbgs()));
+    }
+    
+  } else if (NewUnionMask.any()) {
+    LLVM_DEBUG(dbgs() << "      Simple case: Creating PHI for NewVReg lanes only\n");
+    
+    // Create result register and PHI for NewVReg
+    const TargetRegisterClass *RC = MF.getRegInfo().getRegClass(NewVReg);
+    Register PHIVReg = MF.getRegInfo().createVirtualRegister(RC);
+    
+    auto PHINode = BuildMI(JoinMBB, JoinMBB.begin(), DebugLoc(),
+                          TII->get(TargetOpcode::PHI), PHIVReg);
+    for (const MachineOperand &Op : NewVRegOps) {
+      PHINode.add(Op);
+    }
+    
+    MachineInstr *PHI = PHINode.getInstr();
+    LIS.InsertMachineInstrInMaps(*PHI);
+    LIS.createAndComputeVirtRegInterval(PHIVReg);
+    
+    ResultVRegs.push_back(PHIVReg);
+    LLVM_DEBUG(dbgs() << "      Created NewVReg PHI: ");
+    LLVM_DEBUG(PHI->print(dbgs()));
+    
+  } else if (OldUnionMask.any()) {
+    LLVM_DEBUG(dbgs() << "      Simple case: Creating PHI for OrigVReg lanes only\n");
+    
+    // Create result register and PHI for OrigVReg
+    const TargetRegisterClass *RC = MF.getRegInfo().getRegClass(OrigVReg);
+    Register PHIVReg = MF.getRegInfo().createVirtualRegister(RC);
+    
+    auto PHINode = BuildMI(JoinMBB, JoinMBB.begin(), DebugLoc(),
+                          TII->get(TargetOpcode::PHI), PHIVReg);
+    for (const MachineOperand &Op : OldVRegOps) {
+      PHINode.add(Op);
+    }
+    
+    MachineInstr *PHI = PHINode.getInstr();
+    LIS.InsertMachineInstrInMaps(*PHI);
+    LIS.createAndComputeVirtRegInterval(PHIVReg);
+    
+    ResultVRegs.push_back(PHIVReg);
+    LLVM_DEBUG(dbgs() << "      Created OrigVReg PHI: ");
+    LLVM_DEBUG(PHI->print(dbgs()));
+    
+  } else {
+    LLVM_DEBUG(dbgs() << "      No lanes live-out from any predecessor - unusual case\n");
+  }
+  
+  return ResultVRegs;
+}
+
+void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
+                                                  Register NewSSA,
+                                                  LaneBitmask MaskToRewrite) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::rewriteDominatedUses OrigVReg=" << OrigVReg
+                    << " NewSSA=" << NewSSA << " Mask=" << PrintLaneMask(MaskToRewrite) << "\n");
+  
+  // TODO: Implement dominated use rewriting
+  // This should handle exact/subset/super policy:
+  // - Exact match: direct replacement
+  // - Subset: create REG_SEQUENCE combining old + new
+  // - Super: extract subregister from new def
+  // Preserve undef/dead flags, never mass-clear on partial defs
+}

--- a/llvm/lib/CodeGen/MachineLaneSSAUpdater.cpp
+++ b/llvm/lib/CodeGen/MachineLaneSSAUpdater.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/CodeGen/LiveIntervals.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineDominators.h"
@@ -49,20 +50,18 @@ using namespace llvm;
 // MachineLaneSSAUpdater Implementation
 //===----------------------------------------------------------------------===//
 
-Register MachineLaneSSAUpdater::repairSSAForNewDef(MachineInstr &NewDefMI,
-                                                    Register OrigVReg,
-                                                    Register NewVReg) {
-  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::repairSSAForNewDef VReg=" << OrigVReg);
-  if (NewVReg.isValid()) {
-    LLVM_DEBUG(dbgs() << ", caller-provided NewVReg=" << NewVReg);
-  }
-  LLVM_DEBUG(dbgs() << "\n");
-  
+Register MachineLaneSSAUpdater::repairSSAForNewDef(
+    MachineInstr &NewDefMI, Register OrigVReg,
+    SmallVectorImpl<MachineOperand *> &PHIRegDefOps) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::repairSSAForNewDef VReg="
+                    << OrigVReg << "\n");
+
   MachineRegisterInfo &MRI = MF.getRegInfo();
-  
-  // Step 1: Find the def operand that currently defines OrigVReg (violating SSA)
+
+  // Step 1: Find the def operand for OrigVReg
   MachineOperand *DefOp = nullptr;
   unsigned DefOpIdx = 0;
+  
   for (MachineOperand &MO : NewDefMI.defs()) {
     if (MO.getReg() == OrigVReg) {
       DefOp = &MO;
@@ -89,42 +88,32 @@ Register MachineLaneSSAUpdater::repairSSAForNewDef(MachineInstr &NewDefMI,
     LLVM_DEBUG(dbgs() << "  Full register def, DefMask=" << PrintLaneMask(DefMask) << "\n");
   }
   
-  // Step 3: Create or use provided new virtual register
-  Register NewSSAVReg;
-  if (NewVReg.isValid()) {
-    // Caller provided a register - use it
-    NewSSAVReg = NewVReg;
-    const TargetRegisterClass *RC = MRI.getRegClass(NewSSAVReg);
-    LLVM_DEBUG(dbgs() << "  Using caller-provided SSA vreg " << NewSSAVReg 
-                      << " with RC=" << TRI.getRegClassName(RC) << "\n");
+  // Step 3: Create a new virtual register with class matching MaskToRewrite width
+  const TargetRegisterClass *RC;
+  if (SubRegIdx) {
+    // For subreg defs, create register with class for the subreg (narrower)
+    const TargetRegisterClass *OrigRC = MRI.getRegClass(OrigVReg);
+    RC = TRI.getSubRegisterClass(OrigRC, SubRegIdx);
+    assert(RC && "Failed to get subregister class");
   } else {
-    // Create a new virtual register with appropriate register class
-    // If this is a subreg def, we need the class for the subreg, not the full reg
-    const TargetRegisterClass *RC;
-    if (SubRegIdx) {
-      // For subreg defs, get the subreg class
-      const TargetRegisterClass *OrigRC = MRI.getRegClass(OrigVReg);
-      RC = TRI.getSubRegisterClass(OrigRC, SubRegIdx);
-      assert(RC && "Failed to get subregister class for subreg def - would create incorrect MIR");
-    } else {
-      // For full reg defs, use the same class as OrigVReg
-      RC = MRI.getRegClass(OrigVReg);
-    }
-    
-    NewSSAVReg = MRI.createVirtualRegister(RC);
-    LLVM_DEBUG(dbgs() << "  Created new SSA vreg " << NewSSAVReg << " with RC=" << TRI.getRegClassName(RC) << "\n");
+    // For full register defs, use same class as OrigVReg
+    RC = MRI.getRegClass(OrigVReg);
   }
+  Register NewSSAVReg = MRI.createVirtualRegister(RC);
+  LLVM_DEBUG(dbgs() << "  Created new SSA vreg " << NewSSAVReg << " with RC=" << TRI.getRegClassName(RC) << "\n");
   
   // Step 4: Replace the operand in NewDefMI to define the new vreg
-  // If this was a subreg def, the new vreg is a full register of the subreg class
-  // so we clear the subreg index (e.g., %1.sub0:vreg_64 becomes %3:vgpr_32)
+  // Clear subreg index since NewSSAVReg is a full register of the (possibly narrower) class
   DefOp->setReg(NewSSAVReg);
   if (SubRegIdx) {
-    DefOp->setSubReg(0);
-    LLVM_DEBUG(dbgs() << "  Replaced operand: " << OrigVReg << "." << TRI.getSubRegIndexName(SubRegIdx)
-                      << " -> " << NewSSAVReg << " (full register)\n");
+    DefOp->setSubReg(0);  // Clear subreg - NewSSAVReg is full register of narrower class
+    DefOp->setIsUndef(false);  // Clear undef flag - verifier requires undef only with subreg
+    LLVM_DEBUG(dbgs() << "  Replaced operand: " << OrigVReg << "." 
+                      << TRI.getSubRegIndexName(SubRegIdx) 
+                      << " -> " << NewSSAVReg << " (full narrower register)\n");
   } else {
-    LLVM_DEBUG(dbgs() << "  Replaced operand: " << OrigVReg << " -> " << NewSSAVReg << "\n");
+    LLVM_DEBUG(dbgs() << "  Replaced operand: " << OrigVReg 
+                      << " -> " << NewSSAVReg << "\n");
   }
   
   // Step 5: Index the new instruction in SlotIndexes/LIS
@@ -132,7 +121,7 @@ Register MachineLaneSSAUpdater::repairSSAForNewDef(MachineInstr &NewDefMI,
   
   // Step 6: Perform common SSA repair (PHI placement + use rewriting)
   // LiveInterval for NewSSAVReg will be created by getInterval() as needed
-  performSSARepair(NewSSAVReg, OrigVReg, DefMask, NewDefMI.getParent());
+  PHIRegDefOps = performSSARepair(NewSSAVReg, OrigVReg, DefMask, NewDefMI.getParent());
   
   // Step 7: If SSA repair created subregister uses of OrigVReg (e.g., in PHIs or REG_SEQUENCEs),
   // recompute its LiveInterval to create subranges
@@ -158,7 +147,8 @@ Register MachineLaneSSAUpdater::repairSSAForNewDef(MachineInstr &NewDefMI,
     }
   }
   
-  LLVM_DEBUG(dbgs() << "  repairSSAForNewDef complete, returning " << NewSSAVReg << "\n");
+  LLVM_DEBUG(dbgs() << "  repairSSAForNewDef complete, returning " 
+                    << printReg(NewSSAVReg, &TRI) << "\n");
   return NewSSAVReg;
 }
 
@@ -166,19 +156,22 @@ Register MachineLaneSSAUpdater::repairSSAForNewDef(MachineInstr &NewDefMI,
 // Common SSA Repair Logic
 //===----------------------------------------------------------------------===//
 
-void MachineLaneSSAUpdater::performSSARepair(Register NewVReg, Register OrigVReg, 
-                                              LaneBitmask DefMask, MachineBasicBlock *DefBB) {
+SmallVector<MachineOperand *>
+MachineLaneSSAUpdater::performSSARepair(Register NewVReg, Register OrigVReg,
+                                        LaneBitmask DefMask,
+                                        MachineBasicBlock *DefBB) {
   LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::performSSARepair NewVReg=" << NewVReg
                     << " OrigVReg=" << OrigVReg << " DefMask=" << PrintLaneMask(DefMask) << "\n");
   
   // Step 1: Use worklist-driven PHI placement
-  SmallVector<Register> AllPHIVRegs = insertLaneAwarePHI(NewVReg, OrigVReg, DefMask, DefBB);
-  
+  SmallVector<MachineOperand *> AllPHIVResults =
+      insertLaneAwarePHI(NewVReg, OrigVReg, DefMask, DefBB);
+
   // Step 2: Rewrite dominated uses once for each new register
   // Note: getInterval() will automatically create LiveIntervals if needed
   rewriteDominatedUses(OrigVReg, NewVReg, DefMask);
-  for (Register PHIVReg : AllPHIVRegs) {
-    rewriteDominatedUses(OrigVReg, PHIVReg, DefMask);
+  for (MachineOperand* PHIVRes : AllPHIVResults) {
+    rewriteDominatedUses(OrigVReg, PHIVRes->getReg(), DefMask);
   }
   
   // Step 3: Renumber values if needed
@@ -186,8 +179,8 @@ void MachineLaneSSAUpdater::performSSARepair(Register NewVReg, Register OrigVReg
   NewLI.RenumberValues();
   
   // Also renumber PHI intervals
-  for (Register PHIVReg : AllPHIVRegs) {
-    LiveInterval &PHILI = LIS.getInterval(PHIVReg);
+  for (MachineOperand* PHIVRes : AllPHIVResults) {
+    LiveInterval &PHILI = LIS.getInterval(PHIVRes->getReg());
     PHILI.RenumberValues();
   }
   
@@ -210,8 +203,8 @@ void MachineLaneSSAUpdater::performSSARepair(Register NewVReg, Register OrigVReg
   
   // Step 4: Update operand flags to match the LiveIntervals
   updateDeadFlags(NewVReg);
-  for (Register PHIVReg : AllPHIVRegs) {
-    updateDeadFlags(PHIVReg);
+  for (MachineOperand* PHIVRes : AllPHIVResults) {
+    updateDeadFlags(PHIVRes->getReg());
   }
   
   // Step 5: Verification if enabled
@@ -221,6 +214,7 @@ void MachineLaneSSAUpdater::performSSARepair(Register NewVReg, Register OrigVReg
   }
   
   LLVM_DEBUG(dbgs() << "  performSSARepair complete\n");
+  return AllPHIVResults;
 }
 
 //===----------------------------------------------------------------------===//
@@ -310,12 +304,33 @@ void MachineLaneSSAUpdater::computePrunedIDF(Register OrigVReg,
                                               LaneBitmask DefMask,
                                               ArrayRef<MachineBasicBlock *> NewDefBlocks,
                                               SmallVectorImpl<MachineBasicBlock *> &OutIDFBlocks) {
-  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::computePrunedIDF VReg=" << OrigVReg 
+  const TargetRegisterInfo &TRI = *MF.getRegInfo().getTargetRegisterInfo();
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::computePrunedIDF VReg=" 
+                    << printReg(OrigVReg, &TRI)
                     << " DefMask=" << PrintLaneMask(DefMask)
                     << " with " << NewDefBlocks.size() << " new def blocks\n");
   
   // Clear output vector at entry
   OutIDFBlocks.clear();
+  
+  // Try cache for single-block definitions (most common case in spilling)
+  if (NewDefBlocks.size() == 1 && NewDefBlocks[0]) {
+    IDFCacheKey Key{OrigVReg, DefMask, static_cast<unsigned>(NewDefBlocks[0]->getNumber())};
+    auto It = IDFCache.find(Key);
+    if (It != IDFCache.end()) {
+      OutIDFBlocks.assign(It->second.begin(), It->second.end());
+      LLVM_DEBUG(dbgs() << "  IDF cache HIT for VReg=" << printReg(OrigVReg, &TRI)
+                        << " Mask=" << PrintLaneMask(DefMask)
+                        << " DefBlock=bb." << NewDefBlocks[0]->getNumber() 
+                        << "." << NewDefBlocks[0]->getName()
+                        << " -> " << OutIDFBlocks.size() << " IDF blocks\n");
+      return;
+    }
+    LLVM_DEBUG(dbgs() << "  IDF cache MISS for VReg=" << printReg(OrigVReg, &TRI)
+                      << " Mask=" << PrintLaneMask(DefMask)
+                      << " DefBlock=bb." << NewDefBlocks[0]->getNumber()
+                      << "." << NewDefBlocks[0]->getName() << "\n");
+  }
   
   // Early bail-out checks for robustness
   if (!OrigVReg.isVirtual()) {
@@ -397,18 +412,23 @@ void MachineLaneSSAUpdater::computePrunedIDF(Register OrigVReg,
   
   LLVM_DEBUG(dbgs() << "  Computed " << OutIDFBlocks.size() << " IDF blocks\n");
   
+  // Store in cache if this was a single-block definition
+  if (NewDefBlocks.size() == 1 && NewDefBlocks[0]) {
+    IDFCacheKey Key{OrigVReg, DefMask, static_cast<unsigned>(NewDefBlocks[0]->getNumber())};
+    IDFCache[Key].assign(OutIDFBlocks.begin(), OutIDFBlocks.end());
+  }
+  
   // Note: We do not place PHIs here; this function only computes candidate 
   // join blocks. The IDFCalculator handles deduplication automatically.
 }
 
-SmallVector<Register> MachineLaneSSAUpdater::insertLaneAwarePHI(Register InitialVReg,
-                                                                Register OrigVReg,
-                                                                LaneBitmask DefMask,
-                                                                MachineBasicBlock *InitialDefBB) {
+SmallVector<MachineOperand *> MachineLaneSSAUpdater::insertLaneAwarePHI(
+    Register InitialVReg, Register OrigVReg, LaneBitmask DefMask,
+    MachineBasicBlock *InitialDefBB) {
   LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::insertLaneAwarePHI InitialVReg=" << InitialVReg
                     << " OrigVReg=" << OrigVReg << " DefMask=" << PrintLaneMask(DefMask) << "\n");
   
-  SmallVector<Register> AllCreatedPHIs;
+  SmallVector<MachineOperand*> AllCreatedPHIs;
   
   // Step 1: Compute IDF (Iterated Dominance Frontier) for the initial definition
   // This gives us ALL blocks where PHI nodes need to be inserted
@@ -431,14 +451,14 @@ SmallVector<Register> MachineLaneSSAUpdater::insertLaneAwarePHI(Register Initial
                       << " with CurrentNewVReg=" << CurrentNewVReg << "\n");
     
     // Create PHI: merges OrigVReg and CurrentNewVReg based on dominance
-    Register PHIResult = createPHIInBlock(*JoinMBB, OrigVReg, CurrentNewVReg, DefMask);
+    MachineOperand* PHIResult = createPHIInBlock(*JoinMBB, OrigVReg, CurrentNewVReg, DefMask);
     
-    if (PHIResult.isValid()) {
+    if (PHIResult) {
       AllCreatedPHIs.push_back(PHIResult);
       
       // Update CurrentNewVReg to be the PHI result
       // This ensures the next PHI (if any) uses this PHI's result, not the original InitialVReg
-      CurrentNewVReg = PHIResult;
+      CurrentNewVReg = PHIResult->getReg();
       
       LLVM_DEBUG(dbgs() << "    Created PHI result VReg=" << PHIResult 
                         << ", will use this for subsequent PHIs\n");
@@ -452,16 +472,38 @@ SmallVector<Register> MachineLaneSSAUpdater::insertLaneAwarePHI(Register Initial
 }
 
 // Helper: Create lane-specific PHI in a join block
-Register MachineLaneSSAUpdater::createPHIInBlock(MachineBasicBlock &JoinMBB,
-                                                 Register OrigVReg,
-                                                 Register NewVReg,
-                                                 LaneBitmask DefMask) {
+MachineOperand *
+MachineLaneSSAUpdater::createPHIInBlock(MachineBasicBlock &JoinMBB,
+                                        Register OrigVReg, Register NewVReg,
+                                        LaneBitmask DefMask) {
   LLVM_DEBUG(dbgs() << "    createPHIInBlock in BB#" << JoinMBB.getNumber()
                     << " OrigVReg=" << OrigVReg << " NewVReg=" << NewVReg 
                     << " DefMask=" << PrintLaneMask(DefMask) << "\n");
   
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  const LaneBitmask FullMask = MRI.getMaxLaneMaskForVReg(OrigVReg);
+  
+  // Check for existing PHI that already merges this register with matching lane mask
+  for (MachineInstr &MI : JoinMBB.phis()) {
+    for (unsigned i = 1; i < MI.getNumOperands(); i += 2) {
+      MachineOperand &ValOp = MI.getOperand(i);
+      if (!ValOp.isReg() || ValOp.getReg() != OrigVReg)
+        continue;
+      
+      // Get effective lane mask for this operand
+      LaneBitmask OpMask = TRI.getSubRegIndexLaneMask(ValOp.getSubReg());
+      if (OpMask == LaneBitmask::getAll())
+        OpMask = FullMask;
+      
+      if ((OpMask & DefMask).any()) {
+        LLVM_DEBUG(dbgs() << "      Found existing PHI with matching lanes: ");
+        LLVM_DEBUG(MI.print(dbgs()));
+        return &MI.getOperand(0);
+      }
+    }
+  }
+  
   const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
-  const LaneBitmask FullMask = MF.getRegInfo().getMaxLaneMaskForVReg(OrigVReg);
   
   // Check if this is a partial lane redefinition
   const bool IsPartialReload = (DefMask != FullMask);
@@ -473,7 +515,6 @@ Register MachineLaneSSAUpdater::createPHIInBlock(MachineBasicBlock &JoinMBB,
                     << " DefMask=" << PrintLaneMask(DefMask) << "\n");
   
   // Get the definition block of NewVReg for dominance checks
-  MachineRegisterInfo &MRI = MF.getRegInfo();
   MachineInstr *NewDefMI = MRI.getVRegDef(NewVReg);
   MachineBasicBlock *NewDefBB = NewDefMI->getParent();
   
@@ -498,7 +539,7 @@ Register MachineLaneSSAUpdater::createPHIInBlock(MachineBasicBlock &JoinMBB,
       if (IsPartialReload) {
         // Partial case: z = PHI(y, BB1, x.sub2_3, BB0)
         // Use DefMask to find which subreg of OrigVReg was redefined
-        unsigned SubIdx = getSubRegIndexForLaneMask(DefMask, &TRI);
+        unsigned SubIdx = TRI.getSubRegIndexForLaneMask(DefMask);
         PHIOperands.push_back(MachineOperand::CreateReg(OrigVReg, /*isDef*/ false,
                                                        /*isImp*/ false, /*isKill*/ false,
                                                        /*isDead*/ false, /*isUndef*/ false,
@@ -528,10 +569,10 @@ Register MachineLaneSSAUpdater::createPHIInBlock(MachineBasicBlock &JoinMBB,
     LLVM_DEBUG(dbgs() << "      Created lane-specific PHI: ");
     LLVM_DEBUG(PHI->print(dbgs()));
     
-    return PHIVReg;
+    return &PHINode->getOperand(0);
   }
   
-  return Register();
+  return nullptr;
 }
 
 void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
@@ -551,7 +592,6 @@ void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
   }
   
   MachineBasicBlock *DefBB = DefMI->getParent();
-  const TargetRegisterClass *NewRC = MRI.getRegClass(NewSSA);
 
   LLVM_DEBUG(dbgs() << "  Rewriting uses dominated by definition in BB#" << DefBB->getNumber() << ": ");
   LLVM_DEBUG(DefMI->print(dbgs()));
@@ -567,8 +607,9 @@ void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
     if (UseMI == DefMI)
       continue;
 
-    // Check if this use is reached by our definition
-    if (!defReachesUse(DefMI, UseMI, MO))
+    // Check if this use is DOMINATED by our definition
+    // Reachable-but-not-dominated uses should use PHI results, not NewSSA directly
+    if (!defDominatesUse(DefMI, UseMI, MO))
       continue;
 
     // Get the lane mask for this operand
@@ -580,6 +621,7 @@ void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
     LLVM_DEBUG(UseMI->print(dbgs()));
 
     const TargetRegisterClass *OpRC = MRI.getRegClass(OrigVReg);
+    const TargetRegisterClass *NewRC = MRI.getRegClass(NewSSA);
 
     // Case 1: Exact match - direct replacement
     if (OpMask == MaskToRewrite) {
@@ -596,15 +638,23 @@ void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
         MO.setReg(NewSSA);
         MO.setSubReg(0); // Clear subregister (NewSSA is a full register of NewRC)
         
-        // Extend NewSSA's live interval to cover this use
-        SlotIndex UseIdx = LIS.getInstructionIndex(*UseMI).getRegSlot();
-        LiveInterval &NewLI = LIS.getInterval(NewSSA);
-        LIS.extendToIndices(NewLI, {UseIdx});
+        // NOTE: Don't extend NewSSA's live interval here - it will be computed
+        // later after all use rewriting is complete. Extending during the loop
+        // triggers lazy interval creation with incomplete use info, causing
+        // incorrect "dead" flags.
         
         continue;
       }
       
       // Incompatible register classes with same lane mask indicates corrupted MIR
+      LLVM_DEBUG(dbgs() << "=== Register Class Mismatch ===\n"
+                        << "  OrigVReg: " << printReg(OrigVReg, &TRI) << " class: " << TRI.getRegClassName(OpRC) << "\n"
+                        << "  NewSSA: " << printReg(NewSSA, &TRI) << " class: " << TRI.getRegClassName(NewRC) << "\n"
+                        << "  MaskToRewrite: " << PrintLaneMask(MaskToRewrite) << "\n"
+                        << "  OpMask: " << PrintLaneMask(OpMask) << "\n"
+                        << "  MO.getSubReg(): " << MO.getSubReg() << "\n"
+                        << "  ExpectedRC: " << (ExpectedRC ? TRI.getRegClassName(ExpectedRC) : "null") << "\n"
+                        << "  Use: "; UseMI->print(dbgs()));
       llvm_unreachable("Incompatible register classes with same lane mask - invalid MIR");
     }
 
@@ -638,57 +688,49 @@ void MachineLaneSSAUpdater::rewriteDominatedUses(Register OrigVReg,
       
     } else {
       // Case 3: Subset - use needs fewer lanes than NewSSA provides
-      // Need to remap subregister index from OrigVReg's register class to NewSSA's register class
-      //
-      // Example: OrigVReg is vreg_128, we redefine sub2_3 (64-bit), use accesses sub3 (32-bit)
-      //   MaskToRewrite = 0xF0  // sub2_3: lanes 4-7 in vreg_128 space
-      //   OpMask        = 0xC0  // sub3:   lanes 6-7 in vreg_128 space
-      //   NewSSA is vreg_64, has lanes 0-3 (but represents lanes 4-7 of OrigVReg)
-      //
-      // Algorithm: Shift OpMask down by the bit position of MaskToRewrite's LSB to map
-      // from OrigVReg's lane space into NewSSA's lane space, then find the subreg index.
-      //
-      // Why this works:
-      //   1. MaskToRewrite is contiguous (comes from subreg definition)
-      //   2. OpMask ⊆ MaskToRewrite (we're in subset case by construction)
-      //   3. Lane masks use bit positions that correspond to actual lane indices
-      //   4. Subreg boundaries are power-of-2 aligned in register class design
-      //
-      // Calculation:
-      //   Shift = countTrailingZeros(MaskToRewrite) = 4  // How far "up" MaskToRewrite is
-      //   NewMask = OpMask >> 4 = 0xC0 >> 4 = 0xC        // Map to NewSSA's lane space
-      //   0xC corresponds to sub1 in vreg_64 ✓
-      LLVM_DEBUG(dbgs() << "      Subset case -> remapping subregister index\n");
+      // Need to map OpMask to NewSSA's register class namespace if they differ
+      LLVM_DEBUG(dbgs() << "      Subset case -> finding subregister index\n");
       
-      // Find the bit offset of MaskToRewrite (position of its lowest set bit)
-      unsigned ShiftAmt = llvm::countr_zero(MaskToRewrite.getAsInteger());
-      assert(ShiftAmt < 64 && "MaskToRewrite should have at least one bit set");
+      LaneBitmask MappedOpMask = OpMask;
+      if (NewRC != OpRC) {
+        // Different register classes - need to map lane namespace
+        // MaskToRewrite defines which lanes of OrigVReg we redefined
+        // NewSSA is a narrower register that holds just those lanes
+        // Shift OpMask down to map from OrigVReg space to NewSSA space
+        unsigned ShiftAmt = llvm::countr_zero(MaskToRewrite.getAsInteger());
+        MappedOpMask = LaneBitmask(OpMask.getAsInteger() >> ShiftAmt);
+        
+        LLVM_DEBUG(dbgs() << "        Namespace mapping: OrigRC=" << TRI.getRegClassName(OpRC)
+                          << " NewRC=" << TRI.getRegClassName(NewRC)
+                          << "\n          OpMask=" << PrintLaneMask(OpMask)
+                          << " -> MappedOpMask=" << PrintLaneMask(MappedOpMask) << "\n");
+      }
       
-      // Shift OpMask down into NewSSA's lane space
-      LaneBitmask NewMask = LaneBitmask(OpMask.getAsInteger() >> ShiftAmt);
+      // Find the subregister index for MappedOpMask in NewSSA's register class
+      unsigned NewSubReg = TRI.getSubRegIndexForLaneMask(MappedOpMask);
+      assert(NewSubReg && "Should find subreg index for mapped lanes");
       
-      // Find the subregister index for NewMask in NewSSA's register class
-      unsigned NewSubReg = getSubRegIndexForLaneMask(NewMask, &TRI);
-      assert(NewSubReg && "Should find subreg index for remapped lanes");
-      
-      LLVM_DEBUG(dbgs() << "        Remapping subreg:\n"
-                        << "          OrigVReg lanes: OpMask=" << PrintLaneMask(OpMask) 
-                        << " MaskToRewrite=" << PrintLaneMask(MaskToRewrite) << "\n"
-                        << "          Shift amount: " << ShiftAmt << "\n"
-                        << "          NewSSA lanes: NewMask=" << PrintLaneMask(NewMask)
+      LLVM_DEBUG(dbgs() << "        MappedOpMask=" << PrintLaneMask(MappedOpMask)
                         << " -> SubReg=" << TRI.getSubRegIndexName(NewSubReg) << "\n");
       
       MO.setReg(NewSSA);
       MO.setSubReg(NewSubReg);
       
-      // Extend NewSSA's live interval to cover this use
-      SlotIndex UseIdx = LIS.getInstructionIndex(*UseMI).getRegSlot();
-      LiveInterval &NewLI = LIS.getInterval(NewSSA);
-      LIS.extendToIndices(NewLI, {UseIdx});
+      // NOTE: Don't extend NewSSA's live interval here - computed later.
     }
   }
   
   LLVM_DEBUG(dbgs() << "  Completed rewriting dominated uses\n");
+}
+
+SmallVector<MachineOperand *, 4> MachineLaneSSAUpdater::repairSSAForReload(
+    Register NewVReg, Register OrigVReg, LaneBitmask DefMask,
+    MachineBasicBlock *DefBB) {
+  LLVM_DEBUG(dbgs() << "MachineLaneSSAUpdater::repairSSAForReload NewVReg="
+                    << NewVReg << " OrigVReg=" << OrigVReg
+                    << " DefMask=" << PrintLaneMask(DefMask)
+                    << " DefBB=BB#" << DefBB->getNumber() << "\n");
+  return performSSARepair(NewVReg, OrigVReg, DefMask, DefBB);
 }
 
 //===----------------------------------------------------------------------===//
@@ -705,27 +747,213 @@ VNInfo *MachineLaneSSAUpdater::incomingOnEdge(LiveInterval &LI, MachineInstr *Ph
 }
 
 /// Check if \p DefMI's definition reaches \p UseMI's use operand.
-/// During SSA reconstruction, LiveIntervals may not be complete yet, so we use
-/// dominance-based checking rather than querying LiveInterval reachability.
-bool MachineLaneSSAUpdater::defReachesUse(MachineInstr *DefMI,
-                                           MachineInstr *UseMI, 
-                                           MachineOperand &UseOp) {
-  // For PHI uses, check if DefMI dominates the predecessor block
-  if (UseMI->isPHI()) {
-    unsigned OpIdx = UseMI->getOperandNo(&UseOp);
-    MachineBasicBlock *Pred = UseMI->getOperand(OpIdx + 1).getMBB();
-    return MDT.dominates(DefMI->getParent(), Pred);
+/// Get pruned IDF blocks for a definition (public API).
+/// Caching is handled inside computePrunedIDF.
+void MachineLaneSSAUpdater::getPrunedIDF(Register OrigVReg,
+                                          LaneBitmask DefMask,
+                                          MachineBasicBlock *DefBlock,
+                                          SmallVectorImpl<MachineBasicBlock *> &OutIDFBlocks) {
+  SmallVector<MachineBasicBlock *, 1> DefBlocks = {DefBlock};
+  computePrunedIDF(OrigVReg, DefMask, DefBlocks, OutIDFBlocks);
+}
+
+MachineOperand *MachineLaneSSAUpdater::insertPHIAtBlock(
+    MachineBasicBlock *JoinBB, Register OrigVReg,
+    const DenseMap<MachineBasicBlock *, Register> &IncomingValues,
+    LaneBitmask SpilledMask) {
+  LLVM_DEBUG(dbgs() << "  insertPHIAtBlock in BB#" << JoinBB->getNumber()
+                    << " for vreg" << OrigVReg << "\n");
+
+  const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+
+  // Determine register class for the spilled lanes
+  const TargetRegisterClass *RC;
+  if (!IncomingValues.empty()) {
+    Register AnyIncoming = IncomingValues.begin()->second;
+    RC = MRI.getRegClass(AnyIncoming);
+  } else {
+    // Map is empty - derive RC from OrigVReg and SpilledMask
+    const TargetRegisterClass *OrigRC = MRI.getRegClass(OrigVReg);
+    LaneBitmask FullMask = MRI.getMaxLaneMaskForVReg(OrigVReg);
+    if (SpilledMask != FullMask) {
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      unsigned SubIdx = TRI->getSubRegIndexForLaneMask(SpilledMask);
+      RC = TRI->getSubRegisterClass(OrigRC, SubIdx);
+    } else {
+      RC = OrigRC;
+    }
+  }
+  Register PHIVReg = MRI.createVirtualRegister(RC);
+
+  auto PHIBuilder =
+      BuildMI(*JoinBB, JoinBB->begin(), DebugLoc(), TII->get(TargetOpcode::PHI), PHIVReg);
+
+  // Compute subreg index for partial spills (used when IncomingValues doesn't have an entry)
+  const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+  LaneBitmask FullMask = MRI.getMaxLaneMaskForVReg(OrigVReg);
+  bool IsPartialSpill = (SpilledMask != FullMask);
+  unsigned SubIdx = IsPartialSpill ? TRI->getSubRegIndexForLaneMask(SpilledMask) : 0;
+
+  for (MachineBasicBlock *Pred : JoinBB->predecessors()) {
+    auto It = IncomingValues.find(Pred);
+    if (It != IncomingValues.end()) {
+      PHIBuilder.addReg(It->second).addMBB(Pred);
+    } else {
+      // Predecessor not in map - use OrigVReg with appropriate subreg for partial spills
+      if (IsPartialSpill) {
+        PHIBuilder.addReg(OrigVReg, RegState::NoFlags, SubIdx).addMBB(Pred);
+      } else {
+        PHIBuilder.addReg(OrigVReg).addMBB(Pred);
+      }
+    }
   }
 
-  // For same-block uses, check instruction order
-  if (UseMI->getParent() == DefMI->getParent()) {
+  MachineInstr *PHI = PHIBuilder.getInstr();
+  LIS.InsertMachineInstrInMaps(*PHI);
+
+  LLVM_DEBUG(dbgs() << "    Created PHI: "; PHI->print(dbgs()));
+
+  return &PHI->getOperand(0);
+}
+
+/// Check if a definition dominates a use.
+/// This is stricter than reachability - dominance means the def is on ALL paths to the use.
+///
+/// \param DefMI - The instruction defining a register
+/// \param UseMI - The instruction using a register
+/// \param UseOp - The specific use operand
+/// \returns true if DefMI dominates the use
+bool MachineLaneSSAUpdater::defDominatesUse(MachineInstr *DefMI,
+                                             MachineInstr *UseMI,
+                                             MachineOperand &UseOp) {
+  MachineBasicBlock *DefBlock = DefMI->getParent();
+  MachineBasicBlock *UseBlock = UseMI->getParent();
+  
+  // Fast path 1: Same block - check instruction order
+  if (UseBlock == DefBlock) {
     SlotIndex DefIdx = LIS.getInstructionIndex(*DefMI);
     SlotIndex UseIdx = LIS.getInstructionIndex(*UseMI);
     return DefIdx < UseIdx;
   }
   
-  // For cross-block uses, check block dominance
-  return MDT.dominates(DefMI->getParent(), UseMI->getParent());
+  // For PHI uses, we need to check dominance of the predecessor block
+  // For non-PHI uses, we check dominance of the use block
+  MachineBasicBlock *TargetBlock = UseBlock;
+  if (UseMI->isPHI()) {
+    unsigned OpIdx = UseMI->getOperandNo(&UseOp);
+    TargetBlock = UseMI->getOperand(OpIdx + 1).getMBB();
+  }
+  
+  return MDT.dominates(DefBlock, TargetBlock);
+}
+
+/// Check if a use is reachable from a definition using IDF analysis.
+///
+/// This fixes a bug where PHI operands from non-dominated predecessors were
+/// incorrectly left unrewritten after spills on parallel paths.
+bool MachineLaneSSAUpdater::isUseReachableFromDef(MachineInstr *DefMI,
+                                                    MachineInstr *UseMI,
+                                                    Register OrigVReg,
+                                                    LaneBitmask DefMask) {
+  MachineBasicBlock *DefBlock = DefMI->getParent();
+  
+  // Find the use operand in UseMI for dominance check
+  MachineOperand *UseOp = UseMI->findRegisterUseOperand(OrigVReg, &TRI, /*isKill=*/false);
+  assert(UseOp && "UseMI must use OrigVReg");
+  
+  // Fast path: Check dominance first
+  // If def dominates use, it definitely reaches it
+  if (defDominatesUse(DefMI, UseMI, *UseOp)) {
+    return true;
+  }
+  
+  // Extract the target block for IDF analysis (use block or PHI predecessor)
+  MachineBasicBlock *PredBlock = UseMI->getParent();
+  if (UseMI->isPHI()) {
+    unsigned OpIdx = UseMI->getOperandNo(UseOp);
+    PredBlock = UseMI->getOperand(OpIdx + 1).getMBB();
+  }
+  
+  // IDF-based reachability for non-dominated uses (parallel paths case)
+  //
+  // When a spill happens on one path but not all paths to a join point,
+  // we need PHI insertion. Example from spill-use-before-spill.mir:
+  //
+  //   bb.0.entry:
+  //     %0:vreg_128 = COPY ...
+  //     Branch to bb.1 or bb.2
+  //
+  //   bb.1.spill_path:
+  //     SI_SPILL_V128_SAVE %0  <- Spill here
+  //     %reload:vreg_128 = SI_SPILL_V128_RESTORE  <- Reload immediately
+  //     S_BRANCH %bb.3
+  //
+  //   bb.2.clean_path:
+  //     S_BRANCH %bb.3
+  //
+  //   bb.3.join:
+  //     S_ENDPGM 0, implicit %0  <- Needs PHI: one pred has reload, other has original!
+  //
+  // IDF analysis detects bb.3 is in the dominance frontier of bb.1,
+  // so the use in bb.3 IS reachable from the spill and needs PHI insertion.
+  
+  SmallVector<MachineBasicBlock *, 4> PrunedIDFBlocks;
+  SmallVector<MachineBasicBlock *, 1> DefBlocks = {DefBlock};
+  computePrunedIDF(OrigVReg, DefMask, DefBlocks, PrunedIDFBlocks);
+  
+  LLVM_DEBUG({
+    dbgs() << "  isUseReachableFromDef (slow path): DefBlock=bb." << DefBlock->getNumber()
+           << "." << DefBlock->getName() << " PredBlock=bb." << PredBlock->getNumber()
+           << "." << PredBlock->getName() << "\n";
+    dbgs() << "  Pruned IDF blocks: ";
+    for (auto *BB : PrunedIDFBlocks)
+      dbgs() << "bb." << BB->getNumber() << "." << BB->getName() << " ";
+    dbgs() << "\n";
+  });
+  
+  // Check if PredBlock is in or dominated by any IDF block
+  for (auto *IDFBB : PrunedIDFBlocks) {
+    if (IDFBB == PredBlock || MDT.dominates(IDFBB, PredBlock)) {
+      LLVM_DEBUG(dbgs() << "  => Reachable via IDF\n");
+      return true;
+    }
+  }
+  
+  LLVM_DEBUG(dbgs() << "  => NOT reachable\n");
+  return false;
+}
+
+bool MachineLaneSSAUpdater::isUseReachableFromDef(MachineOperand &DefOp,
+                                                    MachineOperand &UseOp,
+                                                    Register OrigVReg) {
+  // Derive instructions and lane mask from operands and call the MachineInstr* version
+  MachineInstr *DefMI = DefOp.getParent();
+  MachineInstr *UseMI = UseOp.getParent();
+  LaneBitmask DefMask = operandLaneMask(DefOp);
+  return isUseReachableFromDef(DefMI, UseMI, OrigVReg, DefMask);
+}
+
+/// During SSA reconstruction, check if a definition reaches a use.
+/// Uses IDF-based reachability analysis for correctness.
+///
+/// DefMI defines a NEW register (NewSSA), and UseOp uses the ORIGINAL register.
+/// We need to check if the definition of NewSSA can reach this use of OrigVReg.
+bool MachineLaneSSAUpdater::defReachesUse(MachineInstr *DefMI,
+                                           Register NewSSA,
+                                           MachineInstr *UseMI, 
+                                           MachineOperand &UseOp) {
+  Register OrigReg = UseOp.getReg();
+  assert(OrigReg.isVirtual() && "Expected virtual register");
+  assert(NewSSA.isVirtual() && "Expected virtual register");
+  
+  // Find the def operand in DefMI for NewSSA
+  MachineOperand *DefOp = DefMI->findRegisterDefOperand(NewSSA, &TRI, /*isDead=*/false, /*Overlap=*/true);
+  assert(DefOp && "DefMI must define NewSSA");
+  
+  // Use IDF-based reachability check
+  // Check if DefOp (NewSSA's definition) can reach UseOp (OrigReg's use)
+  return isUseReachableFromDef(*DefOp, UseOp, OrigReg);
 }
 
 /// What lanes does this operand read?
@@ -838,9 +1066,9 @@ Register MachineLaneSSAUpdater::buildRSForSuperUse(MachineInstr *UseMI, MachineO
   
   // Add source for lanes from NewVR (updated lanes)
   if (LanesFromNew.any()) {
-    unsigned SubIdx = getSubRegIndexForLaneMask(LanesFromNew, &TRI);
+    unsigned SubIdx = TRI.getSubRegIndexForLaneMask(LanesFromNew);
     assert(SubIdx && "Failed to find subregister index for LanesFromNew");
-    RS.addReg(NewVR, 0, 0).addImm(SubIdx);  // NewVR is full register, no subreg
+    RS.addReg(NewVR, RegState::NoFlags, 0).addImm(SubIdx);  // NewVR is full register, no subreg
     AddedSubIdxs.insert(SubIdx);
     LanesToExtend.push_back(LanesFromNew);
   }
@@ -849,11 +1077,11 @@ Register MachineLaneSSAUpdater::buildRSForSuperUse(MachineInstr *UseMI, MachineO
   // Handle both contiguous and non-contiguous lane masks
   // Non-contiguous example: Redefining only sub2 of vreg_128 leaves LanesFromOld = sub0+sub1+sub3
   if (LanesFromOld.any()) {
-    unsigned SubIdx = getSubRegIndexForLaneMask(LanesFromOld, &TRI);
+    unsigned SubIdx = TRI.getSubRegIndexForLaneMask(LanesFromOld);
     
     if (SubIdx) {
       // Contiguous case: single subregister covers all lanes
-      RS.addReg(OldVR, 0, SubIdx).addImm(SubIdx);  // OldVR.subIdx
+      RS.addReg(OldVR, RegState::NoFlags, SubIdx).addImm(SubIdx);  // OldVR.subIdx
       AddedSubIdxs.insert(SubIdx);
       LanesToExtend.push_back(LanesFromOld);
     } else {
@@ -871,7 +1099,7 @@ Register MachineLaneSSAUpdater::buildRSForSuperUse(MachineInstr *UseMI, MachineO
       // Add each covering subregister as a source to the REG_SEQUENCE
       for (unsigned CoverSubIdx : CoveringSubRegs) {
         LaneBitmask CoverMask = TRI.getSubRegIndexLaneMask(CoverSubIdx);
-        RS.addReg(OldVR, 0, CoverSubIdx).addImm(CoverSubIdx);  // OldVR.CoverSubIdx
+        RS.addReg(OldVR, RegState::NoFlags, CoverSubIdx).addImm(CoverSubIdx);  // OldVR.CoverSubIdx
         AddedSubIdxs.insert(CoverSubIdx);
         LanesToExtend.push_back(CoverMask);
         

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -36,6 +36,7 @@ add_llvm_unittest(CodeGenTests
   MachineDomTreeUpdaterTest.cpp
   MachineInstrBundleIteratorTest.cpp
   MachineInstrTest.cpp
+  MachineLaneSSAUpdaterTest.cpp
   MachineOperandTest.cpp
   MIR2VecTest.cpp
   RegAllocBasicTest.cpp

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -37,6 +37,7 @@ add_llvm_unittest(CodeGenTests
   MachineInstrBundleIteratorTest.cpp
   MachineInstrTest.cpp
   MachineLaneSSAUpdaterTest.cpp
+  MachineLaneSSAUpdaterSpillReloadTest.cpp
   MachineOperandTest.cpp
   MIR2VecTest.cpp
   RegAllocBasicTest.cpp

--- a/llvm/unittests/CodeGen/MachineLaneSSAUpdaterSpillReloadTest.cpp
+++ b/llvm/unittests/CodeGen/MachineLaneSSAUpdaterSpillReloadTest.cpp
@@ -1,0 +1,332 @@
+//===- MachineLaneSSAUpdaterSpillReloadTest.cpp - Spill/Reload tests -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for MachineLaneSSAUpdater focusing on spill/reload scenarios.
+//
+// NOTE: This file is currently a placeholder for future spiller-specific tests.
+// Analysis showed that repairSSAForNewDef() is sufficient for spill/reload 
+// scenarios - no special spill handling is needed. The spiller workflow is:
+//   1. Insert reload instruction before use
+//   2. Call repairSSAForNewDef(ReloadMI, SpilledReg)
+//   3. Done! Uses are rewritten, LiveIntervals naturally pruned
+//
+// Future spiller-specific scenarios (if needed) can be added here.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/MachineLaneSSAUpdater.h"
+#include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/MIRParser/MIRParser.h"
+#include "llvm/CodeGen/SlotIndexes.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/IR/DebugLoc.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/MC/LaneBitmask.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/TargetParser/Triple.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+// TestPass needs to be defined outside anonymous namespace for INITIALIZE_PASS
+struct SpillReloadTestPass : public MachineFunctionPass {
+  static char ID;
+  SpillReloadTestPass() : MachineFunctionPass(ID) {}
+};
+
+char SpillReloadTestPass::ID = 0;
+
+namespace llvm {
+  void initializeSpillReloadTestPassPass(PassRegistry &);
+}
+
+INITIALIZE_PASS(SpillReloadTestPass, "spillreloadtestpass", 
+                "spillreloadtestpass", false, false)
+
+namespace {
+
+void initLLVM() {
+  InitializeAllTargets();
+  InitializeAllTargetMCs();
+  InitializeAllAsmPrinters();
+  InitializeAllAsmParsers();
+
+  PassRegistry *Registry = PassRegistry::getPassRegistry();
+  initializeCore(*Registry);
+  initializeCodeGen(*Registry);
+}
+
+// Helper to create a target machine for AMDGPU
+std::unique_ptr<TargetMachine> createTargetMachine() {
+  Triple TT("amdgcn--");
+  std::string Error;
+  const Target *T = TargetRegistry::lookupTarget("", TT, Error);
+  if (!T)
+    return nullptr;
+    
+  TargetOptions Options;
+  return std::unique_ptr<TargetMachine>(
+      T->createTargetMachine(TT, "gfx900", "", Options, std::nullopt,
+                             std::nullopt, CodeGenOptLevel::Aggressive));
+}
+
+// Helper to parse MIR string with legacy PassManager
+std::unique_ptr<Module> parseMIR(LLVMContext &Context,
+                                 legacy::PassManagerBase &PM,
+                                 std::unique_ptr<MIRParser> &MIR,
+                                 const TargetMachine &TM, StringRef MIRCode) {
+  SMDiagnostic Diagnostic;
+  std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
+  MIR = createMIRParser(std::move(MBuffer), Context);
+  if (!MIR)
+    return nullptr;
+
+  std::unique_ptr<Module> M = MIR->parseIRModule();
+  if (!M)
+    return nullptr;
+
+  M->setDataLayout(TM.createDataLayout());
+
+  MachineModuleInfoWrapperPass *MMIWP = new MachineModuleInfoWrapperPass(&TM);
+  if (MIR->parseMachineFunctions(*M, MMIWP->getMMI()))
+    return nullptr;
+  PM.add(MMIWP);
+
+  return M;
+}
+
+template <typename AnalysisType>
+struct SpillReloadTestPassT : public SpillReloadTestPass {
+  typedef std::function<void(MachineFunction&, AnalysisType&)> TestFx;
+
+  SpillReloadTestPassT() {
+    // We should never call this but always use PM.add(new SpillReloadTestPass(...))
+    abort();
+  }
+  
+  SpillReloadTestPassT(TestFx T, bool ShouldPass)
+      : T(T), ShouldPass(ShouldPass) {
+    initializeSpillReloadTestPassPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    AnalysisType &A = getAnalysis<AnalysisType>();
+    T(MF, A);
+    bool VerifyResult = MF.verify(this, /* Banner=*/nullptr,
+                                   /*OS=*/&llvm::errs(),
+                                   /* AbortOnError=*/false);
+    EXPECT_EQ(VerifyResult, ShouldPass);
+    return true;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+    AU.addRequired<AnalysisType>();
+    AU.addPreserved<AnalysisType>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+  
+private:
+  TestFx T;
+  bool ShouldPass;
+};
+
+template <typename AnalysisType>
+static void doTest(StringRef MIRFunc,
+                   typename SpillReloadTestPassT<AnalysisType>::TestFx T,
+                   bool ShouldPass = true) {
+  initLLVM();
+  
+  LLVMContext Context;
+  std::unique_ptr<TargetMachine> TM = createTargetMachine();
+  if (!TM)
+    GTEST_SKIP() << "AMDGPU target not available";
+
+  legacy::PassManager PM;
+  std::unique_ptr<MIRParser> MIR;
+  std::unique_ptr<Module> M = parseMIR(Context, PM, MIR, *TM, MIRFunc);
+  ASSERT_TRUE(M);
+
+  PM.add(new SpillReloadTestPassT<AnalysisType>(T, ShouldPass));
+
+  PM.run(*M);
+}
+
+static void liveIntervalsTest(StringRef MIRFunc,
+                              SpillReloadTestPassT<LiveIntervalsWrapperPass>::TestFx T,
+                              bool ShouldPass = true) {
+  SmallString<512> S;
+  StringRef MIRString = (Twine(R"MIR(
+--- |
+  define amdgpu_kernel void @func() { ret void }
+...
+---
+name: func
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: vgpr_32 }
+body: |
+  bb.0:
+)MIR") + Twine(MIRFunc) + Twine("...\n")).toNullTerminatedStringRef(S);
+
+  doTest<LiveIntervalsWrapperPass>(MIRString, T, ShouldPass);
+}
+
+//===----------------------------------------------------------------------===//
+// Spill/Reload Tests
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Test 1: Simple Linear Spill/Reload
+//===----------------------------------------------------------------------===//
+//
+// This test demonstrates that repairSSAForNewDef() works for spill/reload
+// scenarios without any special handling.
+//
+// CFG Structure:
+//    BB0 (entry)
+//     |   %0 = initial_def
+//     |
+//    BB1 (intermediate)
+//     |   some operations
+//     |
+//    BB2 (reload & use)
+//     |   %0 = RELOAD (simulated as V_MOV_B32)
+//     |   use %0
+//
+// Scenario:
+// - %0 is defined in BB0 and used in BB2
+// - Insert a reload instruction in BB2 that redefines %0 (violating SSA)
+// - Call repairSSAForNewDef() to fix the SSA violation
+// - Verify that uses are rewritten and LiveIntervals are correct
+//
+// Expected Behavior:
+// - Reload renamed to define a new register
+// - Uses after reload rewritten to new register
+// - OrigReg's LiveInterval naturally pruned to BB0 only
+// - No PHI needed (linear CFG)
+//
+TEST(MachineLaneSSAUpdaterSpillReloadTest, SimpleLinearSpillReload) {
+  liveIntervalsTest(R"MIR(
+    %0:vgpr_32 = V_MOV_B32_e32 42, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+    %1:vgpr_32 = V_MOV_B32_e32 100, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.2:
+    %2:vgpr_32 = V_ADD_U32_e32 %0, %1, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      
+      // Verify we have 3 blocks as expected
+      ASSERT_EQ(MF.size(), 3u) << "Should have bb.0, bb.1, bb.2";
+      
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineBasicBlock *BB2 = MF.getBlockNumbered(2);
+      
+      // Find %0 definition in BB0 (first instruction should be V_MOV_B32)
+      MachineInstr *OrigDefMI = &*BB0->begin();
+      ASSERT_TRUE(OrigDefMI && OrigDefMI->getNumOperands() > 0);
+      Register OrigReg = OrigDefMI->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid()) << "Should have valid original register %0";
+      
+      // STEP 1: Insert reload instruction in BB2 before the use
+      // This creates a second definition of %0, violating SSA
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      auto InsertPt = BB2->getFirstNonPHI();
+      
+      // Get opcode and register from the existing V_MOV_B32 in BB0
+      unsigned MovOpcode = OrigDefMI->getOpcode();
+      Register ExecReg = OrigDefMI->getOperand(2).getReg();
+      
+      // Insert reload: %0 = V_MOV_B32 999 (simulating load from stack)
+      // This violates SSA because %0 is already defined in BB0
+      MachineInstr *ReloadMI = BuildMI(*BB2, InsertPt, DebugLoc(),
+                                        TII->get(MovOpcode), OrigReg)
+                                   .addImm(999)  // Simulated reload value
+                                   .addReg(ExecReg, RegState::Implicit);
+      
+      // Set MachineFunction properties to allow SSA
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+      
+      // STEP 2: Call repairSSAForNewDef to fix the SSA violation
+      // This will:
+      //   - Rename the reload to define a new register
+      //   - Rewrite uses dominated by the reload
+      //   - Naturally prune OrigReg's LiveInterval via recomputation
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      Register ReloadReg = Updater.repairSSAForNewDef(*ReloadMI, OrigReg);
+      
+      // VERIFY RESULTS:
+      
+      // 1. ReloadReg should be valid and different from OrigReg
+      EXPECT_TRUE(ReloadReg.isValid()) << "Updater should return valid register";
+      EXPECT_NE(ReloadReg, OrigReg) << "Reload register should be different from original";
+      
+      // 2. ReloadMI should define the new ReloadReg (not OrigReg)
+      EXPECT_EQ(ReloadMI->getOperand(0).getReg(), ReloadReg) 
+          << "ReloadMI should define new reload register";
+      
+      // 3. Verify the ReloadReg has a valid LiveInterval
+      EXPECT_TRUE(LIS.hasInterval(ReloadReg)) 
+          << "Reload register should have live interval";
+      
+      // 4. No PHI should be inserted (linear CFG, reload dominates subsequent uses)
+      bool FoundPHI = false;
+      for (MachineBasicBlock &MBB : MF) {
+        for (MachineInstr &MI : MBB) {
+          if (MI.isPHI()) {
+            FoundPHI = true;
+            break;
+          }
+        }
+      }
+      EXPECT_FALSE(FoundPHI) 
+          << "Linear CFG should not require PHI nodes";
+      
+      // 5. Verify OrigReg's LiveInterval was naturally pruned
+      //    It should only cover BB0 now (definition to end of block)
+      EXPECT_TRUE(LIS.hasInterval(OrigReg)) 
+          << "Original register should still have live interval";
+      const LiveInterval &OrigLI = LIS.getInterval(OrigReg);
+      
+      // The performSSARepair recomputation naturally prunes OrigReg
+      // because all uses in BB2 were rewritten to ReloadReg
+      SlotIndex OrigEnd = OrigLI.endIndex();
+      
+      // OrigReg should not extend into BB2 where ReloadReg took over
+      SlotIndex BB2Start = LIS.getMBBStartIdx(BB2);
+      EXPECT_LE(OrigEnd, BB2Start) 
+          << "Original register should not extend into BB2 after reload";
+    });
+}
+
+} // anonymous namespace
+

--- a/llvm/unittests/CodeGen/MachineLaneSSAUpdaterSpillReloadTest.cpp
+++ b/llvm/unittests/CodeGen/MachineLaneSSAUpdaterSpillReloadTest.cpp
@@ -8,14 +8,18 @@
 //
 // Unit tests for MachineLaneSSAUpdater focusing on spill/reload scenarios.
 //
-// NOTE: This file is currently a placeholder for future spiller-specific tests.
-// Analysis showed that repairSSAForNewDef() is sufficient for spill/reload 
-// scenarios - no special spill handling is needed. The spiller workflow is:
-//   1. Insert reload instruction before use
-//   2. Call repairSSAForNewDef(ReloadMI, SpilledReg)
-//   3. Done! Uses are rewritten, LiveIntervals naturally pruned
+// Two spiller integration patterns are covered here:
 //
-// Future spiller-specific scenarios (if needed) can be added here.
+//   1. repairSSAForNewDef(ReloadMI, SpilledReg, PHIDefOps)
+//      The caller inserts a reload MI that still writes the spilled register,
+//      then asks the updater to rename the def and repair SSA in one step.
+//      Covered by: SimpleLinearSpillReload.
+//
+//   2. repairSSAForReload(NewVReg, OrigVReg, DefMask, DefBB)
+//      The caller builds a reload MI that already defines a FRESH vreg, then
+//      asks the updater to insert PHIs at IDF blocks and rewrite dominated
+//      uses. No renaming happens inside the updater.
+//      Covered by: RepairSSAForReloadInsertsPHI.
 //
 //===----------------------------------------------------------------------===//
 
@@ -282,7 +286,8 @@ TEST(MachineLaneSSAUpdaterSpillReloadTest, SimpleLinearSpillReload) {
       //   - Rewrite uses dominated by the reload
       //   - Naturally prune OrigReg's LiveInterval via recomputation
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register ReloadReg = Updater.repairSSAForNewDef(*ReloadMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register ReloadReg = Updater.repairSSAForNewDef(*ReloadMI, OrigReg, PHIDefOps);
       
       // VERIFY RESULTS:
       
@@ -325,6 +330,139 @@ TEST(MachineLaneSSAUpdaterSpillReloadTest, SimpleLinearSpillReload) {
       SlotIndex BB2Start = LIS.getMBBStartIdx(BB2);
       EXPECT_LE(OrigEnd, BB2Start) 
           << "Original register should not extend into BB2 after reload";
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test 2: repairSSAForReload on a diamond CFG (new API coverage)
+//
+// Unlike repairSSAForNewDef, this API assumes the caller has ALREADY built an
+// MI that defines a fresh NewVReg (a reload). The updater is asked to insert
+// PHIs at IDF blocks and rewrite dominated uses of OrigVReg.
+//
+// CFG:
+//       bb.0 (entry: %0 = orig def, cond branch)
+//       /  \
+//    bb.1   bb.2     bb.1 = spill path: test builds "%reload = V_MOV 42"
+//       \  /                            and calls repairSSAForReload
+//       bb.3 (use %0)
+//===----------------------------------------------------------------------===//
+TEST(MachineLaneSSAUpdaterSpillReloadTest, RepairSSAForReloadInsertsPHI) {
+  liveIntervalsTest(R"MIR(
+    successors: %bb.1, %bb.2
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.3
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.3
+    S_NOP 0
+    S_BRANCH %bb.3
+
+  bb.3:
+    %99:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+
+      ASSERT_EQ(MF.size(), 4u) << "Should have bb.0..bb.3";
+
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineBasicBlock *BB1 = MF.getBlockNumbered(1);  // spill path
+      MachineBasicBlock *BB2 = MF.getBlockNumbered(2);  // clean path
+      MachineBasicBlock *BB3 = MF.getBlockNumbered(3);  // join
+
+      MachineInstr *OrigDefMI = &*BB0->begin();
+      Register OrigReg = OrigDefMI->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid());
+      unsigned MovOpcode = OrigDefMI->getOpcode();
+      Register ExecReg = OrigDefMI->getOperand(2).getReg();
+
+      // Build a reload-like MI in bb.1 that defines a FRESH vreg.
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      const TargetRegisterClass *RC = MRI.getRegClass(OrigReg);
+      Register ReloadReg = MRI.createVirtualRegister(RC);
+
+      auto InsertPt = BB1->getFirstTerminator();
+      MachineInstr *ReloadMI = BuildMI(*BB1, InsertPt, DebugLoc(),
+                                       TII->get(MovOpcode), ReloadReg)
+                                  .addImm(42)
+                                  .addReg(ExecReg, RegState::Implicit);
+      LIS.InsertMachineInstrInMaps(*ReloadMI);
+
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+
+      LaneBitmask DefMask = MRI.getMaxLaneMaskForVReg(OrigReg);
+
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      SmallVector<MachineOperand *, 4> PHIDefOps =
+          Updater.repairSSAForReload(ReloadReg, OrigReg, DefMask, BB1);
+
+      ASSERT_FALSE(PHIDefOps.empty())
+          << "repairSSAForReload should return PHI def operands";
+
+      EXPECT_EQ(ReloadMI->getOperand(0).getReg(), ReloadReg);
+
+      MachineInstr *JoinPHI = nullptr;
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) { JoinPHI = &MI; break; }
+      }
+      ASSERT_NE(JoinPHI, nullptr) << "Expected a PHI at join block bb.3";
+      ASSERT_EQ(JoinPHI->getNumOperands(), 5u)
+          << "PHI: 1 def + 2*(reg,mbb) = 5 operands";
+
+      DenseMap<MachineBasicBlock *, Register> Incoming;
+      for (unsigned i = 1, e = JoinPHI->getNumOperands(); i < e; i += 2) {
+        Register R = JoinPHI->getOperand(i).getReg();
+        MachineBasicBlock *P = JoinPHI->getOperand(i + 1).getMBB();
+        Incoming[P] = R;
+      }
+      ASSERT_EQ(Incoming.size(), 2u);
+      EXPECT_EQ(Incoming[BB1], ReloadReg)
+          << "PHI operand from spill-path predecessor must be ReloadReg";
+      EXPECT_EQ(Incoming[BB2], OrigReg)
+          << "PHI operand from clean-path predecessor must be OrigReg";
+
+      Register PHIRes = JoinPHI->getOperand(0).getReg();
+      bool JoinUseRewritten = false;
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) continue;
+        for (const MachineOperand &MO : MI.uses()) {
+          if (MO.isReg() && MO.getReg() == PHIRes) {
+            JoinUseRewritten = true;
+            break;
+          }
+        }
+        if (JoinUseRewritten) break;
+      }
+      EXPECT_TRUE(JoinUseRewritten)
+          << "Use at join must be rewritten to the PHI result";
+
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) continue;
+        for (const MachineOperand &MO : MI.uses()) {
+          if (MO.isReg())
+            EXPECT_NE(MO.getReg(), OrigReg)
+                << "No non-PHI use of OrigReg should remain in bb.3";
+        }
+      }
+
+      EXPECT_TRUE(LIS.hasInterval(ReloadReg));
+      EXPECT_TRUE(LIS.hasInterval(OrigReg));
+      EXPECT_TRUE(MF.verify(nullptr, nullptr, nullptr, false))
+          << "MachineFunction verification failed after SSA repair";
     });
 }
 

--- a/llvm/unittests/CodeGen/MachineLaneSSAUpdaterTest.cpp
+++ b/llvm/unittests/CodeGen/MachineLaneSSAUpdaterTest.cpp
@@ -1,0 +1,885 @@
+//===- MachineLaneSSAUpdaterTest.cpp - Unit tests for MachineLaneSSAUpdater -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/MachineLaneSSAUpdater.h"
+#include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/MIRParser/MIRParser.h"
+#include "llvm/CodeGen/SlotIndexes.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/IR/DebugLoc.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/MC/LaneBitmask.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/TargetParser/Triple.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+// TestPass needs to be defined outside anonymous namespace for INITIALIZE_PASS
+struct TestPass : public MachineFunctionPass {
+  static char ID;
+  TestPass() : MachineFunctionPass(ID) {}
+};
+
+char TestPass::ID = 0;
+
+namespace llvm {
+  void initializeTestPassPass(PassRegistry &);
+}
+
+INITIALIZE_PASS(TestPass, "testpass", "testpass", false, false)
+
+namespace {
+
+void initLLVM() {
+  InitializeAllTargets();
+  InitializeAllTargetMCs();
+  InitializeAllAsmPrinters();
+  InitializeAllAsmParsers();
+
+  PassRegistry *Registry = PassRegistry::getPassRegistry();
+  initializeCore(*Registry);
+  initializeCodeGen(*Registry);
+}
+
+// Helper to create a target machine for AMDGPU
+std::unique_ptr<TargetMachine> createTargetMachine() {
+  Triple TT("amdgcn--");
+  std::string Error;
+  const Target *T = TargetRegistry::lookupTarget("", TT, Error);
+  if (!T)
+    return nullptr;
+    
+  TargetOptions Options;
+  return std::unique_ptr<TargetMachine>(
+      T->createTargetMachine(TT, "gfx900", "", Options, std::nullopt,
+                             std::nullopt, CodeGenOptLevel::Aggressive));
+}
+
+// Helper to parse MIR string with legacy PassManager
+std::unique_ptr<Module> parseMIR(LLVMContext &Context,
+                                 legacy::PassManagerBase &PM,
+                                 std::unique_ptr<MIRParser> &MIR,
+                                 const TargetMachine &TM, StringRef MIRCode) {
+  SMDiagnostic Diagnostic;
+  std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
+  MIR = createMIRParser(std::move(MBuffer), Context);
+  if (!MIR)
+    return nullptr;
+
+  std::unique_ptr<Module> M = MIR->parseIRModule();
+  if (!M)
+    return nullptr;
+
+  M->setDataLayout(TM.createDataLayout());
+
+  MachineModuleInfoWrapperPass *MMIWP = new MachineModuleInfoWrapperPass(&TM);
+  if (MIR->parseMachineFunctions(*M, MMIWP->getMMI()))
+    return nullptr;
+  PM.add(MMIWP);
+
+  return M;
+}
+
+template <typename AnalysisType>
+struct TestPassT : public TestPass {
+  typedef std::function<void(MachineFunction&, AnalysisType&)> TestFx;
+
+  TestPassT() {
+    // We should never call this but always use PM.add(new TestPass(...))
+    abort();
+  }
+  
+  TestPassT(TestFx T, bool ShouldPass)
+      : T(T), ShouldPass(ShouldPass) {
+    initializeTestPassPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    AnalysisType &A = getAnalysis<AnalysisType>();
+    T(MF, A);
+    bool VerifyResult = MF.verify(this, /* Banner=*/nullptr,
+                                   /*OS=*/&llvm::errs(),
+                                   /* AbortOnError=*/false);
+    EXPECT_EQ(VerifyResult, ShouldPass);
+    return true;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+    AU.addRequired<AnalysisType>();
+    AU.addPreserved<AnalysisType>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+  
+private:
+  TestFx T;
+  bool ShouldPass;
+};
+
+template <typename AnalysisType>
+static void doTest(StringRef MIRFunc,
+                   typename TestPassT<AnalysisType>::TestFx T,
+                   bool ShouldPass = true) {
+  initLLVM();
+  
+  LLVMContext Context;
+  std::unique_ptr<TargetMachine> TM = createTargetMachine();
+  if (!TM)
+    GTEST_SKIP() << "AMDGPU target not available";
+
+  legacy::PassManager PM;
+  std::unique_ptr<MIRParser> MIR;
+  std::unique_ptr<Module> M = parseMIR(Context, PM, MIR, *TM, MIRFunc);
+  ASSERT_TRUE(M);
+
+  PM.add(new TestPassT<AnalysisType>(T, ShouldPass));
+
+  PM.run(*M);
+}
+
+static void liveIntervalsTest(StringRef MIRFunc,
+                              TestPassT<LiveIntervalsWrapperPass>::TestFx T,
+                              bool ShouldPass = true) {
+  SmallString<512> S;
+  StringRef MIRString = (Twine(R"MIR(
+--- |
+  define amdgpu_kernel void @func() { ret void }
+...
+---
+name: func
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: vgpr_32 }
+body: |
+  bb.0:
+)MIR") + Twine(MIRFunc) + Twine("...\n")).toNullTerminatedStringRef(S);
+
+  doTest<LiveIntervalsWrapperPass>(MIRString, T, ShouldPass);
+}
+
+//===----------------------------------------------------------------------===//
+// Test 1: Insert new definition and verify SSA repair with PHI insertion
+//===----------------------------------------------------------------------===//
+
+TEST(MachineLaneSSAUpdaterTest, NewDefInsertsPhiAndRewritesUses) {
+  liveIntervalsTest(R"MIR(
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+    %1:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.3, implicit $scc
+
+  bb.2:
+    successors: %bb.4
+    %2:vgpr_32 = V_ADD_U32_e32 %1, %1, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.3:
+    successors: %bb.4
+    S_NOP 0
+
+  bb.4:
+    %5:vgpr_32 = V_ADD_U32_e32 %1, %1, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+      
+      // Verify we have 5 blocks as expected
+      ASSERT_EQ(MF.size(), 5u) << "Should have bb.0, bb.1, bb.2, bb.3, bb.4";
+      
+      MachineBasicBlock *BB1 = MF.getBlockNumbered(1);
+      MachineBasicBlock *BB3 = MF.getBlockNumbered(3);
+      MachineBasicBlock *BB4 = MF.getBlockNumbered(4);
+      
+      // Get %1 which is defined in bb.1 (first non-PHI instruction)
+      MachineInstr *OrigDefMI = &*BB1->getFirstNonPHI();
+      ASSERT_TRUE(OrigDefMI) << "Could not find instruction in bb.1";
+      ASSERT_TRUE(OrigDefMI->getNumOperands() > 0) << "Instruction has no operands";
+      
+      Register OrigReg = OrigDefMI->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid()) << "Could not get destination register %1 from bb.1";
+      
+      // Count uses before SSA repair
+      unsigned UseCountBefore = 0;
+      for (const MachineInstr &MI : MRI.use_instructions(OrigReg)) {
+        (void)MI;
+        ++UseCountBefore;
+      }
+      ASSERT_GT(UseCountBefore, 0u) << "Original register should have uses";
+      
+      // Find V_MOV_B32_e32 instruction in bb.0 to get its opcode
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineInstr *MovInst = &*BB0->begin();
+      unsigned MovOpcode = MovInst->getOpcode();
+      Register ExecReg = MovInst->getOperand(2).getReg(); // Get EXEC register
+      
+      // Create a new definition in bb.3 that defines OrigReg (violating SSA)
+      // This creates a scenario where bb.4 needs a PHI to merge values from bb.2 and bb.3
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      auto InsertPt = BB3->getFirstNonPHI();
+      MachineInstr *NewDefMI = BuildMI(*BB3, InsertPt, DebugLoc(), 
+                                        TII->get(MovOpcode), OrigReg)
+                                   .addImm(42)
+                                   .addReg(ExecReg, RegState::Implicit);
+      
+      // Set MachineFunction properties to allow PHIs and indicate SSA form
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+      
+      // NOW TEST MachineLaneSSAUpdater: call repairSSAForNewDef
+      // Before: %1 defined in bb.1, used in bb.2 and bb.4
+      //         NewDefMI in bb.3 also defines %1 (violating SSA!)
+      // After repair: NewDefMI will define a new vreg, bb.4 gets PHI
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      
+      // VERIFY RESULTS:
+      
+      // 1. NewReg should be valid and different from OrigReg
+      EXPECT_TRUE(NewReg.isValid()) << "Updater should create a new register";
+      EXPECT_NE(NewReg, OrigReg) << "New register should be different from original";
+      
+      // 2. NewDefMI should now define NewReg (not OrigReg)
+      EXPECT_EQ(NewDefMI->getOperand(0).getReg(), NewReg) << "NewDefMI should now define the new register";
+      
+      
+      // 3. Check if PHI nodes were inserted in bb.4
+      bool FoundPHI = false;
+      for (MachineInstr &MI : *BB4) {
+        if (MI.isPHI()) {
+          FoundPHI = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(FoundPHI) << "SSA repair should have inserted PHI node in bb.4";
+      
+      // 4. Verify LiveIntervals are still valid
+      EXPECT_TRUE(LIS.hasInterval(NewReg)) << "New register should have live interval";
+      EXPECT_TRUE(LIS.hasInterval(OrigReg)) << "Original register should still have live interval";
+      
+      // Note: MachineFunction verification happens in TestPassT::runOnMachineFunction
+      // If verification fails, print the MachineFunction for debugging
+      if (!MF.verify(nullptr, /* Banner=*/nullptr, /*OS=*/nullptr, /* AbortOnError=*/false)) {
+        llvm::errs() << "MachineFunction verification failed after SSA repair:\n";
+        MF.print(llvm::errs());
+        LIS.print(llvm::errs());
+      }
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test 2: Multiple PHI insertions in nested control flow
+//
+// CFG structure (from user's diagram):
+//        bb.0
+//          |
+//        bb.1 (%1 = original def)
+//        /  \
+//     bb.2  bb.3
+//      |    /  \
+//      | bb.4  bb.5 (new def inserted here)
+//      |   \  /
+//      |   bb.6 (needs first PHI: %X = PHI %1,bb.4  NewDef,bb.5)
+//       \  /
+//        bb.7 (needs second PHI: %Y = PHI %1,bb.2  %X,bb.6)
+//          |
+//        bb.8 (use)
+//
+// Key insight: IDF(bb.5) = {bb.6, bb.7}
+// - bb.6 needs PHI because it's reachable from bb.4 (has %1) and bb.5 (has new def)
+// - bb.7 needs PHI because it's reachable from bb.2 (has %1) and bb.6 (has PHI result %X)
+//
+// This truly requires TWO PHI nodes for proper SSA form!
+//===----------------------------------------------------------------------===//
+
+TEST(MachineLaneSSAUpdaterTest, MultiplePhiInsertion) {
+  liveIntervalsTest(R"MIR(
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+    %1:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.3, implicit $scc
+
+  bb.2:
+    successors: %bb.7
+    %2:vgpr_32 = V_ADD_U32_e32 %1, %1, implicit $exec
+    S_BRANCH %bb.7
+
+  bb.3:
+    successors: %bb.4, %bb.5
+    $sgpr2 = S_MOV_B32 0
+    $sgpr3 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr2, $sgpr3, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.5, implicit $scc
+
+  bb.4:
+    successors: %bb.6
+    %3:vgpr_32 = V_ADD_U32_e32 %1, %1, implicit $exec
+    S_BRANCH %bb.6
+
+  bb.5:
+    successors: %bb.6
+    S_NOP 0
+
+  bb.6:
+    successors: %bb.7
+    %4:vgpr_32 = V_SUB_U32_e32 %1, %1, implicit $exec
+
+  bb.7:
+    successors: %bb.8
+    %5:vgpr_32 = V_AND_B32_e32 %1, %1, implicit $exec
+    S_BRANCH %bb.8
+
+  bb.8:
+    %6:vgpr_32 = V_OR_B32_e32 %1, %1, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+      
+      // Verify we have the expected number of blocks
+      ASSERT_EQ(MF.size(), 9u) << "Should have bb.0 through bb.8";
+      
+      MachineBasicBlock *BB1 = MF.getBlockNumbered(1);
+      MachineBasicBlock *BB5 = MF.getBlockNumbered(5);
+      MachineBasicBlock *BB6 = MF.getBlockNumbered(6);
+      MachineBasicBlock *BB7 = MF.getBlockNumbered(7);
+      
+      // Get %1 which is defined in bb.1
+      MachineInstr *OrigDefMI = &*BB1->getFirstNonPHI();
+      Register OrigReg = OrigDefMI->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid()) << "Could not get original register";
+      
+      // Count uses of %1 before SSA repair
+      unsigned UseCountBefore = 0;
+      for (const MachineInstr &MI : MRI.use_instructions(OrigReg)) {
+        (void)MI;
+        ++UseCountBefore;
+      }
+      ASSERT_GT(UseCountBefore, 0u) << "Original register should have uses";
+      llvm::errs() << "Original register has " << UseCountBefore << " uses before SSA repair\n";
+      
+      // Get V_MOV opcode from bb.0
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineInstr *MovInst = &*BB0->begin();
+      unsigned MovOpcode = MovInst->getOpcode();
+      Register ExecReg = MovInst->getOperand(2).getReg();
+      
+      // Insert new definition in bb.5 that defines OrigReg (violating SSA)
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      auto InsertPt = BB5->getFirstNonPHI();
+      MachineInstr *NewDefMI = BuildMI(*BB5, InsertPt, DebugLoc(), 
+                                        TII->get(MovOpcode), OrigReg)
+                                   .addImm(100)
+                                   .addReg(ExecReg, RegState::Implicit);
+      
+      // Set MachineFunction properties
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+      
+      // Call MachineLaneSSAUpdater
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      
+      EXPECT_TRUE(NewReg.isValid()) << "Updater should create a new register";
+      EXPECT_NE(NewReg, OrigReg) << "New register should be different from original";
+      EXPECT_EQ(NewDefMI->getOperand(0).getReg(), NewReg) << "NewDefMI should now define the new register";
+      
+      // Count PHI nodes inserted and track their locations
+      unsigned PHICount = 0;
+      std::map<unsigned, unsigned> PHIsPerBlock;
+      for (MachineBasicBlock &MBB : MF) {
+        unsigned BlockPHIs = 0;
+        for (MachineInstr &MI : MBB) {
+          if (MI.isPHI()) {
+            ++PHICount;
+            ++BlockPHIs;
+            llvm::errs() << "Found PHI in BB#" << MBB.getNumber() << ": ";
+            MI.print(llvm::errs());
+          }
+        }
+        if (BlockPHIs > 0) {
+          PHIsPerBlock[MBB.getNumber()] = BlockPHIs;
+        }
+      }
+      
+      llvm::errs() << "Total PHI nodes inserted: " << PHICount << "\n";
+      
+      // Check for first PHI in bb.6 (joins bb.4 and bb.5)
+      bool FoundPHIInBB6 = false;
+      for (MachineInstr &MI : *BB6) {
+        if (MI.isPHI()) {
+          FoundPHIInBB6 = true;
+          llvm::errs() << "First PHI in bb.6: ";
+          MI.print(llvm::errs());
+          // Verify it has 2 incoming values (4 operands: 2 x (reg, mbb))
+          unsigned NumIncoming = (MI.getNumOperands() - 1) / 2;
+          EXPECT_EQ(NumIncoming, 2u) << "First PHI in bb.6 should have 2 incoming values (from bb.4 and bb.5)";
+          break;
+        }
+      }
+      EXPECT_TRUE(FoundPHIInBB6) << "Should have first PHI in bb.6 (joins bb.4 with %1 and bb.5 with new def)";
+      
+      // Check for second PHI in bb.7 (joins bb.2 and bb.6)
+      bool FoundPHIInBB7 = false;
+      for (MachineInstr &MI : *BB7) {
+        if (MI.isPHI()) {
+          FoundPHIInBB7 = true;
+          llvm::errs() << "Second PHI in bb.7: ";
+          MI.print(llvm::errs());
+          // Verify it has 2 incoming values (4 operands: 2 x (reg, mbb))
+          unsigned NumIncoming = (MI.getNumOperands() - 1) / 2;
+          EXPECT_EQ(NumIncoming, 2u) << "Second PHI in bb.7 should have 2 incoming values (from bb.2 with %1 and bb.6 with first PHI result)";
+          break;
+        }
+      }
+      EXPECT_TRUE(FoundPHIInBB7) << "Should have second PHI in bb.7 (joins bb.2 with %1 and bb.6 with first PHI)";
+      
+      // Should have exactly 2 PHIs
+      EXPECT_EQ(PHICount, 2u) << "Should have inserted exactly TWO PHI nodes (one at bb.6, one at bb.7)";
+      
+      // Verify LiveIntervals are valid
+      EXPECT_TRUE(LIS.hasInterval(NewReg)) << "New register should have live interval";
+      EXPECT_TRUE(LIS.hasInterval(OrigReg)) << "Original register should have live interval";
+      
+      // Debug output if verification fails
+      if (!MF.verify(nullptr, nullptr, nullptr, false)) {
+        llvm::errs() << "MachineFunction verification failed:\n";
+        MF.print(llvm::errs());
+        LIS.print(llvm::errs());
+      }
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test 3: Subregister lane tracking with partial register updates
+//
+// This tests the "LaneAware" part of MachineLaneSSAUpdater.
+//
+// Scenario:
+//   - Start with a 64-bit register %1 (has sub0 and sub1 lanes)
+//   - Insert a new definition that only updates sub0 (lower 32 bits)
+//   - The SSA updater should:
+//     1. Track that only sub0 lane is modified (not sub1)
+//     2. Create PHI that merges only the sub0 lane
+//     3. Preserve the original sub1 lane
+//
+// CFG:
+//     bb.0
+//       |
+//     bb.1 (%1 = 64-bit def, both lanes)
+//     /  \
+//  bb.2  bb.3 (new def updates only %X.sub0)
+//     \  /
+//     bb.4 (needs PHI for sub0 lane only)
+//       |
+//     bb.5 (use both lanes)
+//===----------------------------------------------------------------------===//
+
+TEST(MachineLaneSSAUpdaterTest, SubregisterLaneTracking) {
+  liveIntervalsTest(R"MIR(
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+    ; Create vregs in order: %1, %2, %3
+    %1:vgpr_32 = V_MOV_B32_e32 10, implicit $exec
+    %2:vgpr_32 = V_MOV_B32_e32 20, implicit $exec
+    %3:vreg_64 = REG_SEQUENCE %1, %subreg.sub0, %2, %subreg.sub1
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.3, implicit $scc
+
+  bb.2:
+    successors: %bb.4
+    ; Use sub0 lane only
+    %4:vgpr_32 = V_ADD_U32_e32 %3.sub0, %3.sub0, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.3:
+    successors: %bb.4
+    S_NOP 0
+
+  bb.4:
+    successors: %bb.5
+    ; Use both sub0 and sub1 lanes separately
+    %5:vgpr_32 = V_ADD_U32_e32 %3.sub0, %3.sub1, implicit $exec
+    S_BRANCH %bb.5
+
+  bb.5:
+    ; Use full 64-bit register (tests REG_SEQUENCE path after PHI)
+    %6:vreg_64 = V_LSHLREV_B64_e64 0, %3, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+      
+      // Verify we have the expected number of blocks
+      ASSERT_EQ(MF.size(), 6u) << "Should have bb.0 through bb.5";
+      
+      MachineBasicBlock *BB3 = MF.getBlockNumbered(3);
+      
+      // Get the 64-bit register %3 (vreg_64) from the MIR
+      Register Reg64 = Register::index2VirtReg(3);
+      ASSERT_TRUE(Reg64.isValid()) << "Register %3 should be valid";
+      
+      const TargetRegisterClass *RC64 = MRI.getRegClass(Reg64);
+      ASSERT_EQ(TRI->getRegSizeInBits(*RC64), 64u) << "Register %3 should be 64-bit";
+      llvm::errs() << "Using 64-bit register: %" << Reg64.virtRegIndex() << " (raw: " << Reg64 << ")\n";
+      
+      // Verify it has subranges for lane tracking
+      ASSERT_TRUE(LIS.hasInterval(Reg64)) << "Register should have live interval";
+      LiveInterval &LI = LIS.getInterval(Reg64);
+      if (LI.hasSubRanges()) {
+        llvm::errs() << "Register has subranges (lane tracking active)\n";
+        for (const LiveInterval::SubRange &SR : LI.subranges()) {
+          llvm::errs() << "  Lane mask: " << PrintLaneMask(SR.LaneMask) << "\n";
+        }
+      } else {
+        llvm::errs() << "Warning: Register does not have subranges\n";
+      }
+      
+      // Find the subreg index for a 32-bit subreg of the 64-bit register
+      unsigned Sub0Idx = 0;
+      for (unsigned Idx = 1, E = TRI->getNumSubRegIndices(); Idx <= E; ++Idx) {
+        const TargetRegisterClass *SubRC = TRI->getSubRegisterClass(RC64, Idx);
+        if (SubRC && TRI->getRegSizeInBits(*SubRC) == 32) {
+          Sub0Idx = Idx;
+          break;
+        }
+      }
+      ASSERT_NE(Sub0Idx, 0u) << "Could not find 32-bit subregister index";
+      LaneBitmask Sub0Mask = TRI->getSubRegIndexLaneMask(Sub0Idx);
+      llvm::errs() << "Sub0 index=" << Sub0Idx << " (" << TRI->getSubRegIndexName(Sub0Idx) 
+                   << "), mask=" << PrintLaneMask(Sub0Mask) << "\n";
+      
+      // Insert new definition in bb.3 that defines Reg64.sub0 (partial update, violating SSA)
+      // Use V_MOV with immediate - no liveness dependencies
+      // It's the caller's responsibility to ensure source operands are valid
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      auto InsertPt = BB3->getFirstNonPHI();
+      
+      // Get V_MOV opcode and EXEC register from bb.0
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineInstr *MovInst = &*BB0->begin();
+      unsigned MovOpcode = MovInst->getOpcode();
+      Register ExecReg = MovInst->getOperand(2).getReg();
+      
+      // Create a 32-bit temporary register
+      Register TempReg = MRI.createVirtualRegister(TRI->getSubRegisterClass(RC64, Sub0Idx));
+      
+      // Insert both instructions first (V_MOV and COPY)
+      MachineInstr *TempMI = BuildMI(*BB3, InsertPt, DebugLoc(), TII->get(MovOpcode), TempReg)
+          .addImm(99)
+          .addReg(ExecReg, RegState::Implicit);
+      
+      MachineInstr *NewDefMI = BuildMI(*BB3, InsertPt, DebugLoc(), 
+                                        TII->get(TargetOpcode::COPY))
+          .addReg(Reg64, RegState::Define, Sub0Idx)  // %3.sub0 = (violates SSA)
+          .addReg(TempReg);                           // COPY from temp
+      
+      // Caller's responsibility: index instructions and create live intervals
+      // Do this AFTER inserting both instructions so uses are visible
+      LIS.InsertMachineInstrInMaps(*TempMI);
+      LIS.InsertMachineInstrInMaps(*NewDefMI);
+      LIS.createAndComputeVirtRegInterval(TempReg);
+      
+      // Set MachineFunction properties
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+      
+      // Call MachineLaneSSAUpdater to repair the SSA violation
+      // This should create a new vreg for the subreg def and insert lane-aware PHIs
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, Reg64);
+      
+      llvm::errs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << " (raw: " << NewReg << ")\n";
+      
+      // VERIFY RESULTS:
+      
+      // 1. NewReg should be a 32-bit register (for sub0), not 64-bit
+      EXPECT_TRUE(NewReg.isValid()) << "Updater should create a new register";
+      EXPECT_NE(NewReg, Reg64) << "New register should be different from original";
+      
+      const TargetRegisterClass *NewRC = MRI.getRegClass(NewReg);
+      EXPECT_EQ(TRI->getRegSizeInBits(*NewRC), 32u) << "New register should be 32-bit (subreg class)";
+      
+      // 2. NewDefMI should now define NewReg (not Reg64.sub0)
+      EXPECT_EQ(NewDefMI->getOperand(0).getReg(), NewReg) << "NewDefMI should now define new 32-bit register";
+      EXPECT_EQ(NewDefMI->getOperand(0).getSubReg(), 0u) << "NewDefMI should no longer have subreg index";
+      
+      // 3. Verify PHIs were inserted where needed
+      MachineBasicBlock *BB4 = MF.getBlockNumbered(4);
+      bool FoundPHI = false;
+      for (MachineInstr &MI : *BB4) {
+        if (MI.isPHI()) {
+          FoundPHI = true;
+          llvm::errs() << "Found PHI in bb.4: ";
+          MI.print(llvm::errs());
+          break;
+        }
+      }
+      EXPECT_TRUE(FoundPHI) << "Should have inserted PHI for sub0 lane in bb.4";
+      
+      // 4. Verify LiveIntervals are valid
+      EXPECT_TRUE(LIS.hasInterval(NewReg)) << "New register should have live interval";
+      
+      // Debug output if verification fails
+      if (!MF.verify(nullptr, nullptr, nullptr, false)) {
+        llvm::errs() << "MachineFunction verification failed:\n";
+        MF.print(llvm::errs());
+        LIS.print(llvm::errs());
+      }
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test 4: Subreg def → Full register PHI (REG_SEQUENCE before PHI)
+//
+// This tests the critical case where:
+// - Input MIR has a PHI that expects full 64-bit register from both paths
+// - We insert a subreg definition (X.sub0) on one path
+// - The updater must build a REG_SEQUENCE before the PHI to combine:
+//     NewSubreg (sub0) + OriginalReg.sub1 → FullReg for PHI
+//
+// CFG:
+//     bb.0 (entry)
+//       |
+//     bb.1 (X=1, full 64-bit def)
+//      / \
+//   bb.2  bb.3
+//   (Y=2)  / \
+//     |  bb.4  bb.5 (NEW DEF: X.sub0 = 3) ← inserted by test
+//     |    \  /
+//     |    bb.6 (first join: bb.4 + bb.5, may need REG_SEQUENCE)
+//     |    /
+//     \  /
+//     bb.7 (second join: PHI Z = PHI(Y, bb.2, X, bb.6)) ← already in input MIR
+//       |
+//     bb.8 (use Z)
+//
+// Expected: REG_SEQUENCE in bb.6 before branching to bb.7
+//===----------------------------------------------------------------------===//
+
+TEST(MachineLaneSSAUpdaterTest, SubregDefToFullRegPHI) {
+  liveIntervalsTest(R"MIR(
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+    ; X = 1 (full 64-bit register)
+    %1:vgpr_32 = V_MOV_B32_e32 10, implicit $exec
+    %2:vgpr_32 = V_MOV_B32_e32 11, implicit $exec
+    %3:vreg_64 = REG_SEQUENCE %1, %subreg.sub0, %2, %subreg.sub1
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.3, implicit $scc
+
+  bb.2:
+    successors: %bb.7
+    ; Y = 2 (full 64-bit register, different from X)
+    %4:vgpr_32 = V_MOV_B32_e32 20, implicit $exec
+    %5:vgpr_32 = V_MOV_B32_e32 21, implicit $exec
+    %6:vreg_64 = REG_SEQUENCE %4, %subreg.sub0, %5, %subreg.sub1
+    S_BRANCH %bb.7
+
+  bb.3:
+    successors: %bb.4, %bb.5
+    $sgpr2 = S_MOV_B32 0
+    $sgpr3 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr2, $sgpr3, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.5, implicit $scc
+
+  bb.4:
+    successors: %bb.6
+    S_NOP 0
+    S_BRANCH %bb.6
+
+  bb.5:
+    successors: %bb.6
+    ; New def will be inserted here: X.sub0 = 3
+    S_NOP 0
+
+  bb.6:
+    successors: %bb.7
+    S_BRANCH %bb.7
+
+  bb.7:
+    ; PHI already in input MIR, expects full 64-bit from both paths
+    %7:vreg_64 = PHI %6:vreg_64, %bb.2, %3:vreg_64, %bb.6
+    S_BRANCH %bb.8
+
+  bb.8:
+    ; Use Z
+    %8:vreg_64 = V_LSHLREV_B64_e64 0, %7, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+      
+      ASSERT_EQ(MF.size(), 9u) << "Should have bb.0 through bb.8";
+      
+      MachineBasicBlock *BB5 = MF.getBlockNumbered(5); // New def inserted here
+      MachineBasicBlock *BB6 = MF.getBlockNumbered(6); // First join (bb.4 + bb.5)
+      MachineBasicBlock *BB7 = MF.getBlockNumbered(7); // PHI block (bb.2 + bb.6)
+      
+      // Get register X (%3, the 64-bit register from bb.1)
+      Register RegX = Register::index2VirtReg(3);
+      ASSERT_TRUE(RegX.isValid()) << "Register %3 (X) should be valid";
+      
+      const TargetRegisterClass *RC64 = MRI.getRegClass(RegX);
+      ASSERT_EQ(TRI->getRegSizeInBits(*RC64), 64u) << "Register X should be 64-bit";
+      
+      // Find sub0 index (32-bit subregister)
+      unsigned Sub0Idx = 0;
+      for (unsigned Idx = 1, E = TRI->getNumSubRegIndices(); Idx <= E; ++Idx) {
+        const TargetRegisterClass *SubRC = TRI->getSubRegisterClass(RC64, Idx);
+        if (SubRC && TRI->getRegSizeInBits(*SubRC) == 32) {
+          Sub0Idx = Idx;
+          break;
+        }
+      }
+      ASSERT_NE(Sub0Idx, 0u) << "Could not find 32-bit subregister index";
+      
+      // Insert new definition in bb.5: X.sub0 = 3
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      auto InsertPt = BB5->getFirstNonPHI();
+      
+      // Get V_MOV opcode and EXEC register
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineInstr *MovInst = &*BB0->begin();
+      unsigned MovOpcode = MovInst->getOpcode();
+      Register ExecReg = MovInst->getOperand(2).getReg();
+      
+      // Create temporary register
+      Register TempReg = MRI.createVirtualRegister(TRI->getSubRegisterClass(RC64, Sub0Idx));
+      
+      MachineInstr *TempMI = BuildMI(*BB5, InsertPt, DebugLoc(), TII->get(MovOpcode), TempReg)
+          .addImm(30)
+          .addReg(ExecReg, RegState::Implicit);
+      
+      MachineInstr *NewDefMI = BuildMI(*BB5, InsertPt, DebugLoc(), 
+                                        TII->get(TargetOpcode::COPY))
+          .addReg(RegX, RegState::Define, Sub0Idx)  // X.sub0 = 
+          .addReg(TempReg);
+      
+      // Index instructions and create live interval for temp
+      LIS.InsertMachineInstrInMaps(*TempMI);
+      LIS.InsertMachineInstrInMaps(*NewDefMI);
+      LIS.createAndComputeVirtRegInterval(TempReg);
+      
+      // Set MachineFunction properties
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+      
+      // Call SSA updater
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, RegX);
+      
+      llvm::errs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << " (raw: " << NewReg << ")\n";
+      
+      // VERIFY RESULTS:
+      
+      // 1. New register should be 32-bit (subreg class)
+      EXPECT_TRUE(NewReg.isValid());
+      EXPECT_NE(NewReg, RegX);
+      const TargetRegisterClass *NewRC = MRI.getRegClass(NewReg);
+      EXPECT_EQ(TRI->getRegSizeInBits(*NewRC), 32u) << "New register should be 32-bit";
+      
+      // 2. NewDefMI should now define NewReg without subreg index
+      EXPECT_EQ(NewDefMI->getOperand(0).getReg(), NewReg);
+      EXPECT_EQ(NewDefMI->getOperand(0).getSubReg(), 0u);
+      
+      // 3. Check the existing PHI in bb.7
+      bool FoundPHI = false;
+      Register PHIReg;
+      MachineInstr *PHI = nullptr;
+      for (MachineInstr &MI : *BB7) {
+        if (MI.isPHI()) {
+          FoundPHI = true;
+          PHI = &MI;
+          PHIReg = MI.getOperand(0).getReg();
+          llvm::errs() << "PHI in bb.7 after SSA repair: ";
+          MI.print(llvm::errs());
+          break;
+        }
+      }
+      ASSERT_TRUE(FoundPHI) << "Should have PHI in bb.7 (from input MIR)";
+      
+      // 4. CRITICAL: Check for REG_SEQUENCE in bb.6 (first join, before branch to PHI)
+      // The updater must build REG_SEQUENCE to provide full register to the PHI
+      bool FoundREGSEQ = false;
+      for (MachineInstr &MI : *BB6) {
+        if (MI.getOpcode() == TargetOpcode::REG_SEQUENCE) {
+          FoundREGSEQ = true;
+          llvm::errs() << "Found REG_SEQUENCE in bb.6: ";
+          MI.print(llvm::errs());
+          
+          // Should combine new sub0 with original sub1
+          EXPECT_GE(MI.getNumOperands(), 5u) << "REG_SEQUENCE should have result + 2 source pairs";
+          break;
+        }
+      }
+      EXPECT_TRUE(FoundREGSEQ) << "Should have built REG_SEQUENCE in bb.6 to provide full register to PHI in bb.7";
+      
+      // 5. Verify LiveIntervals
+      EXPECT_TRUE(LIS.hasInterval(NewReg));
+      EXPECT_TRUE(LIS.hasInterval(PHIReg));
+      
+      // Debug output if verification fails
+      if (!MF.verify(nullptr, nullptr, nullptr, false)) {
+        llvm::errs() << "MachineFunction verification failed:\n";
+        MF.print(llvm::errs());
+        LIS.print(llvm::errs());
+      }
+    });
+}
+
+} // anonymous namespace

--- a/llvm/unittests/CodeGen/MachineLaneSSAUpdaterTest.cpp
+++ b/llvm/unittests/CodeGen/MachineLaneSSAUpdaterTest.cpp
@@ -273,7 +273,8 @@ TEST(MachineLaneSSAUpdaterTest, NewDefInsertsPhiAndRewritesUses) {
       //         NewDefMI in bb.3 also defines %1 (violating SSA!)
       // After repair: NewDefMI will define a new vreg, bb.4 gets PHI
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       // VERIFY RESULTS:
       
@@ -302,6 +303,401 @@ TEST(MachineLaneSSAUpdaterTest, NewDefInsertsPhiAndRewritesUses) {
       // Verify the MachineFunction is still valid after SSA repair
       EXPECT_TRUE(MF.verify(nullptr, /* Banner=*/nullptr, /*OS=*/nullptr, /* AbortOnError=*/false))
           << "MachineFunction verification failed after SSA repair";
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test: Parallel-path PHI operands & use-rewriting (regression for d481f9ac9a90)
+//
+// On a diamond where only ONE path redefines OrigReg (simulating a reload on a
+// spill-path), the repair must:
+//   (a) insert a PHI at the join that merges NewReg (from the redef pred) with
+//       OrigReg (from the clean pred),
+//   (b) rewrite the dominated use at the join to consume the PHI result (NOT
+//       the raw OrigReg).
+//
+// Prior to d481f9ac9a90, defReachesUse incorrectly checked only dominance of
+// the def to the PHI's predecessor, so the clean-path predecessor was skipped
+// and the join use kept pointing at OrigReg.
+//
+// CFG:
+//       bb.0 (entry: %0 = orig def, cond branch)
+//       /  \
+//    bb.1   bb.2        <- bb.1 = spill path; test inserts %0 = NEW_DEF here
+//       \  /
+//       bb.3 (use %0)
+//===----------------------------------------------------------------------===//
+TEST(MachineLaneSSAUpdaterTest, ParallelPathPhiOperandsAfterRedef) {
+  liveIntervalsTest(R"MIR(
+    successors: %bb.1, %bb.2
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.3
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.3
+    S_NOP 0
+    S_BRANCH %bb.3
+
+  bb.3:
+    %99:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+
+      ASSERT_EQ(MF.size(), 4u) << "Should have bb.0..bb.3";
+
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineBasicBlock *BB1 = MF.getBlockNumbered(1);  // spill path
+      MachineBasicBlock *BB2 = MF.getBlockNumbered(2);  // clean path
+      MachineBasicBlock *BB3 = MF.getBlockNumbered(3);  // join
+
+      MachineInstr *OrigDefMI = &*BB0->begin();
+      Register OrigReg = OrigDefMI->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid());
+      unsigned MovOpcode = OrigDefMI->getOpcode();
+      Register ExecReg = OrigDefMI->getOperand(2).getReg();
+
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      auto InsertPt = BB1->getFirstTerminator();
+      MachineInstr *NewDefMI = BuildMI(*BB1, InsertPt, DebugLoc(),
+                                       TII->get(MovOpcode), OrigReg)
+                                  .addImm(42)
+                                  .addReg(ExecReg, RegState::Implicit);
+
+      MF.getProperties().set(MachineFunctionProperties::Property::IsSSA);
+      MF.getProperties().reset(MachineFunctionProperties::Property::NoPHIs);
+
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
+
+      ASSERT_TRUE(NewReg.isValid());
+      EXPECT_NE(NewReg, OrigReg);
+      EXPECT_EQ(NewDefMI->getOperand(0).getReg(), NewReg);
+
+      EXPECT_FALSE(PHIDefOps.empty())
+          << "repair should have reported PHI operands via PHIDefOps";
+
+      MachineInstr *JoinPHI = nullptr;
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) { JoinPHI = &MI; break; }
+      }
+      ASSERT_NE(JoinPHI, nullptr) << "Expected a PHI at join block bb.3";
+
+      ASSERT_EQ(JoinPHI->getNumOperands(), 5u)
+          << "PHI: 1 def + 2*(reg,mbb) = 5 operands";
+
+      DenseMap<MachineBasicBlock *, Register> Incoming;
+      for (unsigned i = 1, e = JoinPHI->getNumOperands(); i < e; i += 2) {
+        Register R = JoinPHI->getOperand(i).getReg();
+        MachineBasicBlock *P = JoinPHI->getOperand(i + 1).getMBB();
+        Incoming[P] = R;
+      }
+      ASSERT_EQ(Incoming.size(), 2u);
+      EXPECT_EQ(Incoming[BB1], NewReg)
+          << "PHI operand from spill-path predecessor bb.1 must be NewReg";
+      EXPECT_EQ(Incoming[BB2], OrigReg)
+          << "PHI operand from clean-path predecessor bb.2 must be OrigReg";
+
+      Register PHIRes = JoinPHI->getOperand(0).getReg();
+      bool JoinUseRewritten = false;
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) continue;
+        for (const MachineOperand &MO : MI.uses()) {
+          if (MO.isReg() && MO.getReg() == PHIRes) {
+            JoinUseRewritten = true;
+            break;
+          }
+        }
+        if (JoinUseRewritten) break;
+      }
+      EXPECT_TRUE(JoinUseRewritten)
+          << "Use at join must be rewritten to the PHI result";
+
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) continue;
+        for (const MachineOperand &MO : MI.uses()) {
+          if (MO.isReg())
+            EXPECT_NE(MO.getReg(), OrigReg)
+                << "No non-PHI use of OrigReg should remain in bb.3";
+        }
+      }
+
+      EXPECT_TRUE(LIS.hasInterval(NewReg));
+      EXPECT_TRUE(LIS.hasInterval(OrigReg));
+      EXPECT_TRUE(MF.verify(nullptr, nullptr, nullptr, false))
+          << "MachineFunction verification failed after SSA repair";
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test: isUseReachableFromDef coverage (both overloads, all paths)
+//
+// The API has two fast paths and one slow path:
+//   - Same block: instruction-order check.
+//   - Different blocks, def dominates use block: true.
+//   - Different blocks, not dominated: compute pruned IDF of def block and
+//     check whether the use block (or PHI predecessor) is in/dominated-by it.
+//
+// CFG (extended parallel-path diamond with an extra same-block use):
+//       bb.0 (entry: %0 = orig def, then %10 = V_ADD %0,%0, then cond branch)
+//       /  \
+//    bb.1   bb.2
+//       \  /
+//       bb.3 (use %0)
+//===----------------------------------------------------------------------===//
+TEST(MachineLaneSSAUpdaterTest, IsUseReachableFromDef) {
+  liveIntervalsTest(R"MIR(
+    successors: %bb.1, %bb.2
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    %10:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.3
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.3
+    S_NOP 0
+    S_BRANCH %bb.3
+
+  bb.3:
+    %99:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+
+      ASSERT_EQ(MF.size(), 4u);
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineBasicBlock *BB1 = MF.getBlockNumbered(1);
+      MachineBasicBlock *BB3 = MF.getBlockNumbered(3);
+
+      MachineInstr *OrigDefMI = &*BB0->begin();
+      Register OrigReg = OrigDefMI->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid());
+      unsigned MovOpcode = OrigDefMI->getOpcode();
+      Register ExecReg = OrigDefMI->getOperand(2).getReg();
+
+      // Pre-diamond use of %0 in bb.0.
+      MachineInstr *UseBeforeMI = nullptr;
+      for (MachineInstr &MI : *BB0) {
+        if (&MI == OrigDefMI) continue;
+        for (const MachineOperand &MO : MI.uses()) {
+          if (MO.isReg() && MO.getReg() == OrigReg) {
+            UseBeforeMI = &MI; break;
+          }
+        }
+        if (UseBeforeMI) break;
+      }
+      ASSERT_NE(UseBeforeMI, nullptr);
+
+      // Join-block use of %0 in bb.3.
+      MachineInstr *UseAfterMI = nullptr;
+      for (MachineInstr &MI : *BB3) {
+        if (MI.isPHI()) continue;
+        for (const MachineOperand &MO : MI.uses()) {
+          if (MO.isReg() && MO.getReg() == OrigReg) {
+            UseAfterMI = &MI; break;
+          }
+        }
+        if (UseAfterMI) break;
+      }
+      ASSERT_NE(UseAfterMI, nullptr);
+
+      // We need a DefMI whose parent is bb.1 so the reachability query can
+      // treat bb.1 as the "def block". The API under test inspects only
+      // DefMI->getParent() (and, for the MachineOperand overload, the def
+      // operand's lane mask); it does NOT look at what vreg the instruction
+      // actually defines. That gives us a choice:
+      //
+      //   (a) redef OrigReg (%0) in bb.1 -- violates SSA (two defs of %0)
+      //       and the test harness's MF.verify() call would legitimately
+      //       fail at teardown, making the test report a false failure;
+      //
+      //   (b) define a FRESH vreg in bb.1 -- SSA stays clean, MF.verify()
+      //       passes, and the query still uses bb.1 as the def block.
+      //
+      // Option (b) is what we do here: DefInBB1MI writes a brand-new
+      // DummyReg of the same register class as OrigReg, purely to anchor
+      // a MachineInstr in bb.1. We continue to pass OrigReg as the
+      // "register under analysis" argument to isUseReachableFromDef.
+      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+      Register DummyReg = MRI.createVirtualRegister(MRI.getRegClass(OrigReg));
+      MachineInstr *DefInBB1MI = BuildMI(*BB1, BB1->getFirstTerminator(),
+                                         DebugLoc(), TII->get(MovOpcode), DummyReg)
+                                     .addImm(42)
+                                     .addReg(ExecReg, RegState::Implicit);
+      LIS.InsertMachineInstrInMaps(*DefInBB1MI);
+      // DummyReg is a brand-new vreg; LIS expects every vreg to have a
+      // LiveInterval. Compute it now so MF.verify() at teardown is happy.
+      LIS.createAndComputeVirtRegInterval(DummyReg);
+
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      LaneBitmask FullMask = MRI.getMaxLaneMaskForVReg(OrigReg);
+
+      // (1) Same-block fast path: OrigDefMI precedes UseBeforeMI in bb.0.
+      EXPECT_TRUE(Updater.isUseReachableFromDef(OrigDefMI, UseBeforeMI,
+                                                OrigReg, FullMask))
+          << "Same-block def before use should be reachable";
+
+      // (2) Dominance fast path: bb.0 dominates bb.3.
+      EXPECT_TRUE(Updater.isUseReachableFromDef(OrigDefMI, UseAfterMI,
+                                                OrigReg, FullMask))
+          << "Def block dominates use block -> reachable";
+
+      // (3) IDF slow path: bb.1 does NOT dominate bb.3, but bb.3 is in IDF(bb.1).
+      EXPECT_TRUE(Updater.isUseReachableFromDef(DefInBB1MI, UseAfterMI,
+                                                OrigReg, FullMask))
+          << "Use is not dominated but is in IDF of def block -> reachable";
+
+      // (4) Negative: bb.0 is upstream of bb.1; not in IDF(bb.1), not dominated.
+      EXPECT_FALSE(Updater.isUseReachableFromDef(DefInBB1MI, UseBeforeMI,
+                                                 OrigReg, FullMask))
+          << "Upstream use is not reachable from def";
+
+      // (5) MachineOperand overload agrees on the IDF case.
+      MachineOperand &DefInBB1Op = DefInBB1MI->getOperand(0);
+      MachineOperand *UseAfterOp =
+          UseAfterMI->findRegisterUseOperand(OrigReg, TRI, /*isKill=*/false);
+      ASSERT_NE(UseAfterOp, nullptr);
+      EXPECT_TRUE(Updater.isUseReachableFromDef(DefInBB1Op, *UseAfterOp, OrigReg))
+          << "MachineOperand overload should agree on IDF-reachable case";
+    });
+}
+
+//===----------------------------------------------------------------------===//
+// Test: IDF cache hit/miss/clear + IDFCacheKey hash behavior
+//
+// Exercises:
+//   - getPrunedIDF() deterministic result (cache HIT on repeat call)
+//   - Different DefBlock key gets its own cache entry (no cross-talk)
+//   - clearIDFCache() invalidates; recompute still correct
+//   - IDFCacheKey equality / DenseMapInfo hash stability
+//
+// CFG: 4-block diamond. For %0 defined in bb.0 and used in bb.3, the pruned
+// IDF of bb.1 (or bb.2) is {bb.3}.
+//===----------------------------------------------------------------------===//
+TEST(MachineLaneSSAUpdaterTest, IDFCacheBehavior) {
+  liveIntervalsTest(R"MIR(
+    successors: %bb.1, %bb.2
+    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    $sgpr0 = S_MOV_B32 0
+    $sgpr1 = S_MOV_B32 1
+    S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.3
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.3
+    S_NOP 0
+    S_BRANCH %bb.3
+
+  bb.3:
+    %99:vgpr_32 = V_ADD_U32_e32 %0, %0, implicit $exec
+    S_ENDPGM 0
+)MIR",
+    [](MachineFunction &MF, LiveIntervalsWrapperPass &LISWrapper) {
+      LiveIntervals &LIS = LISWrapper.getLIS();
+      MachineDominatorTree MDT(MF);
+      const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+      MachineRegisterInfo &MRI = MF.getRegInfo();
+
+      ASSERT_EQ(MF.size(), 4u);
+      MachineBasicBlock *BB0 = MF.getBlockNumbered(0);
+      MachineBasicBlock *BB1 = MF.getBlockNumbered(1);
+      MachineBasicBlock *BB2 = MF.getBlockNumbered(2);
+      MachineBasicBlock *BB3 = MF.getBlockNumbered(3);
+
+      Register OrigReg = BB0->begin()->getOperand(0).getReg();
+      ASSERT_TRUE(OrigReg.isValid());
+
+      MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
+      LaneBitmask FullMask = MRI.getMaxLaneMaskForVReg(OrigReg);
+
+      // (1) First call: cache MISS. Compute and remember result.
+      SmallVector<MachineBasicBlock *, 4> Out1;
+      Updater.getPrunedIDF(OrigReg, FullMask, BB1, Out1);
+      ASSERT_EQ(Out1.size(), 1u)
+          << "IDF(bb.1) for this diamond should be {bb.3}";
+      EXPECT_EQ(Out1[0], BB3);
+
+      // (2) Repeat with the SAME key: cache HIT. Result must be identical
+      //     (both size and contents, in the same order).
+      SmallVector<MachineBasicBlock *, 4> Out2;
+      Updater.getPrunedIDF(OrigReg, FullMask, BB1, Out2);
+      ASSERT_EQ(Out2.size(), Out1.size());
+      for (size_t i = 0, e = Out1.size(); i < e; ++i)
+        EXPECT_EQ(Out2[i], Out1[i])
+            << "Cache HIT must return the same vector as the original compute";
+
+      // (3) Different DefBlock key: gets its own cache entry. In this
+      //     symmetric diamond IDF(bb.2) is also {bb.3}, but it's stored
+      //     under a distinct IDFCacheKey (different DefBlockNum).
+      SmallVector<MachineBasicBlock *, 4> Out3;
+      Updater.getPrunedIDF(OrigReg, FullMask, BB2, Out3);
+      ASSERT_EQ(Out3.size(), 1u);
+      EXPECT_EQ(Out3[0], BB3);
+
+      // (4) Clear cache, then recompute: must still be correct.
+      Updater.clearIDFCache();
+      SmallVector<MachineBasicBlock *, 4> Out4;
+      Updater.getPrunedIDF(OrigReg, FullMask, BB1, Out4);
+      ASSERT_EQ(Out4.size(), Out1.size());
+      for (size_t i = 0, e = Out1.size(); i < e; ++i)
+        EXPECT_EQ(Out4[i], Out1[i])
+            << "After clearIDFCache(), recompute must match original result";
+
+      // (5) IDFCacheKey: operator== + DenseMapInfo hash behavior.
+      using Key = MachineLaneSSAUpdater::IDFCacheKey;
+      using DMI = DenseMapInfo<Key>;
+
+      const unsigned BB1Num = static_cast<unsigned>(BB1->getNumber());
+      const unsigned BB2Num = static_cast<unsigned>(BB2->getNumber());
+
+      Key KA{OrigReg, FullMask, BB1Num};
+      Key KB{OrigReg, FullMask, BB1Num};        // equal to KA
+      Key KDiffBlock{OrigReg, FullMask, BB2Num}; // different DefBlockNum
+      Key KDiffMask{OrigReg, LaneBitmask::getNone(), BB1Num}; // different mask
+
+      EXPECT_TRUE(KA == KB);
+      EXPECT_FALSE(KA == KDiffBlock);
+      EXPECT_FALSE(KA == KDiffMask);
+
+      EXPECT_TRUE(DMI::isEqual(KA, KB));
+      EXPECT_FALSE(DMI::isEqual(KA, KDiffBlock));
+      EXPECT_FALSE(DMI::isEqual(KA, KDiffMask));
+
+      // Equal keys MUST hash equal. (Unequal keys usually hash differently,
+      // but that's not a DenseMap requirement, so we don't assert it.)
+      EXPECT_EQ(DMI::getHashValue(KA), DMI::getHashValue(KB));
+
+      // Empty/Tombstone keys from DenseMapInfo must compare unequal to KA.
+      EXPECT_FALSE(DMI::isEqual(KA, DMI::getEmptyKey()));
+      EXPECT_FALSE(DMI::isEqual(KA, DMI::getTombstoneKey()));
     });
 }
 
@@ -425,7 +821,8 @@ TEST(MachineLaneSSAUpdaterTest, MultiplePhiInsertion) {
       
       // Call MachineLaneSSAUpdater
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       EXPECT_TRUE(NewReg.isValid()) << "Updater should create a new register";
       EXPECT_NE(NewReg, OrigReg) << "New register should be different from original";
@@ -648,7 +1045,8 @@ TEST(MachineLaneSSAUpdaterTest, SubregisterLaneTracking) {
       // Call MachineLaneSSAUpdater to repair the SSA violation
       // This should create a new vreg for the subreg def and insert lane-aware PHIs
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, Reg64);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, Reg64, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << " (raw: " << NewReg << ")\n");
       
@@ -833,7 +1231,8 @@ TEST(MachineLaneSSAUpdaterTest, SubregDefToFullRegPHI) {
       
       // Call SSA updater
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, RegX);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, RegX, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << " (raw: " << NewReg << ")\n");
       
@@ -995,7 +1394,8 @@ TEST(MachineLaneSSAUpdaterTest, LoopWithDefInBody) {
       
       // Call SSA updater
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << "\n");
       
@@ -1216,7 +1616,8 @@ TEST(MachineLaneSSAUpdaterTest, ComplexLoopWithDiamondAndUseBeforeDef) {
       
       // Call SSA updater
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << "\n");
       
@@ -1505,7 +1906,8 @@ body: |
       
       // Create SSA updater and repair after first insertion
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg1 = Updater.repairSSAForNewDef(NewDefMI1, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg1 = Updater.repairSSAForNewDef(NewDefMI1, OrigReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair #1 created new register: %" << NewReg1.virtRegIndex() << "\n");
       
@@ -1544,7 +1946,7 @@ body: |
       LLVM_DEBUG(NewDefMI2.print(dbgs()));
       
       // Repair SSA after second insertion (for %3, the increment result)
-      Register NewReg2 = Updater.repairSSAForNewDef(NewDefMI2, IncrementReg);
+      Register NewReg2 = Updater.repairSSAForNewDef(NewDefMI2, IncrementReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair #2 created new register: %" << NewReg2.virtRegIndex() << "\n");
       
@@ -1753,7 +2155,8 @@ body: |
       
       // Create SSA updater and repair
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << "\n");
       
@@ -2054,7 +2457,8 @@ body: |
       
       // Create SSA updater and repair
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << "\n");
       
@@ -2254,7 +2658,8 @@ body: |
       
       // Create SSA updater and repair
       MachineLaneSSAUpdater Updater(MF, LIS, MDT, *TRI);
-      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg);
+      SmallVector<MachineOperand *, 4> PHIDefOps;
+      Register NewReg = Updater.repairSSAForNewDef(*NewDefMI, OrigReg, PHIDefOps);
       
       LLVM_DEBUG(dbgs() << "SSA repair created new register: %" << NewReg.virtRegIndex() << "\n");
       


### PR DESCRIPTION
📌 Problem
When inserting new definitions into Machine IR (e.g., reloads after spills, rematerialized values, or optimization-driven value rewriting), maintaining SSA form is non-trivial, especially with subregister lanes:

1. SSA Violation: Inserting a new def of an existing vreg creates multiple definitions, violating SSA
2. Subregister Complexity: Partial redefinitions (e.g., redefining only sub2_3 of a 128-bit register) require lane-aware PHI insertion
3. LiveInterval Corruption: Naive rewriting breaks LiveIntervals, causing downstream passes to fail
4. PHI Placement: Computing where to insert PHI nodes requires pruned Iterated Dominance Frontier (IDF) analysis
5. Use Rewriting: Rewriting uses must handle three cases:

   - Exact match: Direct substitution
   - Subset: Subreg remapping (use needs fewer lanes than def provides)
   - Super/Mixed: REG_SEQUENCE insertion (use needs more lanes than def provides)

Existing LLVM utilities (MachineSSAUpdater, LiveRangeEdit) either lack subregister awareness or are tightly coupled to specific passes, making them unsuitable for general-purpose SSA repair.

🧩 Solution
This patch introduces MachineLaneSSAUpdater, a universal SSA repair utility for Machine IR with full subregister lane awareness.
Core API:
`class MachineLaneSSAUpdater {`
`public:`
    `// Main entry point: Repair SSA for a new definition`
    `// NewDefMI: Instruction with def operand that currently defines OrigVReg (violates SSA)`
    `// Returns: Newly created virtual register`
    `Register repairSSAForNewDef(MachineInstr &NewDefMI, Register OrigVReg);`
`};`

Key Features:

1. Lane-Aware PHI Insertion: Uses pruned IDF intersected with LiveInterval subranges to place PHIs only where necessary
2. Intelligent Use Rewriting:

  - Exact match → direct substitution
  - Subset → subreg index remapping with lane mask shifting
  - Super/Mixed → REG_SEQUENCE synthesis with optimal subregister covering
3. LiveInterval Preservation: Automatically extends/recomputes LiveIntervals for all modified vregs
4. Dominance-Based Reachability: Uses MachineDominatorTree for robust def-use analysis during reconstruction
5. Non-Contiguous Lane Support: Handles complex cases like "redefine sub2 of vreg_128, leaving sub0+sub1+sub3"

🔬 Design Highlights
Algorithm Overview:
Rename: Create new vreg, update NewDefMI to define it

1. PHI Placement: Compute pruned IDF(NewDef) ∩ LiveIn(OrigVReg, DefMask)
2. Iterative PHI Insertion: Place PHIs with per-edge lane analysis
3. Use Rewriting: Walk dominated uses, apply exact/subset/super policy
4. LiveInterval Repair: Extend/recompute all affected intervals
5. Verification: Update dead flags, optionally verify MachineFunction

Pruned IDF Computation:
  - Intersects IDF of new def blocks with blocks where OrigVReg[DefMask] is live-in
  - Uses LLVM's IDFCalculatorBase for correctness
  - Avoids placing PHIs in unreachable or irrelevant blocks

REG_SEQUENCE Synthesis:

- For super-uses (use needs lanes from both old and new defs), builds REG_SEQUENCE merging:

  - Lanes from NewVReg (rewritten lanes)
  - Lanes from OrigVReg (unchanged lanes)

- Handles non-contiguous lane masks via getCoveringSubRegsForLaneMask():

  - Sorts candidates by lane count (prefer larger subregs)
  - Greedily selects minimal covering set
  - Example: LanesFromOld = 0x0F | 0xF0 → [sub0, sub2] not [lo16, hi16, sub2, sub3]


🚧 Limitations / Future Work

  - Target Scope: Currently tested on AMDGPU; other targets should work but need validation
  - Integration: Not wired into any existing passes yet (self-contained infrastructure)
  - Optimization: REG_SEQUENCE synthesis could be optimized further for specific target constraints
  - Undef Handling: Policy for undef edges (UndefEdgeAsImplicitDef) is placeholder, not fully exercised

📖 Usage Example
Spill/Reload Scenario:
`// Insert reload instruction that violates SSA`
`MachineInstr *ReloadMI = BuildMI(MBB, InsertPt, DL, TII->get(LoadOp), SpilledReg)`
                                    `.addFrameIndex(StackSlot);`

`// Repair SSA form`
`MachineLaneSSAUpdater Updater(MF, LIS, MDT, TRI);`
`Register NewReg = Updater.repairSSAForNewDef(*ReloadMI, SpilledReg);`

`// Done! ReloadMI now defines NewReg, uses are rewritten, PHIs inserted, LiveIntervals updated`

Partial Subreg Reload:
`// Reload only sub2_3 (64-bit) of a 128-bit register`
`MachineInstr *ReloadMI = BuildMI(MBB, InsertPt, DL, TII->get(LoadOp))`
                             `.addReg(SpilledReg, RegState::Define, AMDGPU::sub2_3)`
                             `.addFrameIndex(StackSlot);`

`Updater.repairSSAForNewDef(*ReloadMI, SpilledReg);`
`// Updater automatically detects lane mask from subreg index, places lane-specific PHIs`

🔗 Related Work
This patch provides the SSA repair infrastructure needed for:

  - SSA-Based Register Allocation (upcoming)
  - SSA-Based Spilling with Belady's algorithm (PR #156079 Next-Use Analysis)
  - Rematerialization optimizations
  - Late optimizations that insert new definitions

🧪 Testing
Unit Tests (llvm/unittests/CodeGen/MachineLaneSSAUpdaterTest.cpp, MachineLaneSSAUpdaterSpillReloadTest.cpp):
Test scenarios:
Simple linear reload (no PHI needed)
  ✅ Diamond CFG (PHI insertion at join point)
  ✅ Partial subreg reloads (e.g., reload only sub2_3 of vreg_128)
  ✅ Multiple predecessor PHIs with mixed lane sources
  ✅ Non-contiguous lane masks
  ✅ Same-block def-use with multiple uses
 ✅ REG_SEQUENCE synthesis for super-uses

Verification:

  - All tests run MachineFunction::verify() to ensure correctness
  - LiveInterval consistency checked via LiveInterval::verify()
  - Tests use MIR format for reproducibility