### PR TITLE
[objdump] Fix dxcontainer tests on big endian host

### DIFF
--- a/llvm/test/tools/llvm-objcopy/DXContainer/dump-section.yaml
+++ b/llvm/test/tools/llvm-objcopy/DXContainer/dump-section.yaml
@@ -11,7 +11,7 @@
 ## Dump the PSV0 part and verify its size.
 # RUN: llvm-objcopy --dump-section=PSV0=%t.psv0 %t.dxbc
 # RUN: wc -c %t.psv0 | FileCheck %s --check-prefix=PSV0-SIZE
-# RUN: od -h %t.psv0 | FileCheck %s --check-prefix=PSV0-CONTENTS
+# RUN: od -v -Ax -t x1 %t.psv0 | FileCheck %s --check-prefix=PSV0-CONTENTS
 # PSV0-SIZE: 76
 
 # For a compute shader the structure size is encoded followed by a bunch of 00'd
@@ -20,8 +20,8 @@
 # TODO: Update this test to use objdump or obj2yaml once we support
 # --add-section in objcopy. See issue:
 # https://github.com/llvm/llvm-project/issues/162159.
-# PSV0-CONTENTS: 0000000      0034    0000    0000    0000    0000    0000    0000    0000
-# PSV0-CONTENTS: 0000020      0000    0000    0000    0000    ffff    ffff    0005    0000
+# PSV0-CONTENTS: 0000000 34 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# PSV0-CONTENTS: 0000010 00 00 00 00 00 00 00 00 ff ff ff ff 05 00 00 00
 
 --- !dxcontainer
 Header:


### PR DESCRIPTION
This fixes a build regression on big endian systems introduced in #159999.