### PR TITLE
[Offload] Enable more refined debug printing

### DIFF
--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -37,12 +37,12 @@ class OffloadPolicy {
       return;
     default:
       if (PM.getNumDevices()) {
-        DP("Default TARGET OFFLOAD policy is now mandatory "
-           "(devices were found)\n");
+        DPIF(RTL, "Default TARGET OFFLOAD policy is now mandatory "
+                  "(devices were found)\n");
         Kind = MANDATORY;
       } else {
-        DP("Default TARGET OFFLOAD policy is now disabled "
-           "(no devices were found)\n");
+        DPIF(RTL, "Default TARGET OFFLOAD policy is now disabled "
+                  "(no devices were found)\n");
         Kind = DISABLED;
       }
       return;

--- a/offload/include/OpenMP/OMPT/Connector.h
+++ b/offload/include/OpenMP/OMPT/Connector.h
@@ -76,7 +76,7 @@ private:
     std::string LibName = LibIdent;
     LibName += ".so";
 
-    DP("OMPT: Trying to load library %s\n", LibName.c_str());
+    DPIF(TOOL, "OMPT: Trying to load library %s\n", LibName.c_str());
     auto DynLibHandle = std::make_unique<llvm::sys::DynamicLibrary>(
         llvm::sys::DynamicLibrary::getPermanentLibrary(LibName.c_str(),
                                                        &ErrMsg));
@@ -85,12 +85,12 @@ private:
       LibConnHandle = nullptr;
     } else {
       auto LibConnRtn = "ompt_" + LibIdent + "_connect";
-      DP("OMPT: Trying to get address of connection routine %s\n",
-         LibConnRtn.c_str());
+      DPIF(TOOL, "OMPT: Trying to get address of connection routine %s\n",
+           LibConnRtn.c_str());
       LibConnHandle = reinterpret_cast<OmptConnectRtnTy>(
           DynLibHandle->getAddressOfSymbol(LibConnRtn.c_str()));
     }
-    DP("OMPT: Library connection handle = %p\n", LibConnHandle);
+    DPIF(TOOL, "OMPT: Library connection handle = %p\n", LibConnHandle);
     IsInitialized = true;
   }
 

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -117,31 +117,26 @@ inline DebugOptionTy &getDebugOption() {
     OptVal.Level = std::atoi(EnvStr);
     if (OptVal.Level)
       return OptVal; // defined as numeric value
+    struct DebugStrToBitTy {
+      const char *Str;
+      uint32_t Bit;
+    } DebugStrToBit[] = {
+        {"rtl", DEBUG_INFOTYPE_RTL},       {"device", DEBUG_INFOTYPE_DEVICE},
+        {"module", DEBUG_INFOTYPE_MODULE}, {"kernel", DEBUG_INFOTYPE_KERNEL},
+        {"memory", DEBUG_INFOTYPE_MEMORY}, {"map", DEBUG_INFOTYPE_MAP},
+        {"copy", DEBUG_INFOTYPE_COPY},     {"interop", DEBUG_INFOTYPE_INTEROP},
+        {"tool", DEBUG_INFOTYPE_TOOL},     {"api", DEBUG_INFOTYPE_API},
+        {"all", DEBUG_INFOTYPE_ALL},       {nullptr, 0},
+    };
     // Check string value of the option
     std::istringstream Tokens(EnvStr);
     for (std::string Token; std::getline(Tokens, Token, ',');) {
-      if (Token == "rtl")
-        OptVal.Type |= DEBUG_INFOTYPE_RTL;
-      else if (Token == "device")
-        OptVal.Type |= DEBUG_INFOTYPE_DEVICE;
-      else if (Token == "module")
-        OptVal.Type |= DEBUG_INFOTYPE_MODULE;
-      else if (Token == "kernel")
-        OptVal.Type |= DEBUG_INFOTYPE_KERNEL;
-      else if (Token == "memory")
-        OptVal.Type |= DEBUG_INFOTYPE_MEMORY;
-      else if (Token == "map")
-        OptVal.Type |= DEBUG_INFOTYPE_MAP;
-      else if (Token == "copy")
-        OptVal.Type |= DEBUG_INFOTYPE_COPY;
-      else if (Token == "interop")
-        OptVal.Type |= DEBUG_INFOTYPE_INTEROP;
-      else if (Token == "tool")
-        OptVal.Type |= DEBUG_INFOTYPE_TOOL;
-      else if (Token == "api")
-        OptVal.Type |= DEBUG_INFOTYPE_API;
-      else if (Token == "all")
-        OptVal.Type |= DEBUG_INFOTYPE_ALL;
+      for (int I = 0; DebugStrToBit[I].Str; I++) {
+        if (Token == DebugStrToBit[I].Str) {
+          OptVal.Type |= DebugStrToBit[I].Bit;
+          break;
+        }
+      }
     }
     return OptVal;
   }();

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -128,7 +128,8 @@ inline DebugOptionTy &getDebugOption() {
         {"tool", DEBUG_INFOTYPE_TOOL},     {"api", DEBUG_INFOTYPE_API},
         {"all", DEBUG_INFOTYPE_ALL},       {nullptr, 0},
     };
-    // Check string value of the option
+    // Check string value of the option. Comma-separated list of the known
+    // keywords are accepted.
     std::istringstream Tokens(EnvStr);
     for (std::string Token; std::getline(Tokens, Token, ',');) {
       for (int I = 0; DebugStrToBit[I].Str; I++) {

--- a/offload/include/Shared/EnvironmentVar.h
+++ b/offload/include/Shared/EnvironmentVar.h
@@ -61,7 +61,8 @@ public:
       IsPresent = StringParser::parse<Ty>(EnvStr, Data);
 
       if (!IsPresent) {
-        DP("Ignoring invalid value %s for envar %s\n", EnvStr, Name.data());
+        DPIF(RTL, "Ignoring invalid value %s for envar %s\n", EnvStr,
+             Name.data());
         Data = Default;
       }
     }
@@ -180,12 +181,13 @@ inline llvm::Error Envar<Ty>::init(llvm::StringRef Name, GetterFunctor Getter,
         // not present and reset to the getter value (default).
         IsPresent = false;
         Data = Default;
-        DP("Setter of envar %s failed, resetting to %s\n", Name.data(),
-           std::to_string(Data).data());
+        DPIF(RTL, "Setter of envar %s failed, resetting to %s\n", Name.data(),
+             std::to_string(Data).data());
         consumeError(std::move(Err));
       }
     } else {
-      DP("Ignoring invalid value %s for envar %s\n", EnvStr, Name.data());
+      DPIF(RTL, "Ignoring invalid value %s for envar %s\n", EnvStr,
+           Name.data());
       Data = Default;
     }
   } else {

--- a/offload/libomptarget/LegacyAPI.cpp
+++ b/offload/libomptarget/LegacyAPI.cpp
@@ -180,7 +180,8 @@ EXTERN int __tgt_target_teams_nowait_mapper(
 EXTERN void __kmpc_push_target_tripcount_mapper(ident_t *Loc, int64_t DeviceId,
                                                 uint64_t LoopTripcount) {
   TIMESCOPE_WITH_IDENT(Loc);
-  DP("WARNING: __kmpc_push_target_tripcount has been deprecated and is a noop");
+  DPIF(RTL, "WARNING: __kmpc_push_target_tripcount has been deprecated and is "
+            "a noop");
 }
 
 EXTERN void __kmpc_push_target_tripcount(int64_t DeviceId,

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -35,7 +35,7 @@ void initRuntime() {
 
   RefCount++;
   if (RefCount == 1) {
-    DP("Init offload library!\n");
+    DPIF(RTL, "Init offload library!\n");
 #ifdef OMPT_SUPPORT
     // Initialize OMPT first
     llvm::omp::target::ompt::connectLibrary();
@@ -54,12 +54,12 @@ void deinitRuntime() {
   assert(PM && "Runtime not initialized");
 
   if (RefCount == 1) {
-    DP("Deinit offload library!\n");
+    DPIF(RTL, "Deinit offload library!\n");
     // RTL deinitialization has started
     RTLAlive = false;
     while (RTLOngoingSyncs > 0) {
-      DP("Waiting for ongoing syncs to finish, count: %d\n",
-         RTLOngoingSyncs.load());
+      DPIF(RTL, "Waiting for ongoing syncs to finish, count: %d\n",
+           RTLOngoingSyncs.load());
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
     PM->deinit();

--- a/offload/libomptarget/OpenMP/OMPT/Callback.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/Callback.cpp
@@ -410,11 +410,13 @@ void Interface::endTarget(int64_t DeviceId, void *Code) {
 }
 
 void Interface::beginTargetDataOperation() {
-  DP("in ompt_target_region_begin (TargetRegionId = %lu)\n", TargetData.value);
+  DPIF(TOOL, "in ompt_target_region_begin (TargetRegionId = %lu)\n",
+       TargetData.value);
 }
 
 void Interface::endTargetDataOperation() {
-  DP("in ompt_target_region_end (TargetRegionId = %lu)\n", TargetData.value);
+  DPIF(TOOL, "in ompt_target_region_end (TargetRegionId = %lu)\n",
+       TargetData.value);
 }
 
 void Interface::beginTargetRegion() {
@@ -462,12 +464,12 @@ private:
 int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
                                                int initial_device_num,
                                                ompt_data_t *tool_data) {
-  DP("Executing initializeLibrary\n");
+  DPIF(TOOL, "Executing initializeLibrary\n");
 #define bindOmptFunctionName(OmptFunction, DestinationFunction)                \
   if (lookup)                                                                  \
     DestinationFunction = (OmptFunction##_t)lookup(#OmptFunction);             \
-  DP("initializeLibrary bound %s=%p\n", #DestinationFunction,                  \
-     ((void *)(uint64_t)DestinationFunction));
+  DPIF(TOOL, "initializeLibrary bound %s=%p\n", #DestinationFunction,          \
+       ((void *)(uint64_t)DestinationFunction));
 
   bindOmptFunctionName(ompt_get_callback, lookupCallbackByCode);
   bindOmptFunctionName(ompt_get_task_data, ompt_get_task_data_fn);
@@ -493,7 +495,7 @@ int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
 }
 
 void llvm::omp::target::ompt::finalizeLibrary(ompt_data_t *data) {
-  DP("Executing finalizeLibrary\n");
+  DPIF(TOOL, "Executing finalizeLibrary\n");
   // Before disabling OMPT, call the (plugin) finalizations that were registered
   // with this library
   LibraryFinalizer->finalize();
@@ -502,7 +504,7 @@ void llvm::omp::target::ompt::finalizeLibrary(ompt_data_t *data) {
 }
 
 void llvm::omp::target::ompt::connectLibrary() {
-  DP("Entering connectLibrary\n");
+  DPIF(TOOL, "Entering connectLibrary\n");
   // Connect with libomp
   static OmptLibraryConnectorTy LibompConnector("libomp");
   static ompt_start_tool_result_t OmptResult;
@@ -525,7 +527,7 @@ void llvm::omp::target::ompt::connectLibrary() {
   FOREACH_OMPT_EMI_EVENT(bindOmptCallback)
 #undef bindOmptCallback
 
-  DP("Exiting connectLibrary\n");
+  DPIF(TOOL, "Exiting connectLibrary\n");
 }
 
 #endif // OMPT_SUPPORT

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -32,11 +32,11 @@ PluginManager *PM = nullptr;
 void PluginManager::init() {
   TIMESCOPE();
   if (OffloadPolicy::isOffloadDisabled()) {
-    DP("Offload is disabled. Skipping plugin initialization\n");
+    DPIF(RTL, "Offload is disabled. Skipping plugin initialization\n");
     return;
   }
 
-  DP("Loading RTLs...\n");
+  DPIF(RTL, "Loading RTLs...\n");
 
   // Attempt to create an instance of each supported plugin.
 #define PLUGIN_TARGET(Name)                                                    \
@@ -46,12 +46,12 @@ void PluginManager::init() {
   } while (false);
 #include "Shared/Targets.def"
 
-  DP("RTLs loaded!\n");
+  DPIF(RTL, "RTLs loaded!\n");
 }
 
 void PluginManager::deinit() {
   TIMESCOPE();
-  DP("Unloading RTLs...\n");
+  DPIF(RTL, "Unloading RTLs...\n");
 
   for (auto &Plugin : Plugins) {
     if (!Plugin->is_initialized())
@@ -59,12 +59,12 @@ void PluginManager::deinit() {
 
     if (auto Err = Plugin->deinit()) {
       [[maybe_unused]] std::string InfoMsg = toString(std::move(Err));
-      DP("Failed to deinit plugin: %s\n", InfoMsg.c_str());
+      DPIF(RTL, "Failed to deinit plugin: %s\n", InfoMsg.c_str());
     }
     Plugin.release();
   }
 
-  DP("RTLs unloaded!\n");
+  DPIF(RTL, "RTLs unloaded!\n");
 }
 
 bool PluginManager::initializePlugin(GenericPluginTy &Plugin) {
@@ -73,12 +73,12 @@ bool PluginManager::initializePlugin(GenericPluginTy &Plugin) {
 
   if (auto Err = Plugin.init()) {
     [[maybe_unused]] std::string InfoMsg = toString(std::move(Err));
-    DP("Failed to init plugin: %s\n", InfoMsg.c_str());
+    DPIF(RTL, "Failed to init plugin: %s\n", InfoMsg.c_str());
     return false;
   }
 
-  DP("Registered plugin %s with %d visible device(s)\n", Plugin.getName(),
-     Plugin.number_of_devices());
+  DPIF(RTL, "Registered plugin %s with %d visible device(s)\n",
+       Plugin.getName(), Plugin.number_of_devices());
   return true;
 }
 
@@ -105,7 +105,7 @@ bool PluginManager::initializeDevice(GenericPluginTy &Plugin,
   auto Device = std::make_unique<DeviceTy>(&Plugin, UserId, DeviceId);
   if (auto Err = Device->init()) {
     [[maybe_unused]] std::string InfoMsg = toString(std::move(Err));
-    DP("Failed to init device %d: %s\n", DeviceId, InfoMsg.c_str());
+    DPIF(RTL, "Failed to init device %d: %s\n", DeviceId, InfoMsg.c_str());
     return false;
   }
 
@@ -229,7 +229,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
         continue;
 
       if (!R.number_of_devices()) {
-        DP("Skipping plugin %s with no visible devices\n", R.getName());
+        DPIF(RTL, "Skipping plugin %s with no visible devices\n", R.getName());
         continue;
       }
 
@@ -239,17 +239,18 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
         // registered for the same device in the case that they are mutually
         // compatible, such as sm_80 and sm_89.
         if (UsedDevices[&R].contains(DeviceId)) {
-          DP("Image " DPxMOD
-             " is a duplicate, not loaded on RTL %s device %d!\n",
-             DPxPTR(Img->ImageStart), R.getName(), DeviceId);
+          DPIF(RTL,
+               "Image " DPxMOD
+               " is a duplicate, not loaded on RTL %s device %d!\n",
+               DPxPTR(Img->ImageStart), R.getName(), DeviceId);
           continue;
         }
 
         if (!R.isDeviceCompatible(DeviceId, Buffer))
           continue;
 
-        DP("Image " DPxMOD " is compatible with RTL %s device %d!\n",
-           DPxPTR(Img->ImageStart), R.getName(), DeviceId);
+        DPIF(RTL, "Image " DPxMOD " is compatible with RTL %s device %d!\n",
+             DPxPTR(Img->ImageStart), R.getName(), DeviceId);
 
         if (!initializeDevice(R, DeviceId))
           continue;
@@ -269,8 +270,8 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
         TranslationTable &TT =
             (PM->HostEntriesBeginToTransTable)[Desc->HostEntriesBegin];
 
-        DP("Registering image " DPxMOD " with RTL %s!\n",
-           DPxPTR(Img->ImageStart), R.getName());
+        DPIF(RTL, "Registering image " DPxMOD " with RTL %s!\n",
+             DPxPTR(Img->ImageStart), R.getName());
 
         auto UserId = PM->DeviceIds[std::make_pair(&R, DeviceId)];
         if (TT.TargetsTable.size() < static_cast<size_t>(UserId + 1)) {
@@ -292,7 +293,8 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
       }
     }
     if (!FoundRTL)
-      DP("No RTL found for image " DPxMOD "!\n", DPxPTR(Img->ImageStart));
+      DPIF(RTL, "No RTL found for image " DPxMOD "!\n",
+           DPxPTR(Img->ImageStart));
   }
   PM->RTLsMtx.unlock();
 
@@ -309,7 +311,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
   if (UseAutoZeroCopy)
     addRequirements(OMPX_REQ_AUTO_ZERO_COPY);
 
-  DP("Done registering entries!\n");
+  DPIF(RTL, "Done registering entries!\n");
 }
 
 // Temporary forward declaration, old style CTor/DTor handling is going away.
@@ -317,7 +319,7 @@ int target(ident_t *Loc, DeviceTy &Device, void *HostPtr,
            KernelArgsTy &KernelArgs, AsyncInfoTy &AsyncInfo);
 
 void PluginManager::unregisterLib(__tgt_bin_desc *Desc) {
-  DP("Unloading target library!\n");
+  DPIF(RTL, "Unloading target library!\n");
 
   Desc = upgradeLegacyEntries(Desc);
 
@@ -341,19 +343,20 @@ void PluginManager::unregisterLib(__tgt_bin_desc *Desc) {
 
       FoundRTL = &R;
 
-      DP("Unregistered image " DPxMOD " from RTL\n", DPxPTR(Img->ImageStart));
+      DPIF(RTL, "Unregistered image " DPxMOD " from RTL\n",
+           DPxPTR(Img->ImageStart));
 
       break;
     }
 
     // if no RTL was found proceed to unregister the next image
     if (!FoundRTL) {
-      DP("No RTLs in use support the image " DPxMOD "!\n",
-         DPxPTR(Img->ImageStart));
+      DPIF(RTL, "No RTLs in use support the image " DPxMOD "!\n",
+           DPxPTR(Img->ImageStart));
     }
   }
   PM->RTLsMtx.unlock();
-  DP("Done unregistering images!\n");
+  DPIF(RTL, "Done unregistering images!\n");
 
   // Remove entries from PM->HostPtrToTableMap
   PM->TblMapMtx.lock();
@@ -367,18 +370,20 @@ void PluginManager::unregisterLib(__tgt_bin_desc *Desc) {
   auto TransTable =
       PM->HostEntriesBeginToTransTable.find(Desc->HostEntriesBegin);
   if (TransTable != PM->HostEntriesBeginToTransTable.end()) {
-    DP("Removing translation table for descriptor " DPxMOD "\n",
-       DPxPTR(Desc->HostEntriesBegin));
+    DPIF(RTL, "Removing translation table for descriptor " DPxMOD "\n",
+         DPxPTR(Desc->HostEntriesBegin));
     PM->HostEntriesBeginToTransTable.erase(TransTable);
   } else {
-    DP("Translation table for descriptor " DPxMOD " cannot be found, probably "
-       "it has been already removed.\n",
-       DPxPTR(Desc->HostEntriesBegin));
+    DPIF(RTL,
+         "Translation table for descriptor " DPxMOD
+         " cannot be found, probably "
+         "it has been already removed.\n",
+         DPxPTR(Desc->HostEntriesBegin));
   }
 
   PM->TblMapMtx.unlock();
 
-  DP("Done unregistering library!\n");
+  DPIF(RTL, "Done unregistering library!\n");
 }
 
 /// Map global data and execute pending ctors
@@ -393,8 +398,8 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
     for (auto *HostEntriesBegin : PM->HostEntriesBeginRegistrationOrder) {
       TranslationTable *TransTable =
           &PM->HostEntriesBeginToTransTable[HostEntriesBegin];
-      DP("Trans table %p : %p\n", TransTable->HostTable.EntriesBegin,
-         TransTable->HostTable.EntriesEnd);
+      DPIF(RTL, "Trans table %p : %p\n", TransTable->HostTable.EntriesBegin,
+           TransTable->HostTable.EntriesEnd);
       if (TransTable->HostTable.EntriesBegin ==
           TransTable->HostTable.EntriesEnd) {
         // No host entry so no need to proceed
@@ -456,9 +461,9 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
                                        &DeviceEntry.Address) != OFFLOAD_SUCCESS)
             REPORT("Failed to load kernel %s\n", Entry.SymbolName);
         }
-        DP("Entry point " DPxMOD " maps to%s %s (" DPxMOD ")\n",
-           DPxPTR(Entry.Address), (Entry.Size) ? " global" : "",
-           Entry.SymbolName, DPxPTR(DeviceEntry.Address));
+        DPIF(MAP, "Entry point " DPxMOD " maps to%s %s (" DPxMOD ")\n",
+             DPxPTR(Entry.Address), (Entry.Size) ? " global" : "",
+             Entry.SymbolName, DPxPTR(DeviceEntry.Address));
 
         DeviceEntries.emplace_back(DeviceEntry);
       }
@@ -509,10 +514,12 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
           CurrDeviceEntryAddr = DevPtr;
         }
 
-        DP("Add mapping from host " DPxMOD " to device " DPxMOD " with size %zu"
-           ", name \"%s\"\n",
-           DPxPTR(CurrHostEntry->Address), DPxPTR(CurrDeviceEntry->Address),
-           CurrDeviceEntry->Size, CurrDeviceEntry->SymbolName);
+        DPIF(MAP,
+             "Add mapping from host " DPxMOD " to device " DPxMOD
+             " with size %zu"
+             ", name \"%s\"\n",
+             DPxPTR(CurrHostEntry->Address), DPxPTR(CurrDeviceEntry->Address),
+             CurrDeviceEntry->Size, CurrDeviceEntry->SymbolName);
         HDTTMap->emplace(new HostDataToTargetTy(
             (uintptr_t)CurrHostEntry->Address /*HstPtrBase*/,
             (uintptr_t)CurrHostEntry->Address /*HstPtrBegin*/,

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -278,8 +278,9 @@ int32_t DeviceTy::dataFence(AsyncInfoTy &AsyncInfo) {
 }
 
 int32_t DeviceTy::notifyDataMapped(void *HstPtr, int64_t Size) {
-  DP("Notifying about new mapping: HstPtr=" DPxMOD ", Size=%" PRId64 "\n",
-     DPxPTR(HstPtr), Size);
+  DPIF(MAP,
+       "Notifying about new mapping: HstPtr=" DPxMOD ", Size=%" PRId64 "\n",
+       DPxPTR(HstPtr), Size);
 
   if (RTL->data_notify_mapped(RTLDeviceID, HstPtr, Size)) {
     REPORT("Notifying about data mapping failed.\n");
@@ -289,7 +290,8 @@ int32_t DeviceTy::notifyDataMapped(void *HstPtr, int64_t Size) {
 }
 
 int32_t DeviceTy::notifyDataUnmapped(void *HstPtr) {
-  DP("Notifying about an unmapping: HstPtr=" DPxMOD "\n", DPxPTR(HstPtr));
+  DPIF(MAP, "Notifying about an unmapping: HstPtr=" DPxMOD "\n",
+       DPxPTR(HstPtr));
 
   if (RTL->data_notify_unmapped(RTLDeviceID, HstPtr)) {
     REPORT("Notifying about data unmapping failed.\n");

--- a/offload/plugins-nextgen/amdgpu/dynamic_hsa/hsa.cpp
+++ b/offload/plugins-nextgen/amdgpu/dynamic_hsa/hsa.cpp
@@ -93,7 +93,7 @@ static bool checkForHSA() {
   auto DynlibHandle = std::make_unique<llvm::sys::DynamicLibrary>(
       llvm::sys::DynamicLibrary::getPermanentLibrary(HsaLib, &ErrMsg));
   if (!DynlibHandle->isValid()) {
-    DP("Unable to load library '%s': %s!\n", HsaLib, ErrMsg.c_str());
+    DPIF(RTL, "Unable to load library '%s': %s!\n", HsaLib, ErrMsg.c_str());
     return false;
   }
 
@@ -102,10 +102,10 @@ static bool checkForHSA() {
 
     void *P = DynlibHandle->getAddressOfSymbol(Sym);
     if (P == nullptr) {
-      DP("Unable to find '%s' in '%s'!\n", Sym, HsaLib);
+      DPIF(RTL, "Unable to find '%s' in '%s'!\n", Sym, HsaLib);
       return false;
     }
-    DP("Implementing %s with dlsym(%s) -> %p\n", Sym, Sym, P);
+    DPIF(RTL, "Implementing %s with dlsym(%s) -> %p\n", Sym, Sym, P);
 
     *dlwrap::pointer(I) = P;
   }

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -558,7 +558,7 @@ struct AMDGPUKernelTy : public GenericKernelTy {
 
     ImplicitArgsSize =
         hsa_utils::getImplicitArgsSize(AMDImage.getELFABIVersion());
-    DP("ELFABIVersion: %d\n", AMDImage.getELFABIVersion());
+    DPIF(MODULE, "ELFABIVersion: %d\n", AMDImage.getELFABIVersion());
 
     // Get additional kernel info read from image
     KernelInfo = AMDImage.getKernelInfo(getName());
@@ -3437,7 +3437,7 @@ struct AMDGPUPluginTy final : public GenericPluginTy {
     hsa_status_t Status = hsa_init();
     if (Status != HSA_STATUS_SUCCESS) {
       // Cannot call hsa_success_string.
-      DP("Failed to initialize AMDGPU's HSA library\n");
+      DPIF(RTL, "Failed to initialize AMDGPU's HSA library\n");
       return 0;
     }
 
@@ -3482,7 +3482,7 @@ struct AMDGPUPluginTy final : public GenericPluginTy {
     int32_t NumDevices = KernelAgents.size();
     if (NumDevices == 0) {
       // Do not initialize if there are no devices.
-      DP("There are no devices supporting AMDGPU.\n");
+      DPIF(RTL, "There are no devices supporting AMDGPU.\n");
       return 0;
     }
 

--- a/offload/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
+++ b/offload/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
@@ -57,7 +57,7 @@ inline Error readAMDGPUMetaDataFromImage(
       MemBuffer, KernelInfoMap, ELFABIVersion);
   if (!Err)
     return Err;
-  DP("ELFABIVERSION Version: %u\n", ELFABIVersion);
+  DPIF(MODULE, "ELFABIVERSION Version: %u\n", ELFABIVersion);
   return Err;
 }
 

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -712,8 +712,8 @@ public:
       IgnoreLockMappedFailures = false;
     } else {
       // Disable by default.
-      DP("Invalid value LIBOMPTARGET_LOCK_MAPPED_HOST_BUFFERS=%s\n",
-         OMPX_LockMappedBuffers.get().data());
+      DPIF(MEMORY, "Invalid value LIBOMPTARGET_LOCK_MAPPED_HOST_BUFFERS=%s\n",
+           OMPX_LockMappedBuffers.get().data());
       LockMappedBuffers = false;
     }
   }
@@ -1608,7 +1608,7 @@ public:
   /// must be called before the destructor.
   virtual Error deinit() {
     if (NextAvailable)
-      DP("Missing %d resources to be returned\n", NextAvailable);
+      DPIF(RTL, "Missing %d resources to be returned\n", NextAvailable);
 
     // TODO: This prevents a bug on libomptarget to make the plugins fail. There
     // may be some resources not returned. Do not destroy these ones.

--- a/offload/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/offload/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -75,12 +75,13 @@ Error GenericGlobalHandlerTy::moveGlobalBetweenDeviceAndHost(
       return Err;
   }
 
-  DP("Successfully %s %u bytes associated with global symbol '%s' %s the "
-     "device "
-     "(%p -> %p).\n",
-     Device2Host ? "read" : "write", HostGlobal.getSize(),
-     HostGlobal.getName().data(), Device2Host ? "from" : "to",
-     DeviceGlobal.getPtr(), HostGlobal.getPtr());
+  DPIF(MAP,
+       "Successfully %s %u bytes associated with global symbol '%s' %s the "
+       "device "
+       "(%p -> %p).\n",
+       Device2Host ? "read" : "write", HostGlobal.getSize(),
+       HostGlobal.getName().data(), Device2Host ? "from" : "to",
+       DeviceGlobal.getPtr(), HostGlobal.getPtr());
 
   return Plugin::success();
 }
@@ -157,10 +158,11 @@ Error GenericGlobalHandlerTy::readGlobalFromImage(GenericDeviceTy &Device,
                          HostGlobal.getName().data(), ImageGlobal.getSize(),
                          HostGlobal.getSize());
 
-  DP("Global symbol '%s' was found in the ELF image and %u bytes will copied "
-     "from %p to %p.\n",
-     HostGlobal.getName().data(), HostGlobal.getSize(), ImageGlobal.getPtr(),
-     HostGlobal.getPtr());
+  DPIF(MAP,
+       "Global symbol '%s' was found in the ELF image and %u bytes will copied "
+       "from %p to %p.\n",
+       HostGlobal.getName().data(), HostGlobal.getSize(), ImageGlobal.getPtr(),
+       HostGlobal.getPtr());
 
   assert(Image.getStart() <= ImageGlobal.getPtr() &&
          utils::advancePtr(ImageGlobal.getPtr(), ImageGlobal.getSize()) <

--- a/offload/plugins-nextgen/cuda/dynamic_cuda/cuda.cpp
+++ b/offload/plugins-nextgen/cuda/dynamic_cuda/cuda.cpp
@@ -141,7 +141,7 @@ static bool checkForCUDA() {
   auto DynlibHandle = std::make_unique<llvm::sys::DynamicLibrary>(
       llvm::sys::DynamicLibrary::getPermanentLibrary(CudaLib, &ErrMsg));
   if (!DynlibHandle->isValid()) {
-    DP("Unable to load library '%s': %s!\n", CudaLib, ErrMsg.c_str());
+    DPIF(RTL, "Unable to load library '%s': %s!\n", CudaLib, ErrMsg.c_str());
     return false;
   }
 
@@ -153,7 +153,7 @@ static bool checkForCUDA() {
       const char *First = It->second;
       void *P = DynlibHandle->getAddressOfSymbol(First);
       if (P) {
-        DP("Implementing %s with dlsym(%s) -> %p\n", Sym, First, P);
+        DPIF(RTL, "Implementing %s with dlsym(%s) -> %p\n", Sym, First, P);
         *dlwrap::pointer(I) = P;
         continue;
       }
@@ -161,10 +161,10 @@ static bool checkForCUDA() {
 
     void *P = DynlibHandle->getAddressOfSymbol(Sym);
     if (P == nullptr) {
-      DP("Unable to find '%s' in '%s'!\n", Sym, CudaLib);
+      DPIF(RTL, "Unable to find '%s' in '%s'!\n", Sym, CudaLib);
       return false;
     }
-    DP("Implementing %s with dlsym(%s) -> %p\n", Sym, Sym, P);
+    DPIF(RTL, "Implementing %s with dlsym(%s) -> %p\n", Sym, Sym, P);
 
     *dlwrap::pointer(I) = P;
   }

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -1516,13 +1516,13 @@ struct CUDAPluginTy final : public GenericPluginTy {
     CUresult Res = cuInit(0);
     if (Res == CUDA_ERROR_INVALID_HANDLE) {
       // Cannot call cuGetErrorString if dlsym failed.
-      DP("Failed to load CUDA shared library\n");
+      DPIF(RTL, "Failed to load CUDA shared library\n");
       return 0;
     }
 
     if (Res == CUDA_ERROR_NO_DEVICE) {
       // Do not initialize if there are no devices.
-      DP("There are no devices supporting CUDA.\n");
+      DPIF(RTL, "There are no devices supporting CUDA.\n");
       return 0;
     }
 
@@ -1537,7 +1537,7 @@ struct CUDAPluginTy final : public GenericPluginTy {
 
     // Do not initialize if there are no devices.
     if (NumDevices == 0)
-      DP("There are no devices supporting CUDA.\n");
+      DPIF(RTL, "There are no devices supporting CUDA.\n");
 
     return NumDevices;
   }
@@ -1645,7 +1645,7 @@ Error CUDADeviceTy::dataExchangeImpl(const void *SrcPtr,
         if (Res == CUDA_ERROR_TOO_MANY_PEERS) {
           // Resources may be exhausted due to many P2P links.
           CanAccessPeer = 0;
-          DP("Too many P2P so fall back to D2D memcpy");
+          DPIF(MEMORY, "Too many P2P so fall back to D2D memcpy");
         } else if (auto Err =
                        Plugin::check(Res, "error in cuCtxEnablePeerAccess: %s"))
           return Err;

--- a/offload/plugins-nextgen/host/dynamic_ffi/ffi.cpp
+++ b/offload/plugins-nextgen/host/dynamic_ffi/ffi.cpp
@@ -41,7 +41,7 @@ uint32_t ffi_init() {
       llvm::sys::DynamicLibrary::getPermanentLibrary(FFI_PATH, &ErrMsg));
 
   if (!DynlibHandle->isValid()) {
-    DP("Unable to load library '%s': %s!\n", FFI_PATH, ErrMsg.c_str());
+    DPIF(RTL, "Unable to load library '%s': %s!\n", FFI_PATH, ErrMsg.c_str());
     return DYNAMIC_FFI_FAIL;
   }
 
@@ -50,10 +50,10 @@ uint32_t ffi_init() {
 
     void *P = DynlibHandle->getAddressOfSymbol(Sym);
     if (P == nullptr) {
-      DP("Unable to find '%s' in '%s'!\n", Sym, FFI_PATH);
+      DPIF(RTL, "Unable to find '%s' in '%s'!\n", Sym, FFI_PATH);
       return DYNAMIC_FFI_FAIL;
     }
-    DP("Implementing %s with dlsym(%s) -> %p\n", Sym, Sym, P);
+    DPIF(RTL, "Implementing %s with dlsym(%s) -> %p\n", Sym, Sym, P);
 
     *dlwrap::pointer(I) = P;
   }
@@ -62,7 +62,7 @@ uint32_t ffi_init() {
   {                                                                            \
     void *SymbolPtr = DynlibHandle->getAddressOfSymbol(#SYMBOL);               \
     if (!SymbolPtr) {                                                          \
-      DP("Unable to find '%s' in '%s'!\n", #SYMBOL, FFI_PATH);                 \
+      DPIF(RTL, "Unable to find '%s' in '%s'!\n", #SYMBOL, FFI_PATH);          \
       return DYNAMIC_FFI_FAIL;                                                 \
     }                                                                          \
     SYMBOL = *reinterpret_cast<decltype(SYMBOL) *>(SymbolPtr);                 \


### PR DESCRIPTION
There are some users who use debug build and/or enable debug printing but are only interested in a subset of the emitted messages. This change addresses such needs by extending the existing environment variable `LIBOMPTARGET_DEBUG` which accepts both numeric and string values that represent subsets of the printed message. The behavior when it is a numeric value did not change.