### PR TITLE
[MLIR][NVVM] Fix assertion failure for insufficient parsing validation of nvvm dialect PureSpecialRangeableRegisterOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -291,8 +291,13 @@ class NVVM_PureSpecialRangeableRegisterOp<string mnemonic, list<Trait> traits = 
       const ::llvm::APInt &upper = rangeAttr->getUpper();
       
       // Check LLVM ConstantRange constructor condition
-      if (!(lower != upper || (lower.isMaxValue() || lower.isMinValue()))) {
-        return emitOpError("invalid range attribute: range must be a valid constant range");
+      if (lower == upper && !lower.isMaxValue() && !lower.isMinValue()) {
+        unsigned bitWidth = lower.getBitWidth();
+        ::llvm::APInt minVal = ::llvm::APInt::getMinValue(bitWidth);
+        ::llvm::APInt maxVal = ::llvm::APInt::getMaxValue(bitWidth);
+        return emitOpError("invalid range attribute: Lower == Upper, but they aren't min (")
+               << ::llvm::toString(minVal, 10, false) << ") or max (" 
+               << ::llvm::toString(maxVal, 10, false) << ") value! This is an invalid constant range.";
       }
       
       return ::mlir::success();

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -283,24 +283,7 @@ class NVVM_PureSpecialRangeableRegisterOp<string mnemonic, list<Trait> traits = 
 
     // Verify the range attribute satisfies LLVM ConstantRange constructor requirements.
     ::llvm::LogicalResult $cppClass::verify() {
-      auto rangeAttr = getRange();
-      if (!rangeAttr)
-        return ::mlir::success(); // No range specified, validation passes
-      
-      const ::llvm::APInt &lower = rangeAttr->getLower();
-      const ::llvm::APInt &upper = rangeAttr->getUpper();
-      
-      // Check LLVM ConstantRange constructor condition
-      if (lower == upper && !lower.isMaxValue() && !lower.isMinValue()) {
-        unsigned bitWidth = lower.getBitWidth();
-        ::llvm::APInt minVal = ::llvm::APInt::getMinValue(bitWidth);
-        ::llvm::APInt maxVal = ::llvm::APInt::getMaxValue(bitWidth);
-        return emitOpError("invalid range attribute: Lower == Upper, but they aren't min (")
-               << ::llvm::toString(minVal, 10, false) << ") or max (" 
-               << ::llvm::toString(maxVal, 10, false) << ") value! This is an invalid constant range.";
-      }
-      
-      return ::mlir::success();
+      return verifyConstantRangeAttr(getOperation(), getRange());
     }
   }];
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -279,6 +279,23 @@ class NVVM_PureSpecialRangeableRegisterOp<string mnemonic, list<Trait> traits = 
         SetIntRangeFn setResultRanges) {
         nvvmInferResultRanges(getOperation(), getResult(), argRanges, setResultRanges);
     }
+
+    // Verify the range attribute satisfies LLVM ConstantRange constructor requirements.
+    ::llvm::LogicalResult $cppClass::verify() {
+      auto rangeAttr = getRange();
+      if (!rangeAttr)
+        return ::mlir::success(); // No range specified, validation passes
+      
+      const ::llvm::APInt &lower = rangeAttr->getLower();
+      const ::llvm::APInt &upper = rangeAttr->getUpper();
+      
+      // Check LLVM ConstantRange constructor condition
+      if (!(lower != upper || (lower.isMaxValue() || lower.isMinValue()))) {
+        return emitOpError("invalid range attribute: range must be a valid constant range");
+      }
+      
+      return ::mlir::success();
+    }
   }];
 
 }

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -263,6 +263,7 @@ class NVVM_PureSpecialRangeableRegisterOp<string mnemonic, list<Trait> traits = 
   let assemblyFormat = "(`range` $range^)? attr-dict `:` type($res)";
   let llvmBuilder = baseLlvmBuilder # setRangeRetAttrCode # baseLlvmBuilderCoda;
   let mlirBuilder = baseMlirBuilder # importRangeRetAttrCode # baseMlirBuilderCoda;
+  let hasVerifier = 1;
 
   // Backwards-compatibility builder for an unspecified range.
   let builders = [

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -2306,6 +2306,32 @@ static void nvvmInferResultRanges(Operation *op, Value result,
   }
 }
 
+/// Verify the range attribute satisfies LLVM ConstantRange constructor
+/// requirements for NVVM SpecialRangeableRegisterOp.
+static LogicalResult
+verifyConstantRangeAttr(Operation *op,
+                        std::optional<LLVM::ConstantRangeAttr> rangeAttr) {
+  if (!rangeAttr)
+    return success();
+
+  const llvm::APInt &lower = rangeAttr->getLower();
+  const llvm::APInt &upper = rangeAttr->getUpper();
+
+  // Check LLVM ConstantRange constructor condition
+  if (lower == upper && !lower.isMaxValue() && !lower.isMinValue()) {
+    unsigned bitWidth = lower.getBitWidth();
+    llvm::APInt minVal = llvm::APInt::getMinValue(bitWidth);
+    llvm::APInt maxVal = llvm::APInt::getMaxValue(bitWidth);
+    return op->emitOpError(
+               "invalid range attribute: Lower == Upper, but they aren't min (")
+           << llvm::toString(minVal, 10, false) << ") or max ("
+           << llvm::toString(maxVal, 10, false)
+           << ") value! This is an invalid constant range.";
+  }
+
+  return success();
+}
+
 static llvm::Value *getAsPackedI32(llvm::Value *arg,
                                    llvm::IRBuilderBase &builder) {
   return builder.CreateBitCast(arg,

--- a/mlir/test/Target/LLVMIR/nvvmir-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir-invalid.mlir
@@ -559,3 +559,13 @@ llvm.func @clusterlaunchcontrol_query_cancel_get_first_cta_id_invalid_return_typ
   %res = nvvm.clusterlaunchcontrol.query.cancel query = get_first_cta_id_x, %try_cancel_response : i1
   llvm.return
 }
+
+
+// -----
+
+// Test for range validation - invalid range where lower == upper but not at extremes
+func.func @invalid_range_equal_bounds() {
+  // expected-error @below {{invalid range attribute: range must be a valid constant range}}
+  %0 = nvvm.read.ptx.sreg.warpsize range <i32, 32, 32> : i32
+  return
+}

--- a/mlir/test/Target/LLVMIR/nvvmir-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir-invalid.mlir
@@ -565,7 +565,7 @@ llvm.func @clusterlaunchcontrol_query_cancel_get_first_cta_id_invalid_return_typ
 
 // Test for range validation - invalid range where lower == upper but not at extremes
 func.func @invalid_range_equal_bounds() {
-  // expected-error @below {{invalid range attribute: range must be a valid constant range}}
+  // expected-error @below {{invalid range attribute: Lower == Upper, but they aren't min (0) or max (4294967295) value! This is an invalid constant range.}}
   %0 = nvvm.read.ptx.sreg.warpsize range <i32, 32, 32> : i32
   return
 }

--- a/mlir/test/Target/LLVMIR/nvvmir.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir.mlir
@@ -152,6 +152,10 @@ llvm.func @nvvm_special_regs() -> i32 {
   %74 = nvvm.read.ptx.sreg.lanemask.ge : i32
   //CHECK: call i32 @llvm.nvvm.read.ptx.sreg.lanemask.gt
   %75 = nvvm.read.ptx.sreg.lanemask.gt : i32
+  // CHECK: %76 = call range(i32 0, 0) i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  %76 = nvvm.read.ptx.sreg.tid.x range <i32, 0, 0> : i32
+  // CHECK: %77 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  %77 = nvvm.read.ptx.sreg.tid.x range <i32, 4294967295, 4294967295> : i32
   llvm.return %1 : i32
 }
 


### PR DESCRIPTION
The nvvm dialect instruction PureSpecialRangeableRegisterOp will trigger an assertion failure in LLVM's constant range class when the lower and upper range bounds are equal, but not equal to the integer minimum or max (as required by constant ranges). This requirement is at [line 56 of ConstantRange.cpp](https://llvm.org/doxygen/ConstantRange_8cpp_source.html#l00056):

`assert((Lower != Upper || (Lower.isMaxValue() || Lower.isMinValue())) && "Lower == Upper, but they aren't min or max value!");`

However, you can write an NVVM dialect operation such as:

`%0 = nvvm.read.ptx.sreg.warpsize range <i32, 32, 32> : i32`

which triggers this assertion. This change adds a fix to ensure that this requirement is also enforced by NVVM.