### PR TITLE
Revert "[MLIR][ROCDL] Add math.clampf -> rocdl.fmed3 conversion"

### DIFF
--- a/mlir/include/mlir/Conversion/MathToROCDL/MathToROCDL.h
+++ b/mlir/include/mlir/Conversion/MathToROCDL/MathToROCDL.h
@@ -9,7 +9,6 @@
 #define MLIR_CONVERSION_MATHTOROCDL_MATHTOROCDL_H_
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
-#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/IR/PatternMatch.h"
 #include <memory>
 
@@ -21,8 +20,7 @@ class Pass;
 
 /// Populate the given list with patterns that convert from Math to ROCDL calls.
 void populateMathToROCDLConversionPatterns(const LLVMTypeConverter &converter,
-                                           RewritePatternSet &patterns,
-                                           amdgpu::Chipset chipset);
+                                           RewritePatternSet &patterns);
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_MATHTOROCDL_MATHTOROCDL_H_

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -778,10 +778,6 @@ def ConvertMathToROCDL : Pass<"convert-math-to-rocdl", "ModuleOp"> {
   let summary = "Convert Math dialect to ROCDL library calls";
   let description = [{
     This pass converts supported Math ops to ROCDL library calls.
-
-    The chipset option specifies the target AMDGPU architecture. If the chipset
-    is empty, none of the chipset-dependent patterns are added and the pass
-    will not attempt to parse the chipset.
   }];
   let dependentDialects = [
     "arith::ArithDialect",
@@ -789,9 +785,6 @@ def ConvertMathToROCDL : Pass<"convert-math-to-rocdl", "ModuleOp"> {
     "ROCDL::ROCDLDialect",
     "vector::VectorDialect",
   ];
-  let options = [Option<"chipset", "chipset", "std::string",
-                        /*default=*/"\"gfx000\"",
-                        "Chipset that these operations will run on">];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -484,5 +484,5 @@ void mlir::populateGpuToROCDLConversionPatterns(
                GPUSubgroupBroadcastOpToROCDL>(converter);
   patterns.add<GPUSubgroupSizeOpToROCDL>(converter, chipset);
 
-  populateMathToROCDLConversionPatterns(converter, patterns, chipset);
+  populateMathToROCDLConversionPatterns(converter, patterns);
 }

--- a/mlir/lib/Conversion/MathToROCDL/MathToROCDL.cpp
+++ b/mlir/lib/Conversion/MathToROCDL/MathToROCDL.cpp
@@ -10,8 +10,6 @@
 #include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
-#include "mlir/Conversion/LLVMCommon/VectorPattern.h"
-#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
@@ -44,65 +42,8 @@ static void populateOpPatterns(const LLVMTypeConverter &converter,
                                            f32ApproxFunc, f16Func);
 }
 
-struct ClampFOpConversion final
-    : public ConvertOpToLLVMPattern<math::ClampFOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
-  ClampFOpConversion(const LLVMTypeConverter &converter,
-                     amdgpu::Chipset chipset)
-      : ConvertOpToLLVMPattern<math::ClampFOp>(converter), chipset(chipset) {}
-
-  LogicalResult
-  matchAndRewrite(math::ClampFOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    // Only f16 and f32 types are supported by fmed3
-    Type opTy = op.getType();
-    auto resultType = getTypeConverter()->convertType(opTy);
-
-    if (auto vectorType = dyn_cast<VectorType>(opTy)) {
-      opTy = vectorType.getElementType();
-    }
-
-    if (!isa<Float16Type, Float32Type>(opTy)) {
-      return rewriter.notifyMatchFailure(
-          op, "fmed3 only supports f16 and f32 types");
-    }
-
-    // Handle multi-dimensional vectors (converted to LLVM arrays)
-    if (auto arrayType = dyn_cast<LLVM::LLVMArrayType>(resultType)) {
-      // Handle multi-dimensional vectors (converted to LLVM arrays)
-      return LLVM::detail::handleMultidimensionalVectors(
-          op.getOperation(), adaptor.getOperands(), *getTypeConverter(),
-          [&](Type llvm1DVectorTy, ValueRange operands) -> Value {
-            typename math::ClampFOp::Adaptor adaptor(operands);
-            return ROCDL::FMed3Op::create(rewriter, op.getLoc(), llvm1DVectorTy,
-                                          adaptor.getValue(), adaptor.getMin(),
-                                          adaptor.getMax());
-          },
-          rewriter);
-    }
-
-    // Handle 1D vectors and scalars directly
-    rewriter.replaceOpWithNewOp<ROCDL::FMed3Op>(op, op.getType(), op.getValue(),
-                                                op.getMin(), op.getMax());
-    return success();
-  }
-
-  amdgpu::Chipset chipset;
-};
-
-static void addChipsetDependentPatterns(const LLVMTypeConverter &converter,
-                                        RewritePatternSet &patterns,
-                                        amdgpu::Chipset chipset) {
-
-  // V_MED3_F16/F32 only exists in gfx9+ architectures
-  if (chipset.majorVersion >= 9) {
-    patterns.add<ClampFOpConversion>(converter, chipset);
-  }
-}
-
 void mlir::populateMathToROCDLConversionPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns,
-    amdgpu::Chipset chipset) {
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
   // Handled by mathToLLVM: math::AbsIOp
   // Handled by mathToLLVM: math::AbsFOp
   // Handled by mathToLLVM: math::CopySignOp
@@ -177,17 +118,15 @@ void mlir::populateMathToROCDLConversionPatterns(
   // worth creating a separate pass for it.
   populateOpPatterns<arith::RemFOp>(converter, patterns, "__ocml_fmod_f32",
                                     "__ocml_fmod_f64", "__ocml_fmod_f16");
-
-  addChipsetDependentPatterns(converter, patterns, chipset);
 }
 
-struct ConvertMathToROCDLPass final
-    : impl::ConvertMathToROCDLBase<ConvertMathToROCDLPass> {
-  using impl::ConvertMathToROCDLBase<
-      ConvertMathToROCDLPass>::ConvertMathToROCDLBase;
-
+namespace {
+struct ConvertMathToROCDLPass
+    : public impl::ConvertMathToROCDLBase<ConvertMathToROCDLPass> {
+  ConvertMathToROCDLPass() = default;
   void runOnOperation() override;
 };
+} // namespace
 
 void ConvertMathToROCDLPass::runOnOperation() {
   auto m = getOperation();
@@ -196,20 +135,10 @@ void ConvertMathToROCDLPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   LowerToLLVMOptions options(ctx, DataLayout(m));
   LLVMTypeConverter converter(ctx, options);
-
-  // Only populate chipset-dependent patterns if chipset is specified
-  if (!chipset.empty()) {
-    FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(chipset);
-    if (failed(maybeChipset)) {
-      return signalPassFailure();
-    }
-    populateMathToROCDLConversionPatterns(converter, patterns, *maybeChipset);
-  }
-
+  populateMathToROCDLConversionPatterns(converter, patterns);
   ConversionTarget target(getContext());
-  target
-      .addLegalDialect<BuiltinDialect, func::FuncDialect, vector::VectorDialect,
-                       LLVM::LLVMDialect, ROCDL::ROCDLDialect>();
+  target.addLegalDialect<BuiltinDialect, func::FuncDialect,
+                         vector::VectorDialect, LLVM::LLVMDialect>();
   target.addIllegalOp<LLVM::CosOp, LLVM::ExpOp, LLVM::Exp2Op, LLVM::FAbsOp,
                       LLVM::FCeilOp, LLVM::FFloorOp, LLVM::FRemOp, LLVM::LogOp,
                       LLVM::Log10Op, LLVM::Log2Op, LLVM::PowOp, LLVM::SinOp,


### PR DESCRIPTION
Reverts llvm/llvm-project#163259 reverting due to missing link libraries causing failures in shared build bots.