### PR TITLE
[ARM] Allow usubo and uaddo to happen for any legal type

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -641,8 +641,9 @@ class VectorType;
 
     bool shouldFormOverflowOp(unsigned Opcode, EVT VT,
                               bool MathUsed) const override {
-      // Using overflow ops for overflow checks only should beneficial on ARM.
-      return TargetLowering::shouldFormOverflowOp(Opcode, VT, true);
+      if (VT.isVector())
+        return false;
+      return !isOperationExpand(Opcode, VT);
     }
 
     bool shouldReassociateReduction(unsigned Opc, EVT VT) const override {

--- a/llvm/test/CodeGen/ARM/atomicrmw-uinc-udec-wrap.ll
+++ b/llvm/test/CodeGen/ARM/atomicrmw-uinc-udec-wrap.ll
@@ -147,11 +147,11 @@ define i32 @atomicrmw_udec_wrap_i32(ptr %ptr, i32 %val) {
 ; CHECK-NEXT:  .LBB6_1: @ %atomicrmw.start
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    ldrex r12, [r0]
-; CHECK-NEXT:    mov r3, r1
 ; CHECK-NEXT:    cmp r12, r1
-; CHECK-NEXT:    subls r3, r12, #1
-; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    moveq r3, r1
+; CHECK-NEXT:    sub r3, r12, #1
+; CHECK-NEXT:    movhi r3, r1
+; CHECK-NEXT:    cmp r12, #1
+; CHECK-NEXT:    movlo r3, r1
 ; CHECK-NEXT:    strex r2, r3, [r0]
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    bne .LBB6_1

--- a/llvm/test/CodeGen/ARM/select_const.ll
+++ b/llvm/test/CodeGen/ARM/select_const.ll
@@ -763,46 +763,35 @@ define i64 @opaque_constant2(i1 %cond, i64 %x) {
 define i64 @func(i64 %arg) {
 ; ARM-LABEL: func:
 ; ARM:       @ %bb.0: @ %entry
-; ARM-NEXT:    adds r0, r0, #1
-; ARM-NEXT:    mov r2, #0
-; ARM-NEXT:    adcs r0, r1, #0
+; ARM-NEXT:    and r0, r0, r1
 ; ARM-NEXT:    mov r1, #0
-; ARM-NEXT:    adcs r0, r2, #0
-; ARM-NEXT:    movne r0, #8
+; ARM-NEXT:    cmn r0, #1
+; ARM-NEXT:    mov r0, #0
+; ARM-NEXT:    moveq r0, #8
 ; ARM-NEXT:    mov pc, lr
 ;
 ; THUMB2-LABEL: func:
 ; THUMB2:       @ %bb.0: @ %entry
+; THUMB2-NEXT:    ands r0, r1
+; THUMB2-NEXT:    movs r1, #0
 ; THUMB2-NEXT:    adds r0, #1
-; THUMB2-NEXT:    mov.w r2, #0
-; THUMB2-NEXT:    adcs r0, r1, #0
-; THUMB2-NEXT:    mov.w r1, #0
-; THUMB2-NEXT:    adcs r0, r2, #0
-; THUMB2-NEXT:    it ne
-; THUMB2-NEXT:    movne r0, #8
+; THUMB2-NEXT:    mov.w r0, #0
+; THUMB2-NEXT:    it eq
+; THUMB2-NEXT:    moveq r0, #8
 ; THUMB2-NEXT:    bx lr
 ;
 ; THUMB-LABEL: func:
 ; THUMB:       @ %bb.0: @ %entry
-; THUMB-NEXT:    .save {r4, lr}
-; THUMB-NEXT:    push {r4, lr}
-; THUMB-NEXT:    movs r2, #0
-; THUMB-NEXT:    adds r3, r0, #1
-; THUMB-NEXT:    mov r12, r1
-; THUMB-NEXT:    mov r3, r12
-; THUMB-NEXT:    adcs r3, r2
-; THUMB-NEXT:    mov r12, r2
-; THUMB-NEXT:    mov r3, r12
-; THUMB-NEXT:    adcs r3, r2
-; THUMB-NEXT:    subs r4, r3, #1
+; THUMB-NEXT:    ands r0, r1
+; THUMB-NEXT:    movs r1, #0
 ; THUMB-NEXT:    adds r0, r0, #1
-; THUMB-NEXT:    adcs r1, r2
-; THUMB-NEXT:    sbcs r3, r4
-; THUMB-NEXT:    lsls r0, r3, #3
-; THUMB-NEXT:    movs r1, r2
-; THUMB-NEXT:    pop {r4}
-; THUMB-NEXT:    pop {r2}
-; THUMB-NEXT:    bx r2
+; THUMB-NEXT:    beq .LBB26_2
+; THUMB-NEXT:  @ %bb.1: @ %entry
+; THUMB-NEXT:    movs r0, r1
+; THUMB-NEXT:    bx lr
+; THUMB-NEXT:  .LBB26_2:
+; THUMB-NEXT:    movs r0, #8
+; THUMB-NEXT:    bx lr
 entry:
   %0 = add i64 %arg, 1
   %1 = icmp ult i64 %0, 1

--- a/llvm/test/CodeGen/Thumb/scheduler-clone-cpsr-def.ll
+++ b/llvm/test/CodeGen/Thumb/scheduler-clone-cpsr-def.ll
@@ -11,27 +11,20 @@
 define i64 @f(i64 %x2, i32 %z) {
 ; CHECK-LABEL: f:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .save {r4, r5, r7, lr}
-; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    subs r3, r0, #1
-; CHECK-NEXT:    mov r3, r1
-; CHECK-NEXT:    sbcs r3, r2
-; CHECK-NEXT:    mov r3, r2
+; CHECK-NEXT:    .save {r4, lr}
+; CHECK-NEXT:    push {r4, lr}
+; CHECK-NEXT:    mov r2, r0
+; CHECK-NEXT:    orrs r2, r1
+; CHECK-NEXT:    rsbs r3, r2, #0
 ; CHECK-NEXT:    adcs r3, r2
-; CHECK-NEXT:    movs r4, #30
-; CHECK-NEXT:    subs r5, r0, #1
-; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    sbcs r5, r2
-; CHECK-NEXT:    adcs r4, r2
-; CHECK-NEXT:    lsls r2, r1, #1
-; CHECK-NEXT:    lsls r2, r4
-; CHECK-NEXT:    movs r4, #1
-; CHECK-NEXT:    eors r4, r3
-; CHECK-NEXT:    lsrs r0, r4
-; CHECK-NEXT:    orrs r0, r2
-; CHECK-NEXT:    lsrs r1, r4
-; CHECK-NEXT:    pop {r4, r5, r7, pc}
+; CHECK-NEXT:    lsrs r0, r3
+; CHECK-NEXT:    movs r2, #31
+; CHECK-NEXT:    eors r2, r3
+; CHECK-NEXT:    lsls r4, r1, #1
+; CHECK-NEXT:    lsls r4, r2
+; CHECK-NEXT:    orrs r0, r4
+; CHECK-NEXT:    lsrs r1, r3
+; CHECK-NEXT:    pop {r4, pc}
   %x3 = add nsw i64 %x2, -1
   %x8 = icmp ne i64 %x2, 0
   %x9 = xor i1 %x8, true


### PR DESCRIPTION
We can do usubo and we should do if we are able to use the CSPR, meaning 32 bits and below.