### PR TITLE
[clang][docs] Fix typos in option names

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -2325,7 +2325,7 @@ are listed below.
    devirtualization and virtual constant propagation, for classes with
    :doc:`hidden LTO visibility <LTOVisibility>`. Requires ``-flto``.
 
-.. option:: -f[no]split-lto-unit
+.. option:: -f[no-]split-lto-unit
 
    Controls splitting the :doc:`LTO unit <LTOVisibility>` into regular LTO and
    :doc:`ThinLTO` portions, when compiling with -flto=thin. Defaults to false
@@ -2518,7 +2518,7 @@ are listed below.
 
 .. _funique_internal_linkage_names:
 
-.. option:: -f[no]-unique-internal-linkage-names
+.. option:: -f[no-]unique-internal-linkage-names
 
    Controls whether Clang emits a unique (best-effort) symbol name for internal
    linkage symbols.  When this option is set, compiler hashes the main source
@@ -2539,7 +2539,7 @@ are listed below.
      $ cd $P/bar && clang -c -funique-internal-linkage-names name_conflict.c
      $ cd $P && clang foo/name_conflict.o && bar/name_conflict.o
 
-.. option:: -f[no]-basic-block-address-map:
+.. option:: -f[no-]basic-block-address-map:
   Emits a ``SHT_LLVM_BB_ADDR_MAP`` section which includes address offsets for each
   basic block in the program, relative to the parent function address.
 


### PR DESCRIPTION
If you type option names in the currnet Clang Compiler User's Manual, you'll see:

```console
$ clang -fnobasic-block-address-map -fnounique-internal-linkage-names -f-split-lto-unit test.c 
clang: error: unknown argument '-fnobasic-block-address-map'; did you mean '-fno-basic-block-address-map'?
clang: error: unknown argument '-fnounique-internal-linkage-names'; did you mean '-fno-unique-internal-linkage-names'?
clang: error: unknown argument '-f-split-lto-unit'; did you mean '-fsplit-lto-unit'?
```
