### PR TITLE
[clang][Driver] Support Outline Flags on RISC-V and X86

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5127,12 +5127,16 @@ def mms_bitfields : Flag<["-"], "mms-bitfields">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Set the default structure layout to be compatible with the Microsoft compiler standard">,
   MarshallingInfoFlag<LangOpts<"MSBitfields">>;
-def moutline : Flag<["-"], "moutline">, Group<f_clang_Group>,
-  Visibility<[ClangOption, CC1Option]>,
-    HelpText<"Enable function outlining (AArch64 only)">;
-def mno_outline : Flag<["-"], "mno-outline">, Group<f_clang_Group>,
-  Visibility<[ClangOption, CC1Option]>,
-    HelpText<"Disable function outlining (AArch64 only)">;
+def moutline
+    : Flag<["-"], "moutline">,
+      Group<f_clang_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Enable function outlining (AArch64,Arm,RISC-V,X86 only)">;
+def mno_outline
+    : Flag<["-"], "mno-outline">,
+      Group<f_clang_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Disable function outlining (AArch64,Arm,RISC-V,X86 only)">;
 def mno_ms_bitfields : Flag<["-"], "mno-ms-bitfields">, Group<m_Group>,
   HelpText<"Do not set the default structure layout to be compatible with the Microsoft compiler standard">;
 def mskip_rax_setup : Flag<["-"], "mskip-rax-setup">, Group<m_Group>,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2916,12 +2916,16 @@ void tools::addMachineOutlinerArgs(const Driver &D,
   if (Arg *A = Args.getLastArg(options::OPT_moutline,
                                options::OPT_mno_outline)) {
     if (A->getOption().matches(options::OPT_moutline)) {
-      // We only support -moutline in AArch64 and ARM targets right now. If
-      // we're not compiling for these, emit a warning and ignore the flag.
-      // Otherwise, add the proper mllvm flags.
-      if (!(Triple.isARM() || Triple.isThumb() || Triple.isAArch64())) {
+      // We only support -moutline in AArch64, ARM, RISC-V and X86 targets right
+      // now. If we're not compiling for these, emit a warning and ignore the
+      // flag. Otherwise, add the proper mllvm flags.
+      if (!(Triple.isARM() || Triple.isThumb() || Triple.isAArch64() ||
+            Triple.isRISCV() || Triple.isX86())) {
         D.Diag(diag::warn_drv_moutline_unsupported_opt) << Triple.getArchName();
       } else {
+        // FIXME: This should probably use the `nooutline` attribute rather than
+        // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline`
+        // objects can be combined correctly during LTO.
         addArg(Twine("-enable-machine-outliner"));
       }
     } else {

--- a/clang/test/Driver/aarch64-outliner.c
+++ b/clang/test/Driver/aarch64-outliner.c
@@ -4,6 +4,3 @@
 // RUN: %clang --target=aarch64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // RUN: %clang --target=aarch64_be -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // OFF: "-mllvm" "-enable-machine-outliner=never"
-// RUN: %clang --target=x86_64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=WARN
-// WARN: warning: 'x86_64' does not support '-moutline'; flag ignored [-Woption-ignored]
-// WARN-NOT: "-mllvm" "-enable-machine-outliner"

--- a/clang/test/Driver/riscv-outliner.c
+++ b/clang/test/Driver/riscv-outliner.c
@@ -1,0 +1,7 @@
+// RUN: %clang --target=riscv32 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// RUN: %clang --target=riscv64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// ON: "-mllvm" "-enable-machine-outliner"
+
+// RUN: %clang --target=riscv32 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// RUN: %clang --target=riscv64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// OFF: "-mllvm" "-enable-machine-outliner=never"

--- a/clang/test/Driver/unsupported-outliner.c
+++ b/clang/test/Driver/unsupported-outliner.c
@@ -1,0 +1,3 @@
+// RUN: %clang --target=ppc64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=WARN
+// WARN: warning: 'ppc64' does not support '-moutline'; flag ignored [-Woption-ignored]
+// WARN-NOT: "-mllvm" "-enable-machine-outliner"

--- a/clang/test/Driver/x86-outliner.c
+++ b/clang/test/Driver/x86-outliner.c
@@ -1,0 +1,7 @@
+// RUN: %clang --target=i386 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// RUN: %clang --target=x86_64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// ON: "-mllvm" "-enable-machine-outliner"
+
+// RUN: %clang --target=i386 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// RUN: %clang --target=x86_64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// OFF: "-mllvm" "-enable-machine-outliner=never"


### PR DESCRIPTION
These two targets both also support the machine outliner, so these flags
should probably be cross-target. This updates the docs for these flags
as well.