### PR TITLE
[mlir][memref] Canonicalize memref.reinterpret_cast when offset/sizes/strides are constants.

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -2166,6 +2166,10 @@ public:
 
   LogicalResult matchAndRewrite(ReinterpretCastOp op,
                                 PatternRewriter &rewriter) const override {
+    // TODO: Using counting comparison instead of direct comparison because
+    // getMixedValues (and consequently ReinterpretCastOp::getMixed...) returns
+    // IntegerAttrs, while constifyIndexValues (and consequently
+    // ReinterpretCastOp::getConstifiedMixed...) returns IndexAttrs.
     unsigned srcStaticCount = llvm::count_if(
         llvm::concat<OpFoldResult>(op.getMixedOffsets(), op.getMixedSizes(),
                                    op.getMixedStrides()),

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -2166,10 +2166,6 @@ public:
 
   LogicalResult matchAndRewrite(ReinterpretCastOp op,
                                 PatternRewriter &rewriter) const override {
-    // TODO: Using counting comparison instead of direct comparison because
-    // getMixedValues (and consequently ReinterpretCastOp::getMixed...) returns
-    // IntegerAttrs, while constifyIndexValues (and consequently
-    // ReinterpretCastOp::getConstifiedMixed...) returns IndexAttrs.
     unsigned srcStaticCount = llvm::count_if(
         llvm::concat<OpFoldResult>(op.getMixedOffsets(), op.getMixedSizes(),
                                    op.getMixedStrides()),
@@ -2179,6 +2175,10 @@ public:
     SmallVector<OpFoldResult> sizes = op.getConstifiedMixedSizes();
     SmallVector<OpFoldResult> strides = op.getConstifiedMixedStrides();
 
+    // TODO: Using counting comparison instead of direct comparison because
+    // getMixedValues (and therefore ReinterpretCastOp::getMixed...) returns
+    // IntegerAttrs, while constifyIndexValues (and therefore
+    // ReinterpretCastOp::getConstifiedMixed...) returns IndexAttrs.
     if (srcStaticCount ==
         llvm::count_if(llvm::concat<OpFoldResult>(offsets, sizes, strides),
                        [](OpFoldResult ofr) { return isa<Attribute>(ofr); }))


### PR DESCRIPTION
Implement folding logic to canonicalize memref.reinterpret_cast ops when offset, sizes and strides are compile-time constants. This removes dynamic shape annotations and produces a static memref form, allowing further lowering and backend optimizations.