### PR TITLE
[libc] Disable null checks on baremetal platforms

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -38,5 +38,10 @@
     "LIBC_CONF_MATH_OPTIMIZATIONS": {
       "value": "(LIBC_MATH_SKIP_ACCURATE_PASS | LIBC_MATH_SMALL_TABLES)"
     }
+  },
+  "general": {
+    "LIBC_ADD_NULL_CHECKS": {
+      "value": false
+    }
   }
 }


### PR DESCRIPTION
On baremetal platforms, 0 is often a valid address and the null checks can break otherwise correct code.