### PR TITLE
[libc++] Improve performance of std::atomic_flag on Windows

### DIFF
--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -113,6 +113,7 @@ static HMODULE win32_get_win_core_synch_api_module() {
   // safely use std::unique_ptr here as a wrapper for the handle, with a destructor freeing the handle when this module
   // is unloaded.
   // https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types
+  // https://devblogs.microsoft.com/oldnewthing/20180307-00/?p=98175
   static auto module_handle = std::unique_ptr<std::remove_pointer<HMODULE>::type, decltype(&FreeLibrary)>(
       LoadLibraryW(L"api-ms-win-core-synch-l1-2-0.dll"), &FreeLibrary);
   return module_handle.get();
@@ -122,7 +123,9 @@ static void
 __libcpp_platform_wait_on_address(__cxx_atomic_contention_t const volatile* __ptr, __cxx_contention_t __val) {
   // WaitOnAddress was added in Windows 8 (build 9200)
   static auto wait_on_address = reinterpret_cast<BOOL(WINAPI*)(volatile void*, PVOID, SIZE_T, DWORD)>(
-      GetProcAddress(win32_get_win_core_synch_api_module(), "WaitOnAddress"));
+      (win32_get_win_core_synch_api_module() != NULL
+           ? GetProcAddress(win32_get_win_core_synch_api_module(), "WaitOnAddress")
+           : nullptr));
   if (wait_on_address != nullptr) {
     wait_on_address(const_cast<__cxx_atomic_contention_t*>(__ptr), &__val, sizeof(__val), INFINITE);
   } else {
@@ -136,7 +139,9 @@ static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const vo
   if (__notify_one) {
     // WakeByAddressSingle was added in Windows 8 (build 9200)
     static auto wake_by_address_single = reinterpret_cast<void(WINAPI*)(PVOID)>(
-        GetProcAddress(win32_get_win_core_synch_api_module(), "WakeByAddressSingle"));
+        (win32_get_win_core_synch_api_module() != NULL
+             ? GetProcAddress(win32_get_win_core_synch_api_module(), "WakeByAddressSingle")
+             : nullptr));
     if (wake_by_address_single != nullptr) {
       wake_by_address_single(const_cast<__cxx_atomic_contention_t*>(__ptr));
     } else {
@@ -146,7 +151,9 @@ static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const vo
   } else {
     // WakeByAddressAll was added in Windows 8 (build 9200)
     static auto wake_by_address_all = reinterpret_cast<void(WINAPI*)(PVOID)>(
-        GetProcAddress(win32_get_win_core_synch_api_module(), "WakeByAddressAll"));
+        (win32_get_win_core_synch_api_module() != NULL
+             ? GetProcAddress(win32_get_win_core_synch_api_module(), "WakeByAddressAll")
+             : nullptr));
     if (wake_by_address_all != nullptr) {
       wake_by_address_all(const_cast<__cxx_atomic_contention_t*>(__ptr));
     } else {

--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -109,10 +109,11 @@ static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const vo
 
 static void
 __libcpp_platform_wait_on_address(__cxx_atomic_contention_t const volatile* __ptr, __cxx_contention_t __val) {
-  static auto pWaitOnAddress = reinterpret_cast<BOOL(WINAPI*)(volatile void*, PVOID, SIZE_T, DWORD)>(
+  // WaitOnAddress was added in Windows 8 (build 9200)
+  static auto __pWaitOnAddress = reinterpret_cast<BOOL(WINAPI*)(volatile void*, PVOID, SIZE_T, DWORD)>(
       GetProcAddress(GetModuleHandleW(L"api-ms-win-core-synch-l1-2-0.dll"), "WaitOnAddress"));
-  if (pWaitOnAddress != nullptr) {
-    pWaitOnAddress(const_cast<__cxx_atomic_contention_t*>(__ptr), &__val, sizeof(__val), INFINITE);
+  if (__pWaitOnAddress != nullptr) {
+    __pWaitOnAddress(const_cast<__cxx_atomic_contention_t*>(__ptr), &__val, sizeof(__val), INFINITE);
   } else {
     __libcpp_thread_poll_with_backoff(
         [=]() -> bool { return !__cxx_nonatomic_compare_equal(__cxx_atomic_load(__ptr, memory_order_relaxed), __val); },
@@ -122,16 +123,18 @@ __libcpp_platform_wait_on_address(__cxx_atomic_contention_t const volatile* __pt
 
 static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const volatile* __ptr, bool __notify_one) {
   if (__notify_one) {
-    static auto pWakeByAddressSingle = reinterpret_cast<void(WINAPI*)(PVOID)>(
+    // WakeByAddressSingle was added in Windows 8 (build 9200)
+    static auto __pWakeByAddressSingle = reinterpret_cast<void(WINAPI*)(PVOID)>(
         GetProcAddress(GetModuleHandleW(L"api-ms-win-core-synch-l1-2-0.dll"), "WakeByAddressSingle"));
-    if (pWakeByAddressSingle != nullptr) {
-      pWakeByAddressSingle(const_cast<__cxx_atomic_contention_t*>(__ptr));
+    if (__pWakeByAddressSingle != nullptr) {
+      __pWakeByAddressSingle(const_cast<__cxx_atomic_contention_t*>(__ptr));
     }
   } else {
-    static auto pWakeByAddressAll = reinterpret_cast<void(WINAPI*)(PVOID)>(
+    // WakeByAddressAll was added in Windows 8 (build 9200)
+    static auto __pWakeByAddressAll = reinterpret_cast<void(WINAPI*)(PVOID)>(
         GetProcAddress(GetModuleHandleW(L"api-ms-win-core-synch-l1-2-0.dll"), "WakeByAddressAll"));
-    if (pWakeByAddressAll != nullptr) {
-      pWakeByAddressAll(const_cast<__cxx_atomic_contention_t*>(__ptr));
+    if (__pWakeByAddressAll != nullptr) {
+      __pWakeByAddressAll(const_cast<__cxx_atomic_contention_t*>(__ptr));
     }
   }
 }

--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -129,7 +129,7 @@ static void* win32_get_synch_api_function(const char* function_name) {
   // Attempt to locate the function in the API and return the result to the caller. Note that the NULL return from this
   // method is documented as being interchangeable with nullptr.
   // https://devblogs.microsoft.com/oldnewthing/20180307-00/?p=98175
-  return GetProcAddress(module_handle.get(), function_name);
+  return reinterpret_cast<void*>(GetProcAddress(module_handle, function_name));
 }
 
 static void


### PR DESCRIPTION
On Windows 8 and above, the WaitOnAddress, WakeByAddressSingle and WakeByAddressAll functions allow efficient implementation of the C++20 wait and notify features of std::atomic_flag. These Windows functions have never been made use of in libc++, leading to very poor performance of these features on Windows platforms, as they are implemented using a spin loop with backoff, rather than using any OS thread signalling whatsoever. This change implements the use of these OS functions where available, falling back to the original implementation on Windows versions prior to 8.

Relevant API docs from Microsoft:
https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitonaddress
https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-wakebyaddresssingle
https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-wakebyaddressall

Fixes #127221