### PR TITLE
Fix C++23 build error in llvm/Support/Caching.h

### DIFF
--- a/llvm/include/llvm/Support/Caching.h
+++ b/llvm/include/llvm/Support/Caching.h
@@ -17,10 +17,9 @@
 
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 namespace llvm {
-
-class MemoryBuffer;
 
 /// This class wraps an output stream for a file. Most clients should just be
 /// able to return an instance of this base class from the stream callback, but


### PR DESCRIPTION
[1] instantiates ~std::unique_ptr<MemoryBuffer>, so it must be a complete type.

[1] https://github.com/llvm/llvm-project/blob/4b89704504dde687ba7983e034cb246581fd1407/llvm/include/llvm/Support/Caching.h#L121