### PR TITLE
[flang][OpenMP]: Allow orphaned distribute construct

### DIFF
--- a/flang/test/Semantics/OpenMP/combined-constructs.f90
+++ b/flang/test/Semantics/OpenMP/combined-constructs.f90
@@ -7,7 +7,7 @@ program main
   real(8) :: a(256), b(256)
   N = 256
 
-  !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
+  !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
   !$omp distribute simd
   do i = 1, N
      a(i) = 3.14d0

--- a/flang/test/Semantics/OpenMP/do05.f90
+++ b/flang/test/Semantics/OpenMP/do05.f90
@@ -49,7 +49,7 @@ program omp_do
   end do
   !$omp end parallel do simd
 
-  !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
+  !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
   !$omp distribute parallel do
   do i=1,10
     if( i == 3 ) then
@@ -64,7 +64,7 @@ program omp_do
   end do
   !$omp end distribute parallel do
 
-  !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
+  !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
   !$omp distribute parallel do simd
   do i=1,10
     if( i == 3 ) then

--- a/flang/test/Semantics/OpenMP/linear-iter.f90
+++ b/flang/test/Semantics/OpenMP/linear-iter.f90
@@ -53,7 +53,7 @@ SUBROUTINE LINEAR_BAD(N)
   !$omp end teams
   !$omp end target 
 
-  !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
+  !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
   !ERROR: Variable 'j' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
   !$omp distribute simd linear(i,j)
    do i = 1, N
@@ -63,7 +63,7 @@ SUBROUTINE LINEAR_BAD(N)
    enddo
    !$omp end distribute simd
 
-   !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
+   !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
    !ERROR: Variable 'j' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
    !$omp distribute simd linear(i,j) collapse(1)
    do i = 1, N
@@ -73,7 +73,7 @@ SUBROUTINE LINEAR_BAD(N)
    enddo
    !$omp end distribute simd
 
-   !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
+   !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
    !$omp distribute simd linear(i,j) collapse(2)
    do i = 1, N
       do j = 1, N

--- a/flang/test/Semantics/OpenMP/nested-distribute.f90
+++ b/flang/test/Semantics/OpenMP/nested-distribute.f90
@@ -1,6 +1,15 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
 ! Check OpenMP clause validity for the following directives:
 !     2.10 Device constructs
+
+subroutine f
+  integer :: i
+  !WARNING: `DISTRIBUTE` must be dynamically enclosed in a `TEAMS` region.
+  !$omp distribute
+  do i = 1, 100
+     print *, "hello"
+  end do
+end subroutine
 program main
 
   real(8) :: arrayA(256), arrayB(256)
@@ -108,4 +117,8 @@ program main
       end do
       !$omp end distribute
   !$omp end task
+
+  !$omp teams
+    call foo
+  !$omp end teams
 end program main


### PR DESCRIPTION
If there is a call inside a TEAMS construct, and that call contains a DISTRIBUTE construct, the DISTRIBUTE region is considered to be enclosed by the TEAMS region (based on the dynamic extent of the construct). Currently, Flang diagnoses this as an error, which is incorrect.
For eg :
```
 subroutine f
  !$omp distribute
  do i = 1, 100
    ...
  end do
end subroutine

subroutine g
  !$omp teams
  call f ! this call is ok, distribute enclosed by teams
  !$omp end teams
end subroutine
```
This patch adjusts the nesting check for the OpenMP DISTRIBUTE directive. It retains the error for DISTRIBUTE directives that are incorrectly nested lexically  but downgrades it to a warning for orphaned directives to allow dynamic nesting, such as when a subroutine with DISTRIBUTE is called from within a TEAMS region.