### PR TITLE
[llvm] Fix C++23 error in InstrProfCorrelator.h

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProfCorrelator.h
+++ b/llvm/include/llvm/ProfileData/InstrProfCorrelator.h
@@ -13,6 +13,7 @@
 #define LLVM_PROFILEDATA_INSTRPROFCORRELATOR_H
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Debuginfod/BuildIDFetcher.h"
 #include "llvm/Object/BuildID.h"
 #include "llvm/ProfileData/InstrProf.h"
@@ -24,7 +25,6 @@
 #include <vector>
 
 namespace llvm {
-class DWARFContext;
 class DWARFDie;
 namespace object {
 class ObjectFile;


### PR DESCRIPTION
[1] instantiates ~unique_ptr<DwarfContext>, so that must be a complete type.

[1] https://github.com/llvm/llvm-project/blob/67e6a376209c9cc9576012c1c042bee9b852d584/llvm/include/llvm/ProfileData/InstrProfCorrelator.h#L182