### PR TITLE
[llvm] Fix C++23 error in {Succ,Pred}Iterator

### DIFF
--- a/llvm/include/llvm/IR/CFG.h
+++ b/llvm/include/llvm/IR/CFG.h
@@ -42,9 +42,9 @@ template <class Ptr, class USE_iterator> // Predecessor Iterator
 class PredIterator {
 public:
   using iterator_category = std::forward_iterator_tag;
-  using value_type = Ptr;
+  using value_type = Ptr *;
   using difference_type = std::ptrdiff_t;
-  using pointer = Ptr *;
+  using pointer = Ptr **;
   using reference = Ptr *;
 
 protected:
@@ -141,7 +141,8 @@ class SuccIterator
                                   std::random_access_iterator_tag, BlockT, int,
                                   BlockT *, BlockT *> {
 public:
-  using difference_type = int;
+  using value_type = BlockT *;
+  using difference_type = std::ptrdiff_t;
   using pointer = BlockT *;
   using reference = BlockT *;
 


### PR DESCRIPTION
[1] calls insert in an underlying vector and in C++23 that requires the iterators to satisfy stricter constraints [2][3].

[1] https://github.com/llvm/llvm-project/blob/67e6a376209c9cc9576012c1c042bee9b852d584/llvm/lib/Analysis/LazyValueInfo.cpp#L333
[2] https://github.com/llvm/llvm-project/blob/20bcf123e2db033f208462f34f63e292efbe0946/libcxx/include/__vector/vector.h#L645-L649
[3] https://github.com/llvm/llvm-project/blob/20bcf123e2db033f208462f34f63e292efbe0946/libcxx/include/__algorithm/ranges_copy_n.h#L61