### PR TITLE
[LiveIntervals] Add function name to debug output header.

### DIFF
--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -179,7 +179,7 @@ void LiveIntervals::analyze(MachineFunction &fn) {
 }
 
 void LiveIntervals::print(raw_ostream &OS) const {
-  OS << "********** INTERVALS **********\n";
+  OS << "********** INTERVALS for function " << MF->getName() << '\n';
 
   // Dump the regunits.
   for (unsigned Unit = 0, UnitE = RegUnitRanges.size(); Unit != UnitE; ++Unit)


### PR DESCRIPTION
Make it easier to locate LiveIntervals debug printing for a specific function, especially in a script.