### PR TITLE
[cmake] Pass PYTHON_EXECUTABLE to native builds

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -101,6 +101,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
         -DLLVM_TABLEGEN_FLAGS="${LLVM_TABLEGEN_FLAGS}"
+        -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"
         ${build_type_flags} ${linker_flag} ${external_clang_dir} ${libc_flags}
         ${ARGN}
     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}


### PR DESCRIPTION
Ensure that the nested native build uses the same python interpreter as the main build, in case the python that CMake detects first is not the python that the user has specified explicitly.

For example, if the person building LLVM wants to use a different python interpreter to build (eg, testing the build with `python3.14` when `python3` is a link to `python3.8`, or the default python doesn't have development headers available) then they could add `-DPYTHON_EXECUTABLE=python3.14` when invoking CMake.  This should be forwarded to the native CMake build to ensure that the same python is used.

Original fix by Anuj Mittal <anuj.mittal@intel.com>.