### PR TITLE
[mlir][python] Add pythonic interface for GPUFuncOp

### DIFF
--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -87,9 +87,8 @@ class GPUFuncOp(GPUFuncOp):
 
         if known_block_size is not None:
             if isinstance(known_block_size, Sequence):
-                self.attributes[self.KNOWN_BLOCK_SIZE_ATTR_NAME] = (
-                    DenseI32ArrayAttr.get(known_block_size)
-                )
+                block_size = DenseI32ArrayAttr.get(known_block_size)
+                self.attributes[self.KNOWN_BLOCK_SIZE_ATTR_NAME] = block_size
             elif isinstance(known_block_size, DenseI32ArrayAttr):
                 self.attributes[self.KNOWN_BLOCK_SIZE_ATTR_NAME] = known_block_size
             else:
@@ -99,9 +98,8 @@ class GPUFuncOp(GPUFuncOp):
 
         if known_grid_size is not None:
             if isinstance(known_grid_size, Sequence):
-                self.attributes[self.KNOWN_GRID_SIZE_ATTR_NAME] = DenseI32ArrayAttr.get(
-                    known_grid_size
-                )
+                grid_size = DenseI32ArrayAttr.get(known_grid_size)
+                self.attributes[self.KNOWN_GRID_SIZE_ATTR_NAME] = grid_size
             elif isinstance(known_grid_size, DenseI32ArrayAttr):
                 self.attributes[self.KNOWN_GRID_SIZE_ATTR_NAME] = known_grid_size
             else:

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -3,5 +3,121 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .._gpu_ops_gen import *
+from .._gpu_ops_gen import _Dialect
 from .._gpu_enum_gen import *
 from ..._mlir_libs._mlirDialectsGPU import *
+from typing import Callable, Sequence, Union, Optional
+
+try:
+    from ...ir import (
+        FunctionType,
+        TypeAttr,
+        StringAttr,
+        UnitAttr,
+        Block,
+        InsertionPoint,
+        ArrayAttr,
+        Type,
+        DictAttr,
+        Attribute,
+    )
+    from .._ods_common import (
+        get_default_loc_context as _get_default_loc_context,
+        _cext as _ods_cext,
+    )
+except ImportError as e:
+    raise RuntimeError("Error loading imports from extension module") from e
+
+
+FUNCTION_TYPE_ATTRIBUTE_NAME = "function_type"
+KERNEL_ATTRIBUTE_NAME = "gpu.kernel"
+SYM_NAME_ATTRIBUTE_NAME = "sym_name"
+ARGUMENT_ATTRIBUTE_NAME = "arg_attrs"
+RESULT_ATTRIBUTE_NAME = "res_attrs"
+
+
+@_ods_cext.register_operation(_Dialect, replace=True)
+class GPUFuncOp(GPUFuncOp):
+    def __init__(
+        self,
+        function_type: Union[FunctionType, TypeAttr],
+        sym_name: Optional[Union[str, StringAttr]] = None,
+        kernel: Optional[bool] = None,
+        body_builder: Optional[Callable[[GPUFuncOp], None]] = None,
+        *args,
+        loc=None,
+        ip=None,
+        **kwargs,
+    ):
+        function_type = (
+            TypeAttr.get(function_type)
+            if not isinstance(function_type, TypeAttr)
+            else function_type
+        )
+        super().__init__(function_type, *args, loc=loc, ip=ip, **kwargs)
+        if sym_name is not None:
+            self.attributes[SYM_NAME_ATTRIBUTE_NAME] = StringAttr.get(str(sym_name))
+        if kernel:
+            self.attributes[KERNEL_ATTRIBUTE_NAME] = UnitAttr.get()
+        if body_builder is not None:
+            with InsertionPoint(self.add_entry_block()):
+                body_builder(self)
+
+    @property
+    def type(self) -> FunctionType:
+        return FunctionType(
+            TypeAttr(self.attributes[FUNCTION_TYPE_ATTRIBUTE_NAME]).value
+        )
+
+    @property
+    def name(self) -> StringAttr:
+        return StringAttr(self.attributes[SYM_NAME_ATTRIBUTE_NAME])
+
+    @property
+    def is_kernel(self) -> bool:
+        return KERNEL_ATTRIBUTE_NAME in self.attributes
+
+    def add_entry_block(self) -> Block:
+        function_type = self.type
+        return self.body.blocks.append(
+            *function_type.inputs,
+            arg_locs=[self.location for _ in function_type.inputs],
+        )
+
+    @property
+    def entry_block(self) -> Block:
+        return self.body.blocks[0]
+
+    @property
+    def arguments(self) -> Sequence[Type]:
+        return self.type.inputs
+
+    @property
+    def arg_attrs(self):
+        if ARGUMENT_ATTRIBUTE_NAME not in self.attributes:
+            return ArrayAttr.get([DictAttr.get({}) for _ in self.type.inputs])
+        return ArrayAttr(self.attributes[ARGUMENT_ATTRIBUTE_NAME])
+
+    @arg_attrs.setter
+    def arg_attrs(self, attribute: Union[ArrayAttr, list[Attribute]]):
+        if isinstance(attribute, ArrayAttr):
+            self.attributes[ARGUMENT_ATTRIBUTE_NAME] = attribute
+        else:
+            self.attributes[ARGUMENT_ATTRIBUTE_NAME] = ArrayAttr.get(
+                attribute, context=self.context
+            )
+
+    @property
+    def result_attrs(self) -> Optional[ArrayAttr]:
+        if RESULT_ATTRIBUTE_NAME not in self.attributes:
+            return ArrayAttr.get([DictAttr.get({}) for _ in self.type.results])
+        return self.attributes[RESULT_ATTRIBUTE_NAME]
+
+    @result_attrs.setter
+    def result_attrs(self, attribute: Union[ArrayAttr, list[Attribute]]):
+        if isinstance(attribute, ArrayAttr):
+            self.attributes[RESULT_ATTRIBUTE_NAME] = attribute
+        else:
+            self.attributes[RESULT_ATTRIBUTE_NAME] = ArrayAttr.get(
+                attribute, context=self.context
+            )

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -132,37 +132,3 @@ class GPUFuncOp(GPUFuncOp):
     @property
     def arguments(self) -> Sequence[Type]:
         return self.function_type.value.inputs
-
-    @property
-    def arg_attrs(self):
-        if self.ARGUMENT_ATTR_NAME not in self.attributes:
-            return ArrayAttr.get(
-                [DictAttr.get({}) for _ in self.function_type.value.inputs]
-            )
-        return ArrayAttr(self.attributes[self.ARGUMENT_ATTR_NAME])
-
-    @arg_attrs.setter
-    def arg_attrs(self, attribute: Union[ArrayAttr, Sequence[Attribute]]):
-        if isinstance(attribute, ArrayAttr):
-            self.attributes[self.ARGUMENT_ATTR_NAME] = attribute
-        else:
-            self.attributes[self.ARGUMENT_ATTR_NAME] = ArrayAttr.get(
-                attribute, context=self.context
-            )
-
-    @property
-    def result_attrs(self) -> Optional[ArrayAttr]:
-        if self.RESULT_ATTR_NAME not in self.attributes:
-            return ArrayAttr.get(
-                [DictAttr.get({}) for _ in self.function_type.value.results]
-            )
-        return self.attributes[self.RESULT_ATTR_NAME]
-
-    @result_attrs.setter
-    def result_attrs(self, attribute: Union[ArrayAttr, Sequence[Attribute]]):
-        if isinstance(attribute, ArrayAttr):
-            self.attributes[self.RESULT_ATTR_NAME] = attribute
-        else:
-            self.attributes[self.RESULT_ATTR_NAME] = ArrayAttr.get(
-                attribute, context=self.context
-            )

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -48,32 +48,42 @@ class GPUFuncOp(GPUFuncOp):
         function_type: Union[FunctionType, TypeAttr],
         sym_name: Optional[Union[str, StringAttr]] = None,
         kernel: Optional[bool] = None,
-        body_builder: Optional[Callable[[GPUFuncOp], None]] = None,
+        workgroup_attrib_attrs: Optional[Sequence[dict]] = None,
+        private_attrib_attrs: Optional[Sequence[dict]] = None,
         known_block_size: Optional[Union[Sequence[int], DenseI32ArrayAttr]] = None,
         known_grid_size: Optional[Union[Sequence[int], DenseI32ArrayAttr]] = None,
-        *args,
         loc=None,
         ip=None,
-        **kwargs,
+        body_builder: Optional[Callable[[GPUFuncOp], None]] = None,
     ):
         """
-        Create a GPUFuncOp with the provided `function_type`, `sym_name`, `kernel`, `body_builder`, `known_block_size`, and `known_grid_size`.
+        Create a GPUFuncOp with the provided `function_type`, `sym_name`, 
+        `kernel`, `workgroup_attrib_attrs`, `private_attrib_attrs`, `known_block_size`, 
+        `known_grid_size`, and `body_builder`.
         - `function_type` is a FunctionType or a TypeAttr.
         - `sym_name` is a string or a StringAttr representing the function name.
         - `kernel` is a boolean representing whether the function is a kernel.
+        - `workgroup_attrib_attrs` is an optional list of dictionaries.
+        - `private_attrib_attrs` is an optional list of dictionaries.
+        - `known_block_size` is an optional list of integers or a DenseI32ArrayAttr representing the known block size.
+        - `known_grid_size` is an optional list of integers or a DenseI32ArrayAttr representing the known grid size.
         - `body_builder` is an optional callback. When provided, a new entry block
           is created and the callback is invoked with the new op as argument within
           an InsertionPoint context already set for the block. The callback is
           expected to insert a terminator in the block.
-        - `known_block_size` is an optional list of integers or a DenseI32ArrayAttr representing the known block size.
-        - `known_grid_size` is an optional list of integers or a DenseI32ArrayAttr representing the known grid size.
         """
         function_type = (
             TypeAttr.get(function_type)
             if not isinstance(function_type, TypeAttr)
             else function_type
         )
-        super().__init__(function_type, *args, loc=loc, ip=ip, **kwargs)
+        super().__init__(
+            function_type,
+            workgroup_attrib_attrs=workgroup_attrib_attrs,
+            private_attrib_attrs=private_attrib_attrs,
+            loc=loc,
+            ip=ip,
+        )
 
         if isinstance(sym_name, str):
             self.attributes[self.SYM_NAME_ATTR_NAME] = StringAttr.get(sym_name)

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -57,8 +57,8 @@ class GPUFuncOp(GPUFuncOp):
         body_builder: Optional[Callable[[GPUFuncOp], None]] = None,
     ):
         """
-        Create a GPUFuncOp with the provided `function_type`, `sym_name`, 
-        `kernel`, `workgroup_attrib_attrs`, `private_attrib_attrs`, `known_block_size`, 
+        Create a GPUFuncOp with the provided `function_type`, `sym_name`,
+        `kernel`, `workgroup_attrib_attrs`, `private_attrib_attrs`, `known_block_size`,
         `known_grid_size`, and `body_builder`.
         - `function_type` is a FunctionType or a TypeAttr.
         - `sym_name` is a string or a StringAttr representing the function name.

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -80,9 +80,7 @@ class GPUFuncOp(GPUFuncOp):
         elif isinstance(sym_name, StringAttr):
             self.attributes[self.SYM_NAME_ATTR_NAME] = sym_name
         else:
-            raise ValueError(
-                "sym_name must be a string or a StringAttr"
-            )
+            raise ValueError("sym_name must be a string or a StringAttr")
 
         if kernel:
             self.attributes[self.KERNEL_ATTR_NAME] = UnitAttr.get()
@@ -137,8 +135,8 @@ class GPUFuncOp(GPUFuncOp):
     def entry_block(self) -> Block:
         if len(self.body.blocks) == 0:
             raise RuntimeError(
-                f"Entry block does not exist for {self.name.value}." +
-                " Do you need to call the add_entry_block() method on this GPUFuncOp?"
+                f"Entry block does not exist for {self.name.value}."
+                + " Do you need to call the add_entry_block() method on this GPUFuncOp?"
             )
         return self.body.blocks[0]
 

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -6,7 +6,7 @@ from .._gpu_ops_gen import *
 from .._gpu_ops_gen import _Dialect
 from .._gpu_enum_gen import *
 from ..._mlir_libs._mlirDialectsGPU import *
-from typing import Callable, Sequence, Union, Optional
+from typing import Callable, Sequence, Union, Optional, List
 
 try:
     from ...ir import (
@@ -20,6 +20,7 @@ try:
         Type,
         DictAttr,
         Attribute,
+        DenseI32ArrayAttr,
     )
     from .._ods_common import (
         get_default_loc_context as _get_default_loc_context,
@@ -29,26 +30,44 @@ except ImportError as e:
     raise RuntimeError("Error loading imports from extension module") from e
 
 
-FUNCTION_TYPE_ATTRIBUTE_NAME = "function_type"
 KERNEL_ATTRIBUTE_NAME = "gpu.kernel"
+KNOWN_BLOCK_SIZE_ATTRIBUTE_NAME = "gpu.known_block_size"
+KNOWN_GRID_SIZE_ATTRIBUTE_NAME = "gpu.known_grid_size"
+
+FUNCTION_TYPE_ATTRIBUTE_NAME = "function_type"
 SYM_NAME_ATTRIBUTE_NAME = "sym_name"
 ARGUMENT_ATTRIBUTE_NAME = "arg_attrs"
 RESULT_ATTRIBUTE_NAME = "res_attrs"
 
-
 @_ods_cext.register_operation(_Dialect, replace=True)
 class GPUFuncOp(GPUFuncOp):
+    __doc__ = GPUFuncOp.__doc__
+
     def __init__(
         self,
         function_type: Union[FunctionType, TypeAttr],
         sym_name: Optional[Union[str, StringAttr]] = None,
         kernel: Optional[bool] = None,
         body_builder: Optional[Callable[[GPUFuncOp], None]] = None,
+        known_block_size: Optional[Union[List[int], DenseI32ArrayAttr]] = None,
+        known_grid_size: Optional[Union[List[int], DenseI32ArrayAttr]] = None,
         *args,
         loc=None,
         ip=None,
         **kwargs,
     ):
+        """
+        Create a GPUFuncOp with the provided `function_type`, `sym_name`, `kernel`, `body_builder`, `known_block_size`, and `known_grid_size`.
+        - `function_type` is a FunctionType or a TypeAttr.
+        - `sym_name` is a string or a StringAttr representing the function name.
+        - `kernel` is a boolean representing whether the function is a kernel.
+        - `body_builder` is an optional callback. When provided, a new entry block
+          is created and the callback is invoked with the new op as argument within
+          an InsertionPoint context already set for the block. The callback is
+          expected to insert a terminator in the block.
+        - `known_block_size` is an optional list of integers or a DenseI32ArrayAttr representing the known block size.
+        - `known_grid_size` is an optional list of integers or a DenseI32ArrayAttr representing the known grid size.
+        """
         function_type = (
             TypeAttr.get(function_type)
             if not isinstance(function_type, TypeAttr)
@@ -62,6 +81,20 @@ class GPUFuncOp(GPUFuncOp):
         if body_builder is not None:
             with InsertionPoint(self.add_entry_block()):
                 body_builder(self)
+        if known_block_size is not None:
+            if isinstance(known_block_size, list):
+                self.attributes[KNOWN_BLOCK_SIZE_ATTRIBUTE_NAME] = (
+                    DenseI32ArrayAttr.get(known_block_size)
+                )
+            else:
+                self.attributes[KNOWN_BLOCK_SIZE_ATTRIBUTE_NAME] = known_block_size
+        if known_grid_size is not None:
+            if isinstance(known_grid_size, list):
+                self.attributes[KNOWN_GRID_SIZE_ATTRIBUTE_NAME] = (
+                    DenseI32ArrayAttr.get(known_grid_size)
+                )
+            else:
+                self.attributes[KNOWN_GRID_SIZE_ATTRIBUTE_NAME] = known_grid_size
 
     @property
     def type(self) -> FunctionType:
@@ -76,6 +109,18 @@ class GPUFuncOp(GPUFuncOp):
     @property
     def is_kernel(self) -> bool:
         return KERNEL_ATTRIBUTE_NAME in self.attributes
+
+    @property
+    def known_block_size(self) -> Optional[DenseI32ArrayAttr]:
+        if KNOWN_BLOCK_SIZE_ATTRIBUTE_NAME not in self.attributes:
+            return None
+        return self.attributes[KNOWN_BLOCK_SIZE_ATTRIBUTE_NAME]
+
+    @property
+    def known_grid_size(self) -> Optional[DenseI32ArrayAttr]:
+        if KNOWN_GRID_SIZE_ATTRIBUTE_NAME not in self.attributes:
+            return None
+        return self.attributes[KNOWN_GRID_SIZE_ATTRIBUTE_NAME]
 
     def add_entry_block(self) -> Block:
         function_type = self.type

--- a/mlir/python/mlir/dialects/gpu/__init__.py
+++ b/mlir/python/mlir/dialects/gpu/__init__.py
@@ -39,6 +39,7 @@ SYM_NAME_ATTRIBUTE_NAME = "sym_name"
 ARGUMENT_ATTRIBUTE_NAME = "arg_attrs"
 RESULT_ATTRIBUTE_NAME = "res_attrs"
 
+
 @_ods_cext.register_operation(_Dialect, replace=True)
 class GPUFuncOp(GPUFuncOp):
     __doc__ = GPUFuncOp.__doc__
@@ -90,8 +91,8 @@ class GPUFuncOp(GPUFuncOp):
                 self.attributes[KNOWN_BLOCK_SIZE_ATTRIBUTE_NAME] = known_block_size
         if known_grid_size is not None:
             if isinstance(known_grid_size, list):
-                self.attributes[KNOWN_GRID_SIZE_ATTRIBUTE_NAME] = (
-                    DenseI32ArrayAttr.get(known_grid_size)
+                self.attributes[KNOWN_GRID_SIZE_ATTRIBUTE_NAME] = DenseI32ArrayAttr.get(
+                    known_grid_size
                 )
             else:
                 self.attributes[KNOWN_GRID_SIZE_ATTRIBUTE_NAME] = known_grid_size

--- a/mlir/test/python/dialects/gpu/dialect.py
+++ b/mlir/test/python/dialects/gpu/dialect.py
@@ -93,7 +93,10 @@ def testGPUFuncOp():
                 func.entry_block
                 assert False, "Expected RuntimeError"
             except RuntimeError as e:
-                assert str(e) == "Entry block does not exist for kernel0. Do you need to call the add_entry_block() method on this GPUFuncOp?"
+                assert (
+                    str(e)
+                    == "Entry block does not exist for kernel0. Do you need to call the add_entry_block() method on this GPUFuncOp?"
+                )
 
             block = func.add_entry_block()
             with InsertionPoint(block):

--- a/mlir/test/python/dialects/gpu/dialect.py
+++ b/mlir/test/python/dialects/gpu/dialect.py
@@ -103,8 +103,8 @@ def testGPUFuncOp():
 
             assert func.name.value == "kernel1"
             assert func.function_type.value == func_type
-            assert func.arg_attrs == ArrayAttr.get([])
-            assert func.result_attrs == ArrayAttr.get([])
+            assert func.arg_attrs == None
+            assert func.res_attrs == None
             assert func.arguments == []
             assert func.entry_block == func.body.blocks[0]
             assert func.is_kernel

--- a/mlir/test/python/dialects/gpu/dialect.py
+++ b/mlir/test/python/dialects/gpu/dialect.py
@@ -148,8 +148,8 @@ def testGPUFuncOp():
     # CHECK:   gpu.return
     # CHECK: }
     # CHECK: gpu.func @kernel1() kernel attributes
-    # CHECK-SAME: gpu.known_block_size = array<i32: 1, 2, 3>
-    # CHECK-SAME: gpu.known_grid_size = array<i32: 4, 5, 6>
+    # CHECK-SAME: known_block_size = array<i32: 1, 2, 3>
+    # CHECK-SAME: known_grid_size = array<i32: 4, 5, 6>
     # CHECK:   %[[VAL_0:.*]] = gpu.global_id  x
     # CHECK:   gpu.return
     # CHECK: }

--- a/mlir/test/python/dialects/gpu/dialect.py
+++ b/mlir/test/python/dialects/gpu/dialect.py
@@ -88,9 +88,22 @@ def testGPUFuncOp():
             func = gpu.GPUFuncOp(type_attr, name)
             func.attributes["sym_name"] = name
             func.attributes["gpu.kernel"] = UnitAttr.get()
-            block = func.body.blocks.append()
+
+            try:
+                func.entry_block
+                assert False, "Expected RuntimeError"
+            except RuntimeError as e:
+                assert str(e) == "Entry block does not exist for kernel0. Do you need to call the add_entry_block() method on this GPUFuncOp?"
+
+            block = func.add_entry_block()
             with InsertionPoint(block):
                 builder(func)
+
+            try:
+                func.add_entry_block()
+                assert False, "Expected RuntimeError"
+            except RuntimeError as e:
+                assert str(e) == "Entry block already exists for kernel0"
 
             func = gpu.GPUFuncOp(
                 func_type,

--- a/mlir/test/python/dialects/gpu/dialect.py
+++ b/mlir/test/python/dialects/gpu/dialect.py
@@ -86,8 +86,8 @@ def testGPUFuncOp():
             func_type = ir.FunctionType.get(inputs=[], results=[])
             type_attr = TypeAttr.get(func_type)
             func = gpu.GPUFuncOp(type_attr, name)
-            func.attributes[gpu.SYM_NAME_ATTRIBUTE_NAME] = name
-            func.attributes[gpu.KERNEL_ATTRIBUTE_NAME] = UnitAttr.get()
+            func.attributes["sym_name"] = name
+            func.attributes["gpu.kernel"] = UnitAttr.get()
             block = func.body.blocks.append()
             with InsertionPoint(block):
                 builder(func)
@@ -102,13 +102,18 @@ def testGPUFuncOp():
             )
 
             assert func.name.value == "kernel1"
+            assert func.function_type.value == func_type
             assert func.arg_attrs == ArrayAttr.get([])
             assert func.result_attrs == ArrayAttr.get([])
             assert func.arguments == []
             assert func.entry_block == func.body.blocks[0]
             assert func.is_kernel
-            assert func.known_block_size == DenseI32ArrayAttr.get([1, 2, 3])
-            assert func.known_grid_size == DenseI32ArrayAttr.get([4, 5, 6])
+            assert func.known_block_size == DenseI32ArrayAttr.get(
+                [1, 2, 3]
+            ), func.known_block_size
+            assert func.known_grid_size == DenseI32ArrayAttr.get(
+                [4, 5, 6]
+            ), func.known_grid_size
 
             func = gpu.GPUFuncOp(
                 func_type,


### PR DESCRIPTION
The func dialect provides a more pythonic interface for constructing operations, but the gpu dialect does not; this is the first PR to provide the same conveniences for the gpu dialect, starting with the gpu.func op.