### PR TITLE
[DWARFLinker] Move __debug_str to the last section

### DIFF
--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -3129,7 +3129,6 @@ Error DWARFLinker::link() {
     // Emit everything that's global.
     if (TheDwarfEmitter != nullptr) {
       TheDwarfEmitter->emitAbbrevs(Abbreviations, Options.TargetDWARFVersion);
-      TheDwarfEmitter->emitStrings(DebugStrPool);
       TheDwarfEmitter->emitStringOffsets(StringOffsetPool.getValues(),
                                          Options.TargetDWARFVersion);
       TheDwarfEmitter->emitLineStrings(DebugLineStrPool);
@@ -3150,6 +3149,7 @@ Error DWARFLinker::link() {
           break;
         }
       }
+      TheDwarfEmitter->emitStrings(DebugStrPool);
     }
   };
 

--- a/llvm/test/tools/dsymutil/X86/swift-ast-section-order.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-section-order.test
@@ -1,0 +1,17 @@
+# Check that the __debug_str section is last in the output
+
+# RUN: rm -rf %t && mkdir %t
+# RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose -no-swiftmodule-timestamp
+# RUN: llvm-dwarfdump --show-section-sizes %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s
+
+# This test verifies that the __debug_str section appears last in the section list.
+
+# CHECK: SECTION
+# CHECK: __swift_ast
+# CHECK: __debug_abbrev
+# CHECK: __apple_namespac
+# CHECK: __apple_names
+# CHECK: __apple_types
+# CHECK: __apple_objc
+# CHECK-NOT: __apple
+# CHECK: __debug_str


### PR DESCRIPTION
Context: MachO defined section offset to be a 32-bit integer, meaning that each section must start within 4GB of the segment.

https://github.com/llvm/llvm-project/blob/c4d7c42b1de2117f104e202ac0f4b808bce4d28b/llvm/include/llvm/BinaryFormat/MachO.h#L580-L593

Problem: With larger and larger dSYM we are running out of space. In our internal builds, __debug_str and __debug_line are the two biggest section each having more than 1GB, combined they pushed the last few sections out of the 4GB range.

This diff tries to mitigate that by moving one of the biggest sections to the last, buying our time to find a more permeant solutions