### PR TITLE
PHIElimination: add target hook to control reuse.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2169,7 +2169,7 @@ public:
     return TargetOpcode::COPY;
   }
 
-  /// During PHI eleimination lets target to make necessary checks and
+  /// During PHI elimination lets target to make necessary checks and
   /// insert the copy to the PHI destination register in a target specific
   /// manner.
   virtual MachineInstr *createPHIDestinationCopy(
@@ -2179,7 +2179,7 @@ public:
         .addReg(Src);
   }
 
-  /// During PHI eleimination lets target to make necessary checks and
+  /// During PHI elimination lets target to make necessary checks and
   /// insert the copy to the PHI destination register in a target specific
   /// manner.
   virtual MachineInstr *createPHISourceCopy(MachineBasicBlock &MBB,
@@ -2189,6 +2189,17 @@ public:
                                             Register Dst) const {
     return BuildMI(MBB, InsPt, DL, get(TargetOpcode::COPY), Dst)
         .addReg(Src, 0, SrcSubReg);
+  }
+
+  /// During PHI elimination lets target to decide if two phis can use the
+  /// same register \p Reg when they have the same rhs. Register \p Reg has
+  /// been used for the first phi and \p PHIReg is the DestReg of the second
+  /// Phi. This function is to check if the second phi can reuse \p Reg as
+  /// its temporary register.
+  /// The default is to allow reuse.
+  virtual bool allowPHIReuse(Register Reg, Register PHIReg,
+                             const MachineFunction &MF) const {
+    return true;
   }
 
   /// Returns a \p outliner::OutlinedFunction struct containing target-specific

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2169,7 +2169,7 @@ public:
     return TargetOpcode::COPY;
   }
 
-  /// During PHI elimination lets target to make necessary checks and
+  /// During PHI eleimination lets target to make necessary checks and
   /// insert the copy to the PHI destination register in a target specific
   /// manner.
   virtual MachineInstr *createPHIDestinationCopy(
@@ -2179,7 +2179,7 @@ public:
         .addReg(Src);
   }
 
-  /// During PHI elimination lets target to make necessary checks and
+  /// During PHI eleimination lets target to make necessary checks and
   /// insert the copy to the PHI destination register in a target specific
   /// manner.
   virtual MachineInstr *createPHISourceCopy(MachineBasicBlock &MBB,
@@ -2189,17 +2189,6 @@ public:
                                             Register Dst) const {
     return BuildMI(MBB, InsPt, DL, get(TargetOpcode::COPY), Dst)
         .addReg(Src, 0, SrcSubReg);
-  }
-
-  /// During PHI elimination lets target to decide if two phis can use the
-  /// same register \p Reg when they have the same rhs. Register \p Reg has
-  /// been used for the first phi and \p PHIReg is the DestReg of the second
-  /// Phi. This function is to check if the second phi can reuse \p Reg as
-  /// its temporary register.
-  /// The default is to allow reuse.
-  virtual bool allowPHIReuse(Register Reg, Register PHIReg,
-                             const MachineFunction &MF) const {
-    return true;
   }
 
   /// Returns a \p outliner::OutlinedFunction struct containing target-specific

--- a/llvm/lib/CodeGen/PHIElimination.cpp
+++ b/llvm/lib/CodeGen/PHIElimination.cpp
@@ -380,7 +380,7 @@ void PHIEliminationImpl::LowerPHINode(MachineBasicBlock &MBB,
     Register *Entry = nullptr;
     if (AllEdgesCritical)
       Entry = &LoweredPHIs[MPhi];
-    if (Entry && *Entry) {
+    if (Entry && *Entry && TII->allowPHIReuse(*Entry, DestReg, MF)) {
       // An identical PHI node was already lowered. Reuse the incoming register.
       IncomingReg = *Entry;
       reusedIncoming = true;

--- a/llvm/test/CodeGen/AMDGPU/phi-elimination-reuse-pr163604.mir
+++ b/llvm/test/CodeGen/AMDGPU/phi-elimination-reuse-pr163604.mir
@@ -1,0 +1,42 @@
+# RUN: llc -mtriple amdgcn -run-pass phi-node-elimination -o - %s | FileCheck %s
+
+---
+# The test is to make sure that two phis, with the same right-hand-site but different
+# register classes for their left-hand-sites, are not doing phi reuse optimization.
+# Not sure whether this test makes any sense for the AMDGPU target, but it is a valid
+# case for aother GPU target that is not in LLVM trunk yet. Thus, this test uses the
+# ADMGPU target as a proof of concept.
+
+# Because of no reuse for the two phis, there are two temps: CP0 and CP1
+# They are translated to:
+#   phi1 (%1:sreg_32) = CP0
+#   phi2 (%4:vgpr_32) = CP1
+#
+# CHECK-LABEL: check-phi-reuse
+# CHECK-LABEL: bb.1:
+# CHECK: %1:sreg_32 = COPY %[[#CP0:]]
+# CHECK: %[[#CP0]]:sreg_32 = COPY {{.+}}
+# CHECK: %[[#CP1:]]:vgpr_32 = COPY {{.+}}
+# CHECK-LABEL: bb.2:
+# CHECK: %4:vgpr_32 = COPY %[[#CP1]]
+
+
+
+name:            check-phi-reuse
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    %1:sreg_32 = S_MOV_B32 255
+    S_CBRANCH_SCC0 %bb.2, implicit undef $scc
+
+  bb.1:
+    %3:sreg_32 = PHI %4, %bb.1, %1, %bb.0
+    %2:sreg_32 = S_ADD_I32 %3, 1, implicit-def $scc
+    %4:vgpr_32 = COPY %2
+    S_CBRANCH_SCC0 %bb.1, implicit killed $scc
+    S_BRANCH %bb.2
+
+  bb.2:
+    %5:vgpr_32 = PHI %4, %bb.1, %1, %bb.0
+...
+


### PR DESCRIPTION
PHI elimination pass may reuse temporary registers during PHI node elimination if two phis have the same right-hand sites.

However, the left-hand sides of phis need to be checked as well for some GPU targets,, such as an Intel GPU target. If the register classes of phis's left-hand sides are different, reuse might be problematic, as shown in https://github.com/llvm/llvm-project/issues/163500. Thus, this change adds additional check for reuse. 

The additional check is to check if the left-hand sites of phis have the same common sub register class. If so, reuse is allowed. Otherwise, resuse is not allowed. This might be conservative, but expect no impact to CPU code.

This is to resolve the issue:
  https://github.com/llvm/llvm-project/issues/163500