### PR TITLE
[LLDB][PDB] Run `pointers.test` with both plugins

### DIFF
--- a/lldb/test/Shell/SymbolFile/PDB/pointers.test
+++ b/lldb/test/Shell/SymbolFile/PDB/pointers.test
@@ -2,38 +2,44 @@ REQUIRES: target-windows, msvc
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/PointerTypeTest.cpp.obj %S/Inputs/PointerTypeTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/PointerTypeTest.cpp.exe %t.dir/PointerTypeTest.cpp.obj
-RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck %s
-RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-F %s
-RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST %s
-RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN %s
-RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=F %s
+
+RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-INT %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-FN %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=F %s
+
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-INT %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-FN %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=F %s
 
 CHECK: Module [[MOD:.*]]
 CHECK: {{^[0-9A-F]+}}:   CompileUnit{{[{]0x[0-9a-f]+[}]}}, language = "c++", file = '{{.*}}\PointerTypeTest.cpp'
 
-MAIN-ST-F:  name = "f"
-MAIN-ST-F-SAME: decl = PointerTypeTest.cpp:8
-MAIN-ST-F-SAME: compiler_type = {{.*}} int (int)
+MAIN-ST-INT-LABEL: name = "ST", size = 4, decl = PointerTypeTest.cpp:6, compiler_type = {{.*}} struct ST {
+MAIN-ST-INT: int a;
+MAIN-ST-INT-LABEL:}
 
-MAIN-ST:  name = "ST", size = 4, decl = PointerTypeTest.cpp:6, compiler_type = {{.*}} struct ST {
-MAIN-ST-NEXT: int a;
-MAIN-ST-NEXT: int {{.*}}f(int);
-MAIN-ST-NEXT:}
+MAIN-ST-FN-LABEL:  name = "ST", size = 4, decl = PointerTypeTest.cpp:6, compiler_type = {{.*}} struct ST {
+MAIN-ST-FN: int {{.*}}f(int);
+MAIN-ST-FN-LABEL:}
 
-MAIN:   Function{[[FID1:.*]]}, mangled = {{_?}}main
+MAIN:   Function{[[FID1:.*]]}, {{(de)?}}mangled = {{_?}}main
 MAIN-NEXT:  Block{[[FID1]]}
 MAIN:     Variable{{.*}}, name = "array_pointer"
 MAIN-SAME:    (int (*)[2][4]), scope = local
 MAIN:     Variable{{.*}}, name = "p_int"
 MAIN-SAME:    (int *), scope = local
 MAIN:     Variable{{.*}}, name = "p_member_field"
-MAIN-SAME:    (int ST::*), scope = local
+MAIN-SAME:    (int {{(`extern "C" main'::`2'::)?}}ST::*), scope = local
 MAIN:     Variable{{.*}}, name = "p_member_method"
-MAIN-SAME:    (int (ST::*)(int){{( __attribute__\(\(thiscall\)\))?}}), scope = local
+MAIN-SAME:    (int ({{(`extern "C" main'::`2'::)?}}ST::*)(int){{( __attribute__\(\(thiscall\)\))?}}), scope = local
 
-F:   Function{[[FID2:.*]]}, demangled = {{.*}}f(int)
+F:   Function{[[FID2:.*]]}, demangled = {{.*}}main::ST::f
 F-NEXT:  Block{[[FID2]]}
 F:     Variable{{.*}}, name = "this"
-F-SAME:    (ST *), scope = parameter, location = {{(DW_OP.*)|(<empty>)}}, artificial
+F-SAME:    ({{(`extern "C" main'::`2'::)?}}ST *), scope = parameter, location = {{DW_OP|<empty>|0x00000000}}
 F:     Variable{{.*}}, name = "x"
-F-SAME:    (int), scope = parameter, decl = PointerTypeTest.cpp:8
+F-SAME:    (int), scope = parameter{{(, decl = PointerTypeTest.cpp:8)?}}


### PR DESCRIPTION
The `pointers.test` was only run with the DIA plugin. I made the following changes:

- Remove the check for the function type. 
  The types of the function are different in the plugins:
  ```
  Native:
  Type{0x00010084} , size = 0, compiler_type = 0x00000209aff60060 int (int) __attribute__((thiscall))
  DIA:
  Type{0x0000000a} , name = "f", decl = PointerTypeTest.cpp:8, compiler_type = 0x0000020bc22356c0 int (int) __attribute__((thiscall))
  ```
  In DIA, each function gets its own type with a name and decl. In the native plugin, only one unnamed type is created per signature. This matches DWARF.
- The check for the `struct ST` fields was split, because the order of members and methods is swapped between the plugins. In DIA, the member is first and in the native plugin the method is first. We still check that both are in the struct.
- The type names for the local variables are different. The native plugin includes <code>\`extern "C" main'::\`2'::ST</code> which I added as an allowed prefix. This comes from the mangled name of the struct `ST` - `.?AUST@?1??main@@9@`.
- The location of local variables is different. DIA creates one static location (e.g. `DW_OP_breg6 ESI-52`) whereas the native plugin limits the location to the block (e.g. `[0x0040100d, 0x00401038): DW_OP_breg6 ESI-52`). This gets printed on a second line and the `location` starts with `0x00000000:`
- DIA adds a decl for each parameter (and local variable). However, this information is not contained in the PDB. I'm not sure how DIA calculates this. It's often wrong and assumes variables are declared earlier. For example, in this test ([PointerTypeTest.cpp](https://github.com/llvm/llvm-project/blob/2b135b931338a57c38d9c4a34ffdd59877ba82d6/lldb/test/Shell/SymbolFile/PDB/Inputs/PointerTypeTest.cpp)), it assumes that all local variables of `main` are created on line 4. The native plugin doesn't include this, so I made the check optional.