### PR TITLE
[lldb] Fix bot failure due to new qSupported packet reply

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -931,6 +931,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
         "QNonStop",
         "SupportedWatchpointTypes",
         "SupportedCompressions",
+        "MultiMemRead",
     ]
 
     def parse_qSupported_response(self, context):


### PR DESCRIPTION
When [1] landed, gdbremote server tests had to be updated to understand the new packet field.

[1]: https://github.com/llvm/llvm-project/pull/163249