### PR TITLE
[clang-tidy][NFC] Enforce Unix line endings

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 QualifierAlignment: Left
+LineEnding: LF


### PR DESCRIPTION
With https://github.com/llvm/llvm-project/pull/161460 merged, we should also enforce it in CI (although nothing changed for current files)