### PR TITLE
[clang][Driver] Support Outline Flags on RISC-V and X86

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -149,6 +149,7 @@ Deprecated Compiler Flags
 
 Modified Compiler Flags
 -----------------------
+- The `-mno-outline` and `-moutline` compiler flags are now allowed on RISC-V and X86, which both support the machine outliner.
 
 Removed Compiler Flags
 ----------------------

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -27,7 +27,7 @@ def GlobalDocumentation {
 #endif
 
 // Use this to generate program specific documentation, for example:
-// StringForProgram<"Control how %Program behaves.">.str
+// StringForProgram<"Control how %Program behaves.".str
 class StringForProgram<string _str> {
   string str = !subst("%Program", GlobalDocumentation.Program, _str);
 }
@@ -5297,14 +5297,18 @@ def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
 def : Joined<["-"], "mmacosx-version-min=">,
   Visibility<[ClangOption, CC1Option, FC1Option, FlangOption]>,
   Group<m_Group>, Alias<mmacos_version_min_EQ>;
+def moutline
+    : Flag<["-"], "moutline">,
+      Group<f_clang_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Enable function outlining (AArch64,Arm,RISC-V,X86 only)">;
+def mno_outline
+    : Flag<["-"], "mno-outline">,
+      Group<f_clang_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Disable function outlining (AArch64,Arm,RISC-V,X86 only)">;
 def mms_bitfields : Flag<["-"], "mms-bitfields">, Group<m_Group>,
   HelpText<"Set the default structure layout to be compatible with the Microsoft compiler standard">;
-def moutline : Flag<["-"], "moutline">, Group<f_clang_Group>,
-  Visibility<[ClangOption, CC1Option]>,
-    HelpText<"Enable function outlining (AArch64 only)">;
-def mno_outline : Flag<["-"], "mno-outline">, Group<f_clang_Group>,
-  Visibility<[ClangOption, CC1Option]>,
-    HelpText<"Disable function outlining (AArch64 only)">;
 def mno_ms_bitfields : Flag<["-"], "mno-ms-bitfields">, Group<m_Group>,
   HelpText<"Do not set the default structure layout to be compatible with the Microsoft compiler standard">;
 def fms_layout_compatibility_EQ : Joined<["-"], "fms-layout-compatibility=">,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -27,7 +27,7 @@ def GlobalDocumentation {
 #endif
 
 // Use this to generate program specific documentation, for example:
-// StringForProgram<"Control how %Program behaves.".str
+// StringForProgram<"Control how %Program behaves.">.str
 class StringForProgram<string _str> {
   string str = !subst("%Program", GlobalDocumentation.Program, _str);
 }

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2961,15 +2961,15 @@ void tools::addMachineOutlinerArgs(const Driver &D,
       // Otherwise, emit a warning and ignore the flag.
       if (Triple.isARM() || Triple.isThumb() || Triple.isAArch64() ||
           Triple.isRISCV() || Triple.isX86()) {
-        // FIXME: This should probably use the `nooutline` attribute rather than
-        // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline`
-        // objects can be combined correctly during LTO.
         addArg(Twine("-enable-machine-outliner"));
       } else {
         D.Diag(diag::warn_drv_moutline_unsupported_opt) << Triple.getArchName();
       }
     } else {
       // Disable all outlining behaviour.
+      // FIXME: This should probably use the `nooutline` attribute rather than
+      // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline`
+      // objects can be combined correctly during LTO.
       addArg(Twine("-enable-machine-outliner=never"));
     }
   }

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2967,9 +2967,10 @@ void tools::addMachineOutlinerArgs(const Driver &D,
       }
     } else {
       // Disable all outlining behaviour.
+      //
       // FIXME: This should probably use the `nooutline` attribute rather than
-      // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline`
-      // objects can be combined correctly during LTO.
+      // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline` objects
+      // can be combined correctly during LTO.
       addArg(Twine("-enable-machine-outliner=never"));
     }
   }

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2956,13 +2956,17 @@ void tools::addMachineOutlinerArgs(const Driver &D,
   if (Arg *A = Args.getLastArg(options::OPT_moutline,
                                options::OPT_mno_outline)) {
     if (A->getOption().matches(options::OPT_moutline)) {
-      // We only support -moutline in AArch64 and ARM targets right now. If
-      // we're not compiling for these, emit a warning and ignore the flag.
-      // Otherwise, add the proper mllvm flags.
-      if (!(Triple.isARM() || Triple.isThumb() || Triple.isAArch64())) {
-        D.Diag(diag::warn_drv_moutline_unsupported_opt) << Triple.getArchName();
-      } else {
+      // We only support -moutline in AArch64, ARM, RISC-V and X86 targets right
+      // now. If we're compiling for these, add the proper mllvm flags.
+      // Otherwise, emit a warning and ignore the flag.
+      if (Triple.isARM() || Triple.isThumb() || Triple.isAArch64() ||
+          Triple.isRISCV() || Triple.isX86()) {
+        // FIXME: This should probably use the `nooutline` attribute rather than
+        // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline`
+        // objects can be combined correctly during LTO.
         addArg(Twine("-enable-machine-outliner"));
+      } else {
+        D.Diag(diag::warn_drv_moutline_unsupported_opt) << Triple.getArchName();
       }
     } else {
       // Disable all outlining behaviour.

--- a/clang/test/Driver/aarch64-outliner.c
+++ b/clang/test/Driver/aarch64-outliner.c
@@ -4,6 +4,3 @@
 // RUN: %clang --target=aarch64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // RUN: %clang --target=aarch64_be -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // OFF: "-mllvm" "-enable-machine-outliner=never"
-// RUN: %clang --target=x86_64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=WARN
-// WARN: warning: 'x86_64' does not support '-moutline'; flag ignored [-Woption-ignored]
-// WARN-NOT: "-mllvm" "-enable-machine-outliner"

--- a/clang/test/Driver/riscv-outliner.c
+++ b/clang/test/Driver/riscv-outliner.c
@@ -1,0 +1,7 @@
+// RUN: %clang --target=riscv32 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// RUN: %clang --target=riscv64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// ON: "-mllvm" "-enable-machine-outliner"
+
+// RUN: %clang --target=riscv32 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// RUN: %clang --target=riscv64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// OFF: "-mllvm" "-enable-machine-outliner=never"

--- a/clang/test/Driver/unsupported-outliner.c
+++ b/clang/test/Driver/unsupported-outliner.c
@@ -1,0 +1,3 @@
+// RUN: %clang --target=ppc64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=WARN
+// WARN: warning: 'ppc64' does not support '-moutline'; flag ignored [-Woption-ignored]
+// WARN-NOT: "-mllvm" "-enable-machine-outliner"

--- a/clang/test/Driver/x86-outliner.c
+++ b/clang/test/Driver/x86-outliner.c
@@ -1,0 +1,7 @@
+// RUN: %clang --target=i386 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// RUN: %clang --target=x86_64 -moutline -S %s -### 2>&1 | FileCheck %s -check-prefix=ON
+// ON: "-mllvm" "-enable-machine-outliner"
+
+// RUN: %clang --target=i386 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// RUN: %clang --target=x86_64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
+// OFF: "-mllvm" "-enable-machine-outliner=never"


### PR DESCRIPTION
These two targets both also support the machine outliner, so these flags
should probably be cross-target. This updates the docs for these flags
as well.