### PR TITLE
[acc][flang] lowering of acc declare on COMMON variables

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4379,8 +4379,9 @@ lookupGlobalBySymbolOrEquivalence(Fortran::lower::AbstractConverter &converter,
   }
   // Not found: if not a COMMON member, try equivalence members
   if (!commonBlock) {
-    if (auto *eqSet = Fortran::semantics::FindEquivalenceSet(sym)) {
-      for (Fortran::semantics::EquivalenceObject eqObj : *eqSet) {
+    if (const Fortran::semantics::EquivalenceSet *eqSet =
+            Fortran::semantics::FindEquivalenceSet(sym)) {
+      for (const Fortran::semantics::EquivalenceObject &eqObj : *eqSet) {
         std::string eqName = converter.mangleName(eqObj.symbol);
         if (fir::GlobalOp g = builder.getNamedGlobal(eqName))
           return g;

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4382,9 +4382,8 @@ lookupGlobalBySymbolOrEquivalence(Fortran::lower::AbstractConverter &converter,
     if (auto *eqSet = Fortran::semantics::FindEquivalenceSet(sym)) {
       for (Fortran::semantics::EquivalenceObject eqObj : *eqSet) {
         std::string eqName = converter.mangleName(eqObj.symbol);
-        if (fir::GlobalOp g = builder.getNamedGlobal(eqName)) {
+        if (fir::GlobalOp g = builder.getNamedGlobal(eqName))
           return g;
-        }
       }
     }
   }

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -3398,6 +3398,7 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
 
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
 
+
   for (const Fortran::parser::AccClause &clause : accClauseList.v) {
     mlir::Location clauseLocation = converter.genLocation(clause.source);
     if (const auto *ifClause =
@@ -4326,6 +4327,50 @@ genDeclareInFunction(Fortran::lower::AbstractConverter &converter,
   Fortran::lower::StatementContext stmtCtx;
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
 
+  // Inline helper to emit module-level declare for COMMON symbols in a clause.
+  auto emitCommonGlobal = [&](const Fortran::parser::AccObject &obj,
+                              mlir::acc::DataClause clause,
+                              auto emitCtorDtor) {
+    Fortran::semantics::Symbol &sym = getSymbolFromAccObject(obj);
+    if (!(sym.detailsIf<Fortran::semantics::CommonBlockDetails>() ||
+          Fortran::semantics::FindCommonBlockContaining(sym)))
+      return;
+
+    std::string globalName = converter.mangleName(sym);
+    fir::GlobalOp globalOp = builder.getNamedGlobal(globalName);
+    if (!globalOp) {
+      if (Fortran::semantics::FindEquivalenceSet(sym)) {
+        for (Fortran::semantics::EquivalenceObject eqObj :
+             *Fortran::semantics::FindEquivalenceSet(sym)) {
+          std::string eqName = converter.mangleName(eqObj.symbol);
+          globalOp = builder.getNamedGlobal(eqName);
+          if (globalOp)
+            break;
+        }
+      }
+    }
+    if (!globalOp)
+      llvm::report_fatal_error("could not retrieve global symbol");
+
+    std::stringstream ctorName;
+    ctorName << globalName << "_acc_ctor";
+    if (builder.getModule().lookupSymbol<mlir::acc::GlobalConstructorOp>(
+            ctorName.str()))
+      return;
+
+    mlir::Location operandLocation = genOperandLocation(converter, obj);
+    addDeclareAttr(builder, globalOp.getOperation(), clause);
+    mlir::OpBuilder modBuilder(builder.getModule().getBodyRegion());
+    modBuilder.setInsertionPointAfter(globalOp);
+    std::stringstream asFortran;
+    asFortran << sym.name().ToString();
+
+    auto savedIP = builder.saveInsertionPoint();
+    emitCtorDtor(modBuilder, operandLocation, globalOp, clause, asFortran,
+                 ctorName.str());
+    builder.restoreInsertionPoint(savedIP);
+  };
+
   for (const Fortran::parser::AccClause &clause : accClauseList.v) {
     if (const auto *copyClause =
             std::get_if<Fortran::parser::AccClause::Copy>(&clause.u)) {
@@ -4343,57 +4388,26 @@ genDeclareInFunction(Fortran::lower::AbstractConverter &converter,
           createClause->v;
       const auto &accObjectList =
           std::get<Fortran::parser::AccObjectList>(listWithModifier.t);
-      // Emit module-level declare for COMMON symbols in this clause.
       for (const auto &obj : accObjectList.v) {
-        Fortran::semantics::Symbol &sym = getSymbolFromAccObject(obj);
-        if (sym.detailsIf<Fortran::semantics::CommonBlockDetails>() ||
-            Fortran::semantics::FindCommonBlockContaining(sym)) {
-          std::string globalName = converter.mangleName(sym);
-          fir::GlobalOp globalOp = builder.getNamedGlobal(globalName);
-          if (!globalOp) {
-            if (Fortran::semantics::FindEquivalenceSet(sym)) {
-              for (Fortran::semantics::EquivalenceObject eqObj :
-                   *Fortran::semantics::FindEquivalenceSet(sym)) {
-                std::string eqName = converter.mangleName(eqObj.symbol);
-                globalOp = builder.getNamedGlobal(eqName);
-                if (globalOp)
-                  break;
-              }
-            }
-          }
-          if (!globalOp)
-            llvm::report_fatal_error("could not retrieve global symbol");
-          std::stringstream ctorName;
-          ctorName << globalName << "_acc_ctor";
-          if (!builder.getModule().lookupSymbol<mlir::acc::GlobalConstructorOp>(
-                  ctorName.str())) {
-            mlir::Location operandLocation = genOperandLocation(converter, obj);
-            addDeclareAttr(builder, globalOp.getOperation(),
-                mlir::acc::DataClause::acc_create);
-            mlir::OpBuilder modBuilder(builder.getModule().getBodyRegion());
-            modBuilder.setInsertionPointAfter(globalOp);
-            std::stringstream asFortran;
-            asFortran << sym.name().ToString();
-            auto savedIP = builder.saveInsertionPoint();
-            createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
-                                  mlir::acc::CreateOp,
-                                  mlir::acc::DeclareEnterOp,
-                                  mlir::acc::DeleteOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_create, ctorName.str(),
+        emitCommonGlobal(obj, mlir::acc::DataClause::acc_create,
+            [&](mlir::OpBuilder &modBuilder, mlir::Location operandLocation,
+                fir::GlobalOp globalOp, mlir::acc::DataClause clause,
+                std::stringstream &asFortran, const std::string &ctorName) {
+              createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
+                                    mlir::acc::CreateOp,
+                                    mlir::acc::DeclareEnterOp,
+                                    mlir::acc::DeleteOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, ctorName,
                     /*implicit=*/false, asFortran);
-            std::stringstream dtorName;
-            dtorName << globalName << "_acc_dtor";
-            createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
-                                  mlir::acc::GetDevicePtrOp,
-                                  mlir::acc::DeclareExitOp,
-                                  mlir::acc::DeleteOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_create, dtorName.str(),
+              std::stringstream dtorName;
+              dtorName << globalOp.getSymName().str() << "_acc_dtor";
+              createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
+                                    mlir::acc::GetDevicePtrOp,
+                                    mlir::acc::DeclareExitOp,
+                                    mlir::acc::DeleteOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, dtorName.str(),
                     /*implicit=*/false, asFortran);
-            builder.restoreInsertionPoint(savedIP);
-          }
-        }
+            });
       }
       auto crtDataStart = dataClauseOperands.size();
       genDeclareDataOperandOperations<mlir::acc::CreateOp, mlir::acc::DeleteOp>(
@@ -4415,60 +4429,29 @@ genDeclareInFunction(Fortran::lower::AbstractConverter &converter,
                                   dataClauseOperands.end());
     } else if (const auto *copyinClause =
                    std::get_if<Fortran::parser::AccClause::Copyin>(&clause.u)) {
-      // Emit module-level declare for COMMON symbols in this clause.
       const auto &listWithModifier = copyinClause->v;
       const auto &copyinObjs =
           std::get<Fortran::parser::AccObjectList>(listWithModifier.t);
       for (const auto &obj : copyinObjs.v) {
-        Fortran::semantics::Symbol &sym = getSymbolFromAccObject(obj);
-        if (sym.detailsIf<Fortran::semantics::CommonBlockDetails>() ||
-            Fortran::semantics::FindCommonBlockContaining(sym)) {
-          std::string globalName = converter.mangleName(sym);
-          fir::GlobalOp globalOp = builder.getNamedGlobal(globalName);
-          if (!globalOp) {
-            if (Fortran::semantics::FindEquivalenceSet(sym)) {
-              for (Fortran::semantics::EquivalenceObject eqObj :
-                   *Fortran::semantics::FindEquivalenceSet(sym)) {
-                std::string eqName = converter.mangleName(eqObj.symbol);
-                globalOp = builder.getNamedGlobal(eqName);
-                if (globalOp)
-                  break;
-              }
-            }
-          }
-          if (!globalOp)
-            llvm::report_fatal_error("could not retrieve global symbol");
-          std::stringstream ctorName;
-          ctorName << globalName << "_acc_ctor";
-          if (!builder.getModule().lookupSymbol<mlir::acc::GlobalConstructorOp>(
-                  ctorName.str())) {
-            mlir::Location operandLocation = genOperandLocation(converter, obj);
-            addDeclareAttr(builder, globalOp.getOperation(),
-                mlir::acc::DataClause::acc_copyin);
-            mlir::OpBuilder modBuilder(builder.getModule().getBodyRegion());
-            modBuilder.setInsertionPointAfter(globalOp);
-            std::stringstream asFortran;
-            asFortran << sym.name().ToString();
-            auto savedIP = builder.saveInsertionPoint();
-            createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
-                                  mlir::acc::CopyinOp,
-                                  mlir::acc::DeclareEnterOp,
-                                  mlir::acc::DeleteOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_copyin, ctorName.str(),
+        emitCommonGlobal(obj, mlir::acc::DataClause::acc_copyin,
+            [&](mlir::OpBuilder &modBuilder, mlir::Location operandLocation,
+                fir::GlobalOp globalOp, mlir::acc::DataClause clause,
+                std::stringstream &asFortran, const std::string &ctorName) {
+              createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
+                                    mlir::acc::CopyinOp,
+                                    mlir::acc::DeclareEnterOp,
+                                    mlir::acc::DeleteOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, ctorName,
                     /*implicit=*/false, asFortran);
-            std::stringstream dtorName;
-            dtorName << globalName << "_acc_dtor";
-            createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
-                                  mlir::acc::GetDevicePtrOp,
-                                  mlir::acc::DeclareExitOp,
-                                  mlir::acc::DeleteOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_copyin, dtorName.str(),
+              std::stringstream dtorName;
+              dtorName << globalOp.getSymName().str() << "_acc_dtor";
+              createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
+                                    mlir::acc::GetDevicePtrOp,
+                                    mlir::acc::DeclareExitOp,
+                                    mlir::acc::DeleteOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, dtorName.str(),
                     /*implicit=*/false, asFortran);
-            builder.restoreInsertionPoint(savedIP);
-          }
-        }
+            });
       }
       auto crtDataStart = dataClauseOperands.size();
       genDeclareDataOperandOperationsWithModifier<mlir::acc::CopyinOp,
@@ -4486,57 +4469,26 @@ genDeclareInFunction(Fortran::lower::AbstractConverter &converter,
           copyoutClause->v;
       const auto &accObjectList =
           std::get<Fortran::parser::AccObjectList>(listWithModifier.t);
-      // Emit module-level declare for COMMON symbols in this clause.
       for (const auto &obj : accObjectList.v) {
-        Fortran::semantics::Symbol &sym = getSymbolFromAccObject(obj);
-        if (sym.detailsIf<Fortran::semantics::CommonBlockDetails>() ||
-            Fortran::semantics::FindCommonBlockContaining(sym)) {
-          std::string globalName = converter.mangleName(sym);
-          fir::GlobalOp globalOp = builder.getNamedGlobal(globalName);
-          if (!globalOp) {
-            if (Fortran::semantics::FindEquivalenceSet(sym)) {
-              for (Fortran::semantics::EquivalenceObject eqObj :
-                   *Fortran::semantics::FindEquivalenceSet(sym)) {
-                std::string eqName = converter.mangleName(eqObj.symbol);
-                globalOp = builder.getNamedGlobal(eqName);
-                if (globalOp)
-                  break;
-              }
-            }
-          }
-          if (!globalOp)
-            llvm::report_fatal_error("could not retrieve global symbol");
-          std::stringstream ctorName;
-          ctorName << globalName << "_acc_ctor";
-          if (!builder.getModule().lookupSymbol<mlir::acc::GlobalConstructorOp>(
-                  ctorName.str())) {
-            mlir::Location operandLocation = genOperandLocation(converter, obj);
-            addDeclareAttr(builder, globalOp.getOperation(),
-                mlir::acc::DataClause::acc_copyout);
-            mlir::OpBuilder modBuilder(builder.getModule().getBodyRegion());
-            modBuilder.setInsertionPointAfter(globalOp);
-            std::stringstream asFortran;
-            asFortran << sym.name().ToString();
-            auto savedIP = builder.saveInsertionPoint();
-            createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
-                                  mlir::acc::CreateOp,
-                                  mlir::acc::DeclareEnterOp,
-                                  mlir::acc::CopyoutOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_copyout, ctorName.str(),
+        emitCommonGlobal(obj, mlir::acc::DataClause::acc_copyout,
+            [&](mlir::OpBuilder &modBuilder, mlir::Location operandLocation,
+                fir::GlobalOp globalOp, mlir::acc::DataClause clause,
+                std::stringstream &asFortran, const std::string &ctorName) {
+              createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
+                                    mlir::acc::CreateOp,
+                                    mlir::acc::DeclareEnterOp,
+                                    mlir::acc::CopyoutOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, ctorName,
                     /*implicit=*/false, asFortran);
-            std::stringstream dtorName;
-            dtorName << globalName << "_acc_dtor";
-            createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
-                                  mlir::acc::GetDevicePtrOp,
-                                  mlir::acc::DeclareExitOp,
-                                  mlir::acc::CopyoutOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_copyout, dtorName.str(),
+              std::stringstream dtorName;
+              dtorName << globalOp.getSymName().str() << "_acc_dtor";
+              createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
+                                    mlir::acc::GetDevicePtrOp,
+                                    mlir::acc::DeclareExitOp,
+                                    mlir::acc::CopyoutOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, dtorName.str(),
                     /*implicit=*/false, asFortran);
-            builder.restoreInsertionPoint(savedIP);
-          }
-        }
+            });
       }
       auto crtDataStart = dataClauseOperands.size();
       genDeclareDataOperandOperations<mlir::acc::CreateOp,
@@ -4556,49 +4508,19 @@ genDeclareInFunction(Fortran::lower::AbstractConverter &converter,
           /*structured=*/true, /*implicit=*/false);
     } else if (const auto *linkClause =
                    std::get_if<Fortran::parser::AccClause::Link>(&clause.u)) {
-      // Emit module-level declare for COMMON symbols in this clause.
       const auto &linkObjs = linkClause->v;
       for (const auto &obj : linkObjs.v) {
-        Fortran::semantics::Symbol &sym = getSymbolFromAccObject(obj);
-        if (sym.detailsIf<Fortran::semantics::CommonBlockDetails>() ||
-            Fortran::semantics::FindCommonBlockContaining(sym)) {
-          std::string globalName = converter.mangleName(sym);
-          fir::GlobalOp globalOp = builder.getNamedGlobal(globalName);
-          if (!globalOp) {
-            if (Fortran::semantics::FindEquivalenceSet(sym)) {
-              for (Fortran::semantics::EquivalenceObject eqObj :
-                   *Fortran::semantics::FindEquivalenceSet(sym)) {
-                std::string eqName = converter.mangleName(eqObj.symbol);
-                globalOp = builder.getNamedGlobal(eqName);
-                if (globalOp)
-                  break;
-              }
-            }
-          }
-          if (!globalOp)
-            llvm::report_fatal_error("could not retrieve global symbol");
-          std::stringstream ctorName;
-          ctorName << globalName << "_acc_ctor";
-          if (!builder.getModule().lookupSymbol<mlir::acc::GlobalConstructorOp>(
-                  ctorName.str())) {
-            mlir::Location operandLocation = genOperandLocation(converter, obj);
-            addDeclareAttr(builder, globalOp.getOperation(),
-                mlir::acc::DataClause::acc_declare_link);
-            mlir::OpBuilder modBuilder(builder.getModule().getBodyRegion());
-            modBuilder.setInsertionPointAfter(globalOp);
-            std::stringstream asFortran;
-            asFortran << sym.name().ToString();
-            auto savedIP = builder.saveInsertionPoint();
-            createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
-                                  mlir::acc::DeclareLinkOp,
-                                  mlir::acc::DeclareEnterOp,
-                                  mlir::acc::DeclareLinkOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_declare_link, ctorName.str(),
+        emitCommonGlobal(obj, mlir::acc::DataClause::acc_declare_link,
+            [&](mlir::OpBuilder &modBuilder, mlir::Location operandLocation,
+                fir::GlobalOp globalOp, mlir::acc::DataClause clause,
+                std::stringstream &asFortran, const std::string &ctorName) {
+              createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
+                                    mlir::acc::DeclareLinkOp,
+                                    mlir::acc::DeclareEnterOp,
+                                    mlir::acc::DeclareLinkOp>(modBuilder,
+                    builder, operandLocation, globalOp, clause, ctorName,
                     /*implicit=*/false, asFortran);
-            builder.restoreInsertionPoint(savedIP);
-          }
-        }
+            });
       }
       genDeclareDataOperandOperations<mlir::acc::DeclareLinkOp,
                                       mlir::acc::DeclareLinkOp>(
@@ -4608,50 +4530,20 @@ genDeclareInFunction(Fortran::lower::AbstractConverter &converter,
     } else if (const auto *deviceResidentClause =
                    std::get_if<Fortran::parser::AccClause::DeviceResident>(
                        &clause.u)) {
-      // Emit module-level declare for COMMON symbols in this clause.
       const auto &devResObjs = deviceResidentClause->v;
       for (const auto &obj : devResObjs.v) {
-        Fortran::semantics::Symbol &sym = getSymbolFromAccObject(obj);
-        if (sym.detailsIf<Fortran::semantics::CommonBlockDetails>() ||
-            Fortran::semantics::FindCommonBlockContaining(sym)) {
-          std::string globalName = converter.mangleName(sym);
-          fir::GlobalOp globalOp = builder.getNamedGlobal(globalName);
-          if (!globalOp) {
-            if (Fortran::semantics::FindEquivalenceSet(sym)) {
-              for (Fortran::semantics::EquivalenceObject eqObj :
-                   *Fortran::semantics::FindEquivalenceSet(sym)) {
-                std::string eqName = converter.mangleName(eqObj.symbol);
-                globalOp = builder.getNamedGlobal(eqName);
-                if (globalOp)
-                  break;
-              }
-            }
-          }
-          if (!globalOp)
-            llvm::report_fatal_error("could not retrieve global symbol");
-          std::stringstream ctorName;
-          ctorName << globalName << "_acc_ctor";
-          if (!builder.getModule().lookupSymbol<mlir::acc::GlobalConstructorOp>(
-                  ctorName.str())) {
-            mlir::Location operandLocation = genOperandLocation(converter, obj);
-            addDeclareAttr(builder, globalOp.getOperation(),
-                mlir::acc::DataClause::acc_declare_device_resident);
-            mlir::OpBuilder modBuilder(builder.getModule().getBodyRegion());
-            modBuilder.setInsertionPointAfter(globalOp);
-            std::stringstream asFortran;
-            asFortran << sym.name().ToString();
-            auto savedIP = builder.saveInsertionPoint();
-            createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
-                                  mlir::acc::DeclareDeviceResidentOp,
-                                  mlir::acc::DeclareEnterOp,
-                                  mlir::acc::DeleteOp>(modBuilder, builder,
-                    operandLocation, globalOp,
-                    mlir::acc::DataClause::acc_declare_device_resident,
-                    ctorName.str(),
+        emitCommonGlobal(obj,
+            mlir::acc::DataClause::acc_declare_device_resident,
+            [&](mlir::OpBuilder &modBuilder, mlir::Location operandLocation,
+                fir::GlobalOp globalOp, mlir::acc::DataClause clause,
+                std::stringstream &asFortran, const std::string &ctorName) {
+              createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
+                                    mlir::acc::DeclareDeviceResidentOp,
+                                    mlir::acc::DeclareEnterOp,
+                                    mlir::acc::DeleteOp>(modBuilder, builder,
+                    operandLocation, globalOp, clause, ctorName,
                     /*implicit=*/false, asFortran);
-            builder.restoreInsertionPoint(savedIP);
-          }
-        }
+            });
       }
       auto crtDataStart = dataClauseOperands.size();
       genDeclareDataOperandOperations<mlir::acc::DeclareDeviceResidentOp,

--- a/flang/test/Lower/OpenACC/acc-declare-common-in-function.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-common-in-function.f90
@@ -8,8 +8,8 @@ program p
   implicit none
   real :: pi
   integer :: i
-  common /RIEMANN_COM/ pi
-!$acc declare copyin(/RIEMANN_COM/)
+  common /COM/ pi
+!$acc declare copyin(/COM/)
   data pi/0.0/
 
 ! CHECK-DAG: acc.global_ctor @{{.*}}_acc_ctor {
@@ -31,8 +31,8 @@ contains
   subroutine s()
     implicit none
     real :: pi
-    common /RIEMANN_COM/ pi
-!$acc declare copyin(/RIEMANN_COM/)
+    common /COM/ pi
+!$acc declare copyin(/COM/)
   end subroutine s
 
 end program p

--- a/flang/test/Lower/OpenACC/acc-declare-common-in-function.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-common-in-function.f90
@@ -1,0 +1,40 @@
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+! Verify that a COMMON block declared with OpenACC declare inside a function
+! is lowered as a global declare (acc.global_ctor/dtor) rather than a
+! structured declare.
+
+program p
+  implicit none
+  real :: pi
+  integer :: i
+  common /RIEMANN_COM/ pi
+!$acc declare copyin(/RIEMANN_COM/)
+  data pi/0.0/
+
+! CHECK-DAG: acc.global_ctor @{{.*}}_acc_ctor {
+! CHECK-DAG: %[[ADDR0:.*]] = fir.address_of(@{{.*}}) {acc.declare = #acc.declare<dataClause = acc_copyin>} : {{.*}}
+! CHECK-DAG: acc.declare_enter dataOperands(%{{.*}} : {{.*}})
+! CHECK-DAG: acc.terminator
+! CHECK-DAG: }
+
+! CHECK-DAG: acc.global_dtor @{{.*}}_acc_dtor {
+! CHECK-DAG: %[[ADDR1:.*]] = fir.address_of(@{{.*}}) {acc.declare = #acc.declare<dataClause = acc_copyin>} : !fir.ref<tuple<f32>>
+! CHECK-DAG: %[[GDP:.*]] = acc.getdeviceptr varPtr(%[[ADDR1]] : !fir.ref<tuple<f32>>) -> !fir.ref<tuple<f32>> {dataClause = #acc<data_clause acc_copyin>, {{.*}}}
+! CHECK-DAG: acc.declare_exit dataOperands(%[[GDP]] : !fir.ref<tuple<f32>>)
+! CHECK-DAG: acc.delete accPtr(%[[GDP]] : !fir.ref<tuple<f32>>) {dataClause = #acc<data_clause acc_copyin>{{.*}}}
+! CHECK-DAG: acc.terminator
+! CHECK-DAG: }
+
+contains
+
+  subroutine s()
+    implicit none
+    real :: pi
+    common /RIEMANN_COM/ pi
+!$acc declare copyin(/RIEMANN_COM/)
+  end subroutine s
+
+end program p
+
+


### PR DESCRIPTION
COMMON variables are treated as locals and lowered to structured declares currently. This is incorrect because variables that are COMMON should be treated as globals. Added implementation to treat these variables differently. 