### PR TITLE
[clang] Ensure -mno-outline adds attributes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -160,6 +160,8 @@ Deprecated Compiler Flags
 Modified Compiler Flags
 -----------------------
 - The `-mno-outline` and `-moutline` compiler flags are now allowed on RISC-V and X86, which both support the machine outliner.
+- The `-mno-outline` flag will now add the `nooutline` IR attribute, so that
+  `-mno-outline` and `-moutline` objects can be mixed correctly during LTO.
 
 Removed Compiler Flags
 ----------------------

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -509,6 +509,9 @@ CODEGENOPT(AllResourcesBound, 1, 0, Benign)
 ENUM_CODEGENOPT(WinX64EHUnwindV2, WinX64EHUnwindV2Mode,
                 2, WinX64EHUnwindV2Mode::Disabled, Benign)
 
+/// Adds attributes that prevent outlining (`-mno-outline`)
+CODEGENOPT(DisableOutlining, 1, 0, Benign)
+
 /// FIXME: Make DebugOptions its own top-level .def file.
 #include "DebugOptions.def"
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5300,16 +5300,13 @@ def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
 def : Joined<["-"], "mmacosx-version-min=">,
   Visibility<[ClangOption, CC1Option, FC1Option, FlangOption]>,
   Group<m_Group>, Alias<mmacos_version_min_EQ>;
-def moutline
-    : Flag<["-"], "moutline">,
-      Group<f_clang_Group>,
-      Visibility<[ClangOption, CC1Option]>,
-      HelpText<"Enable function outlining (AArch64,Arm,RISC-V,X86 only)">;
-def mno_outline
-    : Flag<["-"], "mno-outline">,
-      Group<f_clang_Group>,
-      Visibility<[ClangOption, CC1Option]>,
-      HelpText<"Disable function outlining (AArch64,Arm,RISC-V,X86 only)">;
+defm outline
+    : BoolMOption<
+          "outline", CodeGenOpts<"DisableOutlining">, DefaultFalse,
+          NegFlag<SetTrue, [], [ClangOption, CC1Option],
+                  "Disable function outlining (AArch64,Arm,RISC-V,X86 only)">,
+          PosFlag<SetFalse, [], [ClangOption],
+                  "Enable function outlining (AArch64,Arm,RISC-V,X86 only)">>;
 def mms_bitfields : Flag<["-"], "mms-bitfields">, Group<m_Group>,
   HelpText<"Set the default structure layout to be compatible with the Microsoft compiler standard">;
 def mno_ms_bitfields : Flag<["-"], "mno-ms-bitfields">, Group<m_Group>,

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2928,7 +2928,9 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
       B.addAttribute(llvm::Attribute::MinSize);
   }
 
-  if (D->hasAttr<NoOutlineAttr>())
+  // Add `nooutline` if Outlining is disabled with a command-line flag or a
+  // function attribute.
+  if (CodeGenOpts.DisableOutlining || D->hasAttr<NoOutlineAttr>())
     B.addAttribute(llvm::Attribute::NoOutline);
 
   F->addFnAttrs(B);

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2966,11 +2966,12 @@ void tools::addMachineOutlinerArgs(const Driver &D,
         D.Diag(diag::warn_drv_moutline_unsupported_opt) << Triple.getArchName();
       }
     } else {
-      // Disable all outlining behaviour.
-      //
-      // FIXME: This should probably use the `nooutline` attribute rather than
-      // tweaking Pipeline Pass flags, so `-mno-outline` and `-moutline` objects
-      // can be combined correctly during LTO.
+      if (!IsLTO)
+        // Disable all outlining behaviour using `nooutline` attribute, in case
+        // Linker Invocation lacks `-mno-outline`.
+        CmdArgs.push_back("-mno-outline");
+
+      // Disable Pass in Pipeline
       addArg(Twine("-enable-machine-outliner=never"));
     }
   }

--- a/clang/test/CodeGen/attr-no-outline.c
+++ b/clang/test/CodeGen/attr-no-outline.c
@@ -1,6 +1,17 @@
-// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks | FileCheck %s --check-prefix=C
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks | FileCheck %s --check-prefix=CXX
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -std=c++23 | FileCheck %s --check-prefixes=CXX,CXX23
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR | FileCheck %s --check-prefix=C
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline | FileCheck %s --check-prefix=C
+
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR | FileCheck %s --check-prefix=CXX
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline | FileCheck %s --check-prefix=CXX
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR -std=c++23 | FileCheck %s --check-prefixes=CXX,CXX23
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline -std=c++23 | FileCheck %s --check-prefixes=CXX,CXX23
+
+
+#ifdef TEST_ATTR
+#define NOOUTLINE [[clang::nooutline]]
+#else
+#define NOOUTLINE
+#endif
 
 // C-LABEL: define dso_local i32 @toplevel_func(
 // C-SAME: ) #[[ATTR0:[0-9]+]] {

--- a/clang/test/CodeGen/attr-no-outline.c
+++ b/clang/test/CodeGen/attr-no-outline.c
@@ -1,27 +1,46 @@
-// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR | FileCheck %s --check-prefix=C
-// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline | FileCheck %s --check-prefix=C
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR  | FileCheck %s --check-prefix=C,C-ATTR
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline | FileCheck %s --check-prefix=C,C-ARG
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks              | FileCheck %s --check-prefix=C,C-NONE
 
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR | FileCheck %s --check-prefix=CXX
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline | FileCheck %s --check-prefix=CXX
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -DTEST_ATTR -std=c++23 | FileCheck %s --check-prefixes=CXX,CXX23
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -mno-outline -std=c++23 | FileCheck %s --check-prefixes=CXX,CXX23
 
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -std=c++23 -DTEST_ATTR  | FileCheck %s --check-prefixes=CXX,CXX-ATTR
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -std=c++23 -mno-outline | FileCheck %s --check-prefixes=CXX,CXX-ARG
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -o - -femit-all-decls -fblocks -std=c++23              | FileCheck %s --check-prefixes=CXX,CXX-NONE
+
+// This test checks that:
+// - [[clang::no_outline]] adds the nooutline IR attribute to specific definitions
+// - `-mno-outline` adds the nooutline IR attribute to all definitions
+// - Lack of either does not add nooutline IR attribute
 
 #ifdef TEST_ATTR
-#define NOOUTLINE [[clang::nooutline]]
+#define ATTR [[clang::no_outline]]
+#define ATTR_DUNDER __attribute__((no_outline))
 #else
-#define NOOUTLINE
+#define ATTR
+#define ATTR_DUNDER
 #endif
 
 // C-LABEL: define dso_local i32 @toplevel_func(
-// C-SAME: ) #[[ATTR0:[0-9]+]] {
+// C-SAME: ) #[[ATTR1:[0-9]+]] {
 
 // CXX-LABEL: define dso_local noundef i32 @_Z13toplevel_funci(
-// CXX-SAME: ) #[[ATTR0:[0-9]+]] {
-[[clang::no_outline]] int toplevel_func(int x) {
+// CXX-SAME: ) #[[ATTR1:[0-9]+]] {
+ATTR int toplevel_func(int x) {
   return x;
 }
 
+// C-LABEL: define dso_local i32 @toplevel_func_noattr(
+// C-ATTR-SAME: ) #[[ATTR2:[0-9]+]] {
+// C-ARG-SAME:  ) #[[ATTR1]] {
+// C-NONE-SAME: ) #[[ATTR1]] {
+
+// CXX-LABEL: define dso_local noundef i32 @_Z20toplevel_func_noattri(
+// CXX-ATTR-SAME: ) #[[ATTR2:[0-9]+]] {
+// CXX-ARG-SAME:  ) #[[ATTR1]] {
+// CXX-NONE-SAME: ) #[[ATTR1]] {
+int toplevel_func_noattr(int x) {
+  return x;
+}
 
 // C-only: Function without prototype
 #ifndef __cplusplus
@@ -30,9 +49,9 @@
 #pragma clang diagnostic ignored "-Wimplicit-int"
 
 // C-LABEL: define dso_local i32 @no_proto_func(
-// C-SAME: ) #[[ATTR0]] {
+// C-SAME: ) #[[ATTR1]] {
 
-[[clang::no_outline]] no_proto_func(x)
+ATTR no_proto_func(x)
 int x; {
   return x;
 }
@@ -43,14 +62,25 @@ int x; {
 // With Blocks
 #if __has_feature(blocks)
 
+// C-LABEL: define dso_local i32 @func_with_block(
+// C-ATTR-SAME: ) #[[ATTR2]] {
+// C-ARG-SAME:  ) #[[ATTR1]] {
+// C-NONE-SAME: ) #[[ATTR1]] {
+
+// CXX-LABEL: define dso_local noundef i32 @_Z15func_with_blocki(
+// CXX-ATTR-SAME: ) #[[ATTR2]] {
+// CXX-ARG-SAME:  ) #[[ATTR1]] {
+// CXX-NONE-SAME: ) #[[ATTR1]] {
 int func_with_block(int x) {
+
 // C-LABEL: define internal i32 @__func_with_block_block_invoke(
-// C-SAME: ) #[[ATTR0]] {
+// C-SAME: ) #[[ATTR1]] {
 
 // CXX-LABEL: define internal noundef i32 @___Z15func_with_blocki_block_invoke(
-// CXX-SAME: ) #[[ATTR1:[0-9]+]] {
-
-  int (^block)(int) = ^ __attribute__((no_outline)) int (int y) { return y; };
+// CXX-ATTR-SAME: ) #[[ATTR3:[0-9]+]] {
+// CXX-ARG-SAME:  ) #[[ATTR2:[0-9]+]] {
+// CXX-NONE-SAME: ) #[[ATTR2:[0-9]+]] {
+  int (^block)(int) = ^ ATTR_DUNDER int (int y) { return y; };
 
   return block(x);
 }
@@ -62,57 +92,74 @@ int func_with_block(int x) {
 struct my_struct {
 
 // CXX-LABEL: define linkonce_odr noundef i32 @_ZN9my_struct11member_funcEi(
-// CXX-SAME: ) #[[ATTR0]] comdat
-  [[clang::no_outline]] int member_func(int x) {
+// CXX-SAME: ) #[[ATTR1]] comdat
+  ATTR int member_func(int x) {
     return x;
   }
 
 // CXX-LABEL: define linkonce_odr noundef i32 @_ZN9my_struct11static_funcEi(
-// CXX-SAME: ) #[[ATTR0]] comdat
-  [[clang::no_outline]] static int static_func(int x) {
+// CXX-SAME: ) #[[ATTR1]] comdat
+  ATTR static int static_func(int x) {
     return x;
   }
 };
 
 template <typename T> struct templated_struct {
-  [[clang::no_outline]] T member_func(T x) {
+  ATTR T member_func(T x) {
     return x;
   }
 
-  [[clang::no_outline]] static T static_func(T x) {
+  ATTR static T static_func(T x) {
     return x;
   }
 };
 
 // CXX-LABEL: define weak_odr noundef i32 @_ZN16templated_structIiE11member_funcEi(
-// CXX-SAME: ) #[[ATTR0]] comdat
+// CXX-SAME: ) #[[ATTR1]] comdat
 // CXX-LABEL: define weak_odr noundef i32 @_ZN16templated_structIiE11static_funcEi(
-// CXX-SAME: ) #[[ATTR0]] comdat
+// CXX-SAME: ) #[[ATTR1]] comdat
 template struct templated_struct<int>;
 
 
-#if __cplusplus >= 202302L
+// CXX-LABEL: define dso_local noundef i32 @_Z16func_with_lambdai(
+// CXX-ATTR-SAME: ) #[[ATTR2]]
+// CXX-ARG-SAME:  ) #[[ATTR1]]
+// CXX-NONE-SAME: ) #[[ATTR1]]
 int func_with_lambda(int x) {
-  // CXX23-LABEL: define internal noundef i32 @"_ZZ16func_with_lambdaiENK3$_0clEv"(
-  // CXX23-SAME: ) #[[ATTR0]]
-  auto lambda = [x][[clang::no_outline]]() -> int {
+
+// CXX-LABEL: define internal noundef i32 @"_ZZ16func_with_lambdaiENK3$_0clEv"(
+// CXX-SAME: ) #[[ATTR1]]
+  auto lambda = [x] ATTR () -> int {
     return x;
   };
 
   return lambda();
 }
 #endif
-#endif
 
 
-// C: attributes #[[ATTR0]] = {
-// C-SAME: nooutline
+// C: attributes #[[ATTR1]] = {
+// C-ATTR-SAME: nooutline
+// C-ARG-SAME: nooutline
+// C-NONE-NOT: nooutline
 // C-SAME: }
 
-// CXX: attributes #[[ATTR0]] = {
-// CXX-SAME: nooutline
-// CXX-SAME: }
+// C-ATTR: attributes #[[ATTR2]] = {
+// C-ATTR-NOT: nooutline
+// C-ATTR-SAME: }
 
 // CXX: attributes #[[ATTR1]] = {
-// CXX-SAME: nooutline
+// CXX-ATTR-SAME: nooutline
+// CXX-ARG-SAME: nooutline
+// CXX-NONE-NOT: nooutline
 // CXX-SAME: }
+
+// CXX: attributes #[[ATTR2]] = {
+// CXX-ATTR-NOT: nooutline
+// CXX-ARG-SAME: nooutline
+// CXX-NONE-NOT: nooutline
+// CXX-SAME: }
+
+// CXX-ATTR: attributes #[[ATTR3]] = {
+// CXX-ATTR-SAME: nooutline
+// CXX-ATTR-SAME: }

--- a/clang/test/CodeGenObjC/attr-no-outline.m
+++ b/clang/test/CodeGenObjC/attr-no-outline.m
@@ -1,9 +1,28 @@
-// RUN: %clang_cc1 -emit-llvm %s -triple x86_64-unknown-linux-gnu -o - | FileCheck %s --check-prefix=OBJC
-// RUN: %clang_cc1 -emit-llvm -x objective-c++ %s -triple x86_64-unknown-linux-gnu -o - | FileCheck %s --check-prefix=OBJCXX
+// RUN: %clang_cc1 -emit-llvm %s -triple x86_64-unknown-linux-gnu -o - -DTEST_ATTR  | FileCheck %s --check-prefixes=OBJC,OBJC-ATTR
+// RUN: %clang_cc1 -emit-llvm %s -triple x86_64-unknown-linux-gnu -o - -mno-outline | FileCheck %s --check-prefixes=OBJC,OBJC-ARG
+// RUN: %clang_cc1 -emit-llvm %s -triple x86_64-unknown-linux-gnu -o -              | FileCheck %s --check-prefixes=OBJC,OBJC-NONE
+
+// RUN: %clang_cc1 -emit-llvm -x objective-c++ %s -triple x86_64-unknown-linux-gnu -o - -DTEST_ATTR  | FileCheck %s --check-prefixes=OBJCXX,OBJCXX-ATTR
+// RUN: %clang_cc1 -emit-llvm -x objective-c++ %s -triple x86_64-unknown-linux-gnu -o - -mno-outline | FileCheck %s --check-prefixes=OBJCXX,OBJCXX-ARG
+// RUN: %clang_cc1 -emit-llvm -x objective-c++ %s -triple x86_64-unknown-linux-gnu -o -              | FileCheck %s --check-prefixes=OBJCXX,OBJCXX-NONE
+
+// This test checks that:
+// - [[clang::no_outline]] adds the nooutline IR attribute to specific definitions
+// - `-mno-outline` adds the nooutline IR attribute to all definitions
+// - Lack of either does not add nooutline IR attribute
+
+
+#ifdef TEST_ATTR
+#define ATTR [[clang::no_outline]]
+#else
+#define ATTR
+#endif
 
 @interface Test
 - (int)method:(int)x;
+- (int)method_no_attr:(int)x;
 + (int)static_method:(int)x;
++ (int)static_method_no_attr:(int)x;
 @end
 
 @implementation Test
@@ -13,7 +32,20 @@
 
 // OBJCXX-LABEL: define internal noundef i32 @"\01-[Test method:]"(
 // OBJCXX: ) #[[ATTR0:[0-9]+]] {
-- (int)method:(int)x [[clang::no_outline]] {
+- (int)method:(int)x ATTR {
+  return x;
+}
+
+// OBJC-LABEL: define internal i32 @"\01-[Test method_no_attr:]"(
+// OBJC-ATTR: ) #[[ATTR1:[0-9]+]] {
+// OBJC-ARG:  ) #[[ATTR0]] {
+// OBJC-NONE: ) #[[ATTR0]] {
+
+// OBJCXX-LABEL: define internal noundef i32 @"\01-[Test method_no_attr:]"(
+// OBJCXX-ATTR: ) #[[ATTR1:[0-9]+]] {
+// OBJCXX-ARG:  ) #[[ATTR0]] {
+// OBJCXX-NONE: ) #[[ATTR0]] {
+- (int)method_no_attr:(int) x {
   return x;
 }
 
@@ -22,19 +54,44 @@
 
 // OBJCXX-LABEL: define internal noundef i32 @"\01+[Test static_method:]"(
 // OBJCXX: ) #[[ATTR0]] {
-+ (int)static_method:(int)x [[clang::no_outline]] {
++ (int)static_method:(int)x ATTR {
+  return x;
+}
+
+
+// OBJC-LABEL: define internal i32 @"\01+[Test static_method_no_attr:]"(
+// OBJC-ATTR: ) #[[ATTR1]] {
+// OBJC-ARG:  ) #[[ATTR0]] {
+// OBJC-NONE: ) #[[ATTR0]] {
+
+
+// OBJCXX-LABEL: define internal noundef i32 @"\01+[Test static_method_no_attr:]"(
+// OBJCXX-ATTR: ) #[[ATTR1]] {
+// OBJCXX-ARG:  ) #[[ATTR0]] {
+// OBJCXX-NONE: ) #[[ATTR0]] {
+
++ (int)static_method_no_attr:(int)x {
   return x;
 }
 
 @end
 
 // OBJC: attributes #[[ATTR0]] = {
-// OBJC-SAME: nooutline
+// OBJC-ATTR-SAME: nooutline
+// OBJC-ARG-SAME: nooutline
+// OBJC-NONE-NOT: nooutline
 // OBJC-SAME: }
 
+// OBJC-ATTR: attributes #[[ATTR1]] = {
+// OBJC-ATTR-NOT: nooutline
+// OBJC-ATTR-SAME: }
+
 // OBJCXX: attributes #[[ATTR0]] = {
-// OBJCXX-SAME: nooutline
+// OBJCXX-ATTR-SAME: nooutline
+// OBJCXX-ARG-SAME: nooutline
+// OBJCXX-NONE-NOT: nooutline
 // OBJCXX-SAME: }
 
-
-
+// OBJCXX-ATTR: attributes #[[ATTR1]] = {
+// OBJCXX-ATTR-NOT: nooutline
+// OBJCXX-ATTR-SAME: }

--- a/clang/test/Driver/aarch64-outliner.c
+++ b/clang/test/Driver/aarch64-outliner.c
@@ -3,4 +3,4 @@
 // ON: "-mllvm" "-enable-machine-outliner"
 // RUN: %clang --target=aarch64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // RUN: %clang --target=aarch64_be -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
-// OFF: "-mllvm" "-enable-machine-outliner=never"
+// OFF: "-mno-outline" "-mllvm" "-enable-machine-outliner=never"

--- a/clang/test/Driver/arm-machine-outliner.c
+++ b/clang/test/Driver/arm-machine-outliner.c
@@ -3,6 +3,6 @@
 // RUN: %clang -target armv7-linux-gnueabihf -flto -moutline %s -### 2>&1 | FileCheck %s -check-prefix=ON-LTO
 // ON-LTO: "-plugin-opt=-enable-machine-outliner"
 // RUN: %clang -target armv7-linux-gnueabihf -moutline -mno-outline -c %s -### 2>&1 | FileCheck %s -check-prefix=OFF
-// OFF: "-mllvm" "-enable-machine-outliner=never"
+// OFF: "-mno-outline" "-mllvm" "-enable-machine-outliner=never"
 // RUN: %clang -target armv7-linux-gnueabihf -flto -moutline -mno-outline %s -### 2>&1 | FileCheck %s -check-prefix=OFF-LTO
 // OFF-LTO: "-plugin-opt=-enable-machine-outliner=never"

--- a/clang/test/Driver/riscv-outliner.c
+++ b/clang/test/Driver/riscv-outliner.c
@@ -4,4 +4,4 @@
 
 // RUN: %clang --target=riscv32 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // RUN: %clang --target=riscv64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
-// OFF: "-mllvm" "-enable-machine-outliner=never"
+// OFF: "-mno-outline" "-mllvm" "-enable-machine-outliner=never"

--- a/clang/test/Driver/x86-outliner.c
+++ b/clang/test/Driver/x86-outliner.c
@@ -4,4 +4,4 @@
 
 // RUN: %clang --target=i386 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
 // RUN: %clang --target=x86_64 -moutline -mno-outline -S %s -### 2>&1 | FileCheck %s -check-prefix=OFF
-// OFF: "-mllvm" "-enable-machine-outliner=never"
+// OFF: "-mno-outline" "-mllvm" "-enable-machine-outliner=never"


### PR DESCRIPTION
Before this change, `-mno-outline` and `-moutline` only controlled the
pass pipelines for the invoked compiler/linker.

The drawback of this implementation is that, when using LTO, only the
flag provided to the linker invocation is honoured (and any files which
individually use `-mno-outline` will have that flag ignored).

This change serialises the `-mno-outline` flag into each function's
IR/Bitcode, so that we can correctly disable outlining from functions in
files which disabled outlining, without affecting outlining choices for
functions from other files. This matches how other optimisation flags
are handled so the IR/Bitcode can be correctly merged during LTO.