### PR TITLE
[lld] Replace LLVM_ATTRIBUTE_UNUSED with [[maybe_unused]] (NFC)

### DIFF
--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -35,7 +35,7 @@ template <typename T> struct AssertSymbol {
                 "SymbolUnion not aligned enough");
 };
 
-LLVM_ATTRIBUTE_UNUSED static inline void assertSymbols() {
+[[maybe_unused]] static inline void assertSymbols() {
   AssertSymbol<Defined>();
   AssertSymbol<CommonSymbol>();
   AssertSymbol<Undefined>();

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -355,7 +355,7 @@ void multiThreadedPageInBackground(DeferredFiles &deferred) {
     // Reference all file's mmap'd pages to load them into memory.
     for (const char *page = buff.data(), *end = page + buff.size(); page < end;
          page += pageSize) {
-      LLVM_ATTRIBUTE_UNUSED volatile char t = *page;
+      [[maybe_unused]] volatile char t = *page;
       (void)t;
     }
   };


### PR DESCRIPTION
This patch replaces LLVM_ATTRIBUTE_UNUSED with [[maybe_unused]],
introduced as part of C++17.
