### PR TITLE
SystemZ: Remove override of insertSSPDeclarations

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -45,6 +45,10 @@ def hasStackChkFail : RuntimeLibcallPredicate<
   [{ !TT.isOSOpenBSD() && !TT.isWindowsMSVCEnvironment() &&
      !TT.isWindowsItaniumEnvironment()}]>;
 
+def hasStackChkGuard : RuntimeLibcallPredicate<
+  [{ !TT.isOSOpenBSD() && !TT.isWindowsMSVCEnvironment() &&
+     !TT.isWindowsItaniumEnvironment() && !TT.isSystemZ()}]>;
+
 def isWindowsMSVCOrItaniumEnvironment : RuntimeLibcallPredicate<
   [{TT.isWindowsMSVCEnvironment() || TT.isWindowsItaniumEnvironment()}]>;
 
@@ -2044,7 +2048,7 @@ defvar LibmHasLdexpF128 = LibcallImpls<(add ldexpl_f128), isNotOSWindowsOrIsCygw
 
 defvar has__stack_chk_fail = LibcallImpls<(add __stack_chk_fail), hasStackChkFail>;
 defvar has__stack_chk_guard =
-    LibcallImpls<(add __stack_chk_guard), hasStackChkFail>;
+    LibcallImpls<(add __stack_chk_guard), hasStackChkGuard>;
 defvar has__stack_smash_handler = LibcallImpls<(add __stack_smash_handler), isOSOpenBSD>;
 defvar has___guard_local = LibcallImpls<(add __guard_local), isOSOpenBSD>;
 

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.h
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.h
@@ -220,9 +220,6 @@ public:
 
   /// Override to support customized stack guard loading.
   bool useLoadStackGuardNode(const Module &M) const override { return true; }
-  void
-  insertSSPDeclarations(Module &M,
-                        const LibcallLoweringInfo &Libcalls) const override {}
 
   MachineBasicBlock *
   EmitInstrWithCustomInserter(MachineInstr &MI,

--- a/llvm/test/CodeGen/SystemZ/stack-guard.ll
+++ b/llvm/test/CodeGen/SystemZ/stack-guard.ll
@@ -1,4 +1,15 @@
-; RUN: llc < %s -mtriple=s390x-linux-gnu | FileCheck %s
+; RUN: opt -S -mtriple=s390x-linux-gnu -passes='require<libcall-lowering-info>,stack-protector' < %s | FileCheck -check-prefix=IR %s
+; RUN: opt -S -mtriple=s390x-ibm-zos -passes='require<libcall-lowering-info>,stack-protector' < %s | FileCheck -check-prefix=IR %s
+; RUN: llc -mtriple=s390x-linux-gnu < %s  | FileCheck %s
+
+; FIXME: Codegen error with zos
+
+; IR-NOT: __stack_chk_guard
+; IR-NOT: @
+
+; IR: define i32 @test_stack_guard
+
+; IR-NOT: __stack_chk_guard
 
 ; CHECK-LABEL: @test_stack_guard
 ; CHECK: ear [[REG1:%r[1-9][0-9]?]], %a0


### PR DESCRIPTION
The runtime library does not add a SYSTEM_CHECK_GUARD
implementation so the default will be a no-op anyway.