### PR TITLE
[compiler-rt][asan][test] Make wchar tests more robust

### DIFF
--- a/compiler-rt/test/asan/TestCases/wcscat.cpp
+++ b/compiler-rt/test/asan/TestCases/wcscat.cpp
@@ -9,11 +9,13 @@
 int main() {
   const wchar_t *start = L"X means ";
   const wchar_t *append = L"dog";
-  wchar_t goodDst[12];
+  wchar_t goodArray[12];
+  wchar_t *volatile goodDst = goodArray;
   wcscpy(goodDst, start);
   wcscat(goodDst, append);
 
-  wchar_t badDst[9];
+  wchar_t badArray[9];
+  wchar_t *volatile badDst = badArray;
   wcscpy(badDst, start);
   fprintf(stderr, "Good so far.\n");
   // CHECK-DAG: Good so far.

--- a/compiler-rt/test/asan/TestCases/wcscpy.cpp
+++ b/compiler-rt/test/asan/TestCases/wcscpy.cpp
@@ -8,10 +8,12 @@
 
 int main() {
   const wchar_t *src = L"X means dog";
-  wchar_t goodDst[12];
+  wchar_t goodArray[12];
+  wchar_t *volatile goodDst = goodArray;
   wcscpy(goodDst, src);
 
-  wchar_t badDst[7];
+  wchar_t badArray[7];
+  wchar_t *volatile badDst = badArray;
   fprintf(stderr, "Good so far.\n");
   // CHECK-DAG: Good so far.
   fflush(stderr);

--- a/compiler-rt/test/asan/TestCases/wcsncat.cpp
+++ b/compiler-rt/test/asan/TestCases/wcsncat.cpp
@@ -9,11 +9,13 @@
 int main() {
   const wchar_t *start = L"X means ";
   const wchar_t *append = L"dog";
-  wchar_t goodDst[15];
+  wchar_t goodArray[15];
+  wchar_t *volatile goodDst = goodArray;
   wcscpy(goodDst, start);
   wcsncat(goodDst, append, 5);
 
-  wchar_t badDst[11];
+  wchar_t badArray[11];
+  wchar_t *volatile badDst = badArray;
   wcscpy(badDst, start);
   wcsncat(badDst, append, 1);
   fprintf(stderr, "Good so far.\n");

--- a/compiler-rt/test/asan/TestCases/wcsncpy.cpp
+++ b/compiler-rt/test/asan/TestCases/wcsncpy.cpp
@@ -8,10 +8,12 @@
 
 int main() {
   const wchar_t *src = L"X means dog";
-  wchar_t goodDst[12];
+  wchar_t goodArray[12];
+  wchar_t *volatile goodDst = goodArray;
   wcsncpy(goodDst, src, 12);
 
-  wchar_t badDst[7];
+  wchar_t badArray[7];
+  wchar_t *volatile badDst = badArray;
   wcsncpy(badDst, src, 7); // This should still work.
   fprintf(stderr, "Good so far.\n");
   // CHECK-DAG: Good so far.


### PR DESCRIPTION
The stack buffer which is used to trigger out of bounds issue doesn't have obervable side effects, so it can easily be optimized by compiler as dead code.