### PR TITLE
[clang][docs] Remove Python2 import handler in dump_ast_matchers.py

### DIFF
--- a/clang/docs/tools/dump_ast_matchers.py
+++ b/clang/docs/tools/dump_ast_matchers.py
@@ -6,11 +6,8 @@
 import collections
 import re
 import os
+from urllib.request import urlopen
 
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
 
 CLASS_INDEX_PAGE_URL = "https://clang.llvm.org/doxygen/classes.html"
 try:


### PR DESCRIPTION
LLVM requires Python >=3.8 and in Python 3.0 urllib2 was renamed to urllib.

https://docs.python.org/3/whatsnew/3.0.html#library-changes