### PR TITLE
[lldb][test] Skip `array` test due to ASTImport lambda issue

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
@@ -11,6 +11,9 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(
+        bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
+    )
     def test(self):
         self.build()
 


### PR DESCRIPTION
The test will fail if libc++ starts to use a lambda in `<array>`. This will become the case because
- libc++'s `array::fill` uses `std::fill_n`, and
- `std::fill_n` is to be optimized for segment iterators, and
- the natural approach for such optimization uses lambdas.

Until ASTImport of `clang::LambdaExpr` nodes gets properly fix, this will need to be skipped.