### PR TITLE
[mlir][Analysis] Remove return value from `getBackwardSlice`

### DIFF
--- a/mlir/include/mlir/Analysis/SliceAnalysis.h
+++ b/mlir/include/mlir/Analysis/SliceAnalysis.h
@@ -140,17 +140,13 @@ void getForwardSlice(Value root, SetVector<Operation *> *forwardSlice,
 /// Assuming all local orders match the numbering order:
 ///    {1, 2, 5, 3, 4, 6}
 ///
-/// This function returns whether the backwards slice was able to be
-/// successfully computed, and failure if it was unable to determine the slice.
-LogicalResult getBackwardSlice(Operation *op,
-                               SetVector<Operation *> *backwardSlice,
-                               const BackwardSliceOptions &options = {});
+void getBackwardSlice(Operation *op, SetVector<Operation *> *backwardSlice,
+                      const BackwardSliceOptions &options = {});
 
 /// Value-rooted version of `getBackwardSlice`. Return the union of all backward
 /// slices for the op defining or owning the value `root`.
-LogicalResult getBackwardSlice(Value root,
-                               SetVector<Operation *> *backwardSlice,
-                               const BackwardSliceOptions &options = {});
+void getBackwardSlice(Value root, SetVector<Operation *> *backwardSlice,
+                      const BackwardSliceOptions &options = {});
 
 /// Iteratively computes backward slices and forward slices until
 /// a fixed point is reached. Returns an `SetVector<Operation *>` which

--- a/mlir/include/mlir/Query/Matcher/SliceMatchers.h
+++ b/mlir/include/mlir/Query/Matcher/SliceMatchers.h
@@ -113,9 +113,7 @@ bool BackwardSliceMatcher<Matcher>::matches(
     }
     return true;
   };
-  LogicalResult result = getBackwardSlice(rootOp, &backwardSlice, options);
-  assert(result.succeeded() && "expected backward slice to succeed");
-  (void)result;
+  getBackwardSlice(rootOp, &backwardSlice, options);
   return options.inclusive ? backwardSlice.size() > 1
                            : backwardSlice.size() >= 1;
 }
@@ -143,9 +141,7 @@ public:
       options.filter = [&](Operation *subOp) {
         return !filterMatcher.match(subOp);
       };
-      LogicalResult result = getBackwardSlice(rootOp, &backwardSlice, options);
-      assert(result.succeeded() && "expected backward slice to succeed");
-      (void)result;
+      getBackwardSlice(rootOp, &backwardSlice, options);
       return options.inclusive ? backwardSlice.size() > 1
                                : backwardSlice.size() >= 1;
     }

--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -312,10 +312,7 @@ getSliceContract(Operation *op,
     auto *currentOp = (slice)[currentIndex];
     // Compute and insert the backwardSlice starting from currentOp.
     backwardSlice.clear();
-    LogicalResult result =
-        getBackwardSlice(currentOp, &backwardSlice, backwardSliceOptions);
-    assert(result.succeeded() && "expected a backward slice");
-    (void)result;
+    getBackwardSlice(currentOp, &backwardSlice, backwardSliceOptions);
     slice.insert_range(backwardSlice);
 
     // Compute and insert the forwardSlice starting from currentOp.

--- a/mlir/lib/Dialect/Linalg/Transforms/HoistPadding.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/HoistPadding.cpp
@@ -122,16 +122,10 @@ static void computeBackwardSlice(tensor::PadOp padOp,
   SetVector<Value> valuesDefinedAbove;
   getUsedValuesDefinedAbove(padOp.getRegion(), padOp.getRegion(),
                             valuesDefinedAbove);
-  for (Value v : valuesDefinedAbove) {
-    LogicalResult result = getBackwardSlice(v, &backwardSlice, sliceOptions);
-    assert(result.succeeded() && "expected a backward slice");
-    (void)result;
-  }
+  for (Value v : valuesDefinedAbove)
+    getBackwardSlice(v, &backwardSlice, sliceOptions);
   // Then, add the backward slice from padOp itself.
-  LogicalResult result =
-      getBackwardSlice(padOp.getOperation(), &backwardSlice, sliceOptions);
-  assert(result.succeeded() && "expected a backward slice");
-  (void)result;
+  getBackwardSlice(padOp.getOperation(), &backwardSlice, sliceOptions);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/NVGPU/TransformOps/NVGPUTransformOps.cpp
+++ b/mlir/lib/Dialect/NVGPU/TransformOps/NVGPUTransformOps.cpp
@@ -281,13 +281,9 @@ static void getPipelineStages(
     return visited->getBlock() == forOp.getBody();
   });
   options.inclusive = true;
-  for (Operation &op : forOp.getBody()->getOperations()) {
-    if (stage0Ops.contains(&op)) {
-      LogicalResult result = getBackwardSlice(&op, &dependencies, options);
-      assert(result.succeeded() && "expected a backward slice");
-      (void)result;
-    }
-  }
+  for (Operation &op : forOp.getBody()->getOperations())
+    if (stage0Ops.contains(&op))
+      getBackwardSlice(&op, &dependencies, options);
 
   for (Operation &op : forOp.getBody()->getOperations()) {
     if (!dependencies.contains(&op) && !isa<scf::YieldOp>(op))

--- a/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
@@ -1970,11 +1970,8 @@ checkAssumptionForLoop(Operation *loopOp, Operation *consumerOp,
     return !dominanceInfo.properlyDominates(op, *firstUserOfLoop);
   };
   llvm::SetVector<Operation *> slice;
-  for (auto operand : consumerOp->getOperands()) {
-    LogicalResult result = getBackwardSlice(operand, &slice, options);
-    assert(result.succeeded() && "expected a backward slice");
-    (void)result;
-  }
+  for (auto operand : consumerOp->getOperands())
+    getBackwardSlice(operand, &slice, options);
 
   if (!slice.empty()) {
     // If consumerOp has one producer, which is also the user of loopOp.

--- a/mlir/lib/Transforms/Utils/RegionUtils.cpp
+++ b/mlir/lib/Transforms/Utils/RegionUtils.cpp
@@ -1116,9 +1116,7 @@ LogicalResult mlir::moveOperationDependencies(RewriterBase &rewriter,
     return !dominance.properlyDominates(sliceBoundaryOp, insertionPoint);
   };
   llvm::SetVector<Operation *> slice;
-  LogicalResult result = getBackwardSlice(op, &slice, options);
-  assert(result.succeeded() && "expected a backward slice");
-  (void)result;
+  getBackwardSlice(op, &slice, options);
 
   // If the slice contains `insertionPoint` cannot move the dependencies.
   if (slice.contains(insertionPoint)) {
@@ -1182,11 +1180,8 @@ LogicalResult mlir::moveValueDefinitions(RewriterBase &rewriter,
     return !dominance.properlyDominates(sliceBoundaryOp, insertionPoint);
   };
   llvm::SetVector<Operation *> slice;
-  for (auto value : prunedValues) {
-    LogicalResult result = getBackwardSlice(value, &slice, options);
-    assert(result.succeeded() && "expected a backward slice");
-    (void)result;
-  }
+  for (auto value : prunedValues)
+    getBackwardSlice(value, &slice, options);
 
   // If the slice contains `insertionPoint` cannot move the dependencies.
   if (slice.contains(insertionPoint)) {

--- a/mlir/test/lib/Dialect/Affine/TestVectorizationUtils.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestVectorizationUtils.cpp
@@ -154,10 +154,7 @@ void VectorizerTestPass::testBackwardSlicing(llvm::raw_ostream &outs) {
   patternTestSlicingOps().match(f, &matches);
   for (auto m : matches) {
     SetVector<Operation *> backwardSlice;
-    LogicalResult result =
-        getBackwardSlice(m.getMatchedOperation(), &backwardSlice);
-    assert(result.succeeded() && "expected a backward slice");
-    (void)result;
+    getBackwardSlice(m.getMatchedOperation(), &backwardSlice);
     outs << "\nmatched: " << *m.getMatchedOperation()
          << " backward static slice: ";
     for (auto *op : backwardSlice)

--- a/mlir/test/lib/IR/TestSlicing.cpp
+++ b/mlir/test/lib/IR/TestSlicing.cpp
@@ -41,9 +41,7 @@ static LogicalResult createBackwardSliceFunction(Operation *op,
   options.omitBlockArguments = omitBlockArguments;
   // TODO: Make this default.
   options.omitUsesFromAbove = false;
-  LogicalResult result = getBackwardSlice(op, &slice, options);
-  assert(result.succeeded() && "expected a backward slice");
-  (void)result;
+  getBackwardSlice(op, &slice, options);
   for (Operation *slicedOp : slice)
     builder.clone(*slicedOp, mapper);
   func::ReturnOp::create(builder, loc);


### PR DESCRIPTION
This function went through a series of refactorings, most notably #140961. In the current version, there is no case where the function could return `failure`. It always returns `success`. This PR drops the return value to avoid API bloat.

Note for LLVM integration: Simply drop and ignore the return value of `getBackwardSlice`.
