### PR TITLE
release/21.x: [libc++][docs] Add missing entry for P3379R0 to `21.rst`

### DIFF
--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -53,6 +53,7 @@ Implemented Papers
 - P2711R1: Making multi-param constructors of ``views`` ``explicit`` (`Github <https://github.com/llvm/llvm-project/issues/105252>`__)
 - P2770R0: Stashing stashing ``iterators`` for proper flattening (`Github <https://github.com/llvm/llvm-project/issues/105250>`__)
 - P2655R3: ``common_reference_t`` of ``reference_wrapper`` Should Be a Reference Type (`Github <https://github.com/llvm/llvm-project/issues/105260>`__)
+- P3379R0: Constrain ``std::expected`` equality operators (`Github <https://github.com/llvm/llvm-project/issues/118135>`__)
 
 Improvements and New Features
 -----------------------------


### PR DESCRIPTION
P3379R0 was implemented in LLVM 21 (13c464be84d9715f0825387f30e455eea7ef75f7) but the entry for release note is still missing. A following-up PR (4a509f853fa4821ecdb0f6bc3b90ddd48794cc8c) fixed this as drive-by but backport was not accepted.

This patch only adds the missing entry.