### PR TITLE
[mlir][AMGPU] Replace use of SmallVector with ArrayRef, NFC

### DIFF
--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -757,8 +757,8 @@ struct PackScales final : OpRewritePattern<ScaledMFMAOp> {
         offset = numElements - 4l;
       }
       Type scaleSrcElemType = scaleSrcType.getElementType();
-      auto newSrcType = VectorType::get(SmallVector<int64_t>({numElements}),
-                                        scaleSrcElemType);
+      auto newSrcType =
+          VectorType::get(ArrayRef<int64_t>{numElements}, scaleSrcElemType);
       Value newScaleSrc =
           vector::ShapeCastOp::create(rewriter, loc, newSrcType, scaleSrc);
       auto extract = vector::ExtractStridedSliceOp::create(

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -758,12 +758,12 @@ struct PackScales final : OpRewritePattern<ScaledMFMAOp> {
       }
       Type scaleSrcElemType = scaleSrcType.getElementType();
       auto newSrcType =
-          VectorType::get(ArrayRef<int64_t>{numElements}, scaleSrcElemType);
+          VectorType::get(ArrayRef{numElements}, scaleSrcElemType);
       Value newScaleSrc =
           vector::ShapeCastOp::create(rewriter, loc, newSrcType, scaleSrc);
       auto extract = vector::ExtractStridedSliceOp::create(
-          rewriter, loc, newScaleSrc, ArrayRef<int64_t>{offset},
-          ArrayRef<int64_t>{size}, ArrayRef<int64_t>{1});
+          rewriter, loc, newScaleSrc, ArrayRef{offset}, ArrayRef{size},
+          ArrayRef<int64_t>{1});
       rewriter.modifyOpInPlace(op, [&] {
         op->setOperand(opIdx, extract);
         setOpsel(opIdx, opsel);

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -763,7 +763,7 @@ struct PackScales final : OpRewritePattern<ScaledMFMAOp> {
           vector::ShapeCastOp::create(rewriter, loc, newSrcType, scaleSrc);
       auto extract = vector::ExtractStridedSliceOp::create(
           rewriter, loc, newScaleSrc, ArrayRef{offset}, ArrayRef{size},
-          ArrayRef{INT64_C(1)});
+          ArrayRef{int64_t(1)});
       rewriter.modifyOpInPlace(op, [&] {
         op->setOperand(opIdx, extract);
         setOpsel(opIdx, opsel);

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -763,7 +763,7 @@ struct PackScales final : OpRewritePattern<ScaledMFMAOp> {
           vector::ShapeCastOp::create(rewriter, loc, newSrcType, scaleSrc);
       auto extract = vector::ExtractStridedSliceOp::create(
           rewriter, loc, newScaleSrc, ArrayRef{offset}, ArrayRef{size},
-          ArrayRef<int64_t>{1});
+          ArrayRef{INT64_C(1)});
       rewriter.modifyOpInPlace(op, [&] {
         op->setOperand(opIdx, extract);
         setOpsel(opIdx, opsel);


### PR DESCRIPTION
Improving choice of class used, from SmallVector to ArrayRef (https://llvm.org/docs/ProgrammersManual.html#llvm-adt-arrayref-h). Leftover from https://github.com/llvm/llvm-project/pull/155951.