### PR TITLE
[mlir][python] Fix lit run line for openacc test

### DIFF
--- a/mlir/test/python/dialects/openacc.py
+++ b/mlir/test/python/dialects/openacc.py
@@ -1,4 +1,4 @@
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 from unittest import result
 from mlir.ir import (
     Context,


### PR DESCRIPTION
This test passed locally because I had a python environment with the `python` command available, but I should have used the `%PYTHON` lit command substitution instead. Fixes buildbot failures from #163620.