### PR TITLE
[clang][bytecode] Bail out from type-punning casts

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -423,6 +423,8 @@ private:
   bool checkLiteralType(const Expr *E);
   bool maybeEmitDeferredVarInit(const VarDecl *VD);
 
+  bool isPunningDereference(const Expr *E);
+
   bool refersToUnion(const Expr *E);
 
 protected:


### PR DESCRIPTION
Fixes #163778 (fix might be indirect?)

Prevents emitting byte-code for UB casts