### PR TITLE
[ConstantFPRange] Outline special member functions

### DIFF
--- a/llvm/include/llvm/IR/ConstantFPRange.h
+++ b/llvm/include/llvm/IR/ConstantFPRange.h
@@ -59,6 +59,11 @@ public:
   /// Initialize a range to hold the single specified value.
   LLVM_ABI explicit ConstantFPRange(const APFloat &Value);
 
+  LLVM_ABI ConstantFPRange(const ConstantFPRange &Other);
+  LLVM_ABI ConstantFPRange(ConstantFPRange &&Other);
+  LLVM_ABI ConstantFPRange &operator=(const ConstantFPRange &Other);
+  LLVM_ABI ConstantFPRange &operator=(ConstantFPRange &&Other);
+
   /// Initialize a range of values explicitly.
   /// Note: If \p LowerVal is greater than \p UpperVal, please use the canonical
   /// form [Inf, -Inf].

--- a/llvm/lib/IR/ConstantFPRange.cpp
+++ b/llvm/lib/IR/ConstantFPRange.cpp
@@ -57,6 +57,12 @@ ConstantFPRange::ConstantFPRange(const APFloat &Value)
   }
 }
 
+ConstantFPRange::ConstantFPRange(const ConstantFPRange &Other) = default;
+ConstantFPRange::ConstantFPRange(ConstantFPRange &&Other) = default;
+ConstantFPRange &
+ConstantFPRange::operator=(const ConstantFPRange &Other) = default;
+ConstantFPRange &ConstantFPRange::operator=(ConstantFPRange &&Other) = default;
+
 // We treat that -0 is less than 0 here.
 static APFloat::cmpResult strictCompare(const APFloat &LHS,
                                         const APFloat &RHS) {


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/pull/111544#issuecomment-3405281695, large special member functions in APFloat/ConstantFPRange prevent function inlining and cause compile-time regression. This patch moves them into the cpp file.

Compile-time improvement (with https://github.com/llvm/llvm-project/pull/111544): https://llvm-compile-time-tracker.com/compare.php?from=3df3102ff95af6724e684520d7b75d9f288ceeed&to=e438bae71d1fd55640d942b9ad795de2f60e44f2&stat=instructions:u

On llvm-opt-benchmark, this patch yields about -0.1% improvement: https://github.com/llvm/llvm-project/pull/111544#issuecomment-3406070655

I also did some experiments about outlining special member functions of APInt::Storage: https://llvm-compile-time-tracker.com/compare.php?from=f4359301c033694d36865c7560714164d2050240&to=65f55cdd23a625bd7dc51ae723916b8b5a80c5f8&stat=instructions:u
