### PR TITLE
[llvm-objdump] Fix --disassembler-color with --macho flag

### DIFF
--- a/llvm/test/tools/llvm-objdump/MachO/arm64-disassembly-color.s
+++ b/llvm/test/tools/llvm-objdump/MachO/arm64-disassembly-color.s
@@ -6,7 +6,7 @@
 // RUN: llvm-objdump --disassembler-color=off --disassemble %t | FileCheck %s --check-prefix=NOCOLOR
 // RUN: llvm-objdump --disassembler-color=terminal --disassemble %t | FileCheck %s --check-prefix=NOCOLOR
 
-// Test with --macho flag to ensure DisassembleMachO respects color settings
+//// Test with --macho flag to ensure DisassembleMachO respects color settings.
 // RUN: llvm-objdump --disassembler-color=on --macho --disassemble %t | FileCheck %s --check-prefix=COLOR
 // RUN: llvm-objdump --disassembler-color=off --macho --disassemble %t | FileCheck %s --check-prefix=NOCOLOR
 

--- a/llvm/test/tools/llvm-objdump/MachO/arm64-disassembly-color.s
+++ b/llvm/test/tools/llvm-objdump/MachO/arm64-disassembly-color.s
@@ -6,6 +6,10 @@
 // RUN: llvm-objdump --disassembler-color=off --disassemble %t | FileCheck %s --check-prefix=NOCOLOR
 // RUN: llvm-objdump --disassembler-color=terminal --disassemble %t | FileCheck %s --check-prefix=NOCOLOR
 
+// Test with --macho flag to ensure DisassembleMachO respects color settings
+// RUN: llvm-objdump --disassembler-color=on --macho --disassemble %t | FileCheck %s --check-prefix=COLOR
+// RUN: llvm-objdump --disassembler-color=off --macho --disassemble %t | FileCheck %s --check-prefix=NOCOLOR
+
 sub	sp, sp, #16
 str	w0, [sp, #12]
 ldr	w8, [sp, #12]

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -7235,20 +7235,17 @@ objdump::getMachODSymObject(const MachOObjectFile *MachOOF, StringRef Filename,
   return DbgObj;
 }
 
-static void setUpMachOInstPrinter(MCInstPrinter *IP) {
-  IP->setPrintImmHex(PrintImmHex);
+static bool shouldInstPrinterUseColor() {
   switch (DisassemblyColor) {
   case ColorOutput::Enable:
-    IP->setUseColor(true);
-    break;
+    return true;
   case ColorOutput::Auto:
-    IP->setUseColor(outs().has_colors());
-    break;
+    return outs().has_colors();
   case ColorOutput::Disable:
   case ColorOutput::Invalid:
-    IP->setUseColor(false);
-    break;
+    return false;
   }
+  return false;
 }
 
 static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
@@ -7335,7 +7332,8 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
   std::unique_ptr<MCInstPrinter> IP(TheTarget->createMCInstPrinter(
       TheTriple, AsmPrinterVariant, *AsmInfo, *InstrInfo, *MRI));
   CHECK_TARGET_INFO_CREATION(IP);
-  setUpMachOInstPrinter(IP.get());
+  IP->setPrintImmHex(PrintImmHex);
+  IP->setUseColor(shouldInstPrinterUseColor());
 
   // Comment stream and backing vector.
   SmallString<128> CommentsToEmit;
@@ -7388,7 +7386,8 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
         ThumbTriple, ThumbAsmPrinterVariant, *ThumbAsmInfo, *ThumbInstrInfo,
         *ThumbMRI));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbIP);
-    setUpMachOInstPrinter(ThumbIP.get());
+    ThumbIP->setPrintImmHex(PrintImmHex);
+    ThumbIP->setUseColor(shouldInstPrinterUseColor());
   }
 
 #undef CHECK_TARGET_INFO_CREATION

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -7321,6 +7321,19 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
   CHECK_TARGET_INFO_CREATION(IP);
   // Set the display preference for hex vs. decimal immediates.
   IP->setPrintImmHex(PrintImmHex);
+  // Set up disassembler color output.
+  switch (DisassemblyColor) {
+  case ColorOutput::Enable:
+    IP->setUseColor(true);
+    break;
+  case ColorOutput::Auto:
+    IP->setUseColor(outs().has_colors());
+    break;
+  case ColorOutput::Disable:
+  case ColorOutput::Invalid:
+    IP->setUseColor(false);
+    break;
+  }
   // Comment stream and backing vector.
   SmallString<128> CommentsToEmit;
   raw_svector_ostream CommentStream(CommentsToEmit);
@@ -7374,6 +7387,19 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbIP);
     // Set the display preference for hex vs. decimal immediates.
     ThumbIP->setPrintImmHex(PrintImmHex);
+    // Set up disassembler color output.
+    switch (DisassemblyColor) {
+    case ColorOutput::Enable:
+      ThumbIP->setUseColor(true);
+      break;
+    case ColorOutput::Auto:
+      ThumbIP->setUseColor(outs().has_colors());
+      break;
+    case ColorOutput::Disable:
+    case ColorOutput::Invalid:
+      ThumbIP->setUseColor(false);
+      break;
+    }
   }
 
 #undef CHECK_TARGET_INFO_CREATION

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -7235,7 +7235,7 @@ objdump::getMachODSymObject(const MachOObjectFile *MachOOF, StringRef Filename,
   return DbgObj;
 }
 
-static void setupMachOInstPrinter(MCInstPrinter *IP) {
+static void setUpMachOInstPrinter(MCInstPrinter *IP) {
   IP->setPrintImmHex(PrintImmHex);
   switch (DisassemblyColor) {
   case ColorOutput::Enable:
@@ -7335,7 +7335,7 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
   std::unique_ptr<MCInstPrinter> IP(TheTarget->createMCInstPrinter(
       TheTriple, AsmPrinterVariant, *AsmInfo, *InstrInfo, *MRI));
   CHECK_TARGET_INFO_CREATION(IP);
-  setupMachOInstPrinter(IP.get());
+  setUpMachOInstPrinter(IP.get());
 
   // Comment stream and backing vector.
   SmallString<128> CommentsToEmit;
@@ -7388,7 +7388,7 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
         ThumbTriple, ThumbAsmPrinterVariant, *ThumbAsmInfo, *ThumbInstrInfo,
         *ThumbMRI));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbIP);
-    setupMachOInstPrinter(ThumbIP.get());
+    setUpMachOInstPrinter(ThumbIP.get());
   }
 
 #undef CHECK_TARGET_INFO_CREATION

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -291,13 +291,6 @@ private:
 
 #define DEBUG_TYPE "objdump"
 
-enum class ColorOutput {
-  Auto,
-  Enable,
-  Disable,
-  Invalid,
-};
-
 static uint64_t AdjustVMA;
 static bool AllHeaders;
 static std::string ArchName;
@@ -310,7 +303,7 @@ bool objdump::SymbolDescription;
 bool objdump::TracebackTable;
 static std::vector<std::string> DisassembleSymbols;
 static bool DisassembleZeroes;
-static ColorOutput DisassemblyColor;
+ColorOutput objdump::DisassemblyColor;
 DIDumpType objdump::DwarfDumpType;
 static bool DynamicRelocations;
 static bool FaultMapSection;

--- a/llvm/tools/llvm-objdump/llvm-objdump.h
+++ b/llvm/tools/llvm-objdump/llvm-objdump.h
@@ -43,6 +43,13 @@ namespace objdump {
 
 enum DebugFormat { DFASCII, DFDisabled, DFInvalid, DFLimitsOnly, DFUnicode };
 
+enum class ColorOutput {
+  Auto,
+  Enable,
+  Disable,
+  Invalid,
+};
+
 extern bool ArchiveHeaders;
 extern int DbgIndent;
 extern DebugFormat DbgVariables;
@@ -51,6 +58,7 @@ extern bool Demangle;
 extern bool Disassemble;
 extern bool DisassembleAll;
 extern std::vector<std::string> DisassemblerOptions;
+extern ColorOutput DisassemblyColor;
 extern DIDumpType DwarfDumpType;
 extern std::vector<std::string> FilterSections;
 extern bool LeadingAddr;


### PR DESCRIPTION
The --disassembler-color option was being ignored when using the --macho flag because DisassembleMachO() never called setUseColor() on the instruction printer.