### PR TITLE
[CI] Send Platform Along with Failure Information

### DIFF
--- a/.ci/premerge_advisor_upload.py
+++ b/.ci/premerge_advisor_upload.py
@@ -23,11 +23,13 @@ def main(commit_sha, workflow_run_number, build_log_files):
     )
     test_failures = generate_test_report_lib.get_failures(junit_objects)
     source = "pull_request" if "GITHUB_ACTIONS" in os.environ else "postcommit"
+    current_platform = f"{platform.system()}-{platform.machine()}".lower()
     failure_info = {
         "source_type": source,
         "base_commit_sha": commit_sha,
         "source_id": workflow_run_number,
         "failures": [],
+        "platform": current_platform
     }
     if test_failures:
         for name, failure_message in test_failures:

--- a/.ci/premerge_advisor_upload.py
+++ b/.ci/premerge_advisor_upload.py
@@ -29,7 +29,7 @@ def main(commit_sha, workflow_run_number, build_log_files):
         "base_commit_sha": commit_sha,
         "source_id": workflow_run_number,
         "failures": [],
-        "platform": current_platform
+        "platform": current_platform,
     }
     if test_failures:
         for name, failure_message in test_failures:


### PR DESCRIPTION
To enable disambiguating the platform later when we look at identifying tests failing at HEAD/flaky tests.