### PR TITLE
[lldb-dap] Fix mutex acquisition order for modules event.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -26,6 +26,7 @@
 #include "lldb/API/SBEvent.h"
 #include "lldb/API/SBLanguageRuntime.h"
 #include "lldb/API/SBListener.h"
+#include "lldb/API/SBMutex.h"
 #include "lldb/API/SBProcess.h"
 #include "lldb/API/SBStream.h"
 #include "lldb/Host/JSONTransport.h"
@@ -1455,7 +1456,8 @@ void DAP::EventThread() {
           // NOTE: Both mutexes must be acquired to prevent deadlock when
           // handling `modules_request`, which also requires both locks.
           lldb::SBMutex api_mutex = GetAPIMutex();
-          const std::scoped_lock guard(api_mutex, modules_mutex);
+          const std::scoped_lock<lldb::SBMutex, std::mutex> guard(
+              api_mutex, modules_mutex);
           for (uint32_t i = 0; i < num_modules; ++i) {
             lldb::SBModule module =
                 lldb::SBTarget::GetModuleAtIndexFromEvent(i, event);


### PR DESCRIPTION
The modules event requires the `APIMutex` to create the module load address. this may happen at the same time the `module request` is handled.

The modules request also requires the `APIMutex` and the `modules_mutex, set the order to acquire the mutexes.