### PR TITLE
[AIX] Fix dwarf testcases on AIX

### DIFF
--- a/llvm/test/DebugInfo/Generic/compileunit-source-language-name.ll
+++ b/llvm/test/DebugInfo/Generic/compileunit-source-language-name.ll
@@ -1,3 +1,5 @@
+; AIX doesn't have support for DWARF 6 DW_AT_language_name
+; XFAIL: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 ; RUN: %llc_dwarf -filetype=obj -O0 < %s | llvm-dwarfdump -debug-info - | FileCheck %s --implicit-check-not "DW_AT_language"
 
 ; CHECK: DW_AT_language_name (DW_LNAME_ObjC_plus_plus)

--- a/llvm/test/DebugInfo/Generic/compileunit-source-language.ll
+++ b/llvm/test/DebugInfo/Generic/compileunit-source-language.ll
@@ -1,3 +1,5 @@
+; AIX doesn't have support for DWARF 6 DW_AT_language_name
+; XFAIL: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 ; RUN: %llc_dwarf -filetype=obj -O0 < %s | llvm-dwarfdump -debug-info - | FileCheck %s --implicit-check-not "DW_AT_language_name"
 
 ; CHECK: DW_AT_language (DW_LANG_C)

--- a/llvm/test/DebugInfo/dwarf-complex-int.ll
+++ b/llvm/test/DebugInfo/dwarf-complex-int.ll
@@ -1,4 +1,6 @@
 ; REQUIRES: object-emission
+; AIX doesn't have full support for DWARF 5
+; XFAIL: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 ; RUN: %llc_dwarf %s -filetype=obj -o - | llvm-dwarfdump - | FileCheck %s
 
 ;; https://github.com/llvm/llvm-project/issues/140362


### PR DESCRIPTION
These test cases break the aix bots starting https://lab.llvm.org/buildbot/#/builders/64/builds/6062 and are not supported on AIX 