### PR TITLE
Fix for incomplete buffer types in HLSL

### DIFF
--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -493,6 +493,16 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
         .completeDefinition();
   });
   CompleteType(Decl);
+
+  Decl = BuiltinTypeDeclBuilder(*SemaPtr, HLSLNamespace, "ConstantBuffer")
+             .addSimpleTemplateParams({"element_type"}, StructuredBufferConcept)
+             .finalizeForwardDeclaration();
+  onCompletion(Decl, [this](CXXRecordDecl *Decl) {
+    setupBufferType(Decl, *SemaPtr, ResourceClass::CBuffer, /*IsROV=*/true,
+                    /*RawBuffer=*/false, /*HasCounter=*/false)
+        .completeDefinition();
+  });
+  CompleteType(Decl);
 }
 
 void HLSLExternalSemaSource::onCompletion(CXXRecordDecl *Record,

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -473,6 +473,8 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
                     /*RawBuffer=*/true, /*HasCounter=*/false)
         .completeDefinition();
   });
+  CompleteType(Decl);
+
   Decl = BuiltinTypeDeclBuilder(*SemaPtr, HLSLNamespace, "RWByteAddressBuffer")
              .finalizeForwardDeclaration();
   onCompletion(Decl, [this](CXXRecordDecl *Decl) {
@@ -480,6 +482,8 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
                     /*RawBuffer=*/true, /*HasCounter=*/false)
         .completeDefinition();
   });
+  CompleteType(Decl);
+
   Decl = BuiltinTypeDeclBuilder(*SemaPtr, HLSLNamespace,
                                 "RasterizerOrderedByteAddressBuffer")
              .finalizeForwardDeclaration();
@@ -488,6 +492,7 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
                     /*RawBuffer=*/true, /*HasCounter=*/false)
         .completeDefinition();
   });
+  CompleteType(Decl);
 }
 
 void HLSLExternalSemaSource::onCompletion(CXXRecordDecl *Record,


### PR DESCRIPTION
I am actually looking into getting clangd to work with HLSL. There is currently no good tool available for HLSL and as HLSL seems to be supported (up to a certain point) inside clang, I want to see how far I can push the tool to support the different language features.

The first feature that requires an update is the SEMA (semantics?) around the buffer types. HLSL has updated their usage of buffer types in recent versions, so these need to be updated here as well.

The first issue I ran into is the following;
1. Some buffers are registered as incomplete types inside the clang-dxc compiler
2. `ConstantBuffer<type>` is missing

I will start with 1. in this PR. An explanation for 2. will be later in this post. Please note that I am not familiar with this code base, this is my first time :), so the solution I give here might not be good, but I am willing to learn and move code around if necessary.

# 1. Some buffers are registered as incomplete types
I have a local test case that is as follows. We have a file:
```hlsl
// complete types
RasterizerOrderedStructuredBuffer<float3>   buf0  : register(u0);
ConsumeStructuredBuffer<float3>             buf1  : register(u0);
AppendStructuredBuffer<float3>              buf2  : register(u0);
RWStructuredBuffer<float3>                  buf3  : register(u0);
StructuredBuffer<float3>                    buf4  : register(t0);
RasterizerOrderedBuffer<float3>             buf5  : register(u0);
Buffer<float3>                              buf6 : register(t0);
RWBuffer<float3>                            buf7  : register(u0);

// incomplete types
ByteAddressBuffer                           buf8  : register(t0);
RWByteAddressBuffer                         buf9  : register(u0);
RasterizerOrderedByteAddressBuffer          buf10 : register(u0);

// missing
ConstantBuffer<float4>                      buf11 : register(b0);
```
and we call clangd on this file. I have a compile_commands.json that handles cli args (args in output).

The output is:
```
I[18:30:05.863] clangd version 22.0.0git (https://github.com/KungFuDonkey/llvm-project.git 57957640a6f869622304285da6d25c71b8c3ae4d)
I[18:30:05.864] Features: windows
I[18:30:05.864] PID: 43768
I[18:30:05.864] Working directory: C:\develop\personal_gh\llvm-project\build\tools\clang\tools\extra\clangd\tool
I[18:30:05.864] argv[0]: C:\develop\personal_gh\llvm-project\build\RelWithDebInfo\bin\clangd.exe
I[18:30:05.864] argv[1]: --compile-commands-dir=C:/develop/gh/drivers/drivers/d3d/dxcp_repo/build/imported/gpurt_overridden/src/pipelines/
I[18:30:05.864] argv[2]: --check=C:\develop\personal_gh\hlsl-test\buffers.hlsl
I[18:30:05.880] Entering check mode (no LSP server)
I[18:30:05.880] Testing on source file C:\develop\personal_gh\hlsl-test\buffers.hlsl
I[18:30:05.880] Loading compilation database...
I[18:30:05.893] Loaded compilation database from C:/develop/gh/drivers/drivers/d3d/dxcp_repo/build/imported/gpurt_overridden/src/pipelines/compile_commands.json
I[18:30:05.894] Compile command from CDB is: [C:/develop/personal_gh/hlsl-test] "C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\bin\\clang" --driver-mode=dxc -T cs_6_6 "-resource-dir=C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\lib\\clang\\22" -- "C:\\develop\\personal_gh\\hlsl-test\\buffers.hlsl"
I[18:30:05.894] Parsing command...
I[18:30:05.896] internal (cc1) args are: -cc1 -triple dxilv1.6-unknown-shadermodel6.6-compute -O3 -fsyntax-only -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name buffers.hlsl -mrelocation-model static -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -debugger-tuning=gdb -fdebug-compilation-dir=C:/develop/personal_gh/hlsl-test -fcoverage-compilation-dir=C:/develop/personal_gh/hlsl-test -resource-dir "C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\lib\\clang\\22" -ferror-limit 19 -fmessage-length=112 -O3 -finclude-default-header -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -vectorize-loops -vectorize-slp -no-round-trip-args -x hlsl "C:\\develop\\personal_gh\\hlsl-test\\buffers.hlsl"
I[18:30:05.896] Building preamble...
I[18:30:06.011] Built preamble of size 784568 for file C:\develop\personal_gh\hlsl-test\buffers.hlsl version null in 0.11 seconds
I[18:30:06.011] Indexing headers...
I[18:30:06.042] Building AST...
E[18:30:06.070] [incomplete_type] Line 13: incomplete type 'ByteAddressBuffer' where a complete type is required
E[18:30:06.070] [typecheck_decl_incomplete_type] Line 13: variable has incomplete type 'ByteAddressBuffer'
E[18:30:06.070] [incomplete_type] Line 14: incomplete type 'RWByteAddressBuffer' where a complete type is required
E[18:30:06.071] [typecheck_decl_incomplete_type] Line 14: variable has incomplete type 'RWByteAddressBuffer'
E[18:30:06.071] [incomplete_type] Line 15: incomplete type 'RasterizerOrderedByteAddressBuffer' where a complete type is required
E[18:30:06.071] [typecheck_decl_incomplete_type] Line 15: variable has incomplete type 'RasterizerOrderedByteAddressBuffer'
E[18:30:06.072] [no_template] Line 18: no template named 'ConstantBuffer'
E[18:30:06.072] [-Wlegacy-constant-register-binding] Line 18: binding type 'b' only applies to constant buffers. The 'bool constant' binding type is no longer supported
I[18:30:06.072] Indexing AST...
I[18:30:06.072] Building inlay hints
I[18:30:06.073] Building semantic highlighting
I[18:30:06.073] Testing features at each token (may be slow in large files)
I[18:30:06.116] All checks completed, 8 error
```

Calling `CompleteType(Decl);` on the types makes the issues go away for the incomplete buffers:
```
I[18:31:33.237] clangd version 22.0.0git (https://github.com/KungFuDonkey/llvm-project.git 57957640a6f869622304285da6d25c71b8c3ae4d)
I[18:31:33.238] Features: windows
I[18:31:33.239] PID: 42232
I[18:31:33.239] Working directory: C:\develop\personal_gh\llvm-project\build\tools\clang\tools\extra\clangd\tool
I[18:31:33.239] argv[0]: C:\develop\personal_gh\llvm-project\build\RelWithDebInfo\bin\clangd.exe
I[18:31:33.239] argv[1]: --compile-commands-dir=C:/develop/gh/drivers/drivers/d3d/dxcp_repo/build/imported/gpurt_overridden/src/pipelines/
I[18:31:33.239] argv[2]: --check=C:\develop\personal_gh\hlsl-test\buffers.hlsl
I[18:31:33.257] Entering check mode (no LSP server)
I[18:31:33.257] Testing on source file C:\develop\personal_gh\hlsl-test\buffers.hlsl
I[18:31:33.258] Loading compilation database...
I[18:31:33.273] Loaded compilation database from C:/develop/gh/drivers/drivers/d3d/dxcp_repo/build/imported/gpurt_overridden/src/pipelines/compile_commands.json
I[18:31:33.273] Compile command from CDB is: [C:/develop/personal_gh/hlsl-test] "C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\bin\\clang" --driver-mode=dxc -T cs_6_6 "-resource-dir=C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\lib\\clang\\22" -- "C:\\develop\\personal_gh\\hlsl-test\\buffers.hlsl"
I[18:31:33.274] Parsing command...
I[18:31:33.276] internal (cc1) args are: -cc1 -triple dxilv1.6-unknown-shadermodel6.6-compute -O3 -fsyntax-only -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name buffers.hlsl -mrelocation-model static -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -debugger-tuning=gdb -fdebug-compilation-dir=C:/develop/personal_gh/hlsl-test -fcoverage-compilation-dir=C:/develop/personal_gh/hlsl-test -resource-dir "C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\lib\\clang\\22" -ferror-limit 19 -fmessage-length=112 -O3 -finclude-default-header -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -vectorize-loops -vectorize-slp -no-round-trip-args -x hlsl "C:\\develop\\personal_gh\\hlsl-test\\buffers.hlsl"
I[18:31:33.276] Building preamble...
I[18:31:33.386] Built preamble of size 791660 for file C:\develop\personal_gh\hlsl-test\buffers.hlsl version null in 0.11 seconds
I[18:31:33.387] Indexing headers...
I[18:31:33.422] Building AST...
E[18:31:33.448] [no_template] Line 18: no template named 'ConstantBuffer'
E[18:31:33.449] [-Wlegacy-constant-register-binding] Line 18: binding type 'b' only applies to constant buffers. The 'bool constant' binding type is no longer supported
I[18:31:33.449] Indexing AST...
I[18:31:33.449] Building inlay hints
I[18:31:33.450] Building semantic highlighting
I[18:31:33.450] Testing features at each token (may be slow in large files)
I[18:31:33.491] All checks completed, 2 errors
```

Thus, a call to CompleteType is missing for these 3 buffers. I was not able to find where that is.

# 2. `ConstantBuffer<type>` is missing
This type is in theory the same as saying `cbuffer type`. 

Adding the ConstantBuffer as a new Build in Type here fixes the issue:
```
I[18:45:23.757] clangd version 22.0.0git (https://github.com/KungFuDonkey/llvm-project.git 57957640a6f869622304285da6d25c71b8c3ae4d)
I[18:45:23.758] Features: windows
I[18:45:23.759] PID: 41152
I[18:45:23.759] Working directory: C:\develop\personal_gh\llvm-project\build\tools\clang\tools\extra\clangd\tool
I[18:45:23.759] argv[0]: C:\develop\personal_gh\llvm-project\build\RelWithDebInfo\bin\clangd.exe
I[18:45:23.759] argv[1]: --compile-commands-dir=C:/develop/gh/drivers/drivers/d3d/dxcp_repo/build/imported/gpurt_overridden/src/pipelines/
I[18:45:23.759] argv[2]: --check=C:\develop\personal_gh\hlsl-test\buffers.hlsl
I[18:45:23.776] Entering check mode (no LSP server)
I[18:45:23.777] Testing on source file C:\develop\personal_gh\hlsl-test\buffers.hlsl
I[18:45:23.777] Loading compilation database...
I[18:45:23.790] Loaded compilation database from C:/develop/gh/drivers/drivers/d3d/dxcp_repo/build/imported/gpurt_overridden/src/pipelines/compile_commands.json
I[18:45:23.791] Compile command from CDB is: [C:/develop/personal_gh/hlsl-test] "C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\bin\\clang" --driver-mode=dxc -T cs_6_6 "-resource-dir=C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\lib\\clang\\22" -- "C:\\develop\\personal_gh\\hlsl-test\\buffers.hlsl"
I[18:45:23.791] Parsing command...
I[18:45:23.793] internal (cc1) args are: -cc1 -triple dxilv1.6-unknown-shadermodel6.6-compute -O3 -fsyntax-only -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name buffers.hlsl -mrelocation-model static -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -debugger-tuning=gdb -fdebug-compilation-dir=C:/develop/personal_gh/hlsl-test -fcoverage-compilation-dir=C:/develop/personal_gh/hlsl-test -resource-dir "C:\\develop\\personal_gh\\llvm-project\\build\\RelWithDebInfo\\lib\\clang\\22" -ferror-limit 19 -fmessage-length=120 -O3 -finclude-default-header -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -vectorize-loops -vectorize-slp -no-round-trip-args -x hlsl "C:\\develop\\personal_gh\\hlsl-test\\buffers.hlsl"
I[18:45:23.793] Building preamble...
I[18:45:23.869] Built preamble of size 793840 for file C:\develop\personal_gh\hlsl-test\buffers.hlsl version null in 0.08 seconds
I[18:45:23.869] Indexing headers...
I[18:45:23.890] Building AST...
I[18:45:23.909] Indexing AST...
I[18:45:23.909] Building inlay hints
I[18:45:23.909] Building semantic highlighting
I[18:45:23.910] Testing features at each token (may be slow in large files)
I[18:45:23.941] All checks completed, 0 errors
```


