### PR TITLE
[libc][NFC] Clean up shadow names in constructors.

### DIFF
--- a/libc/benchmarks/LibcBenchmark.h
+++ b/libc/benchmarks/LibcBenchmark.h
@@ -279,8 +279,8 @@ public:
     size_t Offset;
 
   public:
-    explicit const_iterator(llvm::ArrayRef<T> Array, size_t Index = 0)
-        : Array(Array), Index(Index), Offset(Index % Array.size()) {}
+    explicit const_iterator(llvm::ArrayRef<T> Arr, size_t Idx = 0)
+        : Array(Arr), Index(Idx), Offset(Idx % Arr.size()) {}
     const_iterator &operator++() {
       ++Index;
       ++Offset;
@@ -293,9 +293,8 @@ public:
     const T &operator*() const { return Array[Offset]; }
   };
 
-  CircularArrayRef(llvm::ArrayRef<T> Array, size_t Size)
-      : Array(Array), Size(Size) {
-    assert(Array.size() > 0);
+  CircularArrayRef(llvm::ArrayRef<T> Arr, size_t S) : Array(Arr), Size(S) {
+    assert(Arr.size() > 0);
   }
 
   const_iterator begin() const { return const_iterator(Array); }

--- a/libc/benchmarks/LibcMemoryBenchmark.cpp
+++ b/libc/benchmarks/LibcMemoryBenchmark.cpp
@@ -49,9 +49,9 @@ OffsetDistribution::OffsetDistribution(size_t BufferSize, size_t MaxSizeValue,
 // Precomputes offset where to insert mismatches between the two buffers.
 MismatchOffsetDistribution::MismatchOffsetDistribution(size_t BufferSize,
                                                        size_t MaxSizeValue,
-                                                       size_t MismatchAt)
-    : MismatchAt(MismatchAt) {
-  if (MismatchAt <= 1)
+                                                       size_t MisAt)
+    : MismatchAt(MisAt) {
+  if (MisAt <= 1)
     return;
   for (size_t i = MaxSizeValue + 1; i < BufferSize; i += MaxSizeValue)
     MismatchIndices.push_back(i);

--- a/libc/benchmarks/LibcMemoryBenchmark.h
+++ b/libc/benchmarks/LibcMemoryBenchmark.h
@@ -110,10 +110,10 @@ class AlignedBuffer {
 public:
   static constexpr size_t Alignment = 512;
 
-  explicit AlignedBuffer(size_t Size)
+  explicit AlignedBuffer(size_t S)
       : Buffer(static_cast<char *>(
-            aligned_alloc(Alignment, alignTo(Size, Alignment)))),
-        Size(Size) {}
+            aligned_alloc(Alignment, alignTo(S, Alignment)))),
+        Size(S) {}
   ~AlignedBuffer() { free(Buffer); }
 
   inline char *operator+(size_t Index) { return Buffer + Index; }

--- a/libc/benchmarks/LibcMemoryBenchmarkMain.cpp
+++ b/libc/benchmarks/LibcMemoryBenchmarkMain.cpp
@@ -207,8 +207,8 @@ private:
 
 struct MemfunctionBenchmarkDistribution final
     : public MemfunctionBenchmarkBase {
-  MemfunctionBenchmarkDistribution(MemorySizeDistribution Distribution)
-      : Distribution(Distribution), Probabilities(Distribution.Probabilities),
+  MemfunctionBenchmarkDistribution(MemorySizeDistribution Dist)
+      : Distribution(Dist), Probabilities(Distribution.Probabilities),
         SizeSampler(Probabilities.begin(), Probabilities.end()),
         OffsetSampler(MemfunctionBenchmarkBase::BufferSize,
                       Probabilities.size() - 1, MaybeAlign(AlignedAccess)) {}

--- a/libc/benchmarks/gpu/LibcGpuBenchmark.h
+++ b/libc/benchmarks/gpu/LibcGpuBenchmark.h
@@ -156,10 +156,10 @@ public:
     add_benchmark(this);
   }
 
-  Benchmark(uint64_t (*f)(uint32_t), char const *suite_name,
-            char const *test_name, uint32_t num_threads)
-      : target(BenchmarkTarget(f)), suite_name(suite_name),
-        test_name(test_name), num_threads(num_threads) {
+  Benchmark(uint64_t (*f)(uint32_t), char const *suite, char const *test,
+            uint32_t n_threads)
+      : target(BenchmarkTarget(f)), suite_name(suite), test_name(test),
+        num_threads(n_threads) {
     add_benchmark(this);
   }
 

--- a/libc/benchmarks/gpu/Random.h
+++ b/libc/benchmarks/gpu/Random.h
@@ -74,10 +74,10 @@ template <typename T> class UniformExponent {
 public:
   explicit UniformExponent(int min_exp = -FPBits::EXP_BIAS,
                            int max_exp = FPBits::EXP_BIAS,
-                           cpp::optional<Sign> forced_sign = cpp::nullopt)
+                           cpp::optional<Sign> sign = cpp::nullopt)
       : min_exp(clamp_exponent(cpp::min(min_exp, max_exp))),
-        max_exp(clamp_exponent(cpp::max(min_exp, max_exp))),
-        forced_sign(forced_sign) {}
+        max_exp(clamp_exponent(cpp::max(min_exp, max_exp))), forced_sign(sign) {
+  }
 
   LIBC_INLINE T operator()(RandomGenerator &rng) const noexcept {
     // Sample unbiased exponent e uniformly in [min_exp, max_exp] without modulo

--- a/libc/fuzzing/__support/hashtable_fuzz.cpp
+++ b/libc/fuzzing/__support/hashtable_fuzz.cpp
@@ -118,7 +118,7 @@ class HashTable {
 public:
   HashTable(uint64_t size, uint64_t seed)
       : table(internal::HashTable::allocate(size, seed)) {}
-  HashTable(internal::HashTable *table) : table(table) {}
+  HashTable(internal::HashTable *t) : table(t) {}
   ~HashTable() { internal::HashTable::deallocate(table); }
   HashTable(HashTable &&other) : table(other.table) { other.table = nullptr; }
   bool is_valid() const { return table != nullptr; }

--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -88,15 +88,15 @@ template <bool Invert> struct Process {
   static constexpr uint64_t NUM_BITS_IN_WORD = sizeof(uint32_t) * 8;
   uint32_t lock[MAX_PORT_COUNT / NUM_BITS_IN_WORD] = {0};
 
-  RPC_ATTRS Process(uint32_t port_count, void *buffer)
-      : port_count(port_count), inbox(reinterpret_cast<uint32_t *>(
-                                    advance(buffer, inbox_offset(port_count)))),
+  RPC_ATTRS Process(uint32_t n_ports, void *buffer)
+      : port_count(n_ports), inbox(reinterpret_cast<uint32_t *>(
+                                 advance(buffer, inbox_offset(n_ports)))),
         outbox(reinterpret_cast<uint32_t *>(
-            advance(buffer, outbox_offset(port_count)))),
+            advance(buffer, outbox_offset(n_ports)))),
         header(reinterpret_cast<Header *>(
-            advance(buffer, header_offset(port_count)))),
+            advance(buffer, header_offset(n_ports)))),
         packet(reinterpret_cast<Buffer *>(
-            advance(buffer, buffer_offset(port_count)))) {}
+            advance(buffer, buffer_offset(n_ports)))) {}
 
   /// Allocate a memory buffer sufficient to store the following equivalent
   /// representation in memory.
@@ -292,10 +292,10 @@ RPC_ATTRS static void invoke_rpc(F &&fn, uint32_t lane_size, uint64_t lane_mask,
 /// processes. A port is conceptually an index into the memory provided by the
 /// underlying process that is guarded by a lock bit.
 template <bool T> struct Port {
-  RPC_ATTRS Port(Process<T> &process, uint64_t lane_mask, uint32_t lane_size,
-                 uint32_t index, uint32_t out)
-      : process(process), lane_mask(lane_mask), lane_size(lane_size),
-        index(index), out(out), receive(false), owns_buffer(true) {}
+  RPC_ATTRS Port(Process<T> &proc, uint64_t l_mask, uint32_t l_size,
+                 uint32_t idx, uint32_t o)
+      : process(proc), lane_mask(l_mask), lane_size(l_size), index(idx), out(o),
+        receive(false), owns_buffer(true) {}
   RPC_ATTRS ~Port() = default;
 
 private:

--- a/libc/src/__support/CPP/expected.h
+++ b/libc/src/__support/CPP/expected.h
@@ -21,7 +21,7 @@ template <class T> class unexpected {
   T value;
 
 public:
-  LIBC_INLINE constexpr explicit unexpected(T value) : value(value) {}
+  LIBC_INLINE constexpr explicit unexpected(T val) : value(val) {}
   LIBC_INLINE constexpr T error() { return value; }
 };
 
@@ -35,7 +35,7 @@ template <class T, class E> class expected {
   bool is_expected;
 
 public:
-  LIBC_INLINE constexpr expected(T exp) : exp(exp), is_expected(true) {}
+  LIBC_INLINE constexpr expected(T e) : exp(e), is_expected(true) {}
   LIBC_INLINE constexpr expected(unexpected<E> unexp)
       : unexp(unexp.error()), is_expected(false) {}
 

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -210,9 +210,9 @@ protected:
   // different semantics.
   template <typename T> struct TypedInt {
     using value_type = T;
-    LIBC_INLINE constexpr explicit TypedInt(T value) : value(value) {}
-    LIBC_INLINE constexpr TypedInt(const TypedInt &value) = default;
-    LIBC_INLINE constexpr TypedInt &operator=(const TypedInt &value) = default;
+    LIBC_INLINE constexpr explicit TypedInt(T v) : value(v) {}
+    LIBC_INLINE constexpr TypedInt(const TypedInt &v) = default;
+    LIBC_INLINE constexpr TypedInt &operator=(const TypedInt &v) = default;
 
     LIBC_INLINE constexpr explicit operator T() const { return value; }
 

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -27,7 +27,7 @@ struct FileIOResult {
   int error;
 
   constexpr FileIOResult(size_t val) : value(val), error(0) {}
-  constexpr FileIOResult(size_t val, int error) : value(val), error(error) {}
+  constexpr FileIOResult(size_t val, int err) : value(val), error(err) {}
 
   constexpr bool has_error() { return error != 0; }
 

--- a/libc/src/__support/OSUtil/linux/vdso.h
+++ b/libc/src/__support/OSUtil/linux/vdso.h
@@ -34,7 +34,7 @@ class Symbol {
 public:
   LIBC_INLINE_VAR static constexpr size_t COUNT =
       static_cast<size_t>(VDSOSym::VDSOSymCount);
-  LIBC_INLINE constexpr explicit Symbol(VDSOSym sym) : sym(sym) {}
+  LIBC_INLINE constexpr explicit Symbol(VDSOSym s) : sym(s) {}
   LIBC_INLINE constexpr Symbol(size_t idx) : sym(static_cast<VDSOSym>(idx)) {}
   LIBC_INLINE constexpr cpp::string_view name() const {
     return symbol_name(sym);

--- a/libc/src/__support/arg_list.h
+++ b/libc/src/__support/arg_list.h
@@ -102,8 +102,8 @@ template <bool packed> class StructArgList {
   void *end;
 
 public:
-  LIBC_INLINE StructArgList(void *ptr, size_t size)
-      : ptr(ptr), end(reinterpret_cast<unsigned char *>(ptr) + size) {}
+  LIBC_INLINE StructArgList(void *p, size_t size)
+      : ptr(p), end(reinterpret_cast<unsigned char *>(p) + size) {}
   LIBC_INLINE StructArgList(const StructArgList &other) {
     ptr = other.ptr;
     end = other.end;

--- a/libc/src/__support/freetrie.h
+++ b/libc/src/__support/freetrie.h
@@ -62,9 +62,8 @@ public:
     size_t min;
     size_t width;
 
-    LIBC_INLINE constexpr SizeRange(size_t min, size_t width)
-        : min(min), width(width) {
-      LIBC_ASSERT(!(width & (width - 1)) && "width must be a power of two");
+    LIBC_INLINE constexpr SizeRange(size_t m, size_t w) : min(m), width(w) {
+      LIBC_ASSERT(!(w & (w - 1)) && "width must be a power of two");
     }
 
     /// @returns The lower half of the size range.
@@ -83,7 +82,7 @@ public:
   };
 
   LIBC_INLINE constexpr FreeTrie() : FreeTrie(SizeRange{0, 0}) {}
-  LIBC_INLINE constexpr FreeTrie(SizeRange range) : range(range) {}
+  LIBC_INLINE constexpr FreeTrie(SizeRange r) : range(r) {}
 
   /// Sets the range of possible block sizes. This can only be called when the
   /// trie is empty.

--- a/libc/src/__support/integer_to_string.h
+++ b/libc/src/__support/integer_to_string.h
@@ -113,7 +113,7 @@ template <bool forward> class StringBufferWriterImpl {
 
 public:
   StringBufferWriterImpl(const StringBufferWriterImpl &) = delete;
-  StringBufferWriterImpl(cpp::span<char> buffer) : buffer(buffer) {}
+  StringBufferWriterImpl(cpp::span<char> buf) : buffer(buf) {}
 
   LIBC_INLINE size_t size() const { return index; }
   LIBC_INLINE size_t remainder_size() const { return buffer.size() - size(); }

--- a/libc/src/__support/memory_size.h
+++ b/libc/src/__support/memory_size.h
@@ -37,7 +37,7 @@ class SafeMemSize {
 private:
   using type = cpp::make_signed_t<size_t>;
   type value;
-  LIBC_INLINE explicit SafeMemSize(type value) : value(value) {}
+  LIBC_INLINE explicit SafeMemSize(type val) : value(val) {}
 
 public:
   LIBC_INLINE_VAR static constexpr size_t MAX_MEM_SIZE =

--- a/libc/src/__support/sign.h
+++ b/libc/src/__support/sign.h
@@ -32,8 +32,7 @@ struct Sign {
   LIBC_INLINE constexpr Sign negate() const { return Sign(!is_negative); }
 
 private:
-  LIBC_INLINE constexpr explicit Sign(bool is_negative)
-      : is_negative(is_negative) {}
+  LIBC_INLINE constexpr explicit Sign(bool is_neg) : is_negative(is_neg) {}
 
   bool is_negative;
 };

--- a/libc/src/__support/str_to_num_result.h
+++ b/libc/src/__support/str_to_num_result.h
@@ -32,12 +32,12 @@ template <typename T> struct StrToNumResult {
   int error;
   ptrdiff_t parsed_len;
 
-  LIBC_INLINE constexpr StrToNumResult(T value)
-      : value(value), error(0), parsed_len(0) {}
-  LIBC_INLINE constexpr StrToNumResult(T value, ptrdiff_t parsed_len)
-      : value(value), error(0), parsed_len(parsed_len) {}
-  LIBC_INLINE constexpr StrToNumResult(T value, ptrdiff_t parsed_len, int error)
-      : value(value), error(error), parsed_len(parsed_len) {}
+  LIBC_INLINE constexpr StrToNumResult(T val)
+      : value(val), error(0), parsed_len(0) {}
+  LIBC_INLINE constexpr StrToNumResult(T val, ptrdiff_t parsed_length)
+      : value(val), error(0), parsed_len(parsed_length) {}
+  LIBC_INLINE constexpr StrToNumResult(T val, ptrdiff_t parsed_length, int err)
+      : value(val), error(err), parsed_len(parsed_length) {}
 
   LIBC_INLINE constexpr bool has_error() { return error != 0; }
 

--- a/libc/src/__support/threads/linux/rwlock.h
+++ b/libc/src/__support/threads/linux/rwlock.h
@@ -65,9 +65,9 @@ public:
     WaitingQueue &queue;
     bool is_pshared;
 
-    LIBC_INLINE Guard(WaitingQueue &queue, bool is_pshared)
-        : queue(queue), is_pshared(is_pshared) {
-      queue.lock(cpp::nullopt, is_pshared);
+    LIBC_INLINE Guard(WaitingQueue &q, bool pshared)
+        : queue(q), is_pshared(pshared) {
+      queue.lock(cpp::nullopt, pshared);
     }
 
   public:
@@ -154,7 +154,7 @@ private:
 
 public:
   // Construction and conversion functions.
-  LIBC_INLINE constexpr RwState(int state = 0) : state(state) {}
+  LIBC_INLINE constexpr RwState(int s = 0) : state(s) {}
   LIBC_INLINE constexpr operator int() const { return state; }
 
   // Utilities to check the state of the RwLock.

--- a/libc/src/stdio/generic/puts.cpp
+++ b/libc/src/stdio/generic/puts.cpp
@@ -21,7 +21,7 @@ namespace {
 
 // Simple helper to unlock the file once destroyed.
 struct ScopedLock {
-  ScopedLock(LIBC_NAMESPACE::File *stream) : stream(stream) { stream->lock(); }
+  ScopedLock(LIBC_NAMESPACE::File *s) : stream(s) { s->lock(); }
   ~ScopedLock() { stream->unlock(); }
 
 private:

--- a/libc/src/stdio/printf_core/float_dec_converter_limited.h
+++ b/libc/src/stdio/printf_core/float_dec_converter_limited.h
@@ -81,9 +81,9 @@ struct DigitsInput {
   // and shifts it up to the top of the UInt128 so that a function consuming
   // this struct afterwards doesn't have to remember which format it came from.
   DigitsInput(int32_t fraction_len, StorageType mantissa_, int exponent_,
-              Sign sign)
+              Sign sign_)
       : mantissa(UInt128(mantissa_) << (127 - fraction_len)),
-        exponent(exponent_), sign(sign) {
+        exponent(exponent_), sign(sign_) {
     if (!(mantissa & (UInt128(1) << 127)) && mantissa != 0) {
       // Normalize a denormalized input.
       int shift = cpp::countl_zero(mantissa);

--- a/libc/src/stdio/printf_core/writer.h
+++ b/libc/src/stdio/printf_core/writer.h
@@ -54,18 +54,18 @@ template <WriteMode write_mode> struct WriteBuffer {
   // stream writer with function pointers.
   [[maybe_unused]] WriteMode write_mode_;
 
-  LIBC_INLINE WriteBuffer(char *buff, size_t buff_len, StreamWriter hook,
+  LIBC_INLINE WriteBuffer(char *buf, size_t buf_len, StreamWriter hook,
                           void *target)
-      : buff(buff), init_buff(buff), buff_len(buff_len), stream_writer(hook),
+      : buff(buf), init_buff(buf), buff_len(buf_len), stream_writer(hook),
         output_target(target), write_mode_(WriteMode::FLUSH_TO_STREAM) {}
 
-  LIBC_INLINE WriteBuffer(char *buff, size_t buff_len)
-      : buff(buff), init_buff(buff), buff_len(buff_len), stream_writer(nullptr),
+  LIBC_INLINE WriteBuffer(char *buf, size_t buf_len)
+      : buff(buf), init_buff(buf), buff_len(buf_len), stream_writer(nullptr),
         output_target(nullptr),
         write_mode_(WriteMode::FILL_BUFF_AND_DROP_OVERFLOW) {}
 
-  LIBC_INLINE WriteBuffer(char *buff, size_t buff_len, StreamWriter hook)
-      : buff(buff), init_buff(buff), buff_len(buff_len), stream_writer(hook),
+  LIBC_INLINE WriteBuffer(char *buf, size_t buf_len, StreamWriter hook)
+      : buff(buf), init_buff(buf), buff_len(buf_len), stream_writer(hook),
         output_target(this), write_mode_(WriteMode::RESIZE_AND_FILL_BUFF) {}
 
   LIBC_INLINE int flush_to_stream(cpp::string_view new_str) {
@@ -156,7 +156,7 @@ template <WriteMode write_mode> class Writer final {
   }
 
 public:
-  LIBC_INLINE Writer(WriteBuffer<write_mode> &wb) : wb(wb) {}
+  LIBC_INLINE Writer(WriteBuffer<write_mode> &buf) : wb(buf) {}
 
   // Takes a string, copies it into the buffer if there is space, else passes it
   // to the overflow mechanism to be handled separately.

--- a/libc/src/stdio/scanf_core/string_reader.h
+++ b/libc/src/stdio/scanf_core/string_reader.h
@@ -24,8 +24,8 @@ class StringReader : public Reader<StringReader> {
   size_t buff_cur = 0;
 
 public:
-  LIBC_INLINE StringReader(const char *buffer, size_t buff_len)
-      : buffer(buffer), buff_len(buff_len) {}
+  LIBC_INLINE StringReader(const char *buf, size_t buf_len)
+      : buffer(buf), buff_len(buf_len) {}
 
   LIBC_INLINE char getc() {
     char output = buffer[buff_cur];

--- a/libc/src/stdio/scanf_core/vfscanf_internal.h
+++ b/libc/src/stdio/scanf_core/vfscanf_internal.h
@@ -97,7 +97,7 @@ class StreamReader : public Reader<StreamReader> {
   ::FILE *stream;
 
 public:
-  LIBC_INLINE StreamReader(::FILE *stream) : stream(stream) {}
+  LIBC_INLINE StreamReader(::FILE *s) : stream(s) {}
 
   LIBC_INLINE char getc() {
     return static_cast<char>(internal::getc(static_cast<FILE *>(stream)));

--- a/libc/src/string/memory_utils/utils.h
+++ b/libc/src/string/memory_utils/utils.h
@@ -115,7 +115,7 @@ template <typename T> struct StrictIntegralType {
 
   // Can only be constructed from a T.
   template <typename U, cpp::enable_if_t<cpp::is_same_v<U, T>, bool> = 0>
-  LIBC_INLINE StrictIntegralType(U value) : value(value) {}
+  LIBC_INLINE StrictIntegralType(U val) : value(val) {}
 
   // Allows using the type in an if statement.
   LIBC_INLINE explicit operator bool() const { return value; }

--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -60,7 +60,7 @@ namespace internal {
 // A simple location object to allow consistent passing of __FILE__ and
 // __LINE__.
 struct Location {
-  Location(const char *file, int line) : file(file), line(line) {}
+  Location(const char *f, int l) : file(f), line(l) {}
   const char *file;
   int line;
 };
@@ -215,7 +215,7 @@ protected:
   template <typename Func> testutils::FunctionCaller *createCallable(Func f) {
     struct Callable : public testutils::FunctionCaller {
       Func f;
-      Callable(Func f) : f(f) {}
+      Callable(Func func) : f(func) {}
       void operator()() override { f(); }
     };
 

--- a/libc/test/include/sys/queue_test.cpp
+++ b/libc/test/include/sys/queue_test.cpp
@@ -30,7 +30,7 @@ TEST(LlvmLibcQueueTest, SList) {
 
   struct Contains : public testing::Matcher<Head> {
     string s;
-    Contains(string s) : s(s) {}
+    Contains(string str) : s(str) {}
     bool match(Head head) {
       Entry *e;
       CharVector v;
@@ -97,7 +97,7 @@ TEST(LlvmLibcQueueTest, STailQ) {
 
   struct Contains : public testing::Matcher<Head> {
     string s;
-    Contains(string s) : s(s) {}
+    Contains(string str) : s(str) {}
     bool match(Head head) {
       Entry *e;
       CharVector v;

--- a/libc/test/src/__support/hash_test.cpp
+++ b/libc/test/src/__support/hash_test.cpp
@@ -17,13 +17,13 @@ template <class T> struct AlignedMemory {
   T *data;
   size_t offset;
   std::align_val_t alignment;
-  AlignedMemory(size_t size, size_t alignment, size_t offset)
-      : offset(offset), alignment{alignment} {
+  AlignedMemory(size_t size, size_t alignment_, size_t offset_)
+      : offset(offset_), alignment{alignment_} {
     size_t sz = size * sizeof(T);
-    size_t aligned = sz + ((-sz) & (alignment - 1)) + alignment;
+    size_t aligned = sz + ((-sz) & (alignment_ - 1)) + alignment_;
     LIBC_NAMESPACE::AllocChecker ac;
     data = static_cast<T *>(operator new(aligned, this->alignment, ac));
-    data += offset % alignment;
+    data += offset % alignment_;
   }
   ~AlignedMemory() { operator delete(data - offset, alignment); }
 };

--- a/libc/test/src/string/memory_utils/memory_check_utils.h
+++ b/libc/test/src/string/memory_utils/memory_check_utils.h
@@ -41,13 +41,13 @@ enum class Aligned : bool { NO = false, YES = true };
 struct Buffer : private PoisonedBuffer {
   static constexpr size_t kAlign = 64;
   static constexpr size_t kLeeway = 2 * kAlign;
-  Buffer(size_t size, Aligned aligned = Aligned::YES)
-      : PoisonedBuffer(size + kLeeway), size(size) {
+  Buffer(size_t s, Aligned aligned = Aligned::YES)
+      : PoisonedBuffer(size + kLeeway), size(s) {
     offset_ptr = ptr;
     offset_ptr += distance_to_next_aligned<kAlign>(ptr);
     if (aligned == Aligned::NO)
       ++offset_ptr;
-    ASAN_UNPOISON_MEMORY_REGION(offset_ptr, size);
+    ASAN_UNPOISON_MEMORY_REGION(offset_ptr, s);
   }
   cpp::span<char> span() { return cpp::span<char>(offset_ptr, size); }
 

--- a/libc/utils/MPCWrapper/MPCUtils.cpp
+++ b/libc/utils/MPCWrapper/MPCUtils.cpp
@@ -54,17 +54,16 @@ public:
 
   template <typename XType,
             cpp::enable_if_t<cpp::is_same_v<_Complex float, XType>, bool> = 0>
-  MPCNumber(XType x,
-            unsigned int precision = mpfr::ExtraPrecision<float>::VALUE,
+  MPCNumber(XType x, unsigned int prec = mpfr::ExtraPrecision<float>::VALUE,
             RoundingMode rnd = RoundingMode::Nearest)
-      : precision(precision),
+      : precision(prec),
         mpc_rounding(MPC_RND(mpfr::get_mpfr_rounding_mode(rnd),
                              mpfr::get_mpfr_rounding_mode(rnd))) {
-    mpc_init2(value, precision);
+    mpc_init2(value, prec);
     Complex<float> x_c = cpp::bit_cast<Complex<float>>(x);
     mpfr_t real, imag;
-    mpfr_init2(real, precision);
-    mpfr_init2(imag, precision);
+    mpfr_init2(real, prec);
+    mpfr_init2(imag, prec);
     mpfr_set_flt(real, x_c.real, mpfr::get_mpfr_rounding_mode(rnd));
     mpfr_set_flt(imag, x_c.imag, mpfr::get_mpfr_rounding_mode(rnd));
     mpc_set_fr_fr(value, real, imag, mpc_rounding);
@@ -74,13 +73,12 @@ public:
 
   template <typename XType,
             cpp::enable_if_t<cpp::is_same_v<_Complex double, XType>, bool> = 0>
-  MPCNumber(XType x,
-            unsigned int precision = mpfr::ExtraPrecision<double>::VALUE,
+  MPCNumber(XType x, unsigned int prec = mpfr::ExtraPrecision<double>::VALUE,
             RoundingMode rnd = RoundingMode::Nearest)
-      : precision(precision),
+      : precision(prec),
         mpc_rounding(MPC_RND(mpfr::get_mpfr_rounding_mode(rnd),
                              mpfr::get_mpfr_rounding_mode(rnd))) {
-    mpc_init2(value, precision);
+    mpc_init2(value, prec);
     Complex<double> x_c = cpp::bit_cast<Complex<double>>(x);
     mpc_set_d_d(value, x_c.real, x_c.imag, mpc_rounding);
   }

--- a/libc/utils/MPCWrapper/MPCUtils.h
+++ b/libc/utils/MPCWrapper/MPCUtils.h
@@ -117,8 +117,8 @@ private:
   RoundingMode rounding;
 
 public:
-  MPCMatcher(InputType testInput, double ulp_tolerance, RoundingMode rounding)
-      : input(testInput), ulp_tolerance(ulp_tolerance), rounding(rounding) {}
+  MPCMatcher(InputType testInput, double tolerance, RoundingMode r)
+      : input(testInput), ulp_tolerance(tolerance), rounding(r) {}
 
   bool match(OutputType libcResult) {
     match_value = libcResult;

--- a/libc/utils/MPFRWrapper/MPFRUtils.h
+++ b/libc/utils/MPFRWrapper/MPFRUtils.h
@@ -230,8 +230,8 @@ class MPFRMatcher : public testing::Matcher<OutputType> {
   RoundingMode rounding;
 
 public:
-  MPFRMatcher(InputType testInput, double ulp_tolerance, RoundingMode rounding)
-      : input(testInput), ulp_tolerance(ulp_tolerance), rounding(rounding) {}
+  MPFRMatcher(InputType testInput, double tolerance, RoundingMode r)
+      : input(testInput), ulp_tolerance(tolerance), rounding(r) {}
 
   bool match(OutputType libcResult) {
     match_value = libcResult;


### PR DESCRIPTION
Fixes #163677.