### PR TITLE
[lldb-dap] Improve the runInTerminal ux.

### DIFF
--- a/lldb/include/lldb/Utility/AnsiTerminal.h
+++ b/lldb/include/lldb/Utility/AnsiTerminal.h
@@ -72,6 +72,17 @@
 
 #define ANSI_ESC_START_LEN 2
 
+// Cursor Position, set cursor to position [l, c] (default = [1, 1]).
+#define ANSI_CSI_CUP(...) ANSI_ESC_START #__VA_ARGS__ "H"
+// Reset cursor to position.
+#define ANSI_CSI_RESET_CURSOR ANSI_CSI_CUP()
+// Erase In Display.
+#define ANSI_CSI_ED(opt) ANSI_ESC_START #opt "J"
+// Erase complete viewport.
+#define ANSI_CSI_ERASE_VIEWPORT ANSI_CSI_ED(2)
+// Erase scrollback.
+#define ANSI_CSI_ERASE_SCROLLBACK ANSI_CSI_ED(3)
+
 // OSC (Operating System Commands)
 // https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 #define OSC_ESCAPE_START "\033"

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Host/MainLoopBase.h"
 #include "lldb/Host/MemoryMonitor.h"
 #include "lldb/Host/Socket.h"
+#include "lldb/Utility/AnsiTerminal.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/UriParser.h"
 #include "lldb/lldb-forward.h"
@@ -121,15 +122,6 @@ public:
                                    InfoTable, true) {}
 };
 } // anonymous namespace
-
-#define ESCAPE "\x1b"
-#define CSI ESCAPE "["
-// Move the cursor to 0,0
-#define ANSI_CURSOR_HOME CSI "H"
-// Clear the screen buffer
-#define ANSI_ERASE_SCREEN CSI "2J"
-// Clear the scroll back buffer
-#define ANSI_ERASE_SCROLLBACK CSI "3J"
 
 static void PrintHelp(LLDBDAPOptTable &table, llvm::StringRef tool_name) {
   std::string usage_str = tool_name.str() + " options";
@@ -274,7 +266,8 @@ static llvm::Error LaunchRunInTerminalTarget(llvm::opt::Arg &target_arg,
   } else if ((isatty(STDIN_FILENO) != 0) &&
              llvm::StringRef(getenv("TERM")).starts_with_insensitive("xterm")) {
     // Clear the screen.
-    llvm::outs() << ANSI_CURSOR_HOME ANSI_ERASE_SCREEN ANSI_ERASE_SCROLLBACK;
+    llvm::outs() << ANSI_CSI_RESET_CURSOR ANSI_CSI_ERASE_VIEWPORT
+            ANSI_CSI_ERASE_SCROLLBACK;
     // VSCode will reuse the same terminal for the same debug configuration
     // between runs. Clear the input buffer prior to starting the new process so
     // prior input is not carried forward to the new debug session.

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -268,7 +268,7 @@ static llvm::Error LaunchRunInTerminalTarget(llvm::opt::Arg &target_arg,
     // Clear the screen.
     llvm::outs() << ANSI_CSI_RESET_CURSOR ANSI_CSI_ERASE_VIEWPORT
             ANSI_CSI_ERASE_SCROLLBACK;
-    // VSCode will reuse the same terminal for the same debug configuration
+    // VS Code will reuse the same terminal for the same debug configuration
     // between runs. Clear the input buffer prior to starting the new process so
     // prior input is not carried forward to the new debug session.
     tcflush(STDIN_FILENO, TCIFLUSH);


### PR DESCRIPTION
This updates lldb-dap to clear the screen when using `"console": "integratedTerminal"` or `"console": "externalTerminal"`.

VSCode will reuse the same terminal for a given debug configuration. After the process exits it will return to the shell but if the debug session is launched again it will be invoked in the same terminal. VSCode is sending the terminal the launch args as terminal input which means the terminal would now have a string like `lldb-dap --comm-file ... --launch-target ...` and the scrollback buffer from any previous output or shell commands used in the terminal.

To address this, I've updated LaunchRunInTerminalTarget to reset the cursor, clear the screen and clear the scrollback buffer to soft 'reset' the terminal prior to launching the process.