### PR TITLE
[CIR]lAdd name for function type in vtable

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -946,8 +946,7 @@ const char *vTableClassNameForType(const CIRGenModule &cgm, const Type *ty) {
 
   case Type::FunctionNoProto:
   case Type::FunctionProto:
-    cgm.errorNYI("VTableClassNameForType: __function_type_info");
-    break;
+    return "__ZTSN10__cxxabiv120__function_type_infoE";
 
   case Type::Enum:
     cgm.errorNYI("VTableClassNameForType: Enum");


### PR DESCRIPTION
This commit adds the RTTI support for function type in the vtable.

Issue https://github.com/llvm/llvm-project/issues/163601