### PR TITLE
[Driver] Remove profiling support for older releases of FreeBSD

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -289,8 +289,6 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   addLinkerCompressDebugSectionsOption(ToolChain, Args, CmdArgs);
   AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);
 
-  unsigned Major = ToolChain.getTriple().getOSMajorVersion();
-  bool Profiling = Args.hasArg(options::OPT_pg) && Major != 0 && Major < 14;
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
                    options::OPT_r)) {
     // Use the static OpenMP runtime with -static-openmp
@@ -301,10 +299,7 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     if (D.CCCIsCXX()) {
       if (ToolChain.ShouldLinkCXXStdlib(Args))
         ToolChain.AddCXXStdlibLibArgs(Args, CmdArgs);
-      if (Profiling)
-        CmdArgs.push_back("-lm_p");
-      else
-        CmdArgs.push_back("-lm");
+      CmdArgs.push_back("-lm");
     }
 
     // Silence warnings when linking C code with a C++ '-stdlib' argument.
@@ -318,10 +313,7 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         !Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
       ToolChain.addFortranRuntimeLibraryPath(Args, CmdArgs);
       ToolChain.addFortranRuntimeLibs(Args, CmdArgs);
-      if (Profiling)
-        CmdArgs.push_back("-lm_p");
-      else
-        CmdArgs.push_back("-lm");
+      CmdArgs.push_back("-lm");
     }
 
     if (NeedsSanitizerDeps)
@@ -330,42 +322,23 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       linkXRayRuntimeDeps(ToolChain, Args, CmdArgs);
     // FIXME: For some reason GCC passes -lgcc and -lgcc_s before adding
     // the default system libraries. Just mimic this for now.
-    if (Profiling)
-      CmdArgs.push_back("-lgcc_p");
-    else
-      CmdArgs.push_back("-lgcc");
+    CmdArgs.push_back("-lgcc");
     if (Args.hasArg(options::OPT_static)) {
       CmdArgs.push_back("-lgcc_eh");
-    } else if (Profiling) {
-      CmdArgs.push_back("-lgcc_eh_p");
     } else {
       CmdArgs.push_back("--as-needed");
       CmdArgs.push_back("-lgcc_s");
       CmdArgs.push_back("--no-as-needed");
     }
 
-    if (Args.hasArg(options::OPT_pthread)) {
-      if (Profiling)
-        CmdArgs.push_back("-lpthread_p");
-      else
-        CmdArgs.push_back("-lpthread");
-    }
+    if (Args.hasArg(options::OPT_pthread))
+      CmdArgs.push_back("-lpthread");
 
-    if (Profiling) {
-      if (Args.hasArg(options::OPT_shared))
-        CmdArgs.push_back("-lc");
-      else
-        CmdArgs.push_back("-lc_p");
-      CmdArgs.push_back("-lgcc_p");
-    } else {
-      CmdArgs.push_back("-lc");
-      CmdArgs.push_back("-lgcc");
-    }
+    CmdArgs.push_back("-lc");
+    CmdArgs.push_back("-lgcc");
 
     if (Args.hasArg(options::OPT_static)) {
       CmdArgs.push_back("-lgcc_eh");
-    } else if (Profiling) {
-      CmdArgs.push_back("-lgcc_eh_p");
     } else {
       CmdArgs.push_back("--as-needed");
       CmdArgs.push_back("-lgcc_s");
@@ -450,12 +423,6 @@ void FreeBSD::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
 void FreeBSD::AddCXXStdlibLibArgs(const ArgList &Args,
                                   ArgStringList &CmdArgs) const {
   Generic_ELF::AddCXXStdlibLibArgs(Args, CmdArgs);
-  unsigned Major = getTriple().getOSMajorVersion();
-  bool SuffixedLib = Args.hasArg(options::OPT_pg) && Major != 0 && Major < 14;
-  if (SuffixedLib && GetCXXStdlibType(Args) == CST_Libcxx)
-    std::replace_if(
-        CmdArgs.begin(), CmdArgs.end(),
-        [](const char *S) { return StringRef(S) == "-lc++"; }, "-lc++_p");
 }
 
 void FreeBSD::AddCudaIncludeArgs(const ArgList &DriverArgs,

--- a/clang/test/Driver/freebsd.cpp
+++ b/clang/test/Driver/freebsd.cpp
@@ -11,13 +11,8 @@
 
 // RUN: %clangxx %s -### -pg --target=amd64-unknown-freebsd -stdlib=platform 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-PG-DEFAULT %s
-// RUN: %clangxx %s -### -pg --target=amd64-unknown-freebsd14.0 -stdlib=platform 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-PG-FOURTEEN %s
-// RUN: %clangxx %s -### -pg --target=amd64-unknown-freebsd10.0 -stdlib=platform 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-PG-TEN %s
 // CHECK-PG-DEFAULT: "-lc++" "-lm"
-// CHECK-PG-FOURTEEN: "-lc++" "-lm"
-// CHECK-PG-TEN: "-lc++_p" "-lm_p"
+// CHECK-PG-DEFAULT-NOT: "-lc++_p" "-lm_p"
 
 // Test include paths with a sysroot.
 // RUN: %clangxx %s -### -fsyntax-only 2>&1 \


### PR DESCRIPTION
Remove profiling support for older releases of FreeBSD. This affects
FreeBSD 13.x and older.