### PR TITLE
[CIR] TryOp add arg default value and update diagnostic

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4366,12 +4366,12 @@ def CIR_TryOp : CIR_Op<"try",[
   let arguments = (ins
     UnitAttr:$synthetic,
     UnitAttr:$cleanup,
-    CIR_TryHandlerArrayAttr:$handler_types
+    DefaultValuedAttr<CIR_TryHandlerArrayAttr, "{}">:$handler_types
   );
 
   let regions = (region
     AnyRegion:$try_region,
-    VariadicRegion<MinSizedRegion<1>>:$handler_regions
+    VariadicRegion<AnyRegion>:$handler_regions
   );
 
   let assemblyFormat = [{

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2977,8 +2977,11 @@ static mlir::ParseResult parseTryHandlerRegions(
       return failure();
     }
 
-    if (!currRegion.empty() && !(currRegion.back().mightHaveTerminator() &&
-                                 currRegion.back().getTerminator()))
+    if (currRegion.empty())
+      return parser.emitError(regionLoc, "handler region shall not be empty");
+
+    if (!(currRegion.back().mightHaveTerminator() &&
+          currRegion.back().getTerminator()))
       return parser.emitError(
           regionLoc, "blocks are expected to be explicitly terminated");
 

--- a/clang/test/CIR/IR/invalid-try-catch.cir
+++ b/clang/test/CIR/IR/invalid-try-catch.cir
@@ -40,10 +40,11 @@ module {
 
 cir.func dso_local @invalid_catch_empty_block() {
   cir.scope {
-    // expected-error @below {{'cir.try' op region #1 ('handler_regions') failed to verify constraint: region with at least 1 blocks}}
     cir.try {
       cir.yield
-    } catch all {
+    }
+    // expected-error @below {{'cir.try' handler region shall not be empty}}
+    catch all {
     }
   }
   cir.return


### PR DESCRIPTION
- Add a default value to handler_types to be able to construct TryOp, then modify the handlers.
- Move empty region diagnostic from tablegen constraints to C++, because we need the ability to add an empty region, then modify it later, for example, in the handlers builder, but we need to report an error when we find it in the IR while parsing.

Issue https://github.com/llvm/llvm-project/issues/154992