### PR TITLE
[libc][annex_k] Add libannex_k as build target in LLVM libc.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1,3 +1,5 @@
+set(TARGET_ANNEX_K_ENTRYPOINTS "")
+
 set(TARGET_LIBC_ENTRYPOINTS
     # ctype.h entrypoints
     libc.src.ctype.isalnum
@@ -1177,4 +1179,5 @@ endif()
 set(TARGET_LLVMLIBC_ENTRYPOINTS
   ${TARGET_LIBC_ENTRYPOINTS}
   ${TARGET_LIBM_ENTRYPOINTS}
+  ${TARGET_ANNEX_K_ENTRYPOINTS}
 )

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1,3 +1,5 @@
+set(TARGET_ANNEX_K_ENTRYPOINTS "")
+
 set(TARGET_LIBC_ENTRYPOINTS
     # ctype.h entrypoints
     libc.src.ctype.isalnum
@@ -1323,4 +1325,5 @@ endif()
 set(TARGET_LLVMLIBC_ENTRYPOINTS
   ${TARGET_LIBC_ENTRYPOINTS}
   ${TARGET_LIBM_ENTRYPOINTS}
+  ${TARGET_ANNEX_K_ENTRYPOINTS}
 )

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1,3 +1,5 @@
+set(TARGET_ANNEX_K_ENTRYPOINTS "")
+
 set(TARGET_LIBC_ENTRYPOINTS
     # ctype.h entrypoints
     libc.src.ctype.isalnum
@@ -1379,4 +1381,5 @@ endif()
 set(TARGET_LLVMLIBC_ENTRYPOINTS
   ${TARGET_LIBC_ENTRYPOINTS}
   ${TARGET_LIBM_ENTRYPOINTS}
+  ${TARGET_ANNEX_K_ENTRYPOINTS}
 )

--- a/libc/lib/CMakeLists.txt
+++ b/libc/lib/CMakeLists.txt
@@ -2,10 +2,13 @@ set(libc_archive_targets "")
 set(libc_archive_names "")
 set(libc_archive_entrypoint_lists "")
 if(LLVM_LIBC_FULL_BUILD)
-  list(APPEND libc_archive_names c m)
-  list(APPEND libc_archive_targets libc libm)
+  list(APPEND libc_archive_names c m annex_k)
+  list(APPEND libc_archive_targets libc libm libannex_k)
   list(APPEND libc_archive_entrypoint_lists
-       TARGET_LIBC_ENTRYPOINTS TARGET_LIBM_ENTRYPOINTS)
+       TARGET_LIBC_ENTRYPOINTS
+       TARGET_LIBM_ENTRYPOINTS
+       TARGET_ANNEX_K_ENTRYPOINTS
+  )
 else()
   list(APPEND libc_archive_names llvmlibc)
   list(APPEND libc_archive_targets libc)


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add `libannex_k.a` as build target in LLVM libc.