### PR TITLE
[sanitizer][test] Clean up allow_user_segv.cpp test case

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/allow_user_segv.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/allow_user_segv.cpp
@@ -66,8 +66,8 @@ int main() {
     fprintf(stderr, "User sigaction installed\n");
 
   // Trying to organically segfault by dereferencing a pointer can be tricky
-  // in builds with assertions. Additionally, some older platforms may SIGBUS
-  // instead.
+  // when the sanitizer runtime is built with assertions. Additionally, some
+  // older platforms may SIGBUS instead.
   raise(SIGSEGV);
 
   return 0;

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/allow_user_segv.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/allow_user_segv.cpp
@@ -1,7 +1,5 @@
 // Regression test for
 // https://code.google.com/p/address-sanitizer/issues/detail?id=180
-// Fails with debug checks: https://bugs.llvm.org/show_bug.cgi?id=46860
-// XFAIL: !compiler-rt-optimized && tsan
 
 // FIXME: Implement.
 // XFAIL: hwasan
@@ -31,15 +29,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct sigaction original_sigaction_sigbus;
 struct sigaction original_sigaction_sigsegv;
 
 void User_OnSIGSEGV(int signum, siginfo_t *siginfo, void *context) {
   fprintf(stderr, "User sigaction called\n");
   struct sigaction original_sigaction = {};
-  if (signum == SIGBUS)
-    original_sigaction = original_sigaction_sigbus;
-  else if (signum == SIGSEGV)
+  if (signum == SIGSEGV)
     original_sigaction = original_sigaction_sigsegv;
   else {
     printf("Invalid signum");
@@ -55,11 +50,6 @@ void User_OnSIGSEGV(int signum, siginfo_t *siginfo, void *context) {
   exit(1);
 }
 
-int DoSEGV() {
-  volatile int *x = 0;
-  return *x;
-}
-
 bool InstallHandler(int signum, struct sigaction *original_sigaction) {
   struct sigaction user_sigaction = {};
   user_sigaction.sa_sigaction = User_OnSIGSEGV;
@@ -72,13 +62,15 @@ bool InstallHandler(int signum, struct sigaction *original_sigaction) {
 }
 
 int main() {
-  // Let's install handlers for both SIGSEGV and SIGBUS, since pre-Yosemite
-  // 32-bit Darwin triggers SIGBUS instead.
-  if (InstallHandler(SIGSEGV, &original_sigaction_sigsegv) &&
-      InstallHandler(SIGBUS, &original_sigaction_sigbus)) {
+  if (InstallHandler(SIGSEGV, &original_sigaction_sigsegv))
     fprintf(stderr, "User sigaction installed\n");
-  }
-  return DoSEGV();
+
+  // Trying to organically segfault by dereferencing a pointer can be tricky
+  // in builds with assertions. Additionally, some older platforms may SIGBUS
+  // instead.
+  raise(SIGSEGV);
+
+  return 0;
 }
 
 // CHECK0-NOT: Sanitizer:DEADLYSIGNAL


### PR DESCRIPTION
This test case has two issues:
- it has some special treatment of SIGBUS, ostensibly to handle old Darwin platforms, but this been silently broken for years because the assertions only check for SEGV.
- it has `XFAIL: !compiler-rt-optimized && tsan` [*], because the null pointer dereference will trigger an assertion (invalid app memory) rather than a segfault.

We fix both issues by directly raising SIGSEGV. We also considerably simplify the test case, while maintaining the core test of chaining the segfault handlers.

[*] This test might also fail when other sanitizer runtimes are compiled with assertions, though those combinations are not well-tested by buildbots.