### PR TITLE
[MLIR][BUILD]: Add build defs for python bindings after e5825c45

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -10015,8 +10015,10 @@ td_library(
     includes = ["include"],
     deps = [
         ":AtomicInterfacesTdFiles",
+        ":BuiltinDialectTdFiles",
         ":LoopLikeInterfaceTdFiles",
         ":OpBaseTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
@@ -1593,3 +1593,39 @@ filegroup(
         ":VectorOpsPyGen",
     ],
 )
+
+##---------------------------------------------------------------------------##
+# OpenACC dialect.
+##---------------------------------------------------------------------------##
+
+td_library(
+    name = "OpenAccPyTdFiles",
+    srcs = [
+        "mlir/dialects/OpenACCOps.td",
+    ],
+    deps = [
+        "//mlir:OpBaseTdFiles",
+        "//mlir:OpenAccOpsTdFiles",
+    ],
+)
+
+gentbl_filegroup(
+    name = "OpenAccPyGen",
+    tbl_outs = {"mlir/dialects/_acc_ops_gen.py": [
+        "-gen-python-op-bindings",
+        "-bind-dialect=acc",
+    ]},
+    tblgen = "//mlir:mlir-tblgen",
+    td_file = "mlir/dialects/OpenACCOps.td",
+    deps = [
+        ":OpenAccPyTdFiles",
+    ],
+)
+
+filegroup(
+    name = "OpenAccPyFiles",
+    srcs = [
+        "mlir/dialects/openacc.py",
+        ":OpenAccPyGen",
+    ],
+)


### PR DESCRIPTION
[MLIR][BUILD]: Add build defs for python bindings after e5825c45