### PR TITLE
[lldb] Fix misaligned loads violation in DataExtractor

### DIFF
--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -994,7 +994,7 @@ protected:
     constexpr size_t src_size = sizeof(T);
     T val = fail_value;
 
-    const T *src = static_cast<const T *>(GetData(offset_ptr, src_size));
+    const void *src = GetData(offset_ptr, src_size);
     if (!src)
       return val;
 


### PR DESCRIPTION
The implementation of the templated `Get` function contains UB. For example, the "GetDoubleUnaligned" unit test causes `Get` to perform an unaligned 8 byte read. This violates the `double` alignment requirement. Furthermore, it violates strict aliasing rules in C++. (We construct a `const double *` from a `const uint8_t *` and perform a read on the resulting double pointer).

DataExtractor should be able to read unaligned data to deal with different data formats, but we need to be careful to not perform unaligned reads/writes or violate strict aliasing rules.

rdar://160385383