### PR TITLE
[Clang] Consider reachability for file-scope warnings on initializers

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -319,6 +319,9 @@ Improvements to Clang's diagnostics
 -----------------------------------
 - Diagnostics messages now refer to ``structured binding`` instead of ``decomposition``,
   to align with `P0615R0 <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0615r0.html>`_ changing the term. (#GH157880)
+- Clang now suppresses runtime behavior warnings for unreachable code in file-scope
+  variable initializers, matching the behavior for functions. This prevents false
+  positives for operations in unreachable branches of constant expressions.
 - Added a separate diagnostic group ``-Wfunction-effect-redeclarations``, for the more pedantic
   diagnostics for function effects (``[[clang::nonblocking]]`` and ``[[clang::nonallocating]]``).
   Moved the warning for a missing (though implied) attribute on a redeclaration into this group.

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -5223,32 +5223,7 @@ private:
   ///         assignment-expression
   ///         '{' ...
   /// \endverbatim
-  ExprResult ParseInitializer(Decl *DeclForInitializer = nullptr) {
-    // Set DeclForInitializer for file-scope variables.
-    // For constexpr references, set it to suppress runtime warnings.
-    // For non-constexpr references, don't set it to avoid evaluation issues
-    // with self-referencing initializers. Local variables (including local
-    // constexpr) should emit runtime warnings.
-    if (DeclForInitializer && !Actions.ExprEvalContexts.empty()) {
-      if (auto *VD = dyn_cast<VarDecl>(DeclForInitializer)) {
-        if (VD->isFileVarDecl()) {
-          if (!VD->getType()->isReferenceType() || VD->isConstexpr()) {
-            Actions.ExprEvalContexts.back().DeclForInitializer =
-                DeclForInitializer;
-          }
-        }
-      }
-    }
-
-    ExprResult init;
-    if (Tok.isNot(tok::l_brace)) {
-      init = ParseAssignmentExpression();
-    } else {
-      init = ParseBraceInitializer();
-    }
-
-    return init;
-  }
+  ExprResult ParseInitializer(Decl *DeclForInitializer = nullptr);
 
   /// MayBeDesignationStart - Return true if the current token might be the
   /// start of a designator.  If we can tell it is impossible that it is a

--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -67,8 +67,6 @@ private:
   Policy PolicyOverrides;
   void clearOverrides();
 
-  void FlushDiagnostics(SmallVector<clang::sema::PossiblyUnreachableDiag, 4>);
-
   /// \name Statistics
   /// @{
 

--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -61,7 +61,7 @@ private:
 
   enum VisitFlag { NotVisited = 0, Visited = 1, Pending = 2 };
   llvm::DenseMap<const FunctionDecl*, VisitFlag> VisitedFD;
-  llvm::MapVector<VarDecl *, SmallVector<PossiblyUnreachableDiag, 4>>
+  std::multimap<VarDecl *, PossiblyUnreachableDiag>
       VarDeclPossiblyUnreachableDiags;
 
   Policy PolicyOverrides;
@@ -127,9 +127,9 @@ public:
 
   void PrintStats() const;
 
-  void
-  EmitPossiblyUnreachableDiags(AnalysisDeclContext &AC,
-                               SmallVector<PossiblyUnreachableDiag, 4> PUDs);
+  template <typename Iterator>
+  void EmitPossiblyUnreachableDiags(AnalysisDeclContext &AC,
+                                    std::pair<Iterator, Iterator> PUDs);
 };
 
 } // namespace sema

--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -113,9 +113,9 @@ public:
   // Issue warnings that require whole-translation-unit analysis.
   void IssueWarnings(TranslationUnitDecl *D);
 
-  void RegisterVarDeclWarning(VarDecl *VD, PossiblyUnreachableDiag PUD);
+  void registerVarDeclWarning(VarDecl *VD, PossiblyUnreachableDiag PUD);
 
-  void IssueWarningsForRegisteredVarDecl(VarDecl *VD);
+  void issueWarningsForRegisteredVarDecl(VarDecl *VD);
 
   // Gets the default policy which is in effect at the given source location.
   Policy getPolicyInEffectAt(SourceLocation Loc);
@@ -126,10 +126,6 @@ public:
   Policy &getPolicyOverrides() { return PolicyOverrides; }
 
   void PrintStats() const;
-
-  template <typename Iterator>
-  void EmitPossiblyUnreachableDiags(AnalysisDeclContext &AC,
-                                    std::pair<Iterator, Iterator> PUDs);
 };
 
 } // namespace sema

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6765,6 +6765,11 @@ public:
     /// suffice, e.g., in a default function argument.
     Decl *ManglingContextDecl;
 
+    /// Declaration for initializer if one is currently being
+    /// parsed. Used when an expression has a possibly unreachable
+    /// diagnostic to reference the declaration as a whole.
+    Decl *DeclForInitializer = nullptr;
+
     /// If we are processing a decltype type, a set of call expressions
     /// for which we have deferred checking the completeness of the return type.
     SmallVector<CallExpr *, 8> DelayedDecltypeCalls;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6768,7 +6768,7 @@ public:
     /// Declaration for initializer if one is currently being
     /// parsed. Used when an expression has a possibly unreachable
     /// diagnostic to reference the declaration as a whole.
-    Decl *DeclForInitializer = nullptr;
+    VarDecl *DeclForInitializer = nullptr;
 
     /// If we are processing a decltype type, a set of call expressions
     /// for which we have deferred checking the completeness of the return type.

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -117,6 +117,11 @@ Stmt *AnalysisDeclContext::getBody(bool &IsAutosynthesized) const {
     return BD->getBody();
   else if (const auto *FunTmpl = dyn_cast_or_null<FunctionTemplateDecl>(D))
     return FunTmpl->getTemplatedDecl()->getBody();
+  else if (const auto *VD = dyn_cast_or_null<VarDecl>(D)) {
+    if (VD->hasGlobalStorage()) {
+      return const_cast<Stmt *>(dyn_cast_or_null<Stmt>(VD->getInit()));
+    }
+  }
 
   llvm_unreachable("unknown code decl");
 }

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -118,7 +118,7 @@ Stmt *AnalysisDeclContext::getBody(bool &IsAutosynthesized) const {
   else if (const auto *FunTmpl = dyn_cast_or_null<FunctionTemplateDecl>(D))
     return FunTmpl->getTemplatedDecl()->getBody();
   else if (const auto *VD = dyn_cast_or_null<VarDecl>(D)) {
-    if (VD->hasGlobalStorage()) {
+    if (VD->isFileVarDecl()) {
       return const_cast<Stmt *>(dyn_cast_or_null<Stmt>(VD->getInit()));
     }
   }

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2613,7 +2613,7 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
       }
 
       PreferredType.enterVariableInit(Tok.getLocation(), ThisDecl);
-      ExprResult Init = ParseInitializer();
+      ExprResult Init = ParseInitializer(ThisDecl);
 
       // If this is the only decl in (possibly) range based for statement,
       // our best guess is that the user meant ':' instead of '='.

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3359,7 +3359,7 @@ ExprResult Parser::ParseCXXMemberInitializer(Decl *D, bool IsFunction,
     Diag(Tok, diag::err_ms_property_initializer) << PD;
     return ExprError();
   }
-  return ParseInitializer();
+  return ParseInitializer(D);
 }
 
 void Parser::SkipCXXMemberSpecification(SourceLocation RecordLoc,

--- a/clang/lib/Parse/ParseInit.cpp
+++ b/clang/lib/Parse/ParseInit.cpp
@@ -581,3 +581,28 @@ bool Parser::ParseMicrosoftIfExistsBraceInitializer(ExprVector &InitExprs,
 
   return !trailingComma;
 }
+
+ExprResult Parser::ParseInitializer(Decl *DeclForInitializer) {
+  // Set DeclForInitializer for file-scope variables.
+  // For constexpr references, set it to suppress runtime warnings.
+  // For non-constexpr references, don't set it to avoid evaluation issues
+  // with self-referencing initializers. Local variables (including local
+  // constexpr) should emit runtime warnings.
+  if (DeclForInitializer && !Actions.ExprEvalContexts.empty()) {
+    if (auto *VD = dyn_cast<VarDecl>(DeclForInitializer);
+        VD && VD->isFileVarDecl()) {
+      if (!VD->getType()->isReferenceType() || VD->isConstexpr()) {
+        Actions.ExprEvalContexts.back().DeclForInitializer = VD;
+      }
+    }
+  }
+
+  ExprResult init;
+  if (Tok.isNot(tok::l_brace)) {
+    init = ParseAssignmentExpression();
+  } else {
+    init = ParseBraceInitializer();
+  }
+
+  return init;
+}

--- a/clang/lib/Parse/ParseInit.cpp
+++ b/clang/lib/Parse/ParseInit.cpp
@@ -590,11 +590,9 @@ ExprResult Parser::ParseInitializer(Decl *DeclForInitializer) {
   // constexpr) should emit runtime warnings.
   if (DeclForInitializer && !Actions.ExprEvalContexts.empty()) {
     if (auto *VD = dyn_cast<VarDecl>(DeclForInitializer);
-        VD && VD->isFileVarDecl()) {
-      if (!VD->getType()->isReferenceType() || VD->isConstexpr()) {
-        Actions.ExprEvalContexts.back().DeclForInitializer = VD;
-      }
-    }
+        VD && VD->isFileVarDecl() &&
+        (!VD->getType()->isReferenceType() || VD->isConstexpr()))
+      Actions.ExprEvalContexts.back().DeclForInitializer = VD;
   }
 
   ExprResult init;

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -339,7 +339,7 @@ void Parser::ParseOpenMPReductionInitializerForDecl(VarDecl *OmpPrivParm) {
     }
 
     PreferredType.enterVariableInit(Tok.getLocation(), OmpPrivParm);
-    ExprResult Init = ParseInitializer();
+    ExprResult Init = ParseInitializer(OmpPrivParm);
 
     if (Init.isInvalid()) {
       SkipUntil(tok::r_paren, tok::annot_pragma_openmp_end, StopBeforeMatch);

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2754,6 +2754,9 @@ static void emitPossiblyUnreachableDiags(Sema &S, AnalysisDeclContext &AC,
       const auto &D = *I;
       if (llvm::all_of(D.Stmts, [&](const Stmt *St) {
             const CFGBlock *Block = AC.getBlockForRegisteredExpression(St);
+            // FIXME: We should be able to assert that block is non-null, but
+            // the CFG analysis can skip potentially-evaluated expressions in
+            // edge cases; see test/Sema/vla-2.c.
             if (Block && Analysis)
               if (!Analysis->isReachable(&AC.getCFG()->getEntry(), Block))
                 return false;

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2747,11 +2747,12 @@ void sema::AnalysisBasedWarnings::EmitPossiblyUnreachableDiags(
   }
 
   if (AC.getCFG()) {
+    CFGReverseBlockReachabilityAnalysis *Analysis =
+        AC.getCFGReachablityAnalysis();
+
     for (const auto &D : PUDs) {
       if (llvm::all_of(D.Stmts, [&](const Stmt *St) {
             const CFGBlock *Block = AC.getBlockForRegisteredExpression(St);
-            CFGReverseBlockReachabilityAnalysis *Analysis =
-                AC.getCFGReachablityAnalysis();
             if (Block && Analysis)
               if (!Analysis->isReachable(&AC.getCFG()->getEntry(), Block))
                 return false;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13121,9 +13121,9 @@ namespace {
     // Skip checking for file-scope constexpr variables - constant evaluation
     // will produce appropriate errors without needing runtime diagnostics.
     // Local constexpr should still emit runtime warnings.
-    if (auto *VD = dyn_cast<VarDecl>(OrigDecl))
-      if (VD->isConstexpr() && VD->isFileVarDecl())
-        return;
+    if (auto *VD = dyn_cast<VarDecl>(OrigDecl);
+        VD && VD->isConstexpr() && VD->isFileVarDecl())
+      return;
 
     E = E->IgnoreParens();
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -20567,10 +20567,6 @@ void Sema::MarkDeclarationsReferencedInExpr(Expr *E,
 }
 
 /// Emit a diagnostic when statements are reachable.
-/// FIXME: check for reachability even in expressions for which we don't build a
-///        CFG (eg, in the initializer of a global or in a constant expression).
-///        For example,
-///        namespace { auto *p = new double[3][false ? (1, 2) : 3]; }
 bool Sema::DiagIfReachable(SourceLocation Loc, ArrayRef<const Stmt *> Stmts,
                            const PartialDiagnostic &PD) {
   // The initializer of a constexpr variable or of the first declaration of a

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -6473,7 +6473,7 @@ void Sema::InstantiateVariableDefinition(SourceLocation PointOfInstantiation,
     Var->setTemplateSpecializationKind(OldVar->getTemplateSpecializationKind(),
                                        OldVar->getPointOfInstantiation());
     // Emit any deferred warnings for the variable's initializer
-    AnalysisWarnings.IssueWarningsForRegisteredVarDecl(Var);
+    AnalysisWarnings.issueWarningsForRegisteredVarDecl(Var);
   }
 
   // This variable may have local implicit instantiations that need to be

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -6201,6 +6201,10 @@ void Sema::InstantiateVariableInitializer(
   currentEvaluationContext().RebuildDefaultArgOrDefaultInit =
       parentEvaluationContext().RebuildDefaultArgOrDefaultInit;
 
+  // Set DeclForInitializer for this variable so DiagIfReachable can properly
+  // suppress runtime diagnostics for constexpr/static member variables
+  currentEvaluationContext().DeclForInitializer = Var;
+
   if (OldVar->getInit()) {
     // Instantiate the initializer.
     ExprResult Init =
@@ -6468,6 +6472,8 @@ void Sema::InstantiateVariableDefinition(SourceLocation PointOfInstantiation,
     PassToConsumerRAII.Var = Var;
     Var->setTemplateSpecializationKind(OldVar->getTemplateSpecializationKind(),
                                        OldVar->getPointOfInstantiation());
+    // Emit any deferred warnings for the variable's initializer
+    AnalysisWarnings.IssueWarningsForRegisteredVarDecl(Var);
   }
 
   // This variable may have local implicit instantiations that need to be

--- a/clang/test/Sema/warn-unreachable-file-scope.c
+++ b/clang/test/Sema/warn-unreachable-file-scope.c
@@ -28,3 +28,10 @@ void f(void) {
   unsigned long long e3 = 1 ? 0 : 1ULL << 64;
   unsigned long long e4 = 0 ? 0 : 1ULL << 64; // expected-warning {{shift count >= width of type}}
 }
+
+void statics(void) {
+  static u8 f1 = (0 ? 0xffff : 0xff);
+  static u8 f2 = (1 ? 0xffff : 0xff); // expected-warning {{implicit conversion from 'int' to 'u8' (aka 'unsigned char') changes value from 65535 to 255}}
+  static u8 f3 = (1 ? 0xff : 0xffff);
+  static u8 f4 = (0 ? 0xff : 0xffff); // expected-warning {{implicit conversion from 'int' to 'u8' (aka 'unsigned char') changes value from 65535 to 255}}
+}

--- a/clang/test/Sema/warn-unreachable-file-scope.c
+++ b/clang/test/Sema/warn-unreachable-file-scope.c
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+typedef unsigned char u8;
+
+u8 a1 = (0 ? 0xffff : 0xff);
+u8 a2 = (1 ? 0xffff : 0xff); // expected-warning {{implicit conversion from 'int' to 'u8' (aka 'unsigned char') changes value from 65535 to 255}}
+u8 a3 = (1 ? 0xff : 0xffff);
+u8 a4 = (0 ? 0xff : 0xffff); // expected-warning {{implicit conversion from 'int' to 'u8' (aka 'unsigned char') changes value from 65535 to 255}}
+
+unsigned long long b1 = 1 ? 0 : 1ULL << 64;
+unsigned long long b2 = 0 ? 0 : 1ULL << 64; // expected-warning {{shift count >= width of type}}
+unsigned long long b3 = 1 ? 1ULL << 64 : 0; // expected-warning {{shift count >= width of type}}
+
+#define M(n) (((n) == 64) ? ~0ULL : ((1ULL << (n)) - 1))
+unsigned long long c1 = M(64);
+unsigned long long c2 = M(32);
+
+static u8 d1 = (0 ? 0xffff : 0xff);
+static u8 d2 = (1 ? 0xffff : 0xff); // expected-warning {{implicit conversion from 'int' to 'u8' (aka 'unsigned char') changes value from 65535 to 255}}
+
+int a = 1 ? 6 : (1,2);
+int b = 0 ? 6 : (1,2); // expected-warning {{left operand of comma operator has no effect}}
+
+void f(void) {
+  u8 e1 = (0 ? 0xffff : 0xff);
+  u8 e2 = (1 ? 0xffff : 0xff); // expected-warning {{implicit conversion from 'int' to 'u8' (aka 'unsigned char') changes value from 65535 to 255}}
+
+  unsigned long long e3 = 1 ? 0 : 1ULL << 64;
+  unsigned long long e4 = 0 ? 0 : 1ULL << 64; // expected-warning {{shift count >= width of type}}
+}


### PR DESCRIPTION
Every once in awhile, we get a new Linux kernel report about false positive clang warnings being emitted for file-scope variables when initialized. See [[0]](https://lore.kernel.org/all/8c252429-5000-0649-c49f-8225d911241b@gmail.com/) and [[1]](https://lore.kernel.org/all/202112181827.o3X7GmHz-lkp@intel.com/).

To help fix this, back in 2019 Nathan Huckleberry sent a phab PR [D63889](https://reviews.llvm.org/D63889). Nathan was @nickdesaulniers' intern and most likely had to return to school before that PR landed. I was able to use a good amount of code from that PR with a few workarounds to fix bitrot and clang regression suite failures. So, consider this a spiritual revival of that patchset.

cc @nickdesaulniers @kees @nathanchance (the other Nathan)


---

Suppress runtime warnings for unreachable code in global variable initializers while maintaining warnings for the same code in functions.

For context, some global variable declarations using ternaries can emit warnings during initialization even when a particular expression is never used. This behavior differs from GCC since they properly emit warnings based on reachability -- even at file scope.

The simplest example is:
```c
$ cat test.c
unsigned long long b1 = 1 ? 0 : 1ULL << 64;

$ clang-21 -fsyntax-only test.c
test.c:1:39: warning: shift count >= width of type [-Wshift-count-overflow]
    1 | unsigned long long foo = 1 ? 0 : 1ULL << 64;
      |                                       ^  ~~
$ gcc-13 -fsyntax-only test.c
<empty>
```

Clang previously emitted a ``-Wshift-count-overflow`` warning regardless of branch taken. This PR constructs a CFG and defers runtime diagnostic emission until we can analyze the CFG for reachability.

To be clear, the intention is only to modify initializers in global scope and only remove warnings if unreachable, no new warnings should pop up anywhere.

Link: https://reviews.llvm.org/D63889 (original PR by Nathan Huckleberry)
Fixes: https://github.com/clangBuiltLinux/linux/issues/92
Fixes: https://github.com/llvm/llvm-project/issues/38137