### PR TITLE
[ORC] Disable the ReOptimizeLayerTest on Windows.

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -43,7 +43,7 @@ protected:
 
     // COFF-ARM64 is not supported yet
     auto Triple = JTMB->getTargetTriple();
-    if (Triple.isOSBinFormatCOFF() && Triple.isAArch64())
+    if (Triple.isOSBinFormatCOFF())
       GTEST_SKIP();
 
     // SystemZ is not supported yet.


### PR DESCRIPTION
This test has been failing for unclear reasons. ReOptimizeLayer on Windows isn't well supported yet, so just disable this for now.

https://github.com/llvm/llvm-project/issues/158270