### PR TITLE
[flang][OpenMP] Improve reduction of Scalar ArrayElement types

### DIFF
--- a/flang/lib/Semantics/rewrite-parse-tree.cpp
+++ b/flang/lib/Semantics/rewrite-parse-tree.cpp
@@ -9,9 +9,9 @@
 #include "rewrite-parse-tree.h"
 
 #include "flang/Common/indirection.h"
+#include "flang/Parser/openmp-utils.h"
 #include "flang/Parser/parse-tree-visitor.h"
 #include "flang/Parser/parse-tree.h"
-#include "flang/Parser/openmp-utils.h"
 #include "flang/Parser/tools.h"
 #include "flang/Semantics/openmp-directive-sets.h"
 #include "flang/Semantics/scope.h"

--- a/flang/lib/Semantics/rewrite-parse-tree.h
+++ b/flang/lib/Semantics/rewrite-parse-tree.h
@@ -19,6 +19,8 @@ class SemanticsContext;
 
 namespace Fortran::semantics {
 bool RewriteParseTree(SemanticsContext &, parser::Program &);
+bool RewriteReductionArrayElements(
+    SemanticsContext &context, parser::Program &program);
 }
 
 #endif // FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_

--- a/flang/test/Lower/OpenMP/reduction-array-element.f90
+++ b/flang/test/Lower/OpenMP/reduction-array-element.f90
@@ -1,0 +1,105 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s --check-prefix=CHECK-HLFIR
+
+program test
+  integer a(2)
+  integer b(2)
+  integer c(2)
+  integer z(10)
+  integer :: k = 10
+  integer :: j
+
+!! When a scalar array element is used, the array element is replaced with a temprorary so it is correctly lowered as an Integer
+!$omp do reduction (+: a(2))
+  do i = 1,2
+    a(2) = a(2) + i
+  end do
+!$omp end do
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %17#0 -> %arg1 : !fir.ref<i32>) {
+! CHECK-HLFIR: %53:2 = hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: %54:2 = hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %53#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %55 = fir.load %54#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %56 = fir.load %53#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %57 = arith.addi %55, %56 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %57 to %54#0 : i32, !fir.ref<i32>
+
+!! Ensure that consective reduction clauses can be correctly processed in the same block
+!$omp do reduction (+: b(2))
+  do i = 1,3
+    b(2) = b(2) + i
+  end do
+!$omp end do
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %19#0 -> %arg1 : !fir.ref<i32>) {
+! CHECK-HLFIR: %53:2 = hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: %54:2 = hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_b(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %53#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %55 = fir.load %54#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %56 = fir.load %53#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %57 = arith.addi %55, %56 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %57 to %54#0 : i32, !fir.ref<i32>
+
+!! Ensure that we can reuse the same array element later on. This will use the same symbol as the previous use of a(2) for the temporary value
+!$omp do reduction (+: a(2))
+  do i = 1,4
+    a(2) = a(2) + i
+!! We need to make sure that for the array element that has not been reduced, this does not get replaced with a temp
+    a(1) = a(2)
+  end do
+!$omp end do
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %17#0 -> %arg1 : !fir.ref<i32>) {
+! CHECK-HLFIR: %53:2 = hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: %54:2 = hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %53#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %55 = fir.load %54#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %56 = fir.load %53#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %57 = arith.addi %55, %56 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %57 to %54#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %58 = fir.load %54#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %c1 = arith.constant 1 : index
+! CHECK-HLFIR-NEXT: %59 = hlfir.designate %3#0 (%c1)  : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
+! CHECK-HLFIR-NEXT: hlfir.assign %58 to %59 : i32, !fir.ref<i32>
+
+!! Check that multiple reductions work correctly
+!$omp parallel do reduction (+:a(2), b(2))
+  do i=1,10
+    a(2) = a(2) + i
+    b(2) = b(2) + i
+  end do
+!$omp end parallel do
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %17#0 -> %arg1, @add_reduction_i32 %19#0 -> %arg2 : !fir.ref<i32>, !fir.ref<i32>) {
+! CHECK-HLFIR: %53:2 = hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: %54:2 = hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: %55:2 = hlfir.declare %arg2 {uniq_name = "_QFEreduction_temp_b(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg3 to %53#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %56 = fir.load %54#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %57 = fir.load %53#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %58 = arith.addi %56, %57 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %58 to %54#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %59 = fir.load %55#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %60 = fir.load %53#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %61 = arith.addi %59, %60 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %61 to %55#0 : i32, !fir.ref<i32>
+
+!! Check that when the identifier for the elment comes from a variable, this get replaced
+!$omp parallel do reduction (+: c(j))
+  do i=1,10
+    c(j) = c(j) + i
+  end do
+!$omp end parallel do
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %21#0 -> %arg1 : !fir.ref<i32>) {
+! CHECK-HLFIR: %53:2 = hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: %54:2 = hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_c(j)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %53#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %55 = fir.load %54#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %56 = fir.load %53#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: %57 = arith.addi %55, %56 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %57 to %54#0 : i32, !fir.ref<i32>
+
+!! Array Sections will not get changed
+  !$omp parallel do reduction(+:z(1:10:1))
+  do i=1,10
+  end do
+  !$omp end parallel do
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_10xi32 %54 -> %arg1 : !fir.ref<!fir.box<!fir.array<10xi32>>>) {
+
+end program test

--- a/flang/test/Semantics/OpenMP/reduction09.f90
+++ b/flang/test/Semantics/OpenMP/reduction09.f90
@@ -1,22 +1,16 @@
-! RUN: %python %S/../test_symbols.py %s %flang_fc1 -fopenmp
+! RUN: %flang_fc1 -fdebug-unparse-with-symbols -fopenmp %s | FileCheck %s
 ! OpenMP Version 4.5
 ! 2.15.3.6 Reduction Clause Positive cases.
 !DEF: /OMP_REDUCTION MainProgram
 program OMP_REDUCTION
-  !DEF: /OMP_REDUCTION/i ObjectEntity INTEGER(4)
   integer i
-  !DEF: /OMP_REDUCTION/k ObjectEntity INTEGER(4)
   integer :: k = 10
-  !DEF: /OMP_REDUCTION/a ObjectEntity INTEGER(4)
   integer a(10)
-  !DEF: /OMP_REDUCTION/b ObjectEntity INTEGER(4)
   integer b(10,10,10)
 
   !$omp parallel  shared(k)
   !$omp do  reduction(+:k)
-  !DEF: /OMP_REDUCTION/OtherConstruct1/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct1/OtherConstruct1/k (OmpReduction, OmpExplicit) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end do
@@ -24,53 +18,130 @@ program OMP_REDUCTION
 
 
   !$omp parallel do  reduction(+:a(10))
-  !DEF: /OMP_REDUCTION/OtherConstruct2/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct2/k (OmpShared) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end parallel do
 
+  !$omp parallel do  reduction(+:a(10))
+  do i=1,10
+    a(10) = a(10)+1
+  end do
+  !$omp end parallel do
 
   !$omp parallel do  reduction(+:a(1:10:1))
-  !DEF: /OMP_REDUCTION/OtherConstruct3/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct3/k (OmpShared) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end parallel do
 
   !$omp parallel do  reduction(+:b(1:10:1,1:5,2))
-  !DEF: /OMP_REDUCTION/OtherConstruct4/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct4/k (OmpShared) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end parallel do
 
   !$omp parallel do  reduction(+:b(1:10:1,1:5,2:5:1))
-  !DEF: /OMP_REDUCTION/OtherConstruct5/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct5/k (OmpShared) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end parallel do
 
   !$omp parallel  private(i)
   !$omp do reduction(+:k) reduction(+:j)
-  !DEF: /OMP_REDUCTION/OtherConstruct6/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct6/OtherConstruct1/k (OmpReduction, OmpExplicit) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end do
   !$omp end parallel
 
   !$omp do reduction(+:k) reduction(*:j) reduction(+:l)
-  !DEF: /OMP_REDUCTION/OtherConstruct7/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,10
-    !DEF: /OMP_REDUCTION/OtherConstruct7/k (OmpReduction, OmpExplicit) HostAssoc INTEGER(4)
     k = k+1
   end do
   !$omp end do
 end program OMP_REDUCTION
+
+! CHECK: !DEF: /OMP_REDUCTION MainProgram
+! CHECK-NEXT: program OMP_REDUCTION
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/i ObjectEntity INTEGER(4)
+! CHECK-NEXT:  integer i
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/k ObjectEntity INTEGER(4)
+! CHECK-NEXT:  integer :: k = 10
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/a ObjectEntity INTEGER(4)
+! CHECK-NEXT:  integer a(10)
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/b ObjectEntity INTEGER(4)
+! CHECK-NEXT:  integer b(10,10,10)
+! CHECK-NEXT: !$omp parallel shared(k)
+! CHECK-NEXT: !$omp do reduction(+: k)
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct1/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct1/OtherConstruct1/k (OmpReduction, OmpExplicit) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end do
+! CHECK-NEXT: !$omp end parallel
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/reduction_temp_a(10) (CompilerCreated) ObjectEntity INTEGER(4)
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/a
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct3/a (OmpShared) HostAssoc INTEGER(4)
+! CHECK-NEXT:  reduction_temp_a(10) = a(10)
+! CHECK-NEXT: !$omp parallel do reduction(+: reduction_temp_a(10))
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct2/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct2/k (OmpShared) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end parallel do
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/reduction_temp_a(10)
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/a
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/OtherConstruct3/a
+! CHECK-NEXT:  reduction_temp_a(10) = a(10)
+! CHECK-NEXT: !$omp parallel do reduction(+: reduction_temp_a(10))
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct3/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !REF: /OMP_REDUCTION/reduction_temp_a(10)
+! CHECK-NEXT:   reduction_temp_a(10) = reduction_temp_a(10)+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end parallel do
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/reduction_temp_a(10)
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/a
+! CHECK-NEXT:  !REF: /OMP_REDUCTION/OtherConstruct3/a
+! CHECK-NEXT:  a(10) = reduction_temp_a(10)
+! CHECK-NEXT: !$omp parallel do reduction(+: a(1:10:1))
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct4/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct4/k (OmpShared) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end parallel do
+! CHECK-NEXT: !$omp parallel do reduction(+: b(1:10:1,1:5,2))
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct5/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct5/k (OmpShared) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end parallel do
+! CHECK-NEXT: !$omp parallel do reduction(+: b(1:10:1,1:5,2:5:1))
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct6/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct6/k (OmpShared) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end parallel do
+! CHECK-NEXT: !$omp parallel private(i)
+! CHECK-NEXT: !$omp do reduction(+: k) reduction(+: j)
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct7/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct7/OtherConstruct1/k (OmpReduction, OmpExplicit) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end do
+! CHECK-NEXT: !$omp end parallel
+! CHECK-NEXT: !$omp do reduction(+: k) reduction(*: j) reduction(+: l)
+! CHECK-NEXT:  !DEF: /OMP_REDUCTION/OtherConstruct8/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+! CHECK-NEXT:  do i=1,10
+! CHECK-NEXT:   !DEF: /OMP_REDUCTION/OtherConstruct8/k (OmpReduction, OmpExplicit) HostAssoc INTEGER(4)
+! CHECK-NEXT:   k = k+1
+! CHECK-NEXT:  end do
+! CHECK-NEXT: !$omp end do
+! CHECK-NEXT: end program OMP_REDUCTION

--- a/flang/test/Semantics/OpenMP/reduction17.f90
+++ b/flang/test/Semantics/OpenMP/reduction17.f90
@@ -1,0 +1,209 @@
+! This test is targeting the RewriteArrayElements function within rewrite-parse-tree.cpp. Its important that this behaviour is working as otherwise the OpenMP Lowering of ArrayElements in Reduction Clauses will not function correctly.
+! RUN: %flang_fc1 -fdebug-dump-parse-tree -fopenmp %s | FileCheck %s --check-prefix=CHECK-TREE
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s --check-prefix=CHECK-HLFIR
+! RUN: %flang_fc1 -fdebug-unparse -fopenmp %s | FileCheck %s --check-prefix=CHECK-UNPARSE
+
+program test
+  integer a(2)
+  integer b(2)
+  integer c(2)
+  integer z(10)
+  integer :: k = 10
+
+!! When a scalar array element is used, the array element is replaced with a temprorary so it is correctly lowered as an Integer
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=a(2_8)'
+! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | Expr = 'a(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'a'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+!$omp do reduction (+: a(2))
+! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
+! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
+! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %15#0 -> %arg1 : !fir.ref<i32>) { 
+  do i = 1,2
+    a(2) = a(2) + i
+! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=reduction_temp_a(2)+i'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_a(2)+i'
+! CHECK-TREE-NEXT: | | | | | | | Add
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
+! CHECK-HLFIR: hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %33#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: fir.load %34#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: fir.load %33#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: arith.addi %35, %36 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %37 to %34#0 : i32, !fir.ref<i32>
+  end do
+!$omp end do
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(2_8)=reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | Variable = 'a(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'a'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+
+!! Ensure that consective reduction clauses can be correctly processed in the same block
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_b(2)=b(2_8)'
+! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | Expr = 'b(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'b'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+!$omp do reduction (+: b(2))
+! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
+! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
+! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %17#0 -> %arg1 : !fir.ref<i32>) {
+  do i = 1,3
+    b(2) = b(2) + i
+! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_b(2)=reduction_temp_b(2)+i'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_b(2)+i'
+! CHECK-TREE-NEXT: | | | | | | | Add
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
+! CHECK-HLFIR: hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_b(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %33#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: fir.load %34#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: fir.load %33#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: arith.addi %35, %36 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %37 to %34#0 : i32, !fir.ref<i32>
+  end do
+!$omp end do
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'b(2_8)=reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | Variable = 'b(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'b'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+
+!! Ensure that we can reuse the same array element later on. This will use the same symbol as the previous use of a(2) for the temporary value
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=a(2_8)'
+! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | Expr = 'a(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'a'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+!$omp do reduction (+: a(2))
+! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
+! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
+! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %15#0 -> %arg1 : !fir.ref<i32>) {
+  do i = 1,4
+    a(2) = a(2) + i
+! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=reduction_temp_a(2)+i'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_a(2)+i'
+! CHECK-TREE-NEXT: | | | | | | | Add
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
+! CHECK-HLFIR: hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %33#0 : i32, !fir.ref<i32>
+! CHECK-HLFIR-NEXT: fir.load %34#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: fir.load %33#0 : !fir.ref<i32>
+! CHECK-HLFIR-NEXT: arith.addi %35, %36 : i32
+! CHECK-HLFIR-NEXT: hlfir.assign %37 to %34#0 : i32, !fir.ref<i32>
+    !! We need to make sure that for the array element that has not been reduced, this does not get replaced with a temp
+    a(1) = a(2)
+! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(1_8)=reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'a(1_8)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | | | | DataRef -> Name = 'a'
+! CHECK-TREE-NEXT: | | | | | | | | SectionSubscript -> Integer -> Expr = '1_4'
+! CHECK-TREE-NEXT: | | | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+! CHECK-HLFIR: arith.constant 1 : index
+! CHECK-HLFIR-NEXT: hlfir.designate %3#0 (%c1)  : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
+! CHECK-HLFIR-NEXT: hlfir.assign %38 to %39 : i32, !fir.ref<i32>
+  end do
+!$omp end do
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(2_8)=reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | Variable = 'a(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'a'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_a(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
+
+!! Array Sections will not get changed
+  !$omp parallel do reduction(+:z(1:10:1))
+! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
+! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
+! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | | DataRef -> Name = 'z'
+! CHECK-TREE-NEXT: | | | | | | SectionSubscript -> SubscriptTriplet
+! CHECK-TREE-NEXT: | | | | | | | Scalar -> Integer -> Expr = '1_4'
+! CHECK-TREE-NEXT: | | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
+! CHECK-TREE-NEXT: | | | | | | | Scalar -> Integer -> Expr = '10_4'
+! CHECK-TREE-NEXT: | | | | | | | | LiteralConstant -> IntLiteralConstant = '10'
+! CHECK-TREE-NEXT: | | | | | | | Scalar -> Integer -> Expr = '1_4'
+! CHECK-TREE-NEXT: | | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
+! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_10xi32 %34 -> %arg1 : !fir.ref<!fir.box<!fir.array<10xi32>>>) {
+  do i=1,10
+    k = k + 1
+  end do
+  !$omp end parallel do
+
+end program test
+
+! CHECK-UNPARSE: PROGRAM TEST
+! CHECK-UNPARSE-NEXT:  INTEGER a(2_4)
+! CHECK-UNPARSE-NEXT:  INTEGER b(2_4)
+! CHECK-UNPARSE-NEXT:  INTEGER c(2_4)
+! CHECK-UNPARSE-NEXT:  INTEGER z(10_4)
+! CHECK-UNPARSE-NEXT:  INTEGER :: k = 10_4
+! CHECK-UNPARSE-NEXT:   reduction_temp_a(2)=a(2_8)
+! CHECK-UNPARSE-NEXT: !$OMP DO REDUCTION(+: reduction_temp_a(2))
+! CHECK-UNPARSE-NEXT:  DO i=1_4,2_4
+! CHECK-UNPARSE-NEXT:    reduction_temp_a(2)=reduction_temp_a(2)+i
+! CHECK-UNPARSE-NEXT:  END DO
+! CHECK-UNPARSE-NEXT: !$OMP END DO
+! CHECK-UNPARSE-NEXT:   a(2_8)=reduction_temp_a(2)
+! CHECK-UNPARSE-NEXT:   reduction_temp_b(2)=b(2_8)
+! CHECK-UNPARSE-NEXT: !$OMP DO REDUCTION(+: reduction_temp_b(2))
+! CHECK-UNPARSE-NEXT:  DO i=1_4,3_4
+! CHECK-UNPARSE-NEXT:    reduction_temp_b(2)=reduction_temp_b(2)+i
+! CHECK-UNPARSE-NEXT:  END DO
+! CHECK-UNPARSE-NEXT: !$OMP END DO
+! CHECK-UNPARSE-NEXT:   b(2_8)=reduction_temp_b(2)
+! CHECK-UNPARSE-NEXT:   reduction_temp_a(2)=a(2_8)
+! CHECK-UNPARSE-NEXT: !$OMP DO REDUCTION(+: reduction_temp_a(2))
+! CHECK-UNPARSE-NEXT:  DO i=1_4,4_4
+! CHECK-UNPARSE-NEXT:    reduction_temp_a(2)=reduction_temp_a(2)+i
+! CHECK-UNPARSE-NEXT:    a(1_8)=reduction_temp_a(2)
+! CHECK-UNPARSE-NEXT:  END DO
+! CHECK-UNPARSE-NEXT: !$OMP END DO
+! CHECK-UNPARSE-NEXT:   a(2_8)=reduction_temp_a(2)
+! CHECK-UNPARSE-NEXT: !$OMP PARALLEL DO REDUCTION(+: z(1_4:10_4:1_4))
+! CHECK-UNPARSE-NEXT:  DO i=1_4,10_4
+! CHECK-UNPARSE-NEXT:    k=k+1_4
+! CHECK-UNPARSE-NEXT:  END DO
+! CHECK-UNPARSE-NEXT: !$OMP END PARALLEL DO
+! CHECK-UNPARSE-NEXT: END PROGRAM TEST

--- a/flang/test/Semantics/OpenMP/reduction17.f90
+++ b/flang/test/Semantics/OpenMP/reduction17.f90
@@ -1,16 +1,21 @@
 ! This test is targeting the RewriteArrayElements function within rewrite-parse-tree.cpp. Its important that this behaviour is working as otherwise the OpenMP Lowering of ArrayElements in Reduction Clauses will not function correctly.
 ! RUN: %flang_fc1 -fdebug-dump-parse-tree -fopenmp %s | FileCheck %s --check-prefix=CHECK-TREE
-! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s --check-prefix=CHECK-HLFIR
 ! RUN: %flang_fc1 -fdebug-unparse -fopenmp %s | FileCheck %s --check-prefix=CHECK-UNPARSE
 
 program test
-  integer a(2)
-  integer b(2)
-  integer c(2)
+  integer a(200)
+  integer b(200)
+  integer c(200)
   integer z(10)
   integer :: k = 10
+  integer :: j
 
 !! When a scalar array element is used, the array element is replaced with a temprorary so it is correctly lowered as an Integer
+!$omp do reduction (+: a(2))
+  do i = 1,2
+    a(2) = a(2) + i
+  end do
+!$omp end do
 ! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=a(2_8)'
 ! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
@@ -19,13 +24,9 @@ program test
 ! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'a'
 ! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
 ! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
-!$omp do reduction (+: a(2))
 ! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 ! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 ! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_a(2)'
-! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %15#0 -> %arg1 : !fir.ref<i32>) { 
-  do i = 1,2
-    a(2) = a(2) + i
 ! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=reduction_temp_a(2)+i'
 ! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
@@ -35,15 +36,6 @@ program test
 ! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
 ! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
-! CHECK-HLFIR: hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-HLFIR-NEXT: hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %33#0 : i32, !fir.ref<i32>
-! CHECK-HLFIR-NEXT: fir.load %34#0 : !fir.ref<i32>
-! CHECK-HLFIR-NEXT: fir.load %33#0 : !fir.ref<i32>
-! CHECK-HLFIR-NEXT: arith.addi %35, %36 : i32
-! CHECK-HLFIR-NEXT: hlfir.assign %37 to %34#0 : i32, !fir.ref<i32>
-  end do
-!$omp end do
 ! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(2_8)=reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | Variable = 'a(2_8)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
@@ -54,6 +46,11 @@ program test
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
 
 !! Ensure that consective reduction clauses can be correctly processed in the same block
+!$omp do reduction (+: b(2))
+  do i = 1,3
+    b(2) = b(2) + i
+  end do
+!$omp end do
 ! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_b(2)=b(2_8)'
 ! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_b(2)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
@@ -62,13 +59,9 @@ program test
 ! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'b'
 ! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
 ! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
-!$omp do reduction (+: b(2))
 ! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 ! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 ! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_b(2)'
-! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %17#0 -> %arg1 : !fir.ref<i32>) {
-  do i = 1,3
-    b(2) = b(2) + i
 ! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_b(2)=reduction_temp_b(2)+i'
 ! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_b(2)'
 ! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
@@ -78,15 +71,6 @@ program test
 ! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
 ! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
 ! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
-! CHECK-HLFIR: hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-HLFIR-NEXT: hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_b(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %33#0 : i32, !fir.ref<i32>
-! CHECK-HLFIR-NEXT: fir.load %34#0 : !fir.ref<i32>
-! CHECK-HLFIR-NEXT: fir.load %33#0 : !fir.ref<i32>
-! CHECK-HLFIR-NEXT: arith.addi %35, %36 : i32
-! CHECK-HLFIR-NEXT: hlfir.assign %37 to %34#0 : i32, !fir.ref<i32>
-  end do
-!$omp end do
 ! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'b(2_8)=reduction_temp_b(2)'
 ! CHECK-TREE-NEXT: | | | Variable = 'b(2_8)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
@@ -97,6 +81,12 @@ program test
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
 
 !! Ensure that we can reuse the same array element later on. This will use the same symbol as the previous use of a(2) for the temporary value
+!$omp do reduction (+: a(2))
+  do i = 1,4
+    a(2) = a(2) + i
+    a(1) = a(2)
+  end do
+!$omp end do
 ! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=a(2_8)'
 ! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
@@ -105,13 +95,9 @@ program test
 ! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'a'
 ! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
 ! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
-!$omp do reduction (+: a(2))
 ! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 ! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 ! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_a(2)'
-! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(@add_reduction_i32 %15#0 -> %arg1 : !fir.ref<i32>) {
-  do i = 1,4
-    a(2) = a(2) + i
 ! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_a(2)=reduction_temp_a(2)+i'
 ! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
@@ -121,15 +107,6 @@ program test
 ! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
 ! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
-! CHECK-HLFIR: hlfir.declare %arg0 {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-HLFIR-NEXT: hlfir.declare %arg1 {uniq_name = "_QFEreduction_temp_a(2)"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-HLFIR-NEXT: hlfir.assign %arg2 to %33#0 : i32, !fir.ref<i32>
-! CHECK-HLFIR-NEXT: fir.load %34#0 : !fir.ref<i32>
-! CHECK-HLFIR-NEXT: fir.load %33#0 : !fir.ref<i32>
-! CHECK-HLFIR-NEXT: arith.addi %35, %36 : i32
-! CHECK-HLFIR-NEXT: hlfir.assign %37 to %34#0 : i32, !fir.ref<i32>
-    !! We need to make sure that for the array element that has not been reduced, this does not get replaced with a temp
-    a(1) = a(2)
 ! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(1_8)=reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | | | Variable = 'a(1_8)'
 ! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> ArrayElement
@@ -138,11 +115,6 @@ program test
 ! CHECK-TREE-NEXT: | | | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
 ! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
-! CHECK-HLFIR: arith.constant 1 : index
-! CHECK-HLFIR-NEXT: hlfir.designate %3#0 (%c1)  : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
-! CHECK-HLFIR-NEXT: hlfir.assign %38 to %39 : i32, !fir.ref<i32>
-  end do
-!$omp end do
 ! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(2_8)=reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | Variable = 'a(2_8)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
@@ -152,8 +124,121 @@ program test
 ! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_a(2)'
 ! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_a(2)'
 
+!! Check that multiple reductions work correctly
+!$omp parallel do reduction (+:b(2), c(2))
+  do i=1,10
+    b(2) = b(2) + i
+    c(2) = c(2) + i
+  end do
+!$omp end parallel do
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_b(2)=b(2_8)'
+! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | Expr = 'b(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'b'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_c(2)=c(2_8)'
+! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | Expr = 'c(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'c'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
+! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
+! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_c(2)'
+! CHECK-TREE: ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_b(2)=reduction_temp_b(2)+i'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_b(2)+i'
+! CHECK-TREE-NEXT: | | | | | | | Add
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
+! CHECK-TREE-NEXT: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_c(2)=reduction_temp_c(2)+i'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_c(2)+i'
+! CHECK-TREE-NEXT: | | | | | | | Add
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'c(2_8)=reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | Variable = 'c(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'c'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_c(2)'
+! CHECK-TREE-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'b(2_8)=reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | Variable = 'b(2_8)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'b'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = '2_4'
+! CHECK-TREE-NEXT: | | | | | | LiteralConstant -> IntLiteralConstant = '2'
+! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_b(2)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_b(2)'
+
+!! Check that when the identifier for the element comes from a variable, this get replaced
+!$omp parallel do reduction (+: c(j))
+  do i=1,10
+    c(j) = c(j) + i
+    c(j) = c(j) - c(k)
+  end do
+!$omp end parallel do
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_c(j)=c(int(j,kind=8))'
+! CHECK-TREE-NEXT: | | | Variable = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | Expr = 'c(int(j,kind=8))'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'c'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = 'j'
+! CHECK-TREE-NEXT: | | | | | | Designator -> DataRef -> Name = 'j'
+! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
+! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
+! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+! CHECK-TREE: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_c(j)=reduction_temp_c(j)+i'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_c(j)+i'
+! CHECK-TREE-NEXT: | | | | | | | Add
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'i'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'i'
+! CHECK-TREE-NEXT: | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'reduction_temp_c(j)=reduction_temp_c(j)-c(int(k,kind=8))'
+! CHECK-TREE-NEXT: | | | | | | Variable = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | Expr = 'reduction_temp_c(j)-c(int(k,kind=8))'
+! CHECK-TREE-NEXT: | | | | | | | Subtract
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | | | | | Expr = 'c(int(k,kind=8))'
+! CHECK-TREE-NEXT: | | | | | | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | | | | | | DataRef -> Name = 'c'
+! CHECK-TREE-NEXT: | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'k'
+! CHECK-TREE-NEXT: | | | | | | | | | | | Designator -> DataRef -> Name = 'k'
+! CHECK-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'c(int(j,kind=8))=reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | Variable = 'c(int(j,kind=8))'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> ArrayElement
+! CHECK-TREE-NEXT: | | | | | DataRef -> Name = 'c'
+! CHECK-TREE-NEXT: | | | | | SectionSubscript -> Integer -> Expr = 'j'
+! CHECK-TREE-NEXT: | | | | | | Designator -> DataRef -> Name = 'j'
+! CHECK-TREE-NEXT: | | | Expr = 'reduction_temp_c(j)'
+! CHECK-TREE-NEXT: | | | | Designator -> DataRef -> Name = 'reduction_temp_c(j)'
+
 !! Array Sections will not get changed
   !$omp parallel do reduction(+:z(1:10:1))
+  do i=1,10
+  end do
+  !$omp end parallel do
 ! CHECK-TREE: | | | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 ! CHECK-TREE-NEXT: | | | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 ! CHECK-TREE-NEXT: | | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> ArrayElement
@@ -165,20 +250,15 @@ program test
 ! CHECK-TREE-NEXT: | | | | | | | | LiteralConstant -> IntLiteralConstant = '10'
 ! CHECK-TREE-NEXT: | | | | | | | Scalar -> Integer -> Expr = '1_4'
 ! CHECK-TREE-NEXT: | | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-! CHECK-HLFIR: omp.wsloop private(@_QFEi_private_i32 %11#0 -> %arg0 : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_10xi32 %34 -> %arg1 : !fir.ref<!fir.box<!fir.array<10xi32>>>) {
-  do i=1,10
-    k = k + 1
-  end do
-  !$omp end parallel do
-
 end program test
 
 ! CHECK-UNPARSE: PROGRAM TEST
-! CHECK-UNPARSE-NEXT:  INTEGER a(2_4)
-! CHECK-UNPARSE-NEXT:  INTEGER b(2_4)
-! CHECK-UNPARSE-NEXT:  INTEGER c(2_4)
+! CHECK-UNPARSE-NEXT:  INTEGER a(200_4)
+! CHECK-UNPARSE-NEXT:  INTEGER b(200_4)
+! CHECK-UNPARSE-NEXT:  INTEGER c(200_4)
 ! CHECK-UNPARSE-NEXT:  INTEGER z(10_4)
 ! CHECK-UNPARSE-NEXT:  INTEGER :: k = 10_4
+! CHECK-UNPARSE-NEXT:  INTEGER j
 ! CHECK-UNPARSE-NEXT:   reduction_temp_a(2)=a(2_8)
 ! CHECK-UNPARSE-NEXT: !$OMP DO REDUCTION(+: reduction_temp_a(2))
 ! CHECK-UNPARSE-NEXT:  DO i=1_4,2_4
@@ -201,9 +281,26 @@ end program test
 ! CHECK-UNPARSE-NEXT:  END DO
 ! CHECK-UNPARSE-NEXT: !$OMP END DO
 ! CHECK-UNPARSE-NEXT:   a(2_8)=reduction_temp_a(2)
+! CHECK-UNPARSE-NEXT:   reduction_temp_b(2)=b(2_8)
+! CHECK-UNPARSE-NEXT:   reduction_temp_c(2)=c(2_8)
+! CHECK-UNPARSE-NEXT: !$OMP PARALLEL DO REDUCTION(+: reduction_temp_b(2),reduction_temp_c(2))
+! CHECK-UNPARSE-NEXT:  DO i=1_4,10_4
+! CHECK-UNPARSE-NEXT:    reduction_temp_b(2)=reduction_temp_b(2)+i
+! CHECK-UNPARSE-NEXT:    reduction_temp_c(2)=reduction_temp_c(2)+i
+! CHECK-UNPARSE-NEXT:  END DO
+! CHECK-UNPARSE-NEXT: !$OMP END PARALLEL DO
+! CHECK-UNPARSE-NEXT:   c(2_8)=reduction_temp_c(2)
+! CHECK-UNPARSE-NEXT:   b(2_8)=reduction_temp_b(2)
+! CHECK-UNPARSE-NEXT:   reduction_temp_c(j)=c(int(j,kind=8))
+! CHECK-UNPARSE-NEXT: !$OMP PARALLEL DO REDUCTION(+: reduction_temp_c(j))
+! CHECK-UNPARSE-NEXT:  DO i=1_4,10_4
+! CHECK-UNPARSE-NEXT:    reduction_temp_c(j)=reduction_temp_c(j)+i
+! CHECK-UNPARSE-NEXT:    reduction_temp_c(j)=reduction_temp_c(j)-c(int(k,kind=8))
+! CHECK-UNPARSE-NEXT:  END DO
+! CHECK-UNPARSE-NEXT: !$OMP END PARALLEL DO
+! CHECK-UNPARSE-NEXT:   c(int(j,kind=8))=reduction_temp_c(j)
 ! CHECK-UNPARSE-NEXT: !$OMP PARALLEL DO REDUCTION(+: z(1_4:10_4:1_4))
 ! CHECK-UNPARSE-NEXT:  DO i=1_4,10_4
-! CHECK-UNPARSE-NEXT:    k=k+1_4
 ! CHECK-UNPARSE-NEXT:  END DO
 ! CHECK-UNPARSE-NEXT: !$OMP END PARALLEL DO
 ! CHECK-UNPARSE-NEXT: END PROGRAM TEST


### PR DESCRIPTION
Currently, Flang does not correctly lower ArrayElement's when processing an OpenMP Reduction Clause correctly. Rather than lowering the array element, the whole array will be lowered. This leads to slower performance for the end user in their program.

This patch works to rectify this by rewriteing the parse tree while processing semantics. The use of an ArrayElement in an OpenMP Reduction Clause will be identified, and replaced with a temporary both in the reduction clause, and anywhere that array element is used within the respective DoConstruct. Once the DoConstruct has finished, if the ArrayElement has been used within the Do loop, the value of the temporary will be re-assigned to the array element. One limitation of this approach is that if the ArrayElement is not used, there is no available element in the parse tree to use to reassign the value, so its only done if used.

The reason for making the change in the parse tree is due to how ArrayElements are lowered. When lowering, the expression of the ArrayElement being used in the reduction is being substitued with the reference to the symbol. In this case, that would be the whole array. By replacing it with a temporary, it removes the issue of lowering a full array as it will be referencing the temporary instead. To address this in lowering would require a major rethink on how a considerable amount of non-OpenMP code is lowered and as such, not deemed the appropriate course of action for this specific case.

This process is done after the initial Semantics Pass as to not affect the checking of users original code. If the array element has been replaced, the first pass of semantics will need to be rerun to ensure all TypedExpr's are correctly captured otherwise the lowering will not function correctly. This step is only done if an ArrayElement is replaced.

Testing is covered by reduction17.f90. This checks both the parse tree, unparsing and HLFIR to ensure the temproary is being used in the reduction clause and Do loop. Assignment to, and reassignment from the ArrayElement and the Temporary is also considered to ensure this is inserted at the correct location.

reduction09.f90 has also been reformatted to rely on FileCheck. As the Parse Tree is changing, the output is different to that of the user, so we can no longer rely on test_symbols.py for this test. The same information is being checked, with test cases that cover using an ArrayElement in the Do loop, and not using the ArrayElement being covered.

Array Sections are not affected by this change, only uses of single array elements.