### PR TITLE
[Unittest][Cygwin] Set $PATH when running unittests

### DIFF
--- a/clang-tools-extra/clangd/unittests/lit.cfg.py
+++ b/clang-tools-extra/clangd/unittests/lit.cfg.py
@@ -19,12 +19,12 @@ config.parallelism_group = "clangd"
 
 if platform.system() == "Darwin":
     shlibpath_var = "DYLD_LIBRARY_PATH"
-elif platform.system() == "Windows":
+elif platform.system() == "Windows" or sys.platform == "cygwin":
     shlibpath_var = "PATH"
 else:
     shlibpath_var = "LD_LIBRARY_PATH"
 config.environment[shlibpath_var] = os.path.pathsep.join(
-    ("@SHLIBDIR@", "@LLVM_LIBS_DIR@", config.environment.get(shlibpath_var, ""))
+    (config.shlibdir, config.llvm_libs_dir, config.environment.get(shlibpath_var, ""))
 )
 
 # It is not realistically possible to account for all options that could

--- a/clang-tools-extra/clangd/unittests/lit.cfg.py
+++ b/clang-tools-extra/clangd/unittests/lit.cfg.py
@@ -24,7 +24,7 @@ elif platform.system() == "Windows" or sys.platform == "cygwin":
 else:
     shlibpath_var = "LD_LIBRARY_PATH"
 config.environment[shlibpath_var] = os.path.pathsep.join(
-    (config.shlibdir, config.llvm_libs_dir, config.environment.get(shlibpath_var, ""))
+    ("@SHLIBDIR@", "@LLVM_LIBS_DIR@", config.environment.get(shlibpath_var, ""))
 )
 
 # It is not realistically possible to account for all options that could

--- a/clang-tools-extra/include-cleaner/test/Unit/lit.cfg.py
+++ b/clang-tools-extra/include-cleaner/test/Unit/lit.cfg.py
@@ -11,12 +11,12 @@ import platform
 
 if platform.system() == "Darwin":
     shlibpath_var = "DYLD_LIBRARY_PATH"
-elif platform.system() == "Windows":
+elif platform.system() == "Windows" or sys.platform == "cygwin":
     shlibpath_var = "PATH"
 else:
     shlibpath_var = "LD_LIBRARY_PATH"
 config.environment[shlibpath_var] = os.path.pathsep.join(
-    ("@SHLIBDIR@", "@LLVM_LIBS_DIR@", config.environment.get(shlibpath_var, ""))
+    (config.shlibdir, config.llvm_libs_dir, config.environment.get(shlibpath_var, ""))
 )
 
 # It is not realistically possible to account for all options that could

--- a/clang-tools-extra/include-cleaner/test/Unit/lit.cfg.py
+++ b/clang-tools-extra/include-cleaner/test/Unit/lit.cfg.py
@@ -16,7 +16,7 @@ elif platform.system() == "Windows" or sys.platform == "cygwin":
 else:
     shlibpath_var = "LD_LIBRARY_PATH"
 config.environment[shlibpath_var] = os.path.pathsep.join(
-    (config.shlibdir, config.llvm_libs_dir, config.environment.get(shlibpath_var, ""))
+    ("@SHLIBDIR@", "@LLVM_LIBS_DIR@", config.environment.get(shlibpath_var, ""))
 )
 
 # It is not realistically possible to account for all options that could

--- a/clang-tools-extra/test/Unit/lit.cfg.py
+++ b/clang-tools-extra/test/Unit/lit.cfg.py
@@ -21,7 +21,7 @@ config.test_format = lit.formats.GoogleTest(".", "Tests")
 
 if platform.system() == "Darwin":
     shlibpath_var = "DYLD_LIBRARY_PATH"
-elif platform.system() == "Windows":
+elif platform.system() == "Windows" or sys.platform == "cygwin":
     shlibpath_var = "PATH"
 else:
     shlibpath_var = "LD_LIBRARY_PATH"

--- a/clang/test/Unit/lit.cfg.py
+++ b/clang/test/Unit/lit.cfg.py
@@ -51,7 +51,7 @@ def find_shlibpath_var():
         yield "LD_LIBRARY_PATH"
     elif platform.system() == "Darwin":
         yield "DYLD_LIBRARY_PATH"
-    elif platform.system() == "Windows":
+    elif platform.system() == "Windows" or sys.platform == "cygwin":
         yield "PATH"
     elif platform.system() == "AIX":
         yield "LIBPATH"

--- a/llvm/utils/lit/tests/Inputs/googletest-cmd-wrapper/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/googletest-cmd-wrapper/lit.cfg
@@ -2,5 +2,5 @@ import lit.formats
 
 config.name = "googletest-cmd-wrapper"
 config.test_format = lit.formats.GoogleTest(
-    "DummySubDir", "Test" if "win32" in sys.platform else ".exe", [sys.executable]
+    "DummySubDir", "Test" if sys.platform in ["win32", "cygwin"] else ".exe", [sys.executable]
 )

--- a/polly/test/Unit/lit.cfg
+++ b/polly/test/Unit/lit.cfg
@@ -50,7 +50,7 @@ for var in [
 
 if platform.system() == 'Darwin':
     shlibpath_var = 'DYLD_LIBRARY_PATH'
-elif platform.system() == 'Windows':
+elif platform.system() == 'Windows' or sys.platform == "cygwin":
     shlibpath_var = 'PATH'
 else:
     shlibpath_var = 'LD_LIBRARY_PATH'


### PR DESCRIPTION
As the Cygwin platform requires $PATH to be set in order to run unittests, do the same as for the regular Windows target.