### PR TITLE
[lit] Add an option to read an xfail list from a file

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -346,6 +346,10 @@ The timing data is stored in the `test_exec_root` in a file named
 
     LIT_XFAIL="affinity/kmp-hw-subset.c;libomptarget :: x86_64-pc-linux-gnu :: offloading/memory_manager.cpp"
 
+.. option:: --xfail-from-file PATH
+
+  Read a line separated list of tests from a file to be used by :option:`--xfail`.
+
 .. option:: --xfail-not LIST
 
   Do not treat the specified tests as ``XFAIL``.  The environment variable
@@ -355,6 +359,10 @@ The timing data is stored in the `test_exec_root` in a file named
   including an :option:`--xfail` appearing later on the command line.  The
   primary purpose is to suppress an ``XPASS`` result without modifying a test
   case that uses the ``XFAIL`` directive.
+
+.. option:: --xfail-not-from-file PATH
+
+  Read a line separated list of tests from a file to be used by :option:`--xfail-not`.
 
 .. option:: --exclude-xfail
 

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -310,11 +310,23 @@ def parse_args():
         default=os.environ.get("LIT_XFAIL", ""),
     )
     selection_group.add_argument(
+        "--xfail-from-file",
+        metavar="PATH",
+        help="XFAIL tests with paths in the line separated list contained in "
+        "the specified file",
+    )
+    selection_group.add_argument(
         "--xfail-not",
         metavar="LIST",
         type=_semicolon_list,
         help="do not XFAIL tests with paths in the semicolon separated list",
         default=os.environ.get("LIT_XFAIL_NOT", ""),
+    )
+    selection_group.add_argument(
+        "--xfail-not-from-file",
+        metavar="PATH",
+        help="do not XFAIL tests with paths in the line separated list "
+        "contained in the specified file",
     )
     selection_group.add_argument(
         "--exclude-xfail",
@@ -395,6 +407,13 @@ def parse_args():
 
     for report in opts.reports:
         report.use_unique_output_file_name = opts.use_unique_output_file_name
+
+    if opts.xfail_from_file:
+        with open(opts.xfail_from_file, "r", encoding="utf-8") as f:
+            opts.xfail.extend(f.read().splitlines())
+    if opts.xfail_not_from_file:
+        with open(opts.xfail_not_from_file, "r", encoding="utf-8") as f:
+            opts.xfail_not.extend(f.read().splitlines())
 
     return opts
 

--- a/llvm/utils/lit/tests/Inputs/xfail-cl/xfail-not.list
+++ b/llvm/utils/lit/tests/Inputs/xfail-cl/xfail-not.list
@@ -1,0 +1,2 @@
+true-xfail.txt
+top-level-suite :: a :: test-xfail.txt

--- a/llvm/utils/lit/tests/Inputs/xfail-cl/xfail.list
+++ b/llvm/utils/lit/tests/Inputs/xfail-cl/xfail.list
@@ -1,0 +1,3 @@
+false.txt
+false2.txt
+top-level-suite :: b :: test.txt

--- a/llvm/utils/lit/tests/xfail-cl.py
+++ b/llvm/utils/lit/tests/xfail-cl.py
@@ -16,6 +16,10 @@
 # RUN:   %{inputs}/xfail-cl \
 # RUN: | FileCheck --check-prefixes=CHECK-EXCLUDED,CHECK-EXCLUDED-OVERRIDE %s
 
+# RUN: %{lit} --xfail-from-file %{inputs}/xfail-cl/xfail.list \
+# RUN:   --xfail-not-from-file %{inputs}/xfail-cl/xfail-not.list \
+# RUN:   %{inputs}/xfail-cl \
+# RUN: | FileCheck --check-prefix=CHECK-FILTER %s
 
 # RUN: env LIT_XFAIL='false.txt;false2.txt;top-level-suite :: b :: test.txt' \
 # RUN:   LIT_XFAIL_NOT='true-xfail.txt;top-level-suite :: a :: test-xfail.txt' \


### PR DESCRIPTION
The `--xfail` and `--xfail-not` lit options allow a list of tests to be marked as expected to fail/pass on the command line. We've found this to be useful in CI to temporarily change the state of a test without making changes to the test sources, while a more appropriate fix is investigated.

However, we've encountered cases where the list needs to be quite long (100+ tests), which leads to some very long command strings.

This patch extends the existing options with additional ones, `--xfail-from-file` and `--xfail-not-from-file` that will instead read the list from a file instead of directly from the command line. The underlying functionality remains exactly the same, with only an alternative source for the lists.