### PR TITLE
[libc][math] Refactor fma implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -137,6 +137,7 @@
 #include "math/floorf128.h"
 #include "math/floorf16.h"
 #include "math/floorl.h"
+#include "math/fma.h"
 #include "math/fmabf16.h"
 #include "math/fmax.h"
 #include "math/fmaxbf16.h"

--- a/libc/shared/math/fma.h
+++ b/libc/shared/math/fma.h
@@ -1,4 +1,4 @@
-//===-- Implementation of fma function ------------------------------------===//
+//===-- Shared fma function -------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/fma.h"
+#ifndef LLVM_LIBC_SHARED_MATH_FMA_H
+#define LLVM_LIBC_SHARED_MATH_FMA_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/fma.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(double, fma, (double x, double y, double z)) {
-  return math::fma(x, y, z);
-}
+using math::fma;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_FMA_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1321,6 +1321,14 @@ add_header_library(
 )
 
 add_header_library(
+  fma
+  HDRS
+    fma.h
+  DEPENDS
+    libc.src.__support.FPUtil.fma
+)
+
+add_header_library(
   ffma
   HDRS
     ffma.h

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1326,6 +1326,7 @@ add_header_library(
     fma.h
   DEPENDS
     libc.src.__support.FPUtil.fma
+    libc.src.__support.macros.config
 )
 
 add_header_library(

--- a/libc/src/__support/math/fma.h
+++ b/libc/src/__support/math/fma.h
@@ -1,0 +1,27 @@
+//===-- Implementation header for fma ---------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FMA_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_FMA_H
+
+#include "src/__support/FPUtil/FMA.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static double fma(double x, double y, double z) {
+  return fputil::fma<double>(x, y, z);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_FMA_H

--- a/libc/src/__support/math/fma.h
+++ b/libc/src/__support/math/fma.h
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 namespace math {
 
-LIBC_INLINE static double fma(double x, double y, double z) {
+LIBC_INLINE double fma(double x, double y, double z) {
   return fputil::fma<double>(x, y, z);
 }
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -4399,7 +4399,7 @@ add_entrypoint_object(
   HDRS
     ../fma.h
   DEPENDS
-    libc.src.__support.FPUtil.fma
+    libc.src.__support.math.fma
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -134,6 +134,7 @@ add_fp_unittest(
     libc.src.__support.math.floorf128
     libc.src.__support.math.floorf16
     libc.src.__support.math.floorl
+    libc.src.__support.math.fma
     libc.src.__support.math.fmabf16
     libc.src.__support.math.fmax
     libc.src.__support.math.fmaxbf16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -247,6 +247,7 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
   EXPECT_FP_EQ(0x1p+0, LIBC_NAMESPACE::shared::exp2(0.0));
   EXPECT_FP_EQ(0x1p+0, LIBC_NAMESPACE::shared::exp10(0.0));
   EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::expm1(0.0));
+  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::fma(0.0, 0.0, 0.0));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::ffma(0.0, 0.0, 0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::hypot(0.0, 0.0));
   EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::fsqrt(0.0));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4312,6 +4312,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_fma",
+    hdrs = ["src/__support/math/fma.h"],
+    deps = [
+        ":__support_fputil_fma",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_frexpf128",
     hdrs = ["src/__support/math/frexpf128.h"],
     deps = [
@@ -7090,7 +7098,7 @@ libc_math_function(
 libc_math_function(
     name = "fmaf16",
     additional_deps = [
-        ":__support_fputil_fma",
+        ":__support_math_fma",
     ],
 )
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450