### PR TITLE
[libc][math] Refactor fmaf implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -139,6 +139,7 @@
 #include "math/floorl.h"
 #include "math/fma.h"
 #include "math/fmabf16.h"
+#include "math/fmaf.h"
 #include "math/fmax.h"
 #include "math/fmaxbf16.h"
 #include "math/fmaxf.h"

--- a/libc/shared/math/fmaf.h
+++ b/libc/shared/math/fmaf.h
@@ -1,4 +1,4 @@
-//===-- Implementation of fmaf function -----------------------------------===//
+//===-- Shared fmaf function ------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/fmaf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_FMAF_H
+#define LLVM_LIBC_SHARED_MATH_FMAF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/fmaf.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, fmaf, (float x, float y, float z)) {
-  return math::fmaf(x, y, z);
-}
+using math::fmaf;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_FMAF_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1335,6 +1335,7 @@ add_header_library(
     fmaf.h
   DEPENDS
     libc.src.__support.FPUtil.fma
+    libc.src.__support.macros.config
 )
 
 add_header_library(

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1330,6 +1330,14 @@ add_header_library(
 )
 
 add_header_library(
+  fmaf
+  HDRS
+    fmaf.h
+  DEPENDS
+    libc.src.__support.FPUtil.fma
+)
+
+add_header_library(
   ffma
   HDRS
     ffma.h

--- a/libc/src/__support/math/fmaf.h
+++ b/libc/src/__support/math/fmaf.h
@@ -1,0 +1,27 @@
+//===-- Implementation header for fmaf --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FMAF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_FMAF_H
+
+#include "src/__support/FPUtil/FMA.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE float fmaf(float x, float y, float z) {
+  return fputil::fma<float>(x, y, z);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_FMAF_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -4378,7 +4378,7 @@ add_entrypoint_object(
   HDRS
     ../fmaf.h
   DEPENDS
-    libc.src.__support.FPUtil.fma
+    libc.src.__support.math.fmaf
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -135,6 +135,7 @@ add_fp_unittest(
     libc.src.__support.math.floorf16
     libc.src.__support.math.floorl
     libc.src.__support.math.fma
+    libc.src.__support.math.fmaf
     libc.src.__support.math.fmabf16
     libc.src.__support.math.fmax
     libc.src.__support.math.fmaxbf16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -169,6 +169,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::expf(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp2f(0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::expm1f(0.0f));
+  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::fmaf(0.0f, 0.0f, 0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::hypotf(0.0f, 0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::logf(1.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::sinhf(0.0f));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4320,6 +4320,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_fmaf",
+    hdrs = ["src/__support/math/fmaf.h"],
+    deps = [
+        ":__support_fputil_fma",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_frexpf128",
     hdrs = ["src/__support/math/frexpf128.h"],
     deps = [
@@ -7092,7 +7100,7 @@ libc_math_function(
 
 libc_math_function(
     name = "fmaf",
-    additional_deps = [":__support_fputil_fma"],
+    additional_deps = [":__support_math_fmaf"],
 )
 
 libc_math_function(

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4316,6 +4316,7 @@ libc_support_library(
     hdrs = ["src/__support/math/fma.h"],
     deps = [
         ":__support_fputil_fma",
+        ":__support_macros_config",
     ],
 )
 
@@ -4324,6 +4325,7 @@ libc_support_library(
     hdrs = ["src/__support/math/fmaf.h"],
     deps = [
         ":__support_fputil_fma",
+        ":__support_macros_config",
     ],
 )
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450