### PR TITLE
[flang][OpenACC] add TODO for unstructured loops in acc loop directives

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2712,12 +2712,19 @@ genACC(Fortran::lower::AbstractConverter &converter,
   const auto &loopDirective =
       std::get<Fortran::parser::AccLoopDirective>(beginLoopDirective.t);
 
-  bool needEarlyExitHandling = false;
-  if (eval.lowerAsUnstructured())
-    needEarlyExitHandling = hasEarlyReturn(eval);
-
   mlir::Location currentLocation =
       converter.genLocation(beginLoopDirective.source);
+  bool needEarlyExitHandling = false;
+  if (eval.lowerAsUnstructured()) {
+    needEarlyExitHandling = hasEarlyReturn(eval);
+    // If the loop is lowered in an unstructured fashion, lowering generates
+    // explicit control flow that duplicates the looping semantics of the
+    // loops.
+    if (!needEarlyExitHandling)
+      TODO(currentLocation,
+           "loop with early exit inside OpenACC loop construct");
+  }
+
   Fortran::lower::StatementContext stmtCtx;
 
   assert(loopDirective.v == llvm::acc::ACCD_loop &&
@@ -3515,6 +3522,10 @@ genACC(Fortran::lower::AbstractConverter &converter,
   mlir::Location currentLocation =
       converter.genLocation(beginCombinedDirective.source);
   Fortran::lower::StatementContext stmtCtx;
+
+  if (eval.lowerAsUnstructured())
+    TODO(currentLocation,
+         "loop with early exit inside OpenACC combined construct");
 
   if (combinedDirective.v == llvm::acc::ACCD_kernels_loop) {
     createComputeOp<mlir::acc::KernelsOp>(

--- a/flang/test/Lower/OpenACC/acc-unstructured.f90
+++ b/flang/test/Lower/OpenACC/acc-unstructured.f90
@@ -1,4 +1,5 @@
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+! XFAIL: *
 
 subroutine test_unstructured1(a, b, c)
   integer :: i, j, k


### PR DESCRIPTION
The lowering of `!$acc loop` loops with an early exit currently ends-up "duplicating" the control flow in the acc.loop and inside it as explicit control flow (as if each iteration executes each iteration until the early exit).

Add a TODO for now.