### PR TITLE
[llvm-c] Deprecate functions working on the global context

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -239,7 +239,9 @@ value llvm_dispose_context(value C) {
 }
 
 /* unit -> llcontext */
-value llvm_global_context(value Unit) { return to_val(LLVMGetGlobalContext()); }
+value llvm_global_context(value Unit) {
+  return to_val(getGlobalContextForCAPI());
+}
 
 /* llcontext -> string -> int */
 value llvm_mdkind_id(value C, value Name) {

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -206,6 +206,7 @@ Changes to the C API
   * `LLVMMDNode` -> `LLVMMDNodeInContext2`
   * `LLVMAppendBasicBlock` -> `LLVMAppendBasicBlockInContext`
   * `LLVMInsertBasicBlock` -> `LLVMInsertBasicBlockInContext`
+  * `LLVMCreateBuilder` -> `LLVMCreateBuilderInContext`
   * `LLVMIntPtrType` -> `LLVMIntPtrTypeInContext`
   * `LLVMIntPtrTypeForAS` -> `LLVMIntPtrTypeForASInContext`
   * `LLVMParseBitcode` -> `LLVMParseBitcodeInContext2`

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -178,6 +178,40 @@ Changes to the C API
 * Add `LLVMGetOrInsertFunction` to get or insert a function, replacing the combination of `LLVMGetNamedFunction` and `LLVMAddFunction`.
 * Allow `LLVMGetVolatile` to work with any kind of Instruction.
 * Add `LLVMConstFPFromBits` to get a constant floating-point value from an array of 64 bit values.
+* Functions working on the global context have been deprecated. Use the
+  functions that work on a specific context instead.
+
+  * `LLVMGetGlobalContext` -> use `LLVMContextCreate` context instead
+  * `LLVMInt1Type` -> `LLVMInt1TypeInContext`
+  * `LLVMInt8Type` -> `LLVMInt8TypeInContext`
+  * `LLVMInt16Type` -> `LLVMInt16TypeInContext`
+  * `LLVMInt32Type` -> `LLVMInt32TypeInContext`
+  * `LLVMInt64Type` -> `LLVMInt64TypeInContext`
+  * `LLVMInt128Type` -> `LLVMInt128TypeInContext`
+  * `LLVMIntType` -> `LLVMIntTypeInContext`
+  * `LLVMHalfType` -> `LLVMHalfTypeInContext`
+  * `LLVMBFloatType` -> `LLVMBFloatTypeInContext`
+  * `LLVMFloatType` -> `LLVMFloatTypeInContext`
+  * `LLVMDoubleType` -> `LLVMDoubleTypeInContext`
+  * `LLVMX86FP80Type` -> `LLVMX86FP80TypeInContext`
+  * `LLVMFP128Type` -> `LLVMFP128TypeInContext`
+  * `LLVMPPCFP128Type` -> `LLVMPPCFP128TypeInContext`
+  * `LLVMStructType` -> `LLVMStructTypeInContext`
+  * `LLVMVoidType` -> `LLVMVoidTypeInContext`
+  * `LLVMLabelType` -> `LLVMLabelTypeInContext`
+  * `LLVMX86AMXType` -> `LLVMX86AMXTypeInContext`
+  * `LLVMConstString` -> `LLVMConstStringInContext2`
+  * `LLVMConstStruct` -> `LLVMConstStructInContext`
+  * `LLVMMDString` -> `LLVMMDStringInContext2`
+  * `LLVMMDNode` -> `LLVMMDNodeInContext2`
+  * `LLVMAppendBasicBlock` -> `LLVMAppendBasicBlockInContext`
+  * `LLVMInsertBasicBlock` -> `LLVMInsertBasicBlockInContext`
+  * `LLVMIntPtrType` -> `LLVMIntPtrTypeInContext`
+  * `LLVMIntPtrTypeForAS` -> `LLVMIntPtrTypeForASInContext`
+  * `LLVMParseBitcode` -> `LLVMParseBitcodeInContext2`
+  * `LLVMParseBitcode2` -> `LLVMParseBitcodeInContext2`
+  * `LLVMGetBitcodeModule` -> `LLVMGetBitcodeModuleInContext2`
+  * `LLVMGetBitcodeModule2` -> `LLVMGetBitcodeModuleInContext2`
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/OrcV2CBindingsAddObjectFile.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/OrcV2CBindingsAddObjectFile.c
@@ -28,13 +28,14 @@ LLVMModuleRef createDemoModule(LLVMContextRef Ctx) {
 
   // Add a "sum" function":
   //  - Create the function type and function instance.
-  LLVMTypeRef ParamTypes[] = {LLVMInt32Type(), LLVMInt32Type()};
-  LLVMTypeRef SumFunctionType =
-      LLVMFunctionType(LLVMInt32Type(), ParamTypes, 2, 0);
+  LLVMTypeRef Int32Type = LLVMInt32TypeInContext(Ctx);
+  LLVMTypeRef ParamTypes[] = {Int32Type, Int32Type};
+  LLVMTypeRef SumFunctionType = LLVMFunctionType(Int32Type, ParamTypes, 2, 0);
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
 
   //  - Add a basic block to the function.
-  LLVMBasicBlockRef EntryBB = LLVMAppendBasicBlock(SumFunction, "entry");
+  LLVMBasicBlockRef EntryBB =
+      LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
   LLVMBuilderRef Builder = LLVMCreateBuilder();

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/OrcV2CBindingsAddObjectFile.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/OrcV2CBindingsAddObjectFile.c
@@ -38,7 +38,7 @@ LLVMModuleRef createDemoModule(LLVMContextRef Ctx) {
       LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(Ctx);
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
 
   //  - Get the two function arguments and use them co construct an "add"

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/OrcV2CBindingsBasicUsage.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/OrcV2CBindingsBasicUsage.c
@@ -40,7 +40,7 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
       LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(Ctx);
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
 
   //  - Get the two function arguments and use them co construct an "add"

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/OrcV2CBindingsBasicUsage.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/OrcV2CBindingsBasicUsage.c
@@ -30,13 +30,14 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
 
   // Add a "sum" function":
   //  - Create the function type and function instance.
-  LLVMTypeRef ParamTypes[] = {LLVMInt32Type(), LLVMInt32Type()};
-  LLVMTypeRef SumFunctionType =
-      LLVMFunctionType(LLVMInt32Type(), ParamTypes, 2, 0);
+  LLVMTypeRef Int32Type = LLVMInt32TypeInContext(Ctx);
+  LLVMTypeRef ParamTypes[] = {Int32Type, Int32Type};
+  LLVMTypeRef SumFunctionType = LLVMFunctionType(Int32Type, ParamTypes, 2, 0);
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
 
   //  - Add a basic block to the function.
-  LLVMBasicBlockRef EntryBB = LLVMAppendBasicBlock(SumFunction, "entry");
+  LLVMBasicBlockRef EntryBB =
+      LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
   LLVMBuilderRef Builder = LLVMCreateBuilder();

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/OrcV2CBindingsDumpObjects.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/OrcV2CBindingsDumpObjects.c
@@ -33,11 +33,12 @@ int handleError(LLVMErrorRef Err) {
 LLVMOrcThreadSafeModuleRef createDemoModule(void) {
   LLVMContextRef Ctx = LLVMContextCreate();
   LLVMModuleRef M = LLVMModuleCreateWithNameInContext("demo", Ctx);
-  LLVMTypeRef ParamTypes[] = {LLVMInt32Type(), LLVMInt32Type()};
-  LLVMTypeRef SumFunctionType =
-      LLVMFunctionType(LLVMInt32Type(), ParamTypes, 2, 0);
+  LLVMTypeRef Int32Type = LLVMInt32TypeInContext(Ctx);
+  LLVMTypeRef ParamTypes[] = {Int32Type, Int32Type};
+  LLVMTypeRef SumFunctionType = LLVMFunctionType(Int32Type, ParamTypes, 2, 0);
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
-  LLVMBasicBlockRef EntryBB = LLVMAppendBasicBlock(SumFunction, "entry");
+  LLVMBasicBlockRef EntryBB =
+      LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
   LLVMBuilderRef Builder = LLVMCreateBuilder();
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
   LLVMValueRef SumArg0 = LLVMGetParam(SumFunction, 0);

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/OrcV2CBindingsDumpObjects.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/OrcV2CBindingsDumpObjects.c
@@ -39,7 +39,7 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
   LLVMBasicBlockRef EntryBB =
       LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(Ctx);
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
   LLVMValueRef SumArg0 = LLVMGetParam(SumFunction, 0);
   LLVMValueRef SumArg1 = LLVMGetParam(SumFunction, 1);

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/OrcV2CBindingsIRTransforms.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/OrcV2CBindingsIRTransforms.c
@@ -34,11 +34,12 @@ int handleError(LLVMErrorRef Err) {
 LLVMOrcThreadSafeModuleRef createDemoModule(void) {
   LLVMContextRef Ctx = LLVMContextCreate();
   LLVMModuleRef M = LLVMModuleCreateWithNameInContext("demo", Ctx);
-  LLVMTypeRef ParamTypes[] = {LLVMInt32Type(), LLVMInt32Type()};
-  LLVMTypeRef SumFunctionType =
-      LLVMFunctionType(LLVMInt32Type(), ParamTypes, 2, 0);
+  LLVMTypeRef Int32Type = LLVMInt32TypeInContext(Ctx);
+  LLVMTypeRef ParamTypes[] = {Int32Type, Int32Type};
+  LLVMTypeRef SumFunctionType = LLVMFunctionType(Int32Type, ParamTypes, 2, 0);
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
-  LLVMBasicBlockRef EntryBB = LLVMAppendBasicBlock(SumFunction, "entry");
+  LLVMBasicBlockRef EntryBB =
+      LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
   LLVMBuilderRef Builder = LLVMCreateBuilder();
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
   LLVMValueRef SumArg0 = LLVMGetParam(SumFunction, 0);

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/OrcV2CBindingsIRTransforms.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/OrcV2CBindingsIRTransforms.c
@@ -40,7 +40,7 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
   LLVMBasicBlockRef EntryBB =
       LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(Ctx);
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
   LLVMValueRef SumArg0 = LLVMGetParam(SumFunction, 0);
   LLVMValueRef SumArg1 = LLVMGetParam(SumFunction, 1);

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/OrcV2CBindingsMCJITLikeMemoryManager.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/OrcV2CBindingsMCJITLikeMemoryManager.c
@@ -168,7 +168,7 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
       LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(Ctx);
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
 
   //  - Get the two function arguments and use them co construct an "add"

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/OrcV2CBindingsMCJITLikeMemoryManager.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/OrcV2CBindingsMCJITLikeMemoryManager.c
@@ -158,13 +158,14 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
 
   // Add a "sum" function":
   //  - Create the function type and function instance.
-  LLVMTypeRef ParamTypes[] = {LLVMInt32Type(), LLVMInt32Type()};
-  LLVMTypeRef SumFunctionType =
-      LLVMFunctionType(LLVMInt32Type(), ParamTypes, 2, 0);
+  LLVMTypeRef Int32Type = LLVMInt32TypeInContext(Ctx);
+  LLVMTypeRef ParamTypes[] = {Int32Type, Int32Type};
+  LLVMTypeRef SumFunctionType = LLVMFunctionType(Int32Type, ParamTypes, 2, 0);
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
 
   //  - Add a basic block to the function.
-  LLVMBasicBlockRef EntryBB = LLVMAppendBasicBlock(SumFunction, "entry");
+  LLVMBasicBlockRef EntryBB =
+      LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
   LLVMBuilderRef Builder = LLVMCreateBuilder();

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/OrcV2CBindingsRemovableCode.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/OrcV2CBindingsRemovableCode.c
@@ -40,7 +40,7 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
       LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(Ctx);
   LLVMPositionBuilderAtEnd(Builder, EntryBB);
 
   //  - Get the two function arguments and use them co construct an "add"

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/OrcV2CBindingsRemovableCode.c
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/OrcV2CBindingsRemovableCode.c
@@ -30,13 +30,14 @@ LLVMOrcThreadSafeModuleRef createDemoModule(void) {
 
   // Add a "sum" function":
   //  - Create the function type and function instance.
-  LLVMTypeRef ParamTypes[] = {LLVMInt32Type(), LLVMInt32Type()};
-  LLVMTypeRef SumFunctionType =
-      LLVMFunctionType(LLVMInt32Type(), ParamTypes, 2, 0);
+  LLVMTypeRef Int32Type = LLVMInt32TypeInContext(Ctx);
+  LLVMTypeRef ParamTypes[] = {Int32Type, Int32Type};
+  LLVMTypeRef SumFunctionType = LLVMFunctionType(Int32Type, ParamTypes, 2, 0);
   LLVMValueRef SumFunction = LLVMAddFunction(M, "sum", SumFunctionType);
 
   //  - Add a basic block to the function.
-  LLVMBasicBlockRef EntryBB = LLVMAppendBasicBlock(SumFunction, "entry");
+  LLVMBasicBlockRef EntryBB =
+      LLVMAppendBasicBlockInContext(Ctx, SumFunction, "entry");
 
   //  - Add an IR builder and point it at the end of the basic block.
   LLVMBuilderRef Builder = LLVMCreateBuilder();

--- a/llvm/include/llvm-c/BitReader.h
+++ b/llvm/include/llvm-c/BitReader.h
@@ -19,6 +19,7 @@
 #ifndef LLVM_C_BITREADER_H
 #define LLVM_C_BITREADER_H
 
+#include "llvm-c/Deprecated.h"
 #include "llvm-c/ExternC.h"
 #include "llvm-c/Types.h"
 #include "llvm-c/Visibility.h"
@@ -37,14 +38,19 @@ LLVM_C_EXTERN_C_BEGIN
    Optionally returns a human-readable error message via OutMessage.
 
    This is deprecated. Use LLVMParseBitcode2. */
-LLVM_C_ABI LLVMBool LLVMParseBitcode(LLVMMemoryBufferRef MemBuf,
-                                     LLVMModuleRef *OutModule,
-                                     char **OutMessage);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMBool LLVMParseBitcode(LLVMMemoryBufferRef MemBuf,
+                              LLVMModuleRef *OutModule, char **OutMessage),
+    "Use of the global context is deprecated, use LLVMParseBitcodeInContext2 "
+    "instead");
 
 /* Builds a module from the bitcode in the specified memory buffer, returning a
    reference to the module via the OutModule parameter. Returns 0 on success. */
-LLVM_C_ABI LLVMBool LLVMParseBitcode2(LLVMMemoryBufferRef MemBuf,
-                                      LLVMModuleRef *OutModule);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMBool LLVMParseBitcode2(LLVMMemoryBufferRef MemBuf,
+                               LLVMModuleRef *OutModule),
+    "Use of the global context is deprecated, use LLVMParseBitcodeInContext2 "
+    "instead");
 
 /* This is deprecated. Use LLVMParseBitcodeInContext2. */
 LLVM_C_ABI LLVMBool LLVMParseBitcodeInContext(LLVMContextRef ContextRef,
@@ -77,12 +83,17 @@ LLVM_C_ABI LLVMBool LLVMGetBitcodeModuleInContext2(LLVMContextRef ContextRef,
                                                    LLVMModuleRef *OutM);
 
 /* This is deprecated. Use LLVMGetBitcodeModule2. */
-LLVM_C_ABI LLVMBool LLVMGetBitcodeModule(LLVMMemoryBufferRef MemBuf,
-                                         LLVMModuleRef *OutM,
-                                         char **OutMessage);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMBool LLVMGetBitcodeModule(LLVMMemoryBufferRef MemBuf,
+                                  LLVMModuleRef *OutM, char **OutMessage),
+    "Use of the global context is deprecated, use "
+    "LLVMGetBitcodeModuleInContext2 instead");
 
-LLVM_C_ABI LLVMBool LLVMGetBitcodeModule2(LLVMMemoryBufferRef MemBuf,
-                                          LLVMModuleRef *OutM);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMBool LLVMGetBitcodeModule2(LLVMMemoryBufferRef MemBuf,
+                                   LLVMModuleRef *OutM),
+    "Use of the global context is deprecated, use "
+    "LLVMGetBitcodeModuleInContext2 instead");
 
 /**
  * @}

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -4440,7 +4440,10 @@ LLVM_C_ABI const unsigned *LLVMGetIndices(LLVMValueRef Inst);
  */
 
 LLVM_C_ABI LLVMBuilderRef LLVMCreateBuilderInContext(LLVMContextRef C);
-LLVM_C_ABI LLVMBuilderRef LLVMCreateBuilder(void);
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMBuilderRef LLVMCreateBuilder(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMCreateBuilderInContext instead");
 /**
  * Set the builder position before Instr but after any attached debug records,
  * or if Instr is null set the position to the end of Block.

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -588,6 +588,9 @@ LLVM_C_ABI LLVMContextRef LLVMContextCreate(void);
 
 /**
  * Obtain the global context instance.
+ *
+ * Use of the global context is deprecated. Use LLVMContextCreate() and
+ * context-aware functions instead.
  */
 LLVM_C_ABI LLVMContextRef LLVMGetGlobalContext(void);
 
@@ -662,7 +665,10 @@ LLVMGetDiagInfoSeverity(LLVMDiagnosticInfoRef DI);
 
 LLVM_C_ABI unsigned LLVMGetMDKindIDInContext(LLVMContextRef C, const char *Name,
                                              unsigned SLen);
-LLVM_C_ABI unsigned LLVMGetMDKindID(const char *Name, unsigned SLen);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    unsigned LLVMGetMDKindID(const char *Name, unsigned SLen),
+    "Use of the global context is deprecated, use LLVMGetMDKindIDInContext "
+    "instead");
 
 /**
  * Maps a synchronization scope name to a ID unique within this context.
@@ -781,7 +787,10 @@ LLVM_C_ABI LLVMTypeRef LLVMGetTypeByName2(LLVMContextRef C, const char *Name);
  * Every invocation should be paired with LLVMDisposeModule() or memory
  * will be leaked.
  */
-LLVM_C_ABI LLVMModuleRef LLVMModuleCreateWithName(const char *ModuleID);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMModuleRef LLVMModuleCreateWithName(const char *ModuleID),
+    "Use of the global context is deprecated, use "
+    "LLVMModuleCreateWithNameInContext instead");
 
 /**
  * Create a new, empty module in a specific context.
@@ -1376,13 +1385,35 @@ LLVM_C_ABI LLVMTypeRef LLVMIntTypeInContext(LLVMContextRef C, unsigned NumBits);
  * Obtain an integer type from the global context with a specified bit
  * width.
  */
-LLVM_C_ABI LLVMTypeRef LLVMInt1Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMInt8Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMInt16Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMInt32Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMInt64Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMInt128Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMIntType(unsigned NumBits);
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMInt1Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMInt1TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMInt8Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMInt8TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMInt16Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMInt16TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMInt32Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMInt32TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMInt64Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMInt64TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMInt128Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMInt128TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMIntType(unsigned NumBits),
+                            "Use of the global context is deprecated, use "
+                            "LLVMIntTypeInContext instead");
+
 LLVM_C_ABI unsigned LLVMGetIntTypeWidth(LLVMTypeRef IntegerTy);
 
 /**
@@ -1436,13 +1467,34 @@ LLVM_C_ABI LLVMTypeRef LLVMPPCFP128TypeInContext(LLVMContextRef C);
  *
  * These map to the functions in this group of the same name.
  */
-LLVM_C_ABI LLVMTypeRef LLVMHalfType(void);
-LLVM_C_ABI LLVMTypeRef LLVMBFloatType(void);
-LLVM_C_ABI LLVMTypeRef LLVMFloatType(void);
-LLVM_C_ABI LLVMTypeRef LLVMDoubleType(void);
-LLVM_C_ABI LLVMTypeRef LLVMX86FP80Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMFP128Type(void);
-LLVM_C_ABI LLVMTypeRef LLVMPPCFP128Type(void);
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMHalfType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMHalfTypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMBFloatType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMBFloatTypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMFloatType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMFloatTypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMDoubleType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMDoubleTypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMX86FP80Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMX86FP80TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMFP128Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMFP128TypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMPPCFP128Type(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMPPCFP128TypeInContext instead");
 
 /**
  * @}
@@ -1524,8 +1576,11 @@ LLVM_C_ABI LLVMTypeRef LLVMStructTypeInContext(LLVMContextRef C,
  *
  * @see llvm::StructType::create()
  */
-LLVM_C_ABI LLVMTypeRef LLVMStructType(LLVMTypeRef *ElementTypes,
-                                      unsigned ElementCount, LLVMBool Packed);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMTypeRef LLVMStructType(LLVMTypeRef *ElementTypes, unsigned ElementCount,
+                               LLVMBool Packed),
+    "Use of the global context is deprecated, use LLVMStructTypeInContext "
+    "instead");
 
 /**
  * Create an empty structure in a context having a specified name.
@@ -1818,9 +1873,18 @@ LLVM_C_ABI LLVMTypeRef LLVMMetadataTypeInContext(LLVMContextRef C);
  * These are similar to the above functions except they operate on the
  * global context.
  */
-LLVM_C_ABI LLVMTypeRef LLVMVoidType(void);
-LLVM_C_ABI LLVMTypeRef LLVMLabelType(void);
-LLVM_C_ABI LLVMTypeRef LLVMX86AMXType(void);
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMVoidType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMVoidTypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMLabelType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMLabelTypeInContext instead");
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMX86AMXType(void),
+                            "Use of the global context is deprecated, use "
+                            "LLVMX86AMXTypeInContext instead");
 
 /**
  * Create a target extension type in LLVM context.
@@ -2421,8 +2485,11 @@ LLVM_C_ABI LLVMValueRef LLVMConstStringInContext2(LLVMContextRef C,
  * @see LLVMConstStringInContext()
  * @see llvm::ConstantDataArray::getString()
  */
-LLVM_C_ABI LLVMValueRef LLVMConstString(const char *Str, unsigned Length,
-                                        LLVMBool DontNullTerminate);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMValueRef LLVMConstString(const char *Str, unsigned Length,
+                                 LLVMBool DontNullTerminate),
+    "Use of the global context is deprecated, use LLVMConstStringInContext2 "
+    "instead");
 
 /**
  * Returns true if the specified constant is an array of i8.
@@ -2467,8 +2534,11 @@ LLVM_C_ABI LLVMValueRef LLVMConstStructInContext(LLVMContextRef C,
  *
  * @see LLVMConstStructInContext()
  */
-LLVM_C_ABI LLVMValueRef LLVMConstStruct(LLVMValueRef *ConstantVals,
-                                        unsigned Count, LLVMBool Packed);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMValueRef LLVMConstStruct(LLVMValueRef *ConstantVals, unsigned Count,
+                                 LLVMBool Packed),
+    "Use of the global context is deprecated, use LLVMConstStructInContext "
+    "instead");
 
 /**
  * Create a ConstantArray from values.
@@ -3405,12 +3475,18 @@ LLVM_C_ABI void LLVMReplaceMDNodeOperandWith(LLVMValueRef V, unsigned Index,
 LLVM_C_ABI LLVMValueRef LLVMMDStringInContext(LLVMContextRef C, const char *Str,
                                               unsigned SLen);
 /** Deprecated: Use LLVMMDStringInContext2 instead. */
-LLVM_C_ABI LLVMValueRef LLVMMDString(const char *Str, unsigned SLen);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMValueRef LLVMMDString(const char *Str, unsigned SLen),
+    "Use of the global context is deprecated, use LLVMMDStringInContext2 "
+    "instead");
 /** Deprecated: Use LLVMMDNodeInContext2 instead. */
 LLVM_C_ABI LLVMValueRef LLVMMDNodeInContext(LLVMContextRef C,
                                             LLVMValueRef *Vals, unsigned Count);
 /** Deprecated: Use LLVMMDNodeInContext2 instead. */
-LLVM_C_ABI LLVMValueRef LLVMMDNode(LLVMValueRef *Vals, unsigned Count);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMValueRef LLVMMDNode(LLVMValueRef *Vals, unsigned Count),
+    "Use of the global context is deprecated, use LLVMMDNodeInContext2 "
+    "instead");
 
 /**
  * @}
@@ -3637,8 +3713,10 @@ LLVM_C_ABI LLVMBasicBlockRef LLVMAppendBasicBlockInContext(LLVMContextRef C,
  *
  * @see llvm::BasicBlock::Create()
  */
-LLVM_C_ABI LLVMBasicBlockRef LLVMAppendBasicBlock(LLVMValueRef Fn,
-                                                  const char *Name);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMBasicBlockRef LLVMAppendBasicBlock(LLVMValueRef Fn, const char *Name),
+    "Use of the global context is deprecated, use "
+    "LLVMAppendBasicBlockInContext instead");
 
 /**
  * Insert a basic block in a function before another basic block.
@@ -3657,8 +3735,11 @@ LLVM_C_ABI LLVMBasicBlockRef LLVMInsertBasicBlockInContext(LLVMContextRef C,
  *
  * @see llvm::BasicBlock::Create()
  */
-LLVM_C_ABI LLVMBasicBlockRef
-LLVMInsertBasicBlock(LLVMBasicBlockRef InsertBeforeBB, const char *Name);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMBasicBlockRef LLVMInsertBasicBlock(LLVMBasicBlockRef InsertBeforeBB,
+                                           const char *Name),
+    "Use of the global context is deprecated, use "
+    "LLVMInsertBasicBlockInContext instead");
 
 /**
  * Remove a basic block from a function and delete it.

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -588,11 +588,11 @@ LLVM_C_ABI LLVMContextRef LLVMContextCreate(void);
 
 /**
  * Obtain the global context instance.
- *
- * Use of the global context is deprecated. Use LLVMContextCreate() and
- * context-aware functions instead.
  */
-LLVM_C_ABI LLVMContextRef LLVMGetGlobalContext(void);
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMContextRef LLVMGetGlobalContext(void),
+                            "Use of the global context is deprecated, create "
+                            "one using LLVMContextCreate instead");
 
 /**
  * Set the diagnostic handler for this context.

--- a/llvm/include/llvm-c/Target.h
+++ b/llvm/include/llvm-c/Target.h
@@ -19,6 +19,7 @@
 #ifndef LLVM_C_TARGET_H
 #define LLVM_C_TARGET_H
 
+#include "llvm-c/Deprecated.h"
 #include "llvm-c/ExternC.h"
 #include "llvm-c/Types.h"
 #include "llvm-c/Visibility.h"
@@ -229,12 +230,18 @@ LLVM_C_ABI unsigned LLVMPointerSizeForAS(LLVMTargetDataRef TD, unsigned AS);
 
 /** Returns the integer type that is the same size as a pointer on a target.
     See the method llvm::DataLayout::getIntPtrType. */
-LLVM_C_ABI LLVMTypeRef LLVMIntPtrType(LLVMTargetDataRef TD);
+LLVM_C_ABI
+LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMIntPtrType(LLVMTargetDataRef TD),
+                            "Use of the global context is deprecated, use "
+                            "LLVMIntPtrTypeInContext instead");
 
 /** Returns the integer type that is the same size as a pointer on a target.
     This version allows the address space to be specified.
     See the method llvm::DataLayout::getIntPtrType. */
-LLVM_C_ABI LLVMTypeRef LLVMIntPtrTypeForAS(LLVMTargetDataRef TD, unsigned AS);
+LLVM_C_ABI LLVM_ATTRIBUTE_C_DEPRECATED(
+    LLVMTypeRef LLVMIntPtrTypeForAS(LLVMTargetDataRef TD, unsigned AS),
+    "Use of the global context is deprecated, use LLVMIntPtrTypeForASInContext "
+    "instead");
 
 /** Returns the integer type that is the same size as a pointer on a target.
     See the method llvm::DataLayout::getIntPtrType. */

--- a/llvm/include/llvm/IR/LLVMContext.h
+++ b/llvm/include/llvm/IR/LLVMContext.h
@@ -377,6 +377,9 @@ inline LLVMContextRef *wrap(const LLVMContext **Tys) {
   return reinterpret_cast<LLVMContextRef*>(const_cast<LLVMContext**>(Tys));
 }
 
+/// Get the deprecated global context for use by the C API.
+LLVM_ABI LLVMContextRef getGlobalContextForCAPI();
+
 } // end namespace llvm
 
 #endif // LLVM_IR_LLVMCONTEXT_H

--- a/llvm/lib/Bitcode/Reader/BitReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitReader.cpp
@@ -22,13 +22,14 @@ using namespace llvm;
    Optionally returns a human-readable error message via OutMessage. */
 LLVMBool LLVMParseBitcode(LLVMMemoryBufferRef MemBuf, LLVMModuleRef *OutModule,
                           char **OutMessage) {
-  return LLVMParseBitcodeInContext(LLVMGetGlobalContext(), MemBuf, OutModule,
+  return LLVMParseBitcodeInContext(getGlobalContextForCAPI(), MemBuf, OutModule,
                                    OutMessage);
 }
 
 LLVMBool LLVMParseBitcode2(LLVMMemoryBufferRef MemBuf,
                            LLVMModuleRef *OutModule) {
-  return LLVMParseBitcodeInContext2(LLVMGetGlobalContext(), MemBuf, OutModule);
+  return LLVMParseBitcodeInContext2(getGlobalContextForCAPI(), MemBuf,
+                                    OutModule);
 }
 
 LLVMBool LLVMParseBitcodeInContext(LLVMContextRef ContextRef,
@@ -122,11 +123,12 @@ LLVMBool LLVMGetBitcodeModuleInContext2(LLVMContextRef ContextRef,
 
 LLVMBool LLVMGetBitcodeModule(LLVMMemoryBufferRef MemBuf, LLVMModuleRef *OutM,
                               char **OutMessage) {
-  return LLVMGetBitcodeModuleInContext(LLVMGetGlobalContext(), MemBuf, OutM,
+  return LLVMGetBitcodeModuleInContext(getGlobalContextForCAPI(), MemBuf, OutM,
                                        OutMessage);
 }
 
 LLVMBool LLVMGetBitcodeModule2(LLVMMemoryBufferRef MemBuf,
                                LLVMModuleRef *OutM) {
-  return LLVMGetBitcodeModuleInContext2(LLVMGetGlobalContext(), MemBuf, OutM);
+  return LLVMGetBitcodeModuleInContext2(getGlobalContextForCAPI(), MemBuf,
+                                        OutM);
 }

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -97,11 +97,15 @@ static LLVMContext &getGlobalContext() {
   return GlobalContext;
 }
 
+LLVMContextRef llvm::getGlobalContextForCAPI() {
+  return wrap(&getGlobalContext());
+}
+
 LLVMContextRef LLVMContextCreate() {
   return wrap(new LLVMContext());
 }
 
-LLVMContextRef LLVMGetGlobalContext() { return wrap(&getGlobalContext()); }
+LLVMContextRef LLVMGetGlobalContext() { return getGlobalContextForCAPI(); }
 
 void LLVMContextSetDiagnosticHandler(LLVMContextRef C,
                                      LLVMDiagnosticHandler Handler,
@@ -146,7 +150,7 @@ unsigned LLVMGetMDKindIDInContext(LLVMContextRef C, const char *Name,
 }
 
 unsigned LLVMGetMDKindID(const char *Name, unsigned SLen) {
-  return LLVMGetMDKindIDInContext(LLVMGetGlobalContext(), Name, SLen);
+  return LLVMGetMDKindIDInContext(getGlobalContextForCAPI(), Name, SLen);
 }
 
 unsigned LLVMGetSyncScopeID(LLVMContextRef C, const char *Name, size_t SLen) {
@@ -681,25 +685,25 @@ LLVMTypeRef LLVMIntTypeInContext(LLVMContextRef C, unsigned NumBits) {
 }
 
 LLVMTypeRef LLVMInt1Type(void)  {
-  return LLVMInt1TypeInContext(LLVMGetGlobalContext());
+  return LLVMInt1TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMInt8Type(void)  {
-  return LLVMInt8TypeInContext(LLVMGetGlobalContext());
+  return LLVMInt8TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMInt16Type(void) {
-  return LLVMInt16TypeInContext(LLVMGetGlobalContext());
+  return LLVMInt16TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMInt32Type(void) {
-  return LLVMInt32TypeInContext(LLVMGetGlobalContext());
+  return LLVMInt32TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMInt64Type(void) {
-  return LLVMInt64TypeInContext(LLVMGetGlobalContext());
+  return LLVMInt64TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMInt128Type(void) {
-  return LLVMInt128TypeInContext(LLVMGetGlobalContext());
+  return LLVMInt128TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMIntType(unsigned NumBits) {
-  return LLVMIntTypeInContext(LLVMGetGlobalContext(), NumBits);
+  return LLVMIntTypeInContext(getGlobalContextForCAPI(), NumBits);
 }
 
 unsigned LLVMGetIntTypeWidth(LLVMTypeRef IntegerTy) {
@@ -734,28 +738,28 @@ LLVMTypeRef LLVMX86AMXTypeInContext(LLVMContextRef C) {
 }
 
 LLVMTypeRef LLVMHalfType(void) {
-  return LLVMHalfTypeInContext(LLVMGetGlobalContext());
+  return LLVMHalfTypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMBFloatType(void) {
-  return LLVMBFloatTypeInContext(LLVMGetGlobalContext());
+  return LLVMBFloatTypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMFloatType(void) {
-  return LLVMFloatTypeInContext(LLVMGetGlobalContext());
+  return LLVMFloatTypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMDoubleType(void) {
-  return LLVMDoubleTypeInContext(LLVMGetGlobalContext());
+  return LLVMDoubleTypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMX86FP80Type(void) {
-  return LLVMX86FP80TypeInContext(LLVMGetGlobalContext());
+  return LLVMX86FP80TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMFP128Type(void) {
-  return LLVMFP128TypeInContext(LLVMGetGlobalContext());
+  return LLVMFP128TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMPPCFP128Type(void) {
-  return LLVMPPCFP128TypeInContext(LLVMGetGlobalContext());
+  return LLVMPPCFP128TypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMX86AMXType(void) {
-  return LLVMX86AMXTypeInContext(LLVMGetGlobalContext());
+  return LLVMX86AMXTypeInContext(getGlobalContextForCAPI());
 }
 
 /*--.. Operations on function types ........................................--*/
@@ -795,7 +799,7 @@ LLVMTypeRef LLVMStructTypeInContext(LLVMContextRef C, LLVMTypeRef *ElementTypes,
 
 LLVMTypeRef LLVMStructType(LLVMTypeRef *ElementTypes,
                            unsigned ElementCount, LLVMBool Packed) {
-  return LLVMStructTypeInContext(LLVMGetGlobalContext(), ElementTypes,
+  return LLVMStructTypeInContext(getGlobalContextForCAPI(), ElementTypes,
                                  ElementCount, Packed);
 }
 
@@ -952,10 +956,10 @@ LLVMTypeRef LLVMMetadataTypeInContext(LLVMContextRef C) {
 }
 
 LLVMTypeRef LLVMVoidType(void)  {
-  return LLVMVoidTypeInContext(LLVMGetGlobalContext());
+  return LLVMVoidTypeInContext(getGlobalContextForCAPI());
 }
 LLVMTypeRef LLVMLabelType(void) {
-  return LLVMLabelTypeInContext(LLVMGetGlobalContext());
+  return LLVMLabelTypeInContext(getGlobalContextForCAPI());
 }
 
 LLVMTypeRef LLVMTargetExtTypeInContext(LLVMContextRef C, const char *Name,
@@ -1296,7 +1300,7 @@ LLVMValueRef LLVMMDStringInContext(LLVMContextRef C, const char *Str,
 }
 
 LLVMValueRef LLVMMDString(const char *Str, unsigned SLen) {
-  return LLVMMDStringInContext(LLVMGetGlobalContext(), Str, SLen);
+  return LLVMMDStringInContext(getGlobalContextForCAPI(), Str, SLen);
 }
 
 LLVMValueRef LLVMMDNodeInContext(LLVMContextRef C, LLVMValueRef *Vals,
@@ -1327,7 +1331,7 @@ LLVMValueRef LLVMMDNodeInContext(LLVMContextRef C, LLVMValueRef *Vals,
 }
 
 LLVMValueRef LLVMMDNode(LLVMValueRef *Vals, unsigned Count) {
-  return LLVMMDNodeInContext(LLVMGetGlobalContext(), Vals, Count);
+  return LLVMMDNodeInContext(getGlobalContextForCAPI(), Vals, Count);
 }
 
 LLVMValueRef LLVMMetadataAsValue(LLVMContextRef C, LLVMMetadataRef MD) {
@@ -1628,7 +1632,7 @@ LLVMValueRef LLVMConstStringInContext2(LLVMContextRef C, const char *Str,
 
 LLVMValueRef LLVMConstString(const char *Str, unsigned Length,
                              LLVMBool DontNullTerminate) {
-  return LLVMConstStringInContext(LLVMGetGlobalContext(), Str, Length,
+  return LLVMConstStringInContext(getGlobalContextForCAPI(), Str, Length,
                                   DontNullTerminate);
 }
 
@@ -1685,8 +1689,8 @@ LLVMValueRef LLVMConstStructInContext(LLVMContextRef C,
 
 LLVMValueRef LLVMConstStruct(LLVMValueRef *ConstantVals, unsigned Count,
                              LLVMBool Packed) {
-  return LLVMConstStructInContext(LLVMGetGlobalContext(), ConstantVals, Count,
-                                  Packed);
+  return LLVMConstStructInContext(getGlobalContextForCAPI(), ConstantVals,
+                                  Count, Packed);
 }
 
 LLVMValueRef LLVMConstNamedStruct(LLVMTypeRef StructTy,
@@ -2892,7 +2896,7 @@ LLVMBasicBlockRef LLVMAppendBasicBlockInContext(LLVMContextRef C,
 }
 
 LLVMBasicBlockRef LLVMAppendBasicBlock(LLVMValueRef FnRef, const char *Name) {
-  return LLVMAppendBasicBlockInContext(LLVMGetGlobalContext(), FnRef, Name);
+  return LLVMAppendBasicBlockInContext(getGlobalContextForCAPI(), FnRef, Name);
 }
 
 LLVMBasicBlockRef LLVMInsertBasicBlockInContext(LLVMContextRef C,
@@ -2904,7 +2908,7 @@ LLVMBasicBlockRef LLVMInsertBasicBlockInContext(LLVMContextRef C,
 
 LLVMBasicBlockRef LLVMInsertBasicBlock(LLVMBasicBlockRef BBRef,
                                        const char *Name) {
-  return LLVMInsertBasicBlockInContext(LLVMGetGlobalContext(), BBRef, Name);
+  return LLVMInsertBasicBlockInContext(getGlobalContextForCAPI(), BBRef, Name);
 }
 
 void LLVMDeleteBasicBlock(LLVMBasicBlockRef BBRef) {
@@ -3340,7 +3344,7 @@ LLVMBuilderRef LLVMCreateBuilderInContext(LLVMContextRef C) {
 }
 
 LLVMBuilderRef LLVMCreateBuilder(void) {
-  return LLVMCreateBuilderInContext(LLVMGetGlobalContext());
+  return LLVMCreateBuilderInContext(getGlobalContextForCAPI());
 }
 
 static void LLVMPositionBuilderImpl(IRBuilder<> *Builder, BasicBlock *Block,

--- a/llvm/lib/Target/Target.cpp
+++ b/llvm/lib/Target/Target.cpp
@@ -23,9 +23,6 @@
 
 using namespace llvm;
 
-// Avoid including "llvm-c/Core.h" for compile time, fwd-declare this instead.
-extern "C" LLVMContextRef LLVMGetGlobalContext(void);
-
 inline TargetLibraryInfoImpl *unwrap(LLVMTargetLibraryInfoRef P) {
   return reinterpret_cast<TargetLibraryInfoImpl*>(P);
 }
@@ -80,11 +77,12 @@ unsigned LLVMPointerSizeForAS(LLVMTargetDataRef TD, unsigned AS) {
 }
 
 LLVMTypeRef LLVMIntPtrType(LLVMTargetDataRef TD) {
-  return wrap(unwrap(TD)->getIntPtrType(*unwrap(LLVMGetGlobalContext())));
+  return wrap(unwrap(TD)->getIntPtrType(*unwrap(getGlobalContextForCAPI())));
 }
 
 LLVMTypeRef LLVMIntPtrTypeForAS(LLVMTargetDataRef TD, unsigned AS) {
-  return wrap(unwrap(TD)->getIntPtrType(*unwrap(LLVMGetGlobalContext()), AS));
+  return wrap(
+      unwrap(TD)->getIntPtrType(*unwrap(getGlobalContextForCAPI()), AS));
 }
 
 LLVMTypeRef LLVMIntPtrTypeInContext(LLVMContextRef C, LLVMTargetDataRef TD) {

--- a/llvm/tools/llvm-c-test/attributes.c
+++ b/llvm/tools/llvm-c-test/attributes.c
@@ -20,7 +20,8 @@
 int llvm_test_function_attributes(void) {
   LLVMEnablePrettyStackTrace();
 
-  LLVMModuleRef M = llvm_load_module(LLVMGetGlobalContext(), false, true);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = llvm_load_module(C, false, true);
 
   LLVMValueRef F = LLVMGetFirstFunction(M);
   while (F) {
@@ -42,6 +43,7 @@ int llvm_test_function_attributes(void) {
   }
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }
@@ -49,7 +51,8 @@ int llvm_test_function_attributes(void) {
 int llvm_test_callsite_attributes(void) {
   LLVMEnablePrettyStackTrace();
 
-  LLVMModuleRef M = llvm_load_module(LLVMGetGlobalContext(), false, true);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = llvm_load_module(C, false, true);
 
   LLVMValueRef F = LLVMGetFirstFunction(M);
   while (F) {
@@ -81,6 +84,7 @@ int llvm_test_callsite_attributes(void) {
   }
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }

--- a/llvm/tools/llvm-c-test/debuginfo.c
+++ b/llvm/tools/llvm-c-test/debuginfo.c
@@ -33,7 +33,8 @@ declare_objc_class(LLVMDIBuilderRef DIB, LLVMMetadataRef File) {
 
 int llvm_test_dibuilder(void) {
   const char *Filename = "debuginfo.c";
-  LLVMModuleRef M = LLVMModuleCreateWithName(Filename);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext(Filename, C);
 
   LLVMSetIsNewDbgInfoFormat(M, true);
   assert(LLVMIsNewDbgInfoFormat(M));
@@ -101,15 +102,16 @@ int llvm_test_dibuilder(void) {
   LLVMAddNamedMetadataOperand(M, "FooType",
     LLVMMetadataAsValue(LLVMGetModuleContext(M), StructDbgPtrTy));
 
-
+  LLVMTypeRef I64Ty = LLVMInt64TypeInContext(C);
   LLVMTypeRef FooParamTys[] = {
-    LLVMInt64Type(),
-    LLVMInt64Type(),
-    LLVMVectorType(LLVMInt64Type(), 10),
+      I64Ty,
+      I64Ty,
+      LLVMVectorType(I64Ty, 10),
   };
-  LLVMTypeRef FooFuncTy = LLVMFunctionType(LLVMInt64Type(), FooParamTys, 3, 0);
+  LLVMTypeRef FooFuncTy = LLVMFunctionType(I64Ty, FooParamTys, 3, 0);
   LLVMValueRef FooFunction = LLVMAddFunction(M, "foo", FooFuncTy);
-  LLVMBasicBlockRef FooEntryBlock = LLVMAppendBasicBlock(FooFunction, "entry");
+  LLVMBasicBlockRef FooEntryBlock =
+      LLVMAppendBasicBlockInContext(C, FooFunction, "entry");
 
   LLVMMetadataRef Subscripts[] = {
     LLVMDIBuilderGetOrCreateSubrange(DIB, 0, 10),
@@ -130,9 +132,8 @@ int llvm_test_dibuilder(void) {
                                                 LLVMDIFlagFwdDecl,
                                                 "", 0);
 
-  LLVMMetadataRef FooParamLocation =
-    LLVMDIBuilderCreateDebugLocation(LLVMGetGlobalContext(), 42, 0,
-                                     ReplaceableFunctionMetadata, NULL);
+  LLVMMetadataRef FooParamLocation = LLVMDIBuilderCreateDebugLocation(
+      C, 42, 0, ReplaceableFunctionMetadata, NULL);
   LLVMMetadataRef FunctionMetadata = LLVMDIBuilderCreateFunction(
       DIB, File, "foo", 3, "foo", 3, File, 42, NULL, true, true, 42, 0, false);
   LLVMMetadataReplaceAllUsesWith(ReplaceableFunctionMetadata, FunctionMetadata);
@@ -145,24 +146,24 @@ int llvm_test_dibuilder(void) {
     LLVMDIBuilderCreateParameterVariable(DIB, FunctionMetadata, "a", 1, 1, File,
                                          42, Int64Ty, true, 0);
 
-  LLVMDIBuilderInsertDeclareRecordAtEnd(
-      DIB, LLVMConstInt(LLVMInt64Type(), 0, false), FooParamVar1,
-      FooParamExpression, FooParamLocation, FooEntryBlock);
+  LLVMDIBuilderInsertDeclareRecordAtEnd(DIB, LLVMConstInt(I64Ty, 0, false),
+                                        FooParamVar1, FooParamExpression,
+                                        FooParamLocation, FooEntryBlock);
 
   LLVMMetadataRef FooParamVar2 =
     LLVMDIBuilderCreateParameterVariable(DIB, FunctionMetadata, "b", 1, 2, File,
                                          42, Int64Ty, true, 0);
 
-  LLVMDIBuilderInsertDeclareRecordAtEnd(
-      DIB, LLVMConstInt(LLVMInt64Type(), 0, false), FooParamVar2,
-      FooParamExpression, FooParamLocation, FooEntryBlock);
+  LLVMDIBuilderInsertDeclareRecordAtEnd(DIB, LLVMConstInt(I64Ty, 0, false),
+                                        FooParamVar2, FooParamExpression,
+                                        FooParamLocation, FooEntryBlock);
 
   LLVMMetadataRef FooParamVar3 = LLVMDIBuilderCreateParameterVariable(
       DIB, FunctionMetadata, "c", 1, 3, File, 42, VectorTy, true, 0);
 
-  LLVMDIBuilderInsertDeclareRecordAtEnd(
-      DIB, LLVMConstInt(LLVMInt64Type(), 0, false), FooParamVar3,
-      FooParamExpression, FooParamLocation, FooEntryBlock);
+  LLVMDIBuilderInsertDeclareRecordAtEnd(DIB, LLVMConstInt(I64Ty, 0, false),
+                                        FooParamVar3, FooParamExpression,
+                                        FooParamLocation, FooEntryBlock);
 
   LLVMSetSubprogram(FooFunction, FunctionMetadata);
 
@@ -174,14 +175,14 @@ int llvm_test_dibuilder(void) {
   LLVMMetadataRef FooLexicalBlock =
     LLVMDIBuilderCreateLexicalBlock(DIB, FunctionMetadata, File, 42, 0);
 
-  LLVMBasicBlockRef FooVarBlock = LLVMAppendBasicBlock(FooFunction, "vars");
+  LLVMBasicBlockRef FooVarBlock =
+      LLVMAppendBasicBlockInContext(C, FooFunction, "vars");
   LLVMMetadataRef FooVarsLocation =
-    LLVMDIBuilderCreateDebugLocation(LLVMGetGlobalContext(), 43, 0,
-                                     FunctionMetadata, NULL);
+      LLVMDIBuilderCreateDebugLocation(C, 43, 0, FunctionMetadata, NULL);
   LLVMMetadataRef FooVar1 =
     LLVMDIBuilderCreateAutoVariable(DIB, FooLexicalBlock, "d", 1, File,
                                     43, Int64Ty, true, 0, 0);
-  LLVMValueRef FooVal1 = LLVMConstInt(LLVMInt64Type(), 0, false);
+  LLVMValueRef FooVal1 = LLVMConstInt(I64Ty, 0, false);
   LLVMMetadataRef FooVarValueExpr1 =
       LLVMDIBuilderCreateConstantValueExpression(DIB, 0);
 
@@ -190,7 +191,7 @@ int llvm_test_dibuilder(void) {
 
   LLVMMetadataRef FooVar2 = LLVMDIBuilderCreateAutoVariable(
       DIB, FooLexicalBlock, "e", 1, File, 44, Int64Ty, true, 0, 0);
-  LLVMValueRef FooVal2 = LLVMConstInt(LLVMInt64Type(), 1, false);
+  LLVMValueRef FooVal2 = LLVMConstInt(I64Ty, 1, false);
   LLVMMetadataRef FooVarValueExpr2 =
       LLVMDIBuilderCreateConstantValueExpression(DIB, 1);
 
@@ -238,8 +239,8 @@ int llvm_test_dibuilder(void) {
       M, "LargeEnumTest",
       LLVMMetadataAsValue(LLVMGetModuleContext(M), LargeEnumTest));
 
-  LLVMValueRef FooVal3 = LLVMConstInt(LLVMInt64Type(), 8, false);
-  LLVMValueRef FooVal4 = LLVMConstInt(LLVMInt64Type(), 4, false);
+  LLVMValueRef FooVal3 = LLVMConstInt(I64Ty, 8, false);
+  LLVMValueRef FooVal4 = LLVMConstInt(I64Ty, 4, false);
   LLVMMetadataRef lo = LLVMValueAsMetadata(FooVal1);
   LLVMMetadataRef hi = LLVMValueAsMetadata(FooVal2);
   LLVMMetadataRef strd = LLVMValueAsMetadata(FooVal3);
@@ -408,13 +409,14 @@ int llvm_test_dibuilder(void) {
   LLVMDisposeBuilder(Builder);
   LLVMDisposeDIBuilder(DIB);
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_get_di_tag(void) {
-  LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
-  LLVMContextRef Context = LLVMGetModuleContext(M);
+  LLVMContextRef Context = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext("Mod", Context);
 
   const char String[] = "foo";
   LLVMMetadataRef StringMD =
@@ -437,12 +439,14 @@ int llvm_get_di_tag(void) {
 
   LLVMDisposeDIBuilder(Builder);
   LLVMDisposeModule(M);
+  LLVMContextDispose(Context);
 
   return 0;
 }
 
 int llvm_di_type_get_name(void) {
-  LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext("Mod", C);
 
   LLVMDIBuilderRef Builder = LLVMCreateDIBuilder(M);
   const char Filename[] = "metadata.c";
@@ -462,13 +466,15 @@ int llvm_di_type_get_name(void) {
 
   LLVMDisposeDIBuilder(Builder);
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_add_globaldebuginfo(void) {
   const char *Filename = "debuginfo.c";
-  LLVMModuleRef M = LLVMModuleCreateWithName(Filename);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext(Filename, C);
   LLVMDIBuilderRef Builder = LLVMCreateDIBuilder(M);
   LLVMMetadataRef File =
       LLVMDIBuilderCreateFile(Builder, Filename, strlen(Filename), ".", 1);
@@ -484,13 +490,12 @@ int llvm_add_globaldebuginfo(void) {
       Builder, File, "global", 6, "", 0, File, 1, Int64TypeDef, true,
       GlobalVarValueExpr, NULL, 0);
 
-  LLVMTypeRef RecType =
-      LLVMStructCreateNamed(LLVMGetModuleContext(M), "struct");
+  LLVMTypeRef RecType = LLVMStructCreateNamed(C, "struct");
   LLVMValueRef Global = LLVMAddGlobal(M, RecType, "global");
 
   LLVMGlobalAddDebugInfo(Global, GVE);
   // use AddMetadata to add twice
-  int kindId = LLVMGetMDKindID("dbg", 3);
+  int kindId = LLVMGetMDKindIDInContext(C, "dbg", 3);
   LLVMGlobalAddMetadata(Global, kindId, GVE);
   size_t numEntries;
   LLVMValueMetadataEntry *ME = LLVMGlobalCopyAllMetadata(Global, &numEntries);
@@ -500,6 +505,7 @@ int llvm_add_globaldebuginfo(void) {
   LLVMDisposeValueMetadataEntries(ME);
   LLVMDisposeDIBuilder(Builder);
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }

--- a/llvm/tools/llvm-c-test/diagnostic.c
+++ b/llvm/tools/llvm-c-test/diagnostic.c
@@ -45,7 +45,7 @@ static void diagnosticHandler(LLVMDiagnosticInfoRef DI, void *C) {
 static int handlerCalled = 0;
 
 int llvm_test_diagnostic_handler(void) {
-  LLVMContextRef C = LLVMGetGlobalContext();
+  LLVMContextRef C = LLVMContextCreate();
   LLVMContextSetDiagnosticHandler(C, diagnosticHandler, &handlerCalled);
 
   if (LLVMContextGetDiagnosticHandler(C) != diagnosticHandler) {
@@ -79,5 +79,6 @@ int llvm_test_diagnostic_handler(void) {
     fprintf(stderr, "Diagnostic handler was not called while loading module\n");
   }
 
+  LLVMContextDispose(C);
   return 0;
 }

--- a/llvm/tools/llvm-c-test/diagnostic.c
+++ b/llvm/tools/llvm-c-test/diagnostic.c
@@ -69,7 +69,7 @@ int llvm_test_diagnostic_handler(void) {
 
 
   LLVMModuleRef M;
-  int Ret = LLVMGetBitcodeModule2(MB, &M);
+  int Ret = LLVMGetBitcodeModuleInContext2(C, MB, &M);
   if (Ret)
     LLVMDisposeMemoryBuffer(MB);
 

--- a/llvm/tools/llvm-c-test/echo.cpp
+++ b/llvm/tools/llvm-c-test/echo.cpp
@@ -986,9 +986,10 @@ struct FunCloner {
         for (unsigned i = 0; i < NumMaskElts; i++) {
           int Val = LLVMGetMaskValue(Src, i);
           if (Val == LLVMGetUndefMaskElem()) {
-            MaskElts.push_back(LLVMGetUndef(LLVMInt64Type()));
+            MaskElts.push_back(LLVMGetUndef(LLVMInt64TypeInContext(Ctx)));
           } else {
-            MaskElts.push_back(LLVMConstInt(LLVMInt64Type(), Val, true));
+            MaskElts.push_back(
+                LLVMConstInt(LLVMInt64TypeInContext(Ctx), Val, true));
           }
         }
         LLVMValueRef Mask = LLVMConstVector(MaskElts.data(), NumMaskElts);
@@ -1115,7 +1116,8 @@ struct FunCloner {
     if (Name != VName)
       report_fatal_error("Basic block name mismatch");
 
-    LLVMBasicBlockRef BB = LLVMAppendBasicBlock(Fun, Name);
+    LLVMContextRef Ctx = LLVMGetModuleContext(M);
+    LLVMBasicBlockRef BB = LLVMAppendBasicBlockInContext(Ctx, Fun, Name);
     return BBMap[Src] = BB;
   }
 

--- a/llvm/tools/llvm-c-test/metadata.c
+++ b/llvm/tools/llvm-c-test/metadata.c
@@ -19,37 +19,41 @@
 #include <string.h>
 
 int llvm_add_named_metadata_operand(void) {
-  LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
-  LLVMValueRef Int = LLVMConstInt(LLVMInt32Type(), 0, 0);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext("Mod", C);
+  LLVMValueRef Int = LLVMConstInt(LLVMInt32TypeInContext(C), 0, 0);
 
   // This used to trigger an assertion
-  LLVMAddNamedMetadataOperand(M, "name", LLVMMDNode(&Int, 1));
+  LLVMAddNamedMetadataOperand(M, "name", LLVMMDNodeInContext(C, &Int, 1));
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_set_metadata(void) {
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(C);
 
   // This used to trigger an assertion
   LLVMValueRef Return = LLVMBuildRetVoid(Builder);
 
   const char Name[] = "kind";
-  LLVMValueRef Int = LLVMConstInt(LLVMInt32Type(), 0, 0);
-  LLVMSetMetadata(Return, LLVMGetMDKindID(Name, strlen(Name)),
-                  LLVMMDNode(&Int, 1));
+  LLVMValueRef Int = LLVMConstInt(LLVMInt32TypeInContext(C), 0, 0);
+  LLVMSetMetadata(Return, LLVMGetMDKindIDInContext(C, Name, strlen(Name)),
+                  LLVMMDNodeInContext(C, &Int, 1));
 
   LLVMDisposeBuilder(Builder);
   LLVMDeleteInstruction(Return);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_replace_md_operand(void) {
-  LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
-  LLVMContextRef Context = LLVMGetModuleContext(M);
+  LLVMContextRef Context = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext("Mod", Context);
 
   const char String1[] = "foo";
   LLVMMetadataRef String1MD =
@@ -71,17 +75,18 @@ int llvm_replace_md_operand(void) {
   (void)String;
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(Context);
 
   return 0;
 }
 
 int llvm_is_a_value_as_metadata(void) {
-  LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
-  LLVMContextRef Context = LLVMGetModuleContext(M);
+  LLVMContextRef Context = LLVMContextCreate();
+  LLVMModuleRef M = LLVMModuleCreateWithNameInContext("Mod", Context);
 
   {
-    LLVMValueRef Int = LLVMConstInt(LLVMInt32Type(), 0, 0);
-    LLVMValueRef NodeMD = LLVMMDNode(&Int, 1);
+    LLVMValueRef Int = LLVMConstInt(LLVMInt32TypeInContext(Context), 0, 0);
+    LLVMValueRef NodeMD = LLVMMDNodeInContext(Context, &Int, 1);
     assert(LLVMIsAValueAsMetadata(NodeMD) == NodeMD);
     (void)NodeMD;
   }
@@ -95,6 +100,9 @@ int llvm_is_a_value_as_metadata(void) {
     assert(LLVMIsAValueAsMetadata(Value) == NULL);
     (void)Value;
   }
+
+  LLVMDisposeModule(M);
+  LLVMContextDispose(Context);
 
   return 0;
 }

--- a/llvm/tools/llvm-c-test/module.c
+++ b/llvm/tools/llvm-c-test/module.c
@@ -61,19 +61,22 @@ LLVMModuleRef llvm_load_module(LLVMContextRef C, bool Lazy, bool New) {
 }
 
 int llvm_module_dump(bool Lazy, bool New) {
-  LLVMModuleRef M = llvm_load_module(LLVMGetGlobalContext(), Lazy, New);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = llvm_load_module(C, Lazy, New);
 
   char *irstr = LLVMPrintModuleToString(M);
   puts(irstr);
   LLVMDisposeMessage(irstr);
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_module_list_functions(void) {
-  LLVMModuleRef M = llvm_load_module(LLVMGetGlobalContext(), false, false);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = llvm_load_module(C, false, false);
   LLVMValueRef f;
 
   f = LLVMGetFirstFunction(M);
@@ -109,12 +112,14 @@ int llvm_module_list_functions(void) {
   }
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_module_list_globals(void) {
-  LLVMModuleRef M = llvm_load_module(LLVMGetGlobalContext(), false, false);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMModuleRef M = llvm_load_module(C, false, false);
   LLVMValueRef g;
 
   g = LLVMGetFirstGlobal(M);
@@ -132,6 +137,7 @@ int llvm_module_list_globals(void) {
   }
 
   LLVMDisposeModule(M);
+  LLVMContextDispose(C);
 
   return 0;
 }

--- a/llvm/tools/llvm-c-test/object.c
+++ b/llvm/tools/llvm-c-test/object.c
@@ -19,7 +19,6 @@
 
 int llvm_object_list_sections(void) {
   LLVMMemoryBufferRef MB;
-  LLVMBinaryRef O;
   LLVMSectionIteratorRef sect;
 
   char *outBufferErr = NULL;
@@ -30,7 +29,8 @@ int llvm_object_list_sections(void) {
   }
 
   char *outBinaryErr = NULL;
-  O = LLVMCreateBinary(MB, LLVMGetGlobalContext(), &outBinaryErr);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMBinaryRef O = LLVMCreateBinary(MB, C, &outBinaryErr);
   if (!O || outBinaryErr) {
     fprintf(stderr, "Error reading object: %s\n", outBinaryErr);
     free(outBinaryErr);
@@ -50,13 +50,13 @@ int llvm_object_list_sections(void) {
   LLVMDisposeBinary(O);
 
   LLVMDisposeMemoryBuffer(MB);
+  LLVMContextDispose(C);
 
   return 0;
 }
 
 int llvm_object_list_symbols(void) {
   LLVMMemoryBufferRef MB;
-  LLVMBinaryRef O;
   LLVMSectionIteratorRef sect;
   LLVMSymbolIteratorRef sym;
 
@@ -68,7 +68,8 @@ int llvm_object_list_symbols(void) {
   }
 
   char *outBinaryErr = NULL;
-  O = LLVMCreateBinary(MB, LLVMGetGlobalContext(), &outBinaryErr);
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMBinaryRef O = LLVMCreateBinary(MB, C, &outBinaryErr);
   if (!O || outBinaryErr) {
     fprintf(stderr, "Error reading object: %s\n", outBinaryErr);
     free(outBinaryErr);
@@ -92,6 +93,7 @@ int llvm_object_list_symbols(void) {
   LLVMDisposeBinary(O);
 
   LLVMDisposeMemoryBuffer(MB);
+  LLVMContextDispose(C);
 
   return 0;
 }

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -842,7 +842,7 @@ TEST(ConstantsTest, Float128Test) {
   LLVMTypeRef TyFloat = LLVMFloatTypeInContext(C);
   LLVMTypeRef TyDouble = LLVMDoubleTypeInContext(C);
   LLVMTypeRef TyHalf = LLVMHalfTypeInContext(C);
-  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  LLVMBuilderRef Builder = LLVMCreateBuilderInContext(C);
   uint64_t n[2] = {0x4000000000000000, 0x0}; //+2
   uint64_t m[2] = {0xC000000000000000, 0x0}; //-2
   LLVMValueRef val1 = LLVMConstFPFromBits(Ty128, n);


### PR DESCRIPTION
One of the most common mistakes when working with the LLVM C API is to mix functions that work on the global context and those that work on an explicit context. This often results in seemingly nonsensical errors because types from different contexts are mixed.

We have considered the APIs working on the global context to be obsolete for a long time already, and do not add any new APIs using the global context. However, the fact that these still exist (and have shorter names) continues to cause issues.

This PR proposes to deprecate these APIs, with intent to remove them at some point in the future.

RFC: https://discourse.llvm.org/t/rfc-deprecate-c-api-functions-using-the-global-context/88639