### PR TITLE
[MLIR][XeGPU] Improve `xegpu::uArch` design

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/uArch/IntelGpuXe2.h
+++ b/mlir/include/mlir/Dialect/XeGPU/uArch/IntelGpuXe2.h
@@ -49,7 +49,9 @@ protected:
 struct StoreNdInstruction : public Instruction {
   StoreNdInstruction()
       : Instruction(InstructionKind::STORE_ND, InstructionScope::Subgroup) {}
-
+  static bool classof(const Instruction *B) {
+    return B->getInstructionKind() == InstructionKind::STORE_ND;
+  }
   // Source :
   // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups.html#_add_a_new_section_6_13_x_sub_group_read_and_write_functions
   // Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from
@@ -63,7 +65,9 @@ struct StoreNdInstruction : public Instruction {
 struct LoadNdInstruction : public Instruction {
   LoadNdInstruction()
       : Instruction(InstructionKind::LOAD_ND, InstructionScope::Subgroup) {}
-
+  static bool classof(const Instruction *B) {
+    return B->getInstructionKind() == InstructionKind::LOAD_ND;
+  }
   // Source :
   // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups.html#_add_a_new_section_6_13_x_sub_group_read_and_write_functions
   // Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to
@@ -77,7 +81,9 @@ struct LoadNdInstruction : public Instruction {
 struct PrefetchNdInstruction : public Instruction {
   PrefetchNdInstruction()
       : Instruction(InstructionKind::PREFETCH_ND, InstructionScope::Subgroup) {}
-
+  static bool classof(const Instruction *B) {
+    return B->getInstructionKind() == InstructionKind::PREFETCH_ND;
+  }
   // Source :
   // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroup_buffer_prefetch.html#_add_a_new_section_6_15_x_sub_group_prefetch_functions
   llvm::ArrayRef<int> getSortedLaneVectorLengths(int elementBitwidth) const {
@@ -103,6 +109,9 @@ struct DPASInstruction : public Instruction, public MMAInstructionInterface {
         packedFormatBitSizeA(packedFormatBitSizeA),
         packedFormatBitSizeB(packedFormatBitSizeB),
         packedFormatBitSizeC(packedFormatBitSizeC) {}
+  static bool classof(const Instruction *B) {
+    return B->getInstructionKind() == InstructionKind::DPAS;
+  }
   // Source:
   // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroup_matrix_multiply_accumulate.html
 
@@ -146,16 +155,20 @@ protected:
 //===----------------------------------------------------------------------===//
 
 struct PVCuArch final : public Xe2Plus {
-  inline static const DPASInstruction dpasInst{16, 32, 32};
-  inline static const StoreNdInstruction loadNdInst;
-  inline static const StoreNdInstruction storeNdInst;
-  inline static const PrefetchNdInstruction prefetchNdInst;
-  inline static const Instruction *const instructionRegistryArr[] = {
-      &dpasInst, &loadNdInst, &storeNdInst, &prefetchNdInst};
+  static llvm::ArrayRef<const Instruction *> getInstructionRegistryArr() {
+    static const DPASInstruction dpasInst{16, 32, 32};
+    static const StoreNdInstruction loadNdInst;
+    static const StoreNdInstruction storeNdInst;
+    static const PrefetchNdInstruction prefetchNdInst;
+    static const Instruction *arr[] = {&dpasInst, &loadNdInst, &storeNdInst,
+                                       &prefetchNdInst};
+    return arr;
+  }
+
   PVCuArch()
       : Xe2Plus("pvc",                        // archName
                 "Ponte Vecchio Architecture", // archDescription
-                instructionRegistryArr,
+                getInstructionRegistryArr(),
                 XeCoreInfo(8, SharedMemory(512 * 1024, 4), 8, 8) // xeCore
         ) {}
   static const uArch *getInstance() {
@@ -165,16 +178,20 @@ struct PVCuArch final : public Xe2Plus {
 };
 
 struct BMGuArch : public Xe2Plus {
-  inline static const DPASInstruction dpasInst{16, 32, 32};
-  inline static const StoreNdInstruction loadNdInst;
-  inline static const StoreNdInstruction storeNdInst;
-  inline static const PrefetchNdInstruction prefetchNdInst;
-  inline static const Instruction *const instructionRegistryArr[] = {
-      &dpasInst, &loadNdInst, &storeNdInst, &prefetchNdInst};
+  static llvm::ArrayRef<const Instruction *> getInstructionRegistryArr() {
+    static const DPASInstruction dpasInst{16, 32, 32};
+    static const StoreNdInstruction loadNdInst;
+    static const StoreNdInstruction storeNdInst;
+    static const PrefetchNdInstruction prefetchNdInst;
+    static const Instruction *arr[] = {&dpasInst, &loadNdInst, &storeNdInst,
+                                       &prefetchNdInst};
+    return arr;
+  }
+
   BMGuArch()
       : Xe2Plus("bmg",                     // archName
                 "Battlemage Architecture", // archDescription
-                instructionRegistryArr,
+                getInstructionRegistryArr(),
                 XeCoreInfo(8, SharedMemory(256 * 1024, 4), 8, 8) // xeCore
         ) {}
   static const uArch *getInstance() {

--- a/mlir/include/mlir/Dialect/XeGPU/uArch/uArchBase.h
+++ b/mlir/include/mlir/Dialect/XeGPU/uArch/uArchBase.h
@@ -32,11 +32,11 @@ namespace uArch {
 // An enum class to represent the scope of an instruction
 enum class InstructionScope { Lane, Subgroup, Workgroup, Cluster };
 enum class InstructionKind {
-  DPAS,       // Dot Product Accumulate Systolic (DPAS) is a matrix
-              // multiply-add operation
-  STORE_ND,   // Subgroup-level 2D block write instruction
-  LOAD_ND,    // Subgroup-level 2D block load instruction
-  PREFETCH_ND // Subgroup-level 2D block prefetch instruction
+  SubgroupMatrixMultiplyAcc, // Dot Product Accumulate Systolic (DPAS) is a
+                             // matrix multiply-add operation
+  Subgroup2DBlockStore,      // Subgroup-level 2D block write instruction
+  Subgroup2DBlockLoad,       // Subgroup-level 2D block load instruction
+  Subgroup2DBlockPrefetch    // Subgroup-level 2D block prefetch instruction
   // @TODO: Add more instructions as needed
 };
 
@@ -55,13 +55,13 @@ struct Instruction {
   InstructionScope getScope() const { return scope; }
   static llvm::StringRef toString(InstructionKind instKind) {
     switch (instKind) {
-    case InstructionKind::DPAS:
+    case InstructionKind::SubgroupMatrixMultiplyAcc:
       return "dpas";
-    case InstructionKind::STORE_ND:
+    case InstructionKind::Subgroup2DBlockStore:
       return "store_nd";
-    case InstructionKind::LOAD_ND:
+    case InstructionKind::Subgroup2DBlockLoad:
       return "load_nd";
-    case InstructionKind::PREFETCH_ND:
+    case InstructionKind::Subgroup2DBlockPrefetch:
       return "prefetch_nd";
     }
     llvm_unreachable("Unknown InstructionKind");
@@ -70,7 +70,7 @@ struct Instruction {
   static std::optional<InstructionKind>
   parseInstructionKind(llvm::StringRef str) {
     if (str.equals_insensitive("dpas"))
-      return InstructionKind::DPAS;
+      return InstructionKind::SubgroupMatrixMultiplyAcc;
     return std::nullopt;
   }
 
@@ -150,8 +150,7 @@ struct uArch {
   StringRef getName() const { return name; }
   StringRef getDescription() const { return description; }
   virtual int getSubgroupSize() const = 0;
-  virtual unsigned getPackedFormatBitSize() const = 0;
-  virtual unsigned getPackedFormatBitSizeGatherScatter() const = 0;
+  virtual unsigned getGeneralPackedFormatBitSize() const = 0;
 
   const Instruction *getInstruction(InstructionKind instKind) const {
     auto it = instructionRegistry.find(instKind);

--- a/mlir/include/mlir/Dialect/XeGPU/uArch/uArchBase.h
+++ b/mlir/include/mlir/Dialect/XeGPU/uArch/uArchBase.h
@@ -49,7 +49,7 @@ struct Instruction {
   Instruction(InstructionKind kind, InstructionScope scope)
       : instKind(kind), scope(scope) {}
 
-  virtual ~Instruction() = default;
+  ~Instruction() = default;
   // Get methods
   InstructionKind getInstructionKind() const { return instKind; }
   InstructionScope getScope() const { return scope; }


### PR DESCRIPTION
This PR focuses on improving general `xegpu::uArch` design to make it both easier to understand and use (faster is optional).  It is a part of https://github.com/llvm/llvm-project/pull/163801, where we apply `xegpu::uArch` inside xegpu's distribution passes. I try to preserve parts that we need, but remain open to leaving grf and cache info in the base class.