### PR TITLE
[Clang] Handle ?: operator in fold expression

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -9239,6 +9239,9 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
       commonExpr = MatExpr.get();
     }
 
+    if (commonExpr->getDependence() & ExprDependence::UnexpandedPack)
+      return ExprError();
+
     opaqueValue = new (Context) OpaqueValueExpr(commonExpr->getExprLoc(),
                                                 commonExpr->getType(),
                                                 commonExpr->getValueKind(),

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1517,7 +1517,7 @@ static void CheckFoldOperand(Sema &S, Expr *E) {
   E = E->IgnoreImpCasts();
   auto *OCE = dyn_cast<CXXOperatorCallExpr>(E);
   if ((OCE && OCE->isInfixBinaryOp()) || isa<BinaryOperator>(E) ||
-      isa<AbstractConditionalOperator>(E)) {
+      isa<AbstractConditionalOperator>(E) || isa<RecoveryExpr>(E)) {
     S.Diag(E->getExprLoc(), diag::err_fold_expression_bad_operand)
         << E->getSourceRange()
         << FixItHint::CreateInsertion(E->getBeginLoc(), "(")

--- a/clang/test/SemaCXX/fold_expr_typo.cpp
+++ b/clang/test/SemaCXX/fold_expr_typo.cpp
@@ -12,3 +12,8 @@ template <typename... U> struct A {
     foo<T>((... + static_cast<U>(1))); // expected-error {{expression contains unexpanded parameter pack 'T'}}
   }
 };
+
+template <typename ... T>
+void foo(T... Params) {
+  (Params ?: 1, ...); // expected-error {{expression not permitted as operand of fold expression}}
+}


### PR DESCRIPTION
Emit diagnostic when the fold operand produces a RecoveryExpr. This solves #162198 @shafik