### PR TITLE
[RFC][mlir] ViewLikeOpInterface method for detecting partial views.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.h
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 namespace fir {
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2875,8 +2875,8 @@ def fir_ConvertOp
     static bool canBeConverted(mlir::Type inType, mlir::Type outType);
     static bool areVectorsCompatible(mlir::Type inTy, mlir::Type outTy);
     mlir::Value getViewSource() { return getValue(); }
-    bool isSameStart() { return true; }
-    bool isCompleteView() { return true; }
+    bool isKnownToHaveSameStart() { return true; }
+    bool isKnownToBeCompleteView() { return true; }
   }];
   let hasCanonicalizer = 1;
 }

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -17,6 +17,7 @@
 include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "mlir/Dialect/Arith/IR/ArithOpsInterfaces.td"
 include "mlir/Dialect/LLVMIR/LLVMAttrDefs.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 include "flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.td"
 include "flang/Optimizer/Dialect/FIRDialect.td"
 include "flang/Optimizer/Dialect/FIRTypes.td"
@@ -1765,8 +1766,9 @@ def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store",
 // Record and array type operations
 //===----------------------------------------------------------------------===//
 
-def fir_ArrayCoorOp : fir_Op<"array_coor",
-    [NoMemoryEffect, AttrSizedOperandSegments]> {
+def fir_ArrayCoorOp
+    : fir_Op<"array_coor", [NoMemoryEffect, AttrSizedOperandSegments,
+                            ViewLikeOpInterface]> {
 
   let summary = "Find the coordinate of an element of an array";
 
@@ -1809,9 +1811,13 @@ def fir_ArrayCoorOp : fir_Op<"array_coor",
 
   let hasVerifier = 1;
   let hasCanonicalizer = 1;
+  let extraClassDeclaration = [{
+    mlir::Value getViewSource() { return getMemref(); }
+  }];
 }
 
-def fir_CoordinateOp : fir_Op<"coordinate_of", [NoMemoryEffect]> {
+def fir_CoordinateOp
+    : fir_Op<"coordinate_of", [NoMemoryEffect, ViewLikeOpInterface]> {
 
   let summary = "Finds the coordinate (location) of a value in memory";
 
@@ -1863,6 +1869,7 @@ def fir_CoordinateOp : fir_Op<"coordinate_of", [NoMemoryEffect]> {
   let extraClassDeclaration = [{
     constexpr static int32_t kDynamicIndex = std::numeric_limits<int32_t>::min();
     CoordinateIndicesAdaptor getIndices();
+    mlir::Value getViewSource() { return getRef(); }
   }];
 }
 
@@ -2828,7 +2835,8 @@ def fir_VolatileCastOp : fir_SimpleOneResultOp<"volatile_cast", [Pure]> {
   let hasFolder = 1;
 }
 
-def fir_ConvertOp : fir_SimpleOneResultOp<"convert", [NoMemoryEffect]> {
+def fir_ConvertOp
+    : fir_SimpleOneResultOp<"convert", [NoMemoryEffect, ViewLikeOpInterface]> {
   let summary = "encapsulates all Fortran entity type conversions";
 
   let description = [{
@@ -2866,6 +2874,9 @@ def fir_ConvertOp : fir_SimpleOneResultOp<"convert", [NoMemoryEffect]> {
     static bool isPointerCompatible(mlir::Type ty);
     static bool canBeConverted(mlir::Type inType, mlir::Type outType);
     static bool areVectorsCompatible(mlir::Type inTy, mlir::Type outTy);
+    mlir::Value getViewSource() { return getValue(); }
+    bool isSameStart() { return true; }
+    bool isCompleteView() { return true; }
   }];
   let hasCanonicalizer = 1;
 }

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -574,7 +574,7 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
           if (mlir::isa<fir::BaseBoxType>(v.getType()) &&
               !mlir::isa<fir::BaseBoxType>(ty))
             followBoxData = true;
-          if (!op.isSameStart())
+          if (!op.isKnownToHaveSameStart())
             approximateSource = true;
         })
         .Case<fir::PackArrayOp>([&](auto op) {

--- a/mlir/include/mlir/Analysis/AliasAnalysis.h
+++ b/mlir/include/mlir/Analysis/AliasAnalysis.h
@@ -35,9 +35,12 @@ public:
     /// The two locations may or may not alias. This is the least precise
     /// result.
     MayAlias,
-    /// The two locations alias, but only due to a partial overlap.
+    /// The two locations overlap in some way, regardless of whether
+    /// they start at the same address or not.
     PartialAlias,
-    /// The two locations precisely alias each other.
+    /// The two locations precisely alias each other, meaning that
+    /// they always start at exactly the same location.
+    /// This result does not imply that the pointers compare equal.
     MustAlias,
   };
 

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -2351,9 +2351,9 @@ def SubViewOp : MemRef_OpWithOffsetSizesAndStrides<"subview", [
     static FailureOr<Value> rankReduceIfNeeded(
       OpBuilder &b, Location loc, Value value, ArrayRef<int64_t> desiredShape);
 
-    /// Return true iff the input and the resulting views start
-    /// at the same address.
-    bool isSameStart();
+    /// Return true iff the input and the resulting views
+    /// are known to start at the same address.
+    bool isKnownToHaveSameStart();
   }];
 
   let hasCanonicalizer = 1;
@@ -2464,9 +2464,9 @@ def MemRef_ViewOp : MemRef_Op<"view", [
       return {getSizes().begin(), getSizes().end()};
     }
 
-    /// Return true iff the input and the resulting views start
-    /// at the same address.
-    bool isSameStart();
+    /// Return true iff the input and the resulting views
+    /// are known to start at the same address.
+    bool isKnownToHaveSameStart();
   }];
 
   let assemblyFormat = [{

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -2288,7 +2288,7 @@ def SubViewOp : MemRef_OpWithOffsetSizesAndStrides<"subview", [
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>
   ];
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
     /// Returns the type of the base memref operand.
     MemRefType getSourceType() {
       return ::llvm::cast<MemRefType>(getSource().getType());
@@ -2350,6 +2350,10 @@ def SubViewOp : MemRef_OpWithOffsetSizesAndStrides<"subview", [
     /// If the shape of `value` cannot be rank-reduced to `desiredShape`, fail.
     static FailureOr<Value> rankReduceIfNeeded(
       OpBuilder &b, Location loc, Value value, ArrayRef<int64_t> desiredShape);
+
+    /// Return true iff the input and the resulting views start
+    /// at the same address.
+    bool isSameStart();
   }];
 
   let hasCanonicalizer = 1;
@@ -2459,6 +2463,10 @@ def MemRef_ViewOp : MemRef_Op<"view", [
     operand_range getDynamicSizes() {
       return {getSizes().begin(), getSizes().end()};
     }
+
+    /// Return true iff the input and the resulting views start
+    /// at the same address.
+    bool isSameStart();
   }];
 
   let assemblyFormat = [{

--- a/mlir/include/mlir/Interfaces/ViewLikeInterface.td
+++ b/mlir/include/mlir/Interfaces/ViewLikeInterface.td
@@ -23,21 +23,45 @@ def ViewLikeOpInterface : OpInterface<"ViewLikeOpInterface"> {
   }];
   let cppNamespace = "::mlir";
 
-  let methods = [
-    InterfaceMethod<
-      "Returns the source buffer from which the view is created.",
-      "::mlir::Value", "getViewSource">,
-    InterfaceMethod<
-      /*desc=*/[{ Returns the buffer which the view created. }],
-      /*retTy=*/"::mlir::Value",
-      /*methodName=*/"getViewDest",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
+  let methods =
+      [InterfaceMethod<
+           "Returns the source buffer from which the view is created.",
+           "::mlir::Value", "getViewSource">,
+       InterfaceMethod<
+           /*desc=*/[{ Returns the buffer which the view created. }],
+           /*retTy=*/"::mlir::Value",
+           /*methodName=*/"getViewDest",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/[{
         return $_op->getResult(0);
-      }]
-    >
-  ];
+      }]>,
+       InterfaceMethod<
+           /*desc=*/
+           [{ Returns true iff the source buffer and the resulting view start at the same "address". }],
+           /*retTy=*/"bool",
+           /*methodName=*/"isSameStart",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/[{
+        return false;
+      }]>,
+       InterfaceMethod<
+           /*desc=*/
+           [{ Returns true iff the resulting view is a complete view of the source buffer, i.e. isSameStart() is true and the result has the same total size and is not a subview of the input. }],
+           /*retTy=*/"bool",
+           /*methodName=*/"isCompleteView",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/[{
+        return false;
+      }]>];
+
+  let verify = [{
+    auto concreteOp = ::mlir::cast<ConcreteOp>($_op);
+    // isCompleteView() == true implies isSameStart() == true.
+    return !concreteOp.isCompleteView() || concreteOp.isSameStart() ? ::mlir::success() : ::mlir::failure();
+  }];
 }
 
 def OffsetSizeAndStrideOpInterface : OpInterface<"OffsetSizeAndStrideOpInterface"> {

--- a/mlir/include/mlir/Interfaces/ViewLikeInterface.td
+++ b/mlir/include/mlir/Interfaces/ViewLikeInterface.td
@@ -38,9 +38,12 @@ def ViewLikeOpInterface : OpInterface<"ViewLikeOpInterface"> {
       }]>,
        InterfaceMethod<
            /*desc=*/
-           [{ Returns true iff the source buffer and the resulting view start at the same "address". }],
+           [{
+             Returns true iff the source buffer and the resulting view
+             are known to start at the same "address".
+           }],
            /*retTy=*/"bool",
-           /*methodName=*/"isSameStart",
+           /*methodName=*/"isKnownToHaveSameStart",
            /*args=*/(ins),
            /*methodBody=*/"",
            /*defaultImplementation=*/[{
@@ -48,9 +51,14 @@ def ViewLikeOpInterface : OpInterface<"ViewLikeOpInterface"> {
       }]>,
        InterfaceMethod<
            /*desc=*/
-           [{ Returns true iff the resulting view is a complete view of the source buffer, i.e. isSameStart() is true and the result has the same total size and is not a subview of the input. }],
+           [{
+             Returns true iff the resulting view is known to be
+             a complete view of the source buffer, i.e.
+             isKnownToHaveSameStart() is true and the result
+             has the same total size and is not a subview of the input.
+           }],
            /*retTy=*/"bool",
-           /*methodName=*/"isCompleteView",
+           /*methodName=*/"isKnownToBeCompleteView",
            /*args=*/(ins),
            /*methodBody=*/"",
            /*defaultImplementation=*/[{
@@ -59,8 +67,8 @@ def ViewLikeOpInterface : OpInterface<"ViewLikeOpInterface"> {
 
   let verify = [{
     auto concreteOp = ::mlir::cast<ConcreteOp>($_op);
-    // isCompleteView() == true implies isSameStart() == true.
-    return !concreteOp.isCompleteView() || concreteOp.isSameStart() ? ::mlir::success() : ::mlir::failure();
+    // isKnownToBeCompleteView() == true implies isKnownToHaveSameStart() == true.
+    return !concreteOp.isKnownToBeCompleteView() || concreteOp.isKnownToHaveSameStart() ? ::mlir::success() : ::mlir::failure();
   }];
 }
 

--- a/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
+++ b/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
@@ -105,7 +105,8 @@ static void collectUnderlyingAddressValues(
     if (result == view.getViewDest()) {
       LDBG() << "  Unwrapping view to source: " << view.getViewSource();
       return collectUnderlyingAddressValues(
-          view.getViewSource(), maxDepth, visited, !view.isSameStart(), output);
+          view.getViewSource(), maxDepth, visited,
+          !view.isKnownToHaveSameStart(), output);
     }
   }
   // Check to see if we can reason about the control flow of this op.

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -3039,7 +3039,7 @@ void SubViewOp::build(OpBuilder &b, OperationState &result, Value source,
 /// For ViewLikeOpInterface.
 Value SubViewOp::getViewSource() { return getSource(); }
 
-bool SubViewOp::isSameStart() {
+bool SubViewOp::isKnownToHaveSameStart() {
   // TODO: we can recognize simple constant operands.
   if (!getOffsets().empty())
     return false;
@@ -3687,7 +3687,7 @@ LogicalResult ViewOp::verify() {
 
 Value ViewOp::getViewSource() { return getSource(); }
 
-bool ViewOp::isSameStart() {
+bool ViewOp::isKnownToHaveSameStart() {
   IntegerAttr offsetAttr;
   if (matchPattern(getByteShift(), m_Constant(&offsetAttr)))
     return offsetAttr.getValue().isZero();

--- a/mlir/test/Analysis/test-alias-analysis-extending.mlir
+++ b/mlir/test/Analysis/test-alias-analysis-extending.mlir
@@ -6,10 +6,19 @@
 // CHECK-DAG: view1#0 <-> view2#0: NoAlias
 // CHECK-DAG: view1#0 <-> func.region0#0: MustAlias
 // CHECK-DAG: view1#0 <-> func.region0#1: NoAlias
+// CHECK-DAG: view1#0 <-> view3#0: MayAlias
+// CHECK-DAG: view1#0 <-> view4#0: NoAlias
 // CHECK-DAG: view2#0 <-> func.region0#0: NoAlias
 // CHECK-DAG: view2#0 <-> func.region0#1: MustAlias
+// CHECK-DAG: view2#0 <-> view3#0: NoAlias
+// CHECK-DAG: view2#0 <-> view4#0: MayAlias
+// CHECK-DAG: view3#0 <-> func.region0#0: MayAlias
+// CHECK-DAG: view3#0 <-> func.region0#1: NoAlias
+// CHECK-DAG: view3#0 <-> view4#0: NoAlias
 func.func @restrict(%arg: memref<?xf32>, %arg1: memref<?xf32> {local_alias_analysis.restrict}) attributes {test.ptr = "func"} {
   %0 = memref.subview %arg[0][2][1] {test.ptr = "view1"} : memref<?xf32> to memref<2xf32>
   %1 = memref.subview %arg1[0][2][1] {test.ptr = "view2"} : memref<?xf32> to memref<2xf32>
+  %2 = memref.subview %arg[1][2][1] {test.ptr = "view3"} : memref<?xf32> to memref<2xf32, strided<[1], offset: 1>>
+  %3 = memref.subview %arg1[1][2][1] {test.ptr = "view4"} : memref<?xf32> to memref<2xf32, strided<[1], offset: 1>>
   return
 }


### PR DESCRIPTION
I am trying to simplify the implementation of Flang's AliasAnalysis
by using ViewLikeOpInterface for some FIR dialect operations.
Currently, Flang's AliasAnalysis implementation explicitly recognizes
specific set of operations, which is inconvenient.
ViewLikeOpInterface may also be used in other parts of Flang.

This patch adds isKnownToHaveSameStart() method to detect
cases where the input and resulting views may be different
by an offset, in which case FIR alias analysis must not return
`MustAlias`.

New method isKnownToBeCompleteView() returns true iff
the resulting view is a complete view of the input view.
This method will be used by the following patches for OpenACC
support in Flang.

This patch also modifies LocalAliasAnalysis to stop returning
`MustAlias` in cases where both `MustAlias` and `PartialAlias`
are possible - we will return `MayAlias` now, which is conservatively
correct.