### PR TITLE
[ADT] Use CMake to detect host endianness (NFC)

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1079,6 +1079,15 @@ if(NOT LLVM_ENABLE_NEW_PASS_MANAGER)
                       " no longer supported.")
 endif()
 
+# Determine host endianness.
+if(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+  set(LLVM_HOST_IS_BIG_ENDIAN 1)
+elseif(CMAKE_CXX_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
+  set(LLVM_HOST_IS_BIG_ENDIAN 0)
+else()
+  message(FATAL_ERROR "Unsupported CMAKE_CXX_BYTE_ORDER: ${CMAKE_CXX_BYTE_ORDER}")
+endif()
+
 include(HandleLLVMOptions)
 
 ######

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ADT_BIT_H
 #define LLVM_ADT_BIT_H
 
+#include "llvm/Config/config.h"
 #include "llvm/Support/Compiler.h"
 #include <cstddef> // for std::size_t
 #include <cstdint>
@@ -26,32 +27,6 @@
 
 #if defined(_MSC_VER) && !defined(_DEBUG)
 #include <cstdlib>  // for _byteswap_{ushort,ulong,uint64}
-#endif
-
-#if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__) ||            \
-    defined(__Fuchsia__) || defined(__EMSCRIPTEN__) || defined(__NetBSD__) ||  \
-    defined(__OpenBSD__) || defined(__DragonFly__) || defined(__managarm__)
-#include <endian.h>
-#elif defined(_AIX)
-#include <sys/machine.h>
-#elif defined(__sun)
-/* Solaris provides _BIG_ENDIAN/_LITTLE_ENDIAN selector in sys/types.h */
-#include <sys/types.h>
-#define BIG_ENDIAN 4321
-#define LITTLE_ENDIAN 1234
-#if defined(_BIG_ENDIAN)
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
-#elif defined(__MVS__)
-#define BIG_ENDIAN 4321
-#define LITTLE_ENDIAN 1234
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#if !defined(BYTE_ORDER) && !defined(_WIN32)
-#include <machine/endian.h>
-#endif
 #endif
 
 #ifdef _MSC_VER
@@ -71,7 +46,7 @@ namespace llvm {
 enum class endianness {
   big,
   little,
-#if defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN
+#if LLVM_HOST_IS_BIG_ENDIAN
   native = big
 #else
   native = little

--- a/llvm/include/llvm/Config/config.h.cmake
+++ b/llvm/include/llvm/Config/config.h.cmake
@@ -10,6 +10,9 @@
 /* Bug report URL. */
 #define BUG_REPORT_URL "${BUG_REPORT_URL}"
 
+/* Define to 1 if the host is a big endian machine, and to 0 otherwise. */
+#cmakedefine01 LLVM_HOST_IS_BIG_ENDIAN
+
 /* Define to 1 to enable backtraces, and to 0 otherwise. */
 #cmakedefine01 ENABLE_BACKTRACES
 


### PR DESCRIPTION
This patch replaces the manual endian detection logic in ADT/bit.h
with CMake's CMAKE_CXX_BYTE_ORDER, freeing ourselves from the work
that the build system is already capable of.

The public interface, llvm::endianness, remains unchanged.
