### PR TITLE
[Support] Use an inherited constructor in DOTGraphTraits (NFC)

### DIFF
--- a/llvm/include/llvm/Support/DOTGraphTraits.h
+++ b/llvm/include/llvm/Support/DOTGraphTraits.h
@@ -164,7 +164,7 @@ public:
 ///
 template <typename Ty>
 struct DOTGraphTraits : public DefaultDOTGraphTraits {
-  DOTGraphTraits (bool simple=false) : DefaultDOTGraphTraits (simple) {}
+  using DefaultDOTGraphTraits::DefaultDOTGraphTraits;
 };
 
 } // End llvm namespace


### PR DESCRIPTION
This patch simplifies DOTGraphTraits with an inherited constructor.
This way, we do not need to repeat the constructor signature or
manually forward constructor arguments.
