### PR TITLE
[NFC][LLVM] Code cleanup in `llvm-xray`

### DIFF
--- a/llvm/tools/llvm-xray/func-id-helper.h
+++ b/llvm/tools/llvm-xray/func-id-helper.h
@@ -17,8 +17,7 @@
 #include "llvm/DebugInfo/Symbolize/Symbolize.h"
 #include <unordered_map>
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 // This class consolidates common operations related to Function IDs.
 class FuncIdConversionHelper {
@@ -45,7 +44,6 @@ public:
   std::string FileLineAndColumn(int32_t FuncId) const;
 };
 
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
 
 #endif // LLVM_TOOLS_LLVM_XRAY_FUNC_ID_HELPER_H

--- a/llvm/tools/llvm-xray/trie-node.h
+++ b/llvm/tools/llvm-xray/trie-node.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+namespace llvm {
 /// A type to represent a trie of invocations. It is useful to construct a
 /// graph of these nodes from reading an XRay trace, such that each function
 /// call can be placed in a larger context.
@@ -87,5 +88,6 @@ mergeTrieNodes(const TrieNode<T> &Left, const TrieNode<T> &Right,
 
   return Node;
 }
+} // namespace llvm
 
 #endif // LLVM_TOOLS_LLVM_XRAY_STACK_TRIE_H

--- a/llvm/tools/llvm-xray/xray-account.h
+++ b/llvm/tools/llvm-xray/xray-account.h
@@ -21,8 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/XRay/XRayRecord.h"
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 class LatencyAccountant {
 public:
@@ -107,7 +106,6 @@ private:
   template <class F> void exportStats(const XRayFileHeader &Header, F fn) const;
 };
 
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
 
 #endif // LLVM_TOOLS_LLVM_XRAY_XRAY_ACCOUNT_H

--- a/llvm/tools/llvm-xray/xray-color-helper.h
+++ b/llvm/tools/llvm-xray/xray-color-helper.h
@@ -16,8 +16,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include <tuple>
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 /// The color helper class it a healper class which allows you to easily get a
 /// color in a gradient. This is used to color-code edges in XRay-Graph tools.
@@ -82,6 +81,6 @@ public:
   // Convert a tuple to a string
   static std::string getColorString(std::tuple<uint8_t, uint8_t, uint8_t> t);
 };
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
+
 #endif

--- a/llvm/tools/llvm-xray/xray-converter.h
+++ b/llvm/tools/llvm-xray/xray-converter.h
@@ -17,8 +17,7 @@
 #include "llvm/XRay/Trace.h"
 #include "llvm/XRay/XRayRecord.h"
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 class TraceConverter {
   FuncIdConversionHelper &FuncIdHelper;
@@ -37,7 +36,6 @@ public:
   void exportAsChromeTraceEventFormat(const Trace &Records, raw_ostream &OS);
 };
 
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
 
 #endif // LLVM_TOOLS_LLVM_XRAY_XRAY_CONVERTER_H

--- a/llvm/tools/llvm-xray/xray-extract.cpp
+++ b/llvm/tools/llvm-xray/xray-extract.cpp
@@ -52,10 +52,8 @@ static cl::opt<bool> NoDemangle("no-demangle",
                                 cl::desc("don't demangle symbols"),
                                 cl::sub(Extract));
 
-namespace {
-
-void exportAsYAML(const InstrumentationMap &Map, raw_ostream &OS,
-                  FuncIdConversionHelper &FH) {
+static void exportAsYAML(const InstrumentationMap &Map, raw_ostream &OS,
+                         FuncIdConversionHelper &FH) {
   // First we translate the sleds into the YAMLXRaySledEntry objects in a deque.
   std::vector<YAMLXRaySledEntry> YAMLSleds;
   auto Sleds = Map.sleds();
@@ -71,8 +69,6 @@ void exportAsYAML(const InstrumentationMap &Map, raw_ostream &OS,
   Output Out(OS, nullptr, 0);
   Out << YAMLSleds;
 }
-
-} // namespace
 
 static CommandRegistration Unused(&Extract, []() -> Error {
   auto InstrumentationMapOrError = loadInstrumentationMap(ExtractInput);
@@ -94,8 +90,8 @@ static CommandRegistration Unused(&Extract, []() -> Error {
   if (Demangle.getPosition() < NoDemangle.getPosition())
     opts.Demangle = false;
   symbolize::LLVMSymbolizer Symbolizer(opts);
-  llvm::xray::FuncIdConversionHelper FuncIdHelper(ExtractInput, Symbolizer,
-                                                  FunctionAddresses);
+  FuncIdConversionHelper FuncIdHelper(ExtractInput, Symbolizer,
+                                      FunctionAddresses);
   exportAsYAML(*InstrumentationMapOrError, OS, FuncIdHelper);
   return Error::success();
 });

--- a/llvm/tools/llvm-xray/xray-graph-diff.cpp
+++ b/llvm/tools/llvm-xray/xray-graph-diff.cpp
@@ -236,6 +236,7 @@ Expected<GraphDiffRenderer> GraphDiffRenderer::Factory::getGraphDiffRenderer() {
 
   return R;
 }
+
 // Returns the Relative change With respect to LeftStat between LeftStat
 // and RightStat.
 static double statRelDiff(const GraphDiffRenderer::TimeStat &LeftStat,
@@ -363,9 +364,8 @@ void GraphDiffRenderer::exportGraphAsDOT(raw_ostream &OS, StatType EdgeLabel,
   StringMap<int32_t> VertexNo;
 
   int i = 0;
-  for (const auto &V : G.vertices()) {
+  for (const auto &V : G.vertices())
     VertexNo[V.first] = i++;
-  }
 
   ColorHelper H(ColorHelper::DivergingScheme::PiYG);
 

--- a/llvm/tools/llvm-xray/xray-graph-diff.h
+++ b/llvm/tools/llvm-xray/xray-graph-diff.h
@@ -17,8 +17,7 @@
 #include "xray-graph.h"
 #include "llvm/XRay/Graph.h"
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 // This class creates a graph representing the difference between two
 // xray-graphs And allows you to print it to a dot file, with optional color
@@ -66,7 +65,6 @@ public:
 
   const GraphT &getGraph() { return G; }
 };
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
 
 #endif

--- a/llvm/tools/llvm-xray/xray-graph.cpp
+++ b/llvm/tools/llvm-xray/xray-graph.cpp
@@ -153,7 +153,9 @@ static cl::opt<GraphRenderer::StatType> GraphVertexColorType(
 static cl::alias GraphVertexColorType2("b", cl::aliasopt(GraphVertexColorType),
                                        cl::desc("Alias for -edge-label"));
 
-template <class T> T diff(T L, T R) { return std::max(L, R) - std::min(L, R); }
+template <class T> static T diff(T L, T R) {
+  return std::max(L, R) - std::min(L, R);
+}
 
 // Updates the statistics for a GraphRenderer::TimeStat
 static void updateStat(GraphRenderer::TimeStat &S, int64_t L) {
@@ -459,10 +461,9 @@ Expected<GraphRenderer> GraphRenderer::Factory::getGraphRenderer() {
   symbolize::LLVMSymbolizer Symbolizer;
   const auto &Header = Trace.getFileHeader();
 
-  llvm::xray::FuncIdConversionHelper FuncIdHelper(InstrMap, Symbolizer,
-                                                  FunctionAddresses);
+  FuncIdConversionHelper FuncIdHelper(InstrMap, Symbolizer, FunctionAddresses);
 
-  xray::GraphRenderer GR(FuncIdHelper, DeduceSiblingCalls);
+  GraphRenderer GR(FuncIdHelper, DeduceSiblingCalls);
   for (const auto &Record : Trace) {
     auto E = GR.accountRecord(Record);
     if (!E)

--- a/llvm/tools/llvm-xray/xray-graph.h
+++ b/llvm/tools/llvm-xray/xray-graph.h
@@ -28,8 +28,7 @@
 #include "llvm/XRay/Trace.h"
 #include "llvm/XRay/XRayRecord.h"
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 /// A class encapsulating the logic related to analyzing XRay traces, producting
 /// Graphs from them and then exporting those graphs for review.
@@ -225,7 +224,6 @@ inline GraphRenderer::TimeStat operator/(const GraphRenderer::TimeStat &A,
           A.Pct90 / B.Pct90, A.Pct99 / B.Pct99, A.Max / B.Max,
           A.Sum / B.Sum};
 }
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
 
 #endif // XRAY_GRAPH_H

--- a/llvm/tools/llvm-xray/xray-registry.cpp
+++ b/llvm/tools/llvm-xray/xray-registry.cpp
@@ -13,8 +13,8 @@
 
 #include <unordered_map>
 
-namespace llvm {
-namespace xray {
+using namespace llvm;
+using namespace xray;
 
 using HandlerType = std::function<Error()>;
 
@@ -31,12 +31,9 @@ CommandRegistration::CommandRegistration(cl::SubCommand *SC,
   getCommands()[SC] = Command;
 }
 
-HandlerType dispatch(cl::SubCommand *SC) {
+HandlerType xray::dispatch(cl::SubCommand *SC) {
   auto It = getCommands().find(SC);
   assert(It != getCommands().end() &&
          "Attempting to dispatch on un-registered SubCommand.");
   return It->second;
 }
-
-} // namespace xray
-} // namespace llvm

--- a/llvm/tools/llvm-xray/xray-registry.h
+++ b/llvm/tools/llvm-xray/xray-registry.h
@@ -15,8 +15,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 
-namespace llvm {
-namespace xray {
+namespace llvm::xray {
 
 // Use |CommandRegistration| as a global initialiser that registers a function
 // and associates it with |SC|. This requires that a command has not been
@@ -34,7 +33,6 @@ struct CommandRegistration {
 // Requires that |SC| is not null and has an associated function to it.
 std::function<Error()> dispatch(cl::SubCommand *SC);
 
-} // namespace xray
-} // namespace llvm
+} // namespace llvm::xray
 
 #endif // TOOLS_LLVM_XRAY_XRAY_REGISTRY_H

--- a/llvm/tools/llvm-xray/xray-stacks.cpp
+++ b/llvm/tools/llvm-xray/xray-stacks.cpp
@@ -107,6 +107,8 @@ static cl::opt<AggregationType> RequestedAggregation(
                    "of all callees.")),
     cl::sub(Stack), cl::init(AggregationType::TOTAL_TIME));
 
+namespace {
+
 /// A helper struct to work with formatv and XRayRecords. Makes it easier to
 /// use instrumentation map names or addresses in formatted output.
 struct format_xray_record : public FormatAdapter<XRayRecord> {
@@ -252,10 +254,9 @@ private:
 /// maintain an index of unique functions, and provide a means of iterating
 /// through all the instrumented call stacks which we know about.
 
-namespace {
 struct StackDuration {
-  llvm::SmallVector<int64_t, 4> TerminalDurations;
-  llvm::SmallVector<int64_t, 4> IntermediateDurations;
+  SmallVector<int64_t, 4> TerminalDurations;
+  SmallVector<int64_t, 4> IntermediateDurations;
 };
 } // namespace
 
@@ -310,6 +311,7 @@ std::size_t GetValueForStack(const StackTrieNode *Node) {
   return 0;
 }
 
+namespace {
 class StackTrie {
   // Avoid the magic number of 4 propagated through the code with an alias.
   // We use this SmallVector to track the root nodes in a call graph.
@@ -649,6 +651,7 @@ public:
     OS << "\n";
   }
 };
+} // namespace
 
 static std::string CreateErrorMessage(StackTrie::AccountRecordStatus Error,
                                       const XRayRecord &Record,


### PR DESCRIPTION
- Use nested namespace definitions in header files.
- Mark file local function static and enclods file local structs in anonymous namespace.
- Drop some unnecessary namespace qualifiers.