### PR TITLE
[NFCI][LLVM] Remove `raw_string_ostream::flush` calls

### DIFF
--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -1813,7 +1813,6 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
 
     raw_string_ostream OS(Result);
     OS << "color=\"red\"";
-    OS.flush();
     return Result;
   }
 
@@ -1872,8 +1871,6 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
         OS << ",color=\"red\"";
       }
     }
-
-    OS.flush();
     return Str;
   }
 };

--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -1811,8 +1811,7 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
     if (Freq < HotFreq)
       return Result;
 
-    raw_string_ostream OS(Result);
-    OS << "color=\"red\"";
+    raw_string_ostream(Result) << "color=\"red\"";
     return Result;
   }
 
@@ -1867,9 +1866,8 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
       BlockFrequency HotFreq = BlockFrequency(MaxFrequency) *
                                BranchProbability(HotPercentThreshold, 100);
 
-      if (EFreq >= HotFreq) {
+      if (EFreq >= HotFreq)
         OS << ",color=\"red\"";
-      }
     }
     return Str;
   }

--- a/llvm/include/llvm/Analysis/LazyCallGraph.h
+++ b/llvm/include/llvm/Analysis/LazyCallGraph.h
@@ -513,7 +513,6 @@ public:
       std::string Name;
       raw_string_ostream OS(Name);
       OS << *this;
-      OS.flush();
       return Name;
     }
   };
@@ -654,7 +653,6 @@ public:
       std::string Name;
       raw_string_ostream OS(Name);
       OS << *this;
-      OS.flush();
       return Name;
     }
 

--- a/llvm/include/llvm/Analysis/LazyCallGraph.h
+++ b/llvm/include/llvm/Analysis/LazyCallGraph.h
@@ -511,8 +511,7 @@ public:
     /// while still making the use of this in debugging and logging useful.
     std::string getName() const {
       std::string Name;
-      raw_string_ostream OS(Name);
-      OS << *this;
+      raw_string_ostream(Name) << *this;
       return Name;
     }
   };
@@ -651,8 +650,7 @@ public:
     /// while still making the use of this in debugging and logging useful.
     std::string getName() const {
       std::string Name;
-      raw_string_ostream OS(Name);
-      OS << *this;
+      raw_string_ostream(Name) << *this;
       return Name;
     }
 

--- a/llvm/include/llvm/Support/FormatVariadic.h
+++ b/llvm/include/llvm/Support/FormatVariadic.h
@@ -104,7 +104,6 @@ public:
     std::string Result;
     raw_string_ostream Stream(Result);
     Stream << *this;
-    Stream.flush();
     return Result;
   }
 

--- a/llvm/include/llvm/Support/FormatVariadic.h
+++ b/llvm/include/llvm/Support/FormatVariadic.h
@@ -102,15 +102,13 @@ public:
 
   std::string str() const {
     std::string Result;
-    raw_string_ostream Stream(Result);
-    Stream << *this;
+    raw_string_ostream(Result) << *this;
     return Result;
   }
 
   template <unsigned N> SmallString<N> sstr() const {
     SmallString<N> Result;
-    raw_svector_ostream Stream(Result);
-    Stream << *this;
+    raw_svector_ostream(Result) << *this;
     return Result;
   }
 

--- a/llvm/lib/Analysis/ImportedFunctionsInliningStatistics.cpp
+++ b/llvm/lib/Analysis/ImportedFunctionsInliningStatistics.cpp
@@ -167,7 +167,6 @@ void ImportedFunctionsInliningStatistics::dump(const bool Verbose) {
                  "non-imported functions inlined into importing module",
                  InlinedNotImportedFunctionsToImportingModuleCount,
                  NotImportedFuncCount, "non-imported functions");
-  Ostream.flush();
   dbgs() << Out;
 }
 

--- a/llvm/lib/CodeGen/MIRCanonicalizerPass.cpp
+++ b/llvm/lib/CodeGen/MIRCanonicalizerPass.cpp
@@ -96,7 +96,6 @@ rescheduleLexographically(std::vector<MachineInstr *> instructions,
     std::string S;
     raw_string_ostream OS(S);
     II->print(OS);
-    OS.flush();
 
     // Trim the assignment, or start from the beginning in the case of a store.
     const size_t i = S.find('=');

--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -700,7 +700,6 @@ static std::string getBlockName(const MachineBasicBlock *BB) {
   raw_string_ostream OS(Result);
   OS << printMBBReference(*BB);
   OS << " ('" << BB->getName() << "')";
-  OS.flush();
   return Result;
 }
 #endif

--- a/llvm/lib/CodeGen/ModuloSchedule.cpp
+++ b/llvm/lib/CodeGen/ModuloSchedule.cpp
@@ -2033,7 +2033,6 @@ void PeelingModuloScheduleExpander::validateAgainstModuloScheduleExpander() {
   std::string ScheduleDump;
   raw_string_ostream OS(ScheduleDump);
   Schedule.print(OS);
-  OS.flush();
 
   // First, run the normal ModuleScheduleExpander. We don't support any
   // InstrChanges.

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1953,7 +1953,6 @@ void TargetLoweringObjectFileCOFF::emitLinkerDirectives(
     raw_string_ostream OS(Flags);
     emitLinkerFlagsForGlobalCOFF(OS, &GV, getContext().getTargetTriple(),
                                  getMangler());
-    OS.flush();
     if (!Flags.empty()) {
       Streamer.switchSection(getDrectveSection());
       Streamer.emitBytes(Flags);
@@ -1978,7 +1977,6 @@ void TargetLoweringObjectFileCOFF::emitLinkerDirectives(
         raw_string_ostream OS(Flags);
         emitLinkerFlagsForUsedCOFF(OS, GV, getContext().getTargetTriple(),
                                    getMangler());
-        OS.flush();
 
         if (!Flags.empty()) {
           Streamer.switchSection(getDrectveSection());

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -234,7 +234,6 @@ bool DWARFVerifier::verifyName(const DWARFDie &Die) {
   raw_string_ostream OS(ReconstructedName);
   std::string OriginalFullName;
   Die.getFullName(OS, &OriginalFullName);
-  OS.flush();
   if (OriginalFullName.empty() || OriginalFullName == ReconstructedName)
     return false;
 

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -564,7 +564,6 @@ llvm::Error GsymCreator::saveSegments(StringRef Path,
       std::optional<uint64_t> FirstFuncAddr = GC->getFirstFunctionAddress();
       if (FirstFuncAddr) {
         SGP << Path << "-" << llvm::format_hex(*FirstFuncAddr, 1);
-        SGP.flush();
         Err = GC->save(SegmentedGsymPath, ByteOrder, std::nullopt);
         if (Err)
           return Err;

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -544,7 +544,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     Result += '(';
     raw_string_ostream OS(Result);
     getValueAsType()->print(OS, false, true);
-    OS.flush();
     Result += ')';
     return Result;
   }
@@ -666,7 +665,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
       OS << getModRefStr(MR);
     }
     OS << ")";
-    OS.flush();
     return Result;
   }
 
@@ -692,7 +690,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     OS << "i" << CR.getBitWidth() << " ";
     OS << CR.getLower() << ", " << CR.getUpper();
     OS << ")";
-    OS.flush();
     return Result;
   }
 
@@ -703,7 +700,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     OS << "initializes(";
     CRL.print(OS);
     OS << ")";
-    OS.flush();
     return Result;
   }
 

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -670,15 +670,13 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
 
   if (hasAttribute(Attribute::Captures)) {
     std::string Result;
-    raw_string_ostream OS(Result);
-    OS << getCaptureInfo();
+    raw_string_ostream(Result) << getCaptureInfo();
     return Result;
   }
 
   if (hasAttribute(Attribute::NoFPClass)) {
     std::string Result = "nofpclass";
-    raw_string_ostream OS(Result);
-    OS << getNoFPClass();
+    raw_string_ostream(Result) << getNoFPClass();
     return Result;
   }
 

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -249,7 +249,6 @@ char *LLVMGetDiagInfoDescription(LLVMDiagnosticInfoRef DI) {
   DiagnosticPrinterRawOStream DP(Stream);
 
   unwrap(DI)->print(DP);
-  Stream.flush();
 
   return LLVMCreateMessage(MsgStorage.c_str());
 }
@@ -477,7 +476,6 @@ char *LLVMPrintModuleToString(LLVMModuleRef M) {
   raw_string_ostream os(buf);
 
   unwrap(M)->print(os, nullptr);
-  os.flush();
 
   return strdup(buf.c_str());
 }
@@ -654,8 +652,6 @@ char *LLVMPrintTypeToString(LLVMTypeRef Ty) {
     unwrap(Ty)->print(os);
   else
     os << "Printing <null> Type";
-
-  os.flush();
 
   return strdup(buf.c_str());
 }
@@ -1050,8 +1046,6 @@ char* LLVMPrintValueToString(LLVMValueRef Val) {
   else
     os << "Printing <null> Value";
 
-  os.flush();
-
   return strdup(buf.c_str());
 }
 
@@ -1067,8 +1061,6 @@ char *LLVMPrintDbgRecordToString(LLVMDbgRecordRef Record) {
     unwrap(Record)->print(os);
   else
     os << "Printing <null> DbgRecord";
-
-  os.flush();
 
   return strdup(buf.c_str());
 }

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -217,8 +217,7 @@ DiagnosticInfoOptimizationBase::Argument::Argument(StringRef Key,
     raw_string_ostream OS(Val);
     V->printAsOperand(OS, /*PrintType=*/false);
   } else if (auto *II = dyn_cast<IntrinsicInst>(V)) {
-    raw_string_ostream OS(Val);
-    OS << "call " << II->getCalledFunction()->getName();
+    raw_string_ostream(Val) << "call " << II->getCalledFunction()->getName();
   } else if (auto *I = dyn_cast<Instruction>(V)) {
     Val = I->getOpcodeName();
   } else if (auto *MD = dyn_cast<MetadataAsValue>(V)) {
@@ -229,8 +228,7 @@ DiagnosticInfoOptimizationBase::Argument::Argument(StringRef Key,
 
 DiagnosticInfoOptimizationBase::Argument::Argument(StringRef Key, const Type *T)
     : Key(std::string(Key)) {
-  raw_string_ostream OS(Val);
-  OS << *T;
+  raw_string_ostream(Val) << *T;
 }
 
 DiagnosticInfoOptimizationBase::Argument::Argument(StringRef Key, StringRef S)
@@ -413,10 +411,10 @@ bool DiagnosticInfoOptimizationFailure::isEnabled() const {
 
 void DiagnosticInfoUnsupported::print(DiagnosticPrinter &DP) const {
   std::string Str;
-  raw_string_ostream OS(Str);
-
-  OS << getLocationStr() << ": in function " << getFunction().getName() << ' '
-     << *getFunction().getFunctionType() << ": " << Msg << '\n';
+  raw_string_ostream(Str) << getLocationStr() << ": in function "
+                          << getFunction().getName() << ' '
+                          << *getFunction().getFunctionType() << ": " << Msg
+                          << '\n';
   DP << Str;
 }
 

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -417,7 +417,6 @@ void DiagnosticInfoUnsupported::print(DiagnosticPrinter &DP) const {
 
   OS << getLocationStr() << ": in function " << getFunction().getName() << ' '
      << *getFunction().getFunctionType() << ": " << Msg << '\n';
-  OS.flush();
   DP << Str;
 }
 

--- a/llvm/lib/IR/Mangler.cpp
+++ b/llvm/lib/IR/Mangler.cpp
@@ -227,7 +227,6 @@ void llvm::emitLinkerFlagsForGlobalCOFF(raw_ostream &OS, const GlobalValue *GV,
       std::string Flag;
       raw_string_ostream FlagOS(Flag);
       Mangler.getNameWithPrefix(FlagOS, GV, false);
-      FlagOS.flush();
       if (Flag[0] == GV->getDataLayout().getGlobalPrefix())
         OS << Flag.substr(1);
       else
@@ -266,7 +265,6 @@ void llvm::emitLinkerFlagsForGlobalCOFF(raw_ostream &OS, const GlobalValue *GV,
     std::string Flag;
     raw_string_ostream FlagOS(Flag);
     Mangler.getNameWithPrefix(FlagOS, GV, false);
-    FlagOS.flush();
     if (Flag[0] == GV->getDataLayout().getGlobalPrefix())
       OS << Flag.substr(1);
     else

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -699,7 +699,6 @@ void LTOCodeGenerator::DiagnosticHandler(const DiagnosticInfo &DI) {
   raw_string_ostream Stream(MsgStorage);
   DiagnosticPrinterRawOStream DP(Stream);
   DI.print(DP);
-  Stream.flush();
 
   // If this method has been called it means someone has set up an external
   // diagnostic handler. Assert on that.

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -110,7 +110,6 @@ ArchiveMemberHeader::ArchiveMemberHeader(const Archive *Parent,
       raw_string_ostream OS(Buf);
       OS.write_escaped(
           StringRef(ArMemHdr->Terminator, sizeof(ArMemHdr->Terminator)));
-      OS.flush();
       std::string Msg("terminator characters in archive member \"" + Buf +
                       "\" not the correct \"`\\n\" values for the archive "
                       "member header ");
@@ -281,7 +280,6 @@ Expected<StringRef> ArchiveMemberHeader::getName(uint64_t Size) const {
       std::string Buf;
       raw_string_ostream OS(Buf);
       OS.write_escaped(Name.substr(1).rtrim(' '));
-      OS.flush();
       uint64_t ArchiveOffset =
           reinterpret_cast<const char *>(ArMemHdr) - Parent->getData().data();
       return malformedError("long name offset characters after the '/' are "
@@ -320,7 +318,6 @@ Expected<StringRef> ArchiveMemberHeader::getName(uint64_t Size) const {
       std::string Buf;
       raw_string_ostream OS(Buf);
       OS.write_escaped(Name.substr(3).rtrim(' '));
-      OS.flush();
       uint64_t ArchiveOffset =
           reinterpret_cast<const char *>(ArMemHdr) - Parent->getData().data();
       return malformedError("long name length characters after the #1/ are "

--- a/llvm/lib/Object/ArchiveWriter.cpp
+++ b/llvm/lib/Object/ArchiveWriter.cpp
@@ -347,7 +347,6 @@ static MemberData computeStringTable(StringRef Names) {
   printWithSpacePadding(Out, "//", 48);
   printWithSpacePadding(Out, Size + Pad, 10);
   Out << "`\n";
-  Out.flush();
   return {{}, std::move(Header), Names, Pad ? "\n" : ""};
 }
 
@@ -959,7 +958,6 @@ computeMemberData(raw_ostream &StringTable, raw_ostream &SymNames,
       printMemberHeader(Out, Pos, StringTable, MemberNames, Kind, Thin, *M,
                         ModTime, Size);
     }
-    Out.flush();
 
     std::vector<unsigned> Symbols;
     if (NeedSymbols != SymtabWritingMode::NoSymtab) {

--- a/llvm/lib/Object/IRSymtab.cpp
+++ b/llvm/lib/Object/IRSymtab.cpp
@@ -317,7 +317,6 @@ Error Builder::addSymbol(const ModuleSymbolTable &Msymtab,
       std::string FallbackName;
       raw_string_ostream OS(FallbackName);
       Msymtab.printSymbolName(OS, Fallback);
-      OS.flush();
       setStr(Uncommon().COFFWeakExternFallbackName, Saver.save(FallbackName));
     }
   }
@@ -341,7 +340,6 @@ Error Builder::build(ArrayRef<Module *> IRMods) {
     if (Error Err = addModule(M))
       return Err;
 
-  COFFLinkerOptsOS.flush();
   setStr(Hdr.COFFLinkerOpts, Saver.save(COFFLinkerOpts));
 
   // We are about to fill in the header's range fields, so reserve space for it

--- a/llvm/lib/ObjectYAML/DWARFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/DWARFEmitter.cpp
@@ -1257,7 +1257,6 @@ emitDebugSectionImpl(const DWARFYAML::Data &DI, StringRef Sec,
 
   if (Error Err = EmitFunc(DebugInfoStream, DI))
     return Err;
-  DebugInfoStream.flush();
   if (!Data.empty())
     OutputBuffers[Sec] = MemoryBuffer::getMemBufferCopy(Data);
 

--- a/llvm/lib/ObjectYAML/WasmEmitter.cpp
+++ b/llvm/lib/ObjectYAML/WasmEmitter.cpp
@@ -77,7 +77,6 @@ public:
   SubSectionWriter(raw_ostream &OS) : OS(OS), StringStream(OutString) {}
 
   void done() {
-    StringStream.flush();
     encodeULEB128(OutString.size(), OS);
     OS << OutString;
     OutString.clear();
@@ -545,7 +544,6 @@ void WasmWriter::writeSectionContent(raw_ostream &OS,
     Func.Body.writeAsBinary(StringStream);
 
     // Write the section size followed by the content
-    StringStream.flush();
     encodeULEB128(OutString.size(), OS);
     OS << OutString;
   }
@@ -653,8 +651,6 @@ bool WasmWriter::writeWasm(raw_ostream &OS) {
     if (HasError)
       return false;
 
-    StringStream.flush();
-
     unsigned HeaderSecSizeEncodingLen =
         Sec->HeaderSecSizeEncodingLen.value_or(5);
     unsigned RequiredLen = getULEB128Size(OutString.size());
@@ -682,7 +678,6 @@ bool WasmWriter::writeWasm(raw_ostream &OS) {
     std::string OutString;
     raw_string_ostream StringStream(OutString);
     writeRelocSection(StringStream, *Sec, SectionIndex++);
-    StringStream.flush();
 
     encodeULEB128(OutString.size(), OS);
     OS << OutString;

--- a/llvm/lib/Remarks/YAMLRemarkParser.cpp
+++ b/llvm/lib/Remarks/YAMLRemarkParser.cpp
@@ -31,7 +31,6 @@ static void handleDiagnostic(const SMDiagnostic &Diag, void *Ctx) {
   Diag.print(/*ProgName=*/nullptr, OS, /*ShowColors*/ false,
              /*ShowKindLabels*/ true);
   OS << '\n';
-  OS.flush();
 }
 
 YAMLParseError::YAMLParseError(StringRef Msg, SourceMgr &SM,

--- a/llvm/lib/Support/Chrono.cpp
+++ b/llvm/lib/Support/Chrono.cpp
@@ -101,7 +101,6 @@ static void format(const T &Fractional, struct tm &LT, raw_ostream &OS,
       }
     FStream << Style[I];
   }
-  FStream.flush();
   char Buffer[256];  // Should be enough for anywhen.
   size_t Len = strftime(Buffer, sizeof(Buffer), Format.c_str(), &LT);
   OS << (Len ? Buffer : "BAD-DATE-FORMAT");

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -571,7 +571,6 @@ int main(int argc, char **argv, char * const *envp) {
       std::string Buf;
       raw_string_ostream OS(Buf);
       logAllUnhandledErrors(ArOrErr.takeError(), OS);
-      OS.flush();
       errs() << Buf;
       exit(1);
     }

--- a/llvm/tools/llvm-cov/TestingSupport.cpp
+++ b/llvm/tools/llvm-cov/TestingSupport.cpp
@@ -38,7 +38,6 @@ int convertForTestingMain(int argc, const char *argv[]) {
     std::string Buf;
     raw_string_ostream OS(Buf);
     logAllUnhandledErrors(ObjErr.takeError(), OS);
-    OS.flush();
     errs() << "error: " << Buf;
     return 1;
   }

--- a/llvm/tools/llvm-cxxdump/llvm-cxxdump.cpp
+++ b/llvm/tools/llvm-cxxdump/llvm-cxxdump.cpp
@@ -507,7 +507,6 @@ static void dumpArchive(const Archive *Arc) {
         std::string Buf;
         raw_string_ostream OS(Buf);
         logAllUnhandledErrors(std::move(E), OS);
-        OS.flush();
         reportError(Arc->getFileName(), Buf);
       }
       consumeError(ChildOrErr.takeError());

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
@@ -297,7 +297,6 @@ template <> struct MappingContextTraits<exegesis::Benchmark, YamlContext> {
       std::string Str;
       raw_string_ostream OSS(Str);
       Binary.writeAsBinary(OSS);
-      OSS.flush();
       Data.assign(Str.begin(), Str.end());
       return Data;
     }

--- a/llvm/tools/llvm-ifs/llvm-ifs.cpp
+++ b/llvm/tools/llvm-ifs/llvm-ifs.cpp
@@ -259,7 +259,6 @@ static Error writeIFS(StringRef FilePath, IFSStub &Stub, bool WriteIfChanged) {
   Error YAMLErr = writeIFSToOutputStream(OutStr, Stub);
   if (YAMLErr)
     return YAMLErr;
-  OutStr.flush();
 
   if (WriteIfChanged) {
     if (ErrorOr<std::unique_ptr<MemoryBuffer>> BufOrError =

--- a/llvm/tools/llvm-libtool-darwin/llvm-libtool-darwin.cpp
+++ b/llvm/tools/llvm-libtool-darwin/llvm-libtool-darwin.cpp
@@ -572,7 +572,6 @@ checkForDuplicates(const MembersPerArchitectureMap &MembersPerArch) {
       }
     }
 
-    ErrorStream.flush();
     if (ErrorData.size() > 0)
       return createStringError(std::errc::invalid_argument, ErrorData.c_str());
   }

--- a/llvm/tools/llvm-lipo/llvm-lipo.cpp
+++ b/llvm/tools/llvm-lipo/llvm-lipo.cpp
@@ -49,7 +49,6 @@ static const StringRef ToolName = "llvm-lipo";
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   reportError(Buf);
 }
 
@@ -58,7 +57,6 @@ static const StringRef ToolName = "llvm-lipo";
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   WithColor::error(errs(), ToolName) << "'" << File << "': " << Buf;
   exit(EXIT_FAILURE);
 }

--- a/llvm/tools/llvm-mca/Views/BottleneckAnalysis.cpp
+++ b/llvm/tools/llvm-mca/Views/BottleneckAnalysis.cpp
@@ -635,7 +635,6 @@ void BottleneckAnalysis::printView(raw_ostream &OS) const {
   std::string Buffer;
   raw_string_ostream TempStream(Buffer);
   printBottleneckHints(TempStream);
-  TempStream.flush();
   OS << Buffer;
   printCriticalSequence(OS);
 }

--- a/llvm/tools/llvm-mca/Views/DispatchStatistics.cpp
+++ b/llvm/tools/llvm-mca/Views/DispatchStatistics.cpp
@@ -44,7 +44,6 @@ void DispatchStatistics::printDispatchHistogram(raw_ostream &OS) const {
                << "%)\n";
   }
 
-  TempStream.flush();
   OS << Buffer;
 }
 
@@ -79,7 +78,6 @@ void DispatchStatistics::printDispatchStalls(raw_ostream &OS) const {
   SS << "\nUSH     - Uncategorised Structural Hazard:           ";
   printStalls(SS, HWStalls[HWStallEvent::CustomBehaviourStall], NumCycles);
   SS << '\n';
-  SS.flush();
   OS << Buffer;
 }
 

--- a/llvm/tools/llvm-mca/Views/InstructionView.cpp
+++ b/llvm/tools/llvm-mca/Views/InstructionView.cpp
@@ -25,7 +25,6 @@ StringRef
 InstructionView::printInstructionString(const llvm::MCInst &MCI) const {
   InstructionString = "";
   MCIP.printInst(&MCI, 0, "", STI, InstrStream);
-  InstrStream.flush();
   // Remove any tabs or spaces at the beginning of the instruction.
   return StringRef(InstructionString).ltrim();
 }

--- a/llvm/tools/llvm-mca/Views/RegisterFileStatistics.cpp
+++ b/llvm/tools/llvm-mca/Views/RegisterFileStatistics.cpp
@@ -162,7 +162,6 @@ void RegisterFileStatistics::printView(raw_ostream &OS) const {
     }
   }
 
-  TempStream.flush();
   OS << Buffer;
 }
 

--- a/llvm/tools/llvm-mca/Views/RetireControlUnitStatistics.cpp
+++ b/llvm/tools/llvm-mca/Views/RetireControlUnitStatistics.cpp
@@ -83,7 +83,6 @@ void RetireControlUnitStatistics::printView(raw_ostream &OS) const {
              << "\nAverage Used ROB Entries per cy:  " << AvgUsage
              << format("  ( %.1f%% )\n", NormalizedAvgPercentage);
 
-  TempStream.flush();
   OS << Buffer;
 }
 

--- a/llvm/tools/llvm-mca/Views/SummaryView.cpp
+++ b/llvm/tools/llvm-mca/Views/SummaryView.cpp
@@ -79,7 +79,6 @@ void SummaryView::printView(raw_ostream &OS) const {
   TempStream << "\nBlock RThroughput: "
              << format("%.1f", floor((DV.BlockRThroughput * 10) + 0.5) / 10)
              << '\n';
-  TempStream.flush();
   OS << Buffer;
 }
 

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -664,7 +664,6 @@ int main(int argc, char **argv) {
                         << ", use -skip-unsupported-instructions=lack-sched to "
                            "ignore these on the input.\n";
                   IP->printInst(&IE.Inst, 0, "", *STI, SS);
-                  SS.flush();
                   WithColor::note()
                       << "instruction: " << InstructionStr << '\n';
                 })) {

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -194,7 +194,6 @@ static void error(llvm::Error E, StringRef FileName, const Archive::Child &C,
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   errs() << ": " << Buf << "\n";
 }
 
@@ -213,7 +212,6 @@ static void error(llvm::Error E, StringRef FileName,
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   errs() << ": " << Buf << "\n";
 }
 
@@ -1404,7 +1402,6 @@ static void dumpSymbolsFromDLInfoMachO(MachOObjectFile &MachO,
       error(std::move(Err), MachO.getFileName());
     // Set the symbol names and indirect names for the added symbols.
     if (ExportsAdded) {
-      EOS.flush();
       const char *Q = ExportsNameBuffer.c_str();
       for (unsigned K = 0; K < ExportsAdded; K++) {
         SymbolList[I].Name = Q;
@@ -1457,7 +1454,6 @@ static void dumpSymbolsFromDLInfoMachO(MachOObjectFile &MachO,
       error(std::move(BErr), MachO.getFileName());
     // Set the symbol names and indirect names for the added symbols.
     if (BindsAdded) {
-      BOS.flush();
       const char *Q = BindsNameBuffer.c_str();
       for (unsigned K = 0; K < BindsAdded; K++) {
         SymbolList[I].Name = Q;
@@ -1516,7 +1512,6 @@ static void dumpSymbolsFromDLInfoMachO(MachOObjectFile &MachO,
       error(std::move(LErr), MachO.getFileName());
     // Set the symbol names and indirect names for the added symbols.
     if (LazysAdded) {
-      LOS.flush();
       const char *Q = LazysNameBuffer.c_str();
       for (unsigned K = 0; K < LazysAdded; K++) {
         SymbolList[I].Name = Q;
@@ -1584,7 +1579,6 @@ static void dumpSymbolsFromDLInfoMachO(MachOObjectFile &MachO,
       error(std::move(WErr), MachO.getFileName());
     // Set the symbol names and indirect names for the added symbols.
     if (WeaksAdded) {
-      WOS.flush();
       const char *Q = WeaksNameBuffer.c_str();
       for (unsigned K = 0; K < WeaksAdded; K++) {
         SymbolList[I].Name = Q;
@@ -1675,7 +1669,6 @@ static void dumpSymbolsFromDLInfoMachO(MachOObjectFile &MachO,
       }
     }
     if (FunctionStartsAdded) {
-      FOS.flush();
       const char *Q = FunctionStartsNameBuffer.c_str();
       for (unsigned K = 0; K < FunctionStartsAdded; K++) {
         SymbolList[I].Name = Q;

--- a/llvm/tools/llvm-objdump/COFFDump.cpp
+++ b/llvm/tools/llvm-objdump/COFFDump.cpp
@@ -837,7 +837,6 @@ void objdump::printCOFFSymbolTable(const object::COFFImportFile &i) {
     raw_string_ostream NS(Name);
 
     cantFail(Sym.printName(NS));
-    NS.flush();
 
     outs() << "[" << format("%2d", Index) << "]"
            << "(sec " << format("%2d", 0) << ")"

--- a/llvm/tools/llvm-objdump/ELFDump.cpp
+++ b/llvm/tools/llvm-objdump/ELFDump.cpp
@@ -164,7 +164,6 @@ static Error getRelocationValueString(const ELFObjectFile<ELFT> *Obj,
           : "+") << format("0x%" PRIx64,
                           (Addend < 0 ? -(uint64_t)Addend : (uint64_t)Addend));
   }
-  Fmt.flush();
   Result.append(FmtBuf.begin(), FmtBuf.end());
   return Error::success();
 }

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -590,7 +590,6 @@ Error objdump::getMachORelocationValueString(const MachOObjectFile *Obj,
   } else
     printRelocationTargetName(Obj, RE, Fmt);
 
-  Fmt.flush();
   Result.append(FmtBuf.begin(), FmtBuf.end());
   return Error::success();
 }

--- a/llvm/tools/llvm-objdump/WasmDump.cpp
+++ b/llvm/tools/llvm-objdump/WasmDump.cpp
@@ -60,7 +60,6 @@ Error objdump::getWasmRelocationValueString(const WasmObjectFile *Obj,
     Result.append(SymName.begin(), SymName.end());
   }
   Fmt << (Rel.Addend < 0 ? "" : "+") << Rel.Addend;
-  Fmt.flush();
   Result.append(FmtBuf.begin(), FmtBuf.end());
   return Error::success();
 }

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -129,7 +129,6 @@ void XCOFFDumper::checkAndPrintAuxHeaderParseError(
   if (PartialFieldOffset < AuxSize) {
     std::string Buf;
     raw_string_ostream OS(Buf);
-    OS.flush();
     OS << FormattedString("Raw data", 0, FormattedString::JustifyLeft) << " ("
        << format_bytes(
               ArrayRef<uint8_t>(reinterpret_cast<const uint8_t *>(&AuxHeader) +

--- a/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
+++ b/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
@@ -434,7 +434,6 @@ static int printLineInfoForInput(bool LoadObjects, bool UseDebugObj) {
       std::string Buf;
       raw_string_ostream OS(Buf);
       logAllUnhandledErrors(MaybeObj.takeError(), OS);
-      OS.flush();
       ErrorAndExit("unable to create object file: '" + Buf + "'");
     }
 
@@ -570,7 +569,6 @@ static int executeInput() {
         std::string Buf;
         raw_string_ostream OS(Buf);
         logAllUnhandledErrors(MaybeObj.takeError(), OS);
-        OS.flush();
         ErrorAndExit("unable to create object file: '" + Buf + "'");
       }
 
@@ -976,7 +974,6 @@ static int linkAndVerify() {
       std::string Buf;
       raw_string_ostream OS(Buf);
       logAllUnhandledErrors(MaybeObj.takeError(), OS);
-      OS.flush();
       ErrorAndExit("unable to create object file: '" + Buf + "'");
     }
 

--- a/llvm/tools/llvm-size/llvm-size.cpp
+++ b/llvm/tools/llvm-size/llvm-size.cpp
@@ -131,7 +131,6 @@ static void error(llvm::Error E, StringRef FileName, const Archive::Child &C,
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   errs() << ": " << Buf << "\n";
 }
 
@@ -149,7 +148,6 @@ static void error(llvm::Error E, StringRef FileName,
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   errs() << ": " << Buf << "\n";
 }
 

--- a/llvm/tools/obj2yaml/obj2yaml.cpp
+++ b/llvm/tools/obj2yaml/obj2yaml.cpp
@@ -94,7 +94,6 @@ static void reportError(StringRef Input, Error Err) {
   std::string ErrMsg;
   raw_string_ostream OS(ErrMsg);
   logAllUnhandledErrors(std::move(Err), OS);
-  OS.flush();
   errs() << "Error reading file: " << Input << ": " << ErrMsg;
   errs().flush();
 }

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -21,8 +21,7 @@ TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
   Clause.setDefaultFlags(llvm::dxbc::RootSignatureVersion::V1_1);
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Clause;
+  llvm::raw_string_ostream(Out) << Clause;
 
   std::string Expected = "CBV(b0, numDescriptors = 1, space = 0, "
                          "offset = DescriptorTableOffsetAppend, "
@@ -40,8 +39,7 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
   Clause.Flags = llvm::dxbc::DescriptorRangeFlags::None;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Clause;
+  llvm::raw_string_ostream(Out) << Clause;
 
   std::string Expected = "SRV(t0, numDescriptors = unbounded, space = 42, "
                          "offset = 3, flags = None)";
@@ -65,8 +63,7 @@ TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
   Clause.Flags = ValidDescriptorRangeFlags;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Clause;
+  llvm::raw_string_ostream(Out) << Clause;
 
   std::string Expected =
       "UAV(u92374, numDescriptors = 3298, space = 932847, offset = 1, flags = "
@@ -88,8 +85,7 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   Clause.Flags = llvm::dxbc::DescriptorRangeFlags::DescriptorsVolatile;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Clause;
+  llvm::raw_string_ostream(Out) << Clause;
 
   std::string Expected = "Sampler(s0, numDescriptors = 2, space = 42, offset = "
                          "DescriptorTableOffsetAppend, "
@@ -104,8 +100,7 @@ TEST(HLSLRootSignatureTest, DescriptorCBVV10ClauseDump) {
   Clause.setDefaultFlags(llvm::dxbc::RootSignatureVersion::V1_0);
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Clause;
+  llvm::raw_string_ostream(Out) << Clause;
 
   std::string Expected = "CBV(b0, numDescriptors = 1, space = 0, "
                          "offset = DescriptorTableOffsetAppend, "
@@ -120,8 +115,7 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerV10ClauseDump) {
   Clause.setDefaultFlags(llvm::dxbc::RootSignatureVersion::V1_0);
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Clause;
+  llvm::raw_string_ostream(Out) << Clause;
 
   std::string Expected = "Sampler(s0, numDescriptors = 1, space = 0, offset = "
                          "DescriptorTableOffsetAppend, "
@@ -135,8 +129,7 @@ TEST(HLSLRootSignatureTest, DescriptorTableDump) {
   Table.Visibility = llvm::dxbc::ShaderVisibility::Geometry;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Table;
+  llvm::raw_string_ostream(Out) << Table;
 
   std::string Expected =
       "DescriptorTable(numClauses = 4, visibility = Geometry)";
@@ -150,8 +143,7 @@ TEST(HLSLRootSignatureTest, RootCBVDump) {
   Descriptor.setDefaultFlags(llvm::dxbc::RootSignatureVersion::V1_1);
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Descriptor;
+  llvm::raw_string_ostream(Out) << Descriptor;
 
   std::string Expected = "RootCBV(b0, space = 0, "
                          "visibility = All, "
@@ -166,8 +158,7 @@ TEST(HLSLRootSignatureTest, RootSRV10Dump) {
   Descriptor.setDefaultFlags(llvm::dxbc::RootSignatureVersion::V1_0);
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Descriptor;
+  llvm::raw_string_ostream(Out) << Descriptor;
 
   std::string Expected = "RootSRV(t0, space = 0, "
                          "visibility = All, "
@@ -182,8 +173,7 @@ TEST(HLSLRootSignatureTest, RootUAVV10Dump) {
   Descriptor.setDefaultFlags(llvm::dxbc::RootSignatureVersion::V1_0);
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Descriptor;
+  llvm::raw_string_ostream(Out) << Descriptor;
 
   std::string Expected = "RootUAV(u0, space = 0, "
                          "visibility = All, "
@@ -200,8 +190,7 @@ TEST(HLSLRootSignatureTest, RootSRVDump) {
   Descriptor.Flags = llvm::dxbc::RootDescriptorFlags::None;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Descriptor;
+  llvm::raw_string_ostream(Out) << Descriptor;
 
   std::string Expected =
       "RootSRV(t0, space = 42, visibility = Geometry, flags = None)";
@@ -222,8 +211,7 @@ TEST(HLSLRootSignatureTest, RootUAVDump) {
   Descriptor.Flags = ValidRootDescriptorFlags;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Descriptor;
+  llvm::raw_string_ostream(Out) << Descriptor;
 
   std::string Expected =
       "RootUAV(u92374, space = 932847, visibility = Hull, flags = "
@@ -238,8 +226,7 @@ TEST(HLSLRootSignatureTest, DefaultStaticSamplerDump) {
   Sampler.Reg = {RegisterType::SReg, 0};
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Sampler;
+  llvm::raw_string_ostream(Out) << Sampler;
 
   std::string Expected = "StaticSampler(s0, "
                          "filter = Anisotropic, "
@@ -278,8 +265,7 @@ TEST(HLSLRootSignatureTest, DefinedStaticSamplerDump) {
   Sampler.Flags = llvm::dxbc::StaticSamplerFlags::NonNormalizedCoordinates;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Sampler;
+  llvm::raw_string_ostream(Out) << Sampler;
 
   std::string Expected = "StaticSampler(s0, "
                          "filter = ComparisonMinMagLinearMipPoint, "
@@ -305,8 +291,7 @@ TEST(HLSLRootSignatureTest, DefaultRootConstantsDump) {
   Constants.Reg = {RegisterType::BReg, 3};
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Constants;
+  llvm::raw_string_ostream(Out) << Constants;
 
   std::string Expected = "RootConstants(num32BitConstants = 1, b3, space = 0, "
                          "visibility = All)";
@@ -321,8 +306,7 @@ TEST(HLSLRootSignatureTest, SetRootConstantsDump) {
   Constants.Visibility = llvm::dxbc::ShaderVisibility::Pixel;
 
   std::string Out;
-  llvm::raw_string_ostream OS(Out);
-  OS << Constants;
+  llvm::raw_string_ostream(Out) << Constants;
 
   std::string Expected = "RootConstants(num32BitConstants = 983, b34593, "
                          "space = 7, visibility = Pixel)";

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -23,7 +23,6 @@ TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Clause;
-  OS.flush();
 
   std::string Expected = "CBV(b0, numDescriptors = 1, space = 0, "
                          "offset = DescriptorTableOffsetAppend, "
@@ -43,7 +42,6 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Clause;
-  OS.flush();
 
   std::string Expected = "SRV(t0, numDescriptors = unbounded, space = 42, "
                          "offset = 3, flags = None)";
@@ -69,7 +67,6 @@ TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Clause;
-  OS.flush();
 
   std::string Expected =
       "UAV(u92374, numDescriptors = 3298, space = 932847, offset = 1, flags = "
@@ -93,7 +90,6 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Clause;
-  OS.flush();
 
   std::string Expected = "Sampler(s0, numDescriptors = 2, space = 42, offset = "
                          "DescriptorTableOffsetAppend, "
@@ -110,7 +106,6 @@ TEST(HLSLRootSignatureTest, DescriptorCBVV10ClauseDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Clause;
-  OS.flush();
 
   std::string Expected = "CBV(b0, numDescriptors = 1, space = 0, "
                          "offset = DescriptorTableOffsetAppend, "
@@ -127,7 +122,6 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerV10ClauseDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Clause;
-  OS.flush();
 
   std::string Expected = "Sampler(s0, numDescriptors = 1, space = 0, offset = "
                          "DescriptorTableOffsetAppend, "
@@ -143,7 +137,6 @@ TEST(HLSLRootSignatureTest, DescriptorTableDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Table;
-  OS.flush();
 
   std::string Expected =
       "DescriptorTable(numClauses = 4, visibility = Geometry)";
@@ -159,7 +152,6 @@ TEST(HLSLRootSignatureTest, RootCBVDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Descriptor;
-  OS.flush();
 
   std::string Expected = "RootCBV(b0, space = 0, "
                          "visibility = All, "
@@ -176,7 +168,6 @@ TEST(HLSLRootSignatureTest, RootSRV10Dump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Descriptor;
-  OS.flush();
 
   std::string Expected = "RootSRV(t0, space = 0, "
                          "visibility = All, "
@@ -193,7 +184,6 @@ TEST(HLSLRootSignatureTest, RootUAVV10Dump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Descriptor;
-  OS.flush();
 
   std::string Expected = "RootUAV(u0, space = 0, "
                          "visibility = All, "
@@ -212,7 +202,6 @@ TEST(HLSLRootSignatureTest, RootSRVDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Descriptor;
-  OS.flush();
 
   std::string Expected =
       "RootSRV(t0, space = 42, visibility = Geometry, flags = None)";
@@ -235,7 +224,6 @@ TEST(HLSLRootSignatureTest, RootUAVDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Descriptor;
-  OS.flush();
 
   std::string Expected =
       "RootUAV(u92374, space = 932847, visibility = Hull, flags = "
@@ -252,7 +240,6 @@ TEST(HLSLRootSignatureTest, DefaultStaticSamplerDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Sampler;
-  OS.flush();
 
   std::string Expected = "StaticSampler(s0, "
                          "filter = Anisotropic, "
@@ -293,7 +280,6 @@ TEST(HLSLRootSignatureTest, DefinedStaticSamplerDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Sampler;
-  OS.flush();
 
   std::string Expected = "StaticSampler(s0, "
                          "filter = ComparisonMinMagLinearMipPoint, "
@@ -321,7 +307,6 @@ TEST(HLSLRootSignatureTest, DefaultRootConstantsDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Constants;
-  OS.flush();
 
   std::string Expected = "RootConstants(num32BitConstants = 1, b3, space = 0, "
                          "visibility = All)";
@@ -338,7 +323,6 @@ TEST(HLSLRootSignatureTest, SetRootConstantsDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Constants;
-  OS.flush();
 
   std::string Expected = "RootConstants(num32BitConstants = 983, b34593, "
                          "space = 7, visibility = Pixel)";
@@ -351,7 +335,6 @@ TEST(HLSLRootSignatureTest, NoneRootFlagsDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << Flags;
-  OS.flush();
 
   std::string Expected = "RootFlags(None)";
   EXPECT_EQ(Out, Expected);
@@ -375,7 +358,6 @@ TEST(HLSLRootSignatureTest, AllRootFlagsDump) {
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   OS << ValidRootFlags;
-  OS.flush();
 
   std::string Expected = "RootFlags("
                          "AllowInputAssemblerInputLayout | "

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -256,7 +256,6 @@ formatted_bytes_str(ArrayRef<uint8_t> Bytes,
   std::string S;
   raw_string_ostream Str(S);
   Str << format_bytes(Bytes, Offset, NumPerLine, ByteGroupSize);
-  Str.flush();
   return S;
 }
 
@@ -266,7 +265,6 @@ static std::string format_bytes_with_ascii_str(
   std::string S;
   raw_string_ostream Str(S);
   Str << format_bytes_with_ascii(Bytes, Offset, NumPerLine, ByteGroupSize);
-  Str.flush();
   return S;
 }
 
@@ -553,7 +551,6 @@ TEST(raw_ostreamTest, reserve_stream) {
   OS << "hello";
   OS << 1;
   OS << 'w' << 'o' << 'r' << 'l' << 'd';
-  OS.flush();
   EXPECT_EQ("11111111111111111111hello1world", Str);
 }
 


### PR DESCRIPTION
Remove calls to `flush()` on `raw_string_ostream` objects as they are not needed.