### PR TITLE
[libc][annex_k] Add abort_handler_s.

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -235,6 +235,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib._Exit
     libc.src.stdlib.a64l
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.abs
     libc.src.stdlib.aligned_alloc
     libc.src.stdlib.atexit

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -235,6 +235,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib._Exit
     libc.src.stdlib.a64l
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.abs
     libc.src.stdlib.aligned_alloc
     libc.src.stdlib.atexit

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -232,6 +232,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib._Exit
     libc.src.stdlib.a64l
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.abs
     libc.src.stdlib.aligned_alloc
     libc.src.stdlib.atexit

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -159,6 +159,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # stdlib.h entrypoints
     libc.src.stdlib._Exit
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.abs
     libc.src.stdlib.atexit
     libc.src.stdlib.atof

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -159,6 +159,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # stdlib.h entrypoints
     libc.src.stdlib._Exit
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.abs
     libc.src.stdlib.atexit
     libc.src.stdlib.atof

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1109,6 +1109,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # stdlib.h entrypoints
     libc.src.stdlib._Exit
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.at_quick_exit
     libc.src.stdlib.atexit
     libc.src.stdlib.exit

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1238,6 +1238,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # stdlib.h entrypoints
     libc.src.stdlib._Exit
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.at_quick_exit
     libc.src.stdlib.atexit
     libc.src.stdlib.exit

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1296,6 +1296,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # stdlib.h entrypoints
     libc.src.stdlib._Exit
     libc.src.stdlib.abort
+    libc.src.stdlib.abort_handler_s
     libc.src.stdlib.at_quick_exit
     libc.src.stdlib.atexit
     libc.src.stdlib.exit

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -4,7 +4,9 @@ standards:
 merge_yaml_files:
   - stdlib-malloc.yaml
 macros:
-  - macro_name: "NULL"
+  - macro_name: 'LIBC_HAS_ANNEX_K'
+    macro_header: annex-k-macros.h
+  - macro_name: 'NULL'
     macro_header: null-macro.h
   - macro_name: EXIT_SUCCESS
     macro_header: stdlib-macros.h
@@ -17,6 +19,7 @@ types:
   - type_name: __search_compare_t
   - type_name: constraint_handler_t
   - type_name: div_t
+  - type_name: errno_t
   - type_name: ldiv_t
   - type_name: lldiv_t
   - type_name: locale_t
@@ -203,6 +206,15 @@ functions:
     return_type: int
     arguments:
       - type: void
+  - name: abort_handler_s
+    standards:
+      - stdc
+    return_type: void
+    arguments:
+      - type: const char *__restrict
+      - type: void *__restrict
+      - type: errno_t
+    guard: 'LIBC_HAS_ANNEX_K'
   - name: srand
     standards:
       - stdc

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -19,7 +19,6 @@ types:
   - type_name: __search_compare_t
   - type_name: constraint_handler_t
   - type_name: div_t
-  - type_name: errno_t
   - type_name: ldiv_t
   - type_name: lldiv_t
   - type_name: locale_t

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(annex_k)
 add_subdirectory(CPP)
 add_subdirectory(macros)
 

--- a/libc/src/__support/annex_k/CMakeLists.txt
+++ b/libc/src/__support/annex_k/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_header_library(
+  abort_handler_s
+  HDRS
+    abort_handler_s.h
+  DEPENDS
+    libc.hdr.stdio_macros
+    libc.hdr.types.errno_t
+    libc.src.__support.macros.config
+    libc.src.__support.macros.attributes
+    libc.src.__support.OSUtil.osutil
+    libc.src.stdlib.abort
+)

--- a/libc/src/__support/annex_k/CMakeLists.txt
+++ b/libc/src/__support/annex_k/CMakeLists.txt
@@ -3,10 +3,9 @@ add_header_library(
   HDRS
     abort_handler_s.h
   DEPENDS
-    libc.hdr.stdio_macros
     libc.hdr.types.errno_t
-    libc.src.__support.macros.config
-    libc.src.__support.macros.attributes
     libc.src.__support.OSUtil.osutil
+    libc.src.__support.macros.attributes
+    libc.src.__support.macros.config
     libc.src.stdlib.abort
 )

--- a/libc/src/__support/annex_k/abort_handler_s.h
+++ b/libc/src/__support/annex_k/abort_handler_s.h
@@ -1,0 +1,43 @@
+//===-- Implementation for abort_handler_s ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_ANNEX_K_ABORT_HANDLER_S_H
+#define LLVM_LIBC_SRC___SUPPORT_ANNEX_K_ABORT_HANDLER_S_H
+
+#include "hdr/stdio_macros.h"
+#include "hdr/types/errno_t.h"
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/common.h"
+#include "src/stdlib/abort.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace annex_k {
+
+LIBC_INLINE static void abort_handler_s(const char *__restrict msg,
+                                        [[maybe_unused]] void *__restrict ptr,
+                                        [[maybe_unused]] errno_t error) {
+  write_to_stderr("abort_handler_s was called in response to a "
+                  "runtime-constraint violation.\n\n");
+
+  if (msg)
+    write_to_stderr(msg);
+
+  write_to_stderr(
+      "\n\nNote to end users: This program was terminated as a result\
+of a bug present in the software. Please reach out to your\
+software's vendor to get more help.\n");
+
+  abort();
+}
+
+} // namespace annex_k
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_ANNEX_K_ABORT_HANDLER_S_H

--- a/libc/src/__support/annex_k/abort_handler_s.h
+++ b/libc/src/__support/annex_k/abort_handler_s.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_ANNEX_K_ABORT_HANDLER_S_H
 #define LLVM_LIBC_SRC___SUPPORT_ANNEX_K_ABORT_HANDLER_S_H
 
-#include "hdr/stdio_macros.h"
 #include "hdr/types/errno_t.h"
 #include "src/__support/OSUtil/io.h"
-#include "src/__support/common.h"
+#include "src/__support/macros/attributes.h"
+#include "src/__support/macros/config.h"
 #include "src/stdlib/abort.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -732,6 +732,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  abort_handler_s
+  SRCS
+    abort_handler_s.cpp
+  HDRS
+    abort_handler_s.h
+  DEPENDS
+    libc.src.__support.annex_k.abort_handler_s
+)
+
+add_entrypoint_object(
   system
   ALIAS
   DEPENDS

--- a/libc/src/stdlib/abort_handler_s.cpp
+++ b/libc/src/stdlib/abort_handler_s.cpp
@@ -1,0 +1,20 @@
+//===-- Implementation for abort_handler_s ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdlib/abort_handler_s.h"
+#include "src/__support/annex_k/abort_handler_s.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, abort_handler_s,
+                   (const char *__restrict msg, void *__restrict ptr,
+                    errno_t error)) {
+  return annex_k::abort_handler_s(msg, ptr, error);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/abort_handler_s.cpp
+++ b/libc/src/stdlib/abort_handler_s.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/stdlib/abort_handler_s.h"
+#include "abort_handler_s.h"
 #include "src/__support/annex_k/abort_handler_s.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/stdlib/abort_handler_s.h
+++ b/libc/src/stdlib/abort_handler_s.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for abort_handler_s ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDLIB_ABORT_HANDLER_S_H
+#define LLVM_LIBC_SRC_STDLIB_ABORT_HANDLER_S_H
+
+#include "hdr/types/errno_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void abort_handler_s(const char *__restrict msg, void *__restrict ptr,
+                     errno_t error);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_ABORT_HANDLER_S_H


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add `abort_handler_s` required by Annex K interface in LLVM libc.