### PR TITLE
[libc][annex_k] Add libc_constraint_handler.

### DIFF
--- a/libc/src/__support/annex_k/CMakeLists.txt
+++ b/libc/src/__support/annex_k/CMakeLists.txt
@@ -9,3 +9,12 @@ add_header_library(
     libc.src.__support.macros.config
     libc.src.stdlib.abort
 )
+
+add_header_library(
+  libc_constraint_handler
+  HDRS
+    libc_constraint_handler.h
+  DEPENDS
+    .abort_handler_s
+    libc.hdr.types.constraint_handler_t
+)

--- a/libc/src/__support/annex_k/libc_constraint_handler.h
+++ b/libc/src/__support/annex_k/libc_constraint_handler.h
@@ -23,4 +23,4 @@ LIBC_INLINE static constraint_handler_t libc_constraint_handler =
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif  // LLVM_LIBC_SRC___SUPPORT_ANNEX_K_LIBC_CONSTRAINT_HANDLER_H
+#endif // LLVM_LIBC_SRC___SUPPORT_ANNEX_K_LIBC_CONSTRAINT_HANDLER_H

--- a/libc/src/__support/annex_k/libc_constraint_handler.h
+++ b/libc/src/__support/annex_k/libc_constraint_handler.h
@@ -1,0 +1,26 @@
+//===-- Static header for libc_constraint_handler ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_ANNEX_K_LIBC_CONSTRAINT_HANDLER_H
+#define LLVM_LIBC_SRC___SUPPORT_ANNEX_K_LIBC_CONSTRAINT_HANDLER_H
+
+#include "abort_handler_s.h"
+#include "hdr/types/constraint_handler_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace annex_k {
+
+LIBC_INLINE static constraint_handler_t libc_constraint_handler =
+    &abort_handler_s;
+
+} // namespace annex_k
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif  // LLVM_LIBC_SRC___SUPPORT_ANNEX_K_LIBC_CONSTRAINT_HANDLER_H


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add internal `libc_constraint_handler` required by Annex K interface in LLVM libc.