### PR TITLE
[libc][stdlib][annex_k] Add set_constraint_handler_s.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1116,6 +1116,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.getenv
     libc.src.stdlib.ignore_handler_s
     libc.src.stdlib.quick_exit
+    libc.src.stdlib.set_constraint_handler_s
 
     # signal.h entrypoints
     libc.src.signal.kill

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1245,6 +1245,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.getenv
     libc.src.stdlib.ignore_handler_s
     libc.src.stdlib.quick_exit
+    libc.src.stdlib.set_constraint_handler_s
 
     # signal.h entrypoints
     libc.src.signal.kill

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1305,6 +1305,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.mbstowcs
     libc.src.stdlib.mbtowc
     libc.src.stdlib.quick_exit
+    libc.src.stdlib.set_constraint_handler_s
     libc.src.stdlib.wcstombs
     libc.src.stdlib.wctomb
 

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -223,6 +223,13 @@ functions:
       - type: void *__restrict
       - type: errno_t
     guard: 'LIBC_HAS_ANNEX_K'
+  - name: set_constraint_handler_s
+    standards:
+      - stdc
+    return_type: constraint_handler_t
+    arguments:
+      - type: constraint_handler_t
+    guard: 'LIBC_HAS_ANNEX_K'
   - name: srand
     standards:
       - stdc

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -749,6 +749,17 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  set_constraint_handler_s
+  SRCS
+    set_constraint_handler_s.cpp
+  HDRS
+    set_constraint_handler_s.h
+  DEPENDS
+    libc.src.__support.annex_k.abort_handler_s
+    libc.src.__support.annex_k.libc_constraint_handler
+)
+
+add_entrypoint_object(
   ignore_handler_s
   HDRS
     ignore_handler_s.h

--- a/libc/src/stdlib/set_constraint_handler_s.cpp
+++ b/libc/src/stdlib/set_constraint_handler_s.cpp
@@ -1,0 +1,28 @@
+//===-- Implementation of set_constraint_handler_s ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "set_constraint_handler_s.h"
+#include "src/__support/annex_k/abort_handler_s.h"
+#include "src/__support/annex_k/libc_constraint_handler.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(constraint_handler_t, set_constraint_handler_s,
+                   (constraint_handler_t handler)) {
+  auto previous_handler = annex_k::libc_constraint_handler;
+
+  if (!handler) {
+    annex_k::libc_constraint_handler = &annex_k::abort_handler_s;
+  } else {
+    annex_k::libc_constraint_handler = handler;
+  }
+
+  return previous_handler;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/set_constraint_handler_s.h
+++ b/libc/src/stdlib/set_constraint_handler_s.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for set_constraint_handler_s ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDLIB_SET_CONSTRAINT_HANDLER_S_H
+#define LLVM_LIBC_SRC_STDLIB_SET_CONSTRAINT_HANDLER_S_H
+
+#include "hdr/types/constraint_handler_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+constraint_handler_t set_constraint_handler_s(constraint_handler_t handler);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_SET_CONSTRAINT_HANDLER_S_H


### PR DESCRIPTION
RFC https://discourse.llvm.org/t/rfc-bounds-checking-interfaces-for-llvm-libc/87685

Add `set_constraint_handler_s` required by Annex K interface in LLVM libc.