### PR TITLE
[NFC][doc] Mark P1857R3 as partial implemented

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -926,7 +926,14 @@ C++23, informally referred to as C++26.</p>
       </tr>
       <tr>
         <td><a href="https://wg21.link/p1857r3">P1857R3</a></td>
-        <td class="none" align="center">No</td>
+        <td class="partial" align="center">
+          <details>
+            <summary>>Clang 21(Partial)</summary>
+            The restriction 'A module directive may only appear as
+            the first preprocessing tokens in a file' was supported
+            in clang-21.
+          </details>
+        </td>
       </tr>
       <tr>
         <td><a href="https://wg21.link/p2115r0">P2115R0</a></td>

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -929,9 +929,9 @@ C++23, informally referred to as C++26.</p>
         <td class="partial" align="center">
           <details>
             <summary>Clang 21 (Partial)</summary>
-            The restriction 'A module directive may only appear as
-            the first preprocessing tokens in a file' was supported
-            in clang-21.
+            The restriction that "[a] module directive may only appear
+            as the first preprocessing tokens in a file" is enforced
+            starting in Clang 21.
           </details>
         </td>
       </tr>

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -928,7 +928,7 @@ C++23, informally referred to as C++26.</p>
         <td><a href="https://wg21.link/p1857r3">P1857R3</a></td>
         <td class="partial" align="center">
           <details>
-            <summary>>Clang 21(Partial)</summary>
+            <summary>Clang 21 (Partial)</summary>
             The restriction 'A module directive may only appear as
             the first preprocessing tokens in a file' was supported
             in clang-21.


### PR DESCRIPTION
Since the following 2 patches was landed, mark P1857R3 as partial implemented.

- [[C++][Modules] A module directive may only appear as the first preprocessing tokens in a file](https://github.com/llvm/llvm-project/pull/144233).
- [[clang] Allow trivial pp-directives before C++ module directive](https://github.com/llvm/llvm-project/pull/153641).