### PR TITLE
[mlir][spirv] Remove destroyed values from ValueIDMap

### DIFF
--- a/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
+++ b/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
@@ -311,6 +311,15 @@ LogicalResult Serializer::processFuncOp(spirv::FuncOp op) {
     op.addEntryBlock();
     if (failed(processFuncParameter(op)))
       return failure();
+
+    // Erasing the body of the function destroys arguments, so we need to remove
+    // them from the map to avoid problems when processing invalid values used
+    // as keys. We have already serialized function arguments so we probably can
+    // remove them from the map as external function will not have any uses.
+    for (Value arg : op.getArguments())
+      if (valueIDMap.count(arg))
+        valueIDMap.erase(arg);
+
     // Don't need to process the added block, there is nothing to process,
     // the fake body was added just to get the arguments, remove the body,
     // since it's use is done.

--- a/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
+++ b/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
@@ -317,8 +317,7 @@ LogicalResult Serializer::processFuncOp(spirv::FuncOp op) {
     // as keys. We have already serialized function arguments so we probably can
     // remove them from the map as external function will not have any uses.
     for (Value arg : op.getArguments())
-      if (valueIDMap.count(arg))
-        valueIDMap.erase(arg);
+      valueIDMap.erase(arg);
 
     // Don't need to process the added block, there is nothing to process,
     // the fake body was added just to get the arguments, remove the body,

--- a/mlir/test/Target/SPIRV/function-decorations.mlir
+++ b/mlir/test/Target/SPIRV/function-decorations.mlir
@@ -1,4 +1,5 @@
-// RUN: mlir-translate -no-implicit-module -test-spirv-roundtrip -split-input-file -verify-diagnostics %s | FileCheck %s
+// RUN: mlir-translate --no-implicit-module --test-spirv-roundtrip --split-input-file %s | FileCheck %s
+// RUN: mlir-translate --no-implicit-module --test-spirv-roundtrip --split-input-file --debug %s | FileCheck %s
 
 spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader, Linkage], []> {
     spirv.func @linkage_attr_test_kernel()  "DontInline"  attributes {}  {


### PR DESCRIPTION
When serializing SPIR-V MLIR containing externally linked function with debug enabled, the serialization crashes as `printValueIDMap` tries to print a key value that has been already destroyed. This happen as for externally linked function the body of the function is erased, that causes arguments to be destroyed as well, but the valueIDMap was never updated.