### PR TITLE
workflows/release-binaries: Remove LLVM_PARALLEL_LINK_JOBS option

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -230,7 +230,6 @@ jobs:
         cmake -G Ninja -S llvm -B ${{ steps.setup-stage.outputs.build-prefix }}/build \
             ${{ needs.prepare.outputs.target-cmake-flags }} \
             -C clang/cmake/caches/Release.cmake \
-            -DBOOTSTRAP_LLVM_PARALLEL_LINK_JOBS=1 \
             -DBOOTSTRAP_BOOTSTRAP_CPACK_PACKAGE_FILE_NAME="${{ needs.prepare.outputs.release-binary-basename }}"
 
     - name: Build


### PR DESCRIPTION
This was left over from when we were using smaller runners and was only being applied to the stage2-instrumented build, and not the stage2 build.