### PR TITLE
[ADT] Simplify ResolveUnderlyingType (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/Bitfields.h
+++ b/llvm/include/llvm/ADT/Bitfields.h
@@ -154,12 +154,9 @@ struct ResolveUnderlyingType {
   using type = std::underlying_type_t<T>;
 };
 template <typename T> struct ResolveUnderlyingType<T, false> {
-  using type = T;
-};
-template <> struct ResolveUnderlyingType<bool, false> {
-  /// In case sizeof(bool) != 1, replace `void` by an additionnal
-  /// std::conditional.
-  using type = std::conditional_t<sizeof(bool) == 1, uint8_t, void>;
+  static_assert(!std::is_same_v<T, bool> || sizeof(bool) == 1,
+                "T being bool requires sizeof(bool) == 1.");
+  using type = std::conditional_t<std::is_same_v<T, bool>, uint8_t, T>;
 };
 
 } // namespace bitfields_details


### PR DESCRIPTION
We have three implementations of ResolveUnderlyingType:

- enum
- bool
- neither

This patch combines the latter two with std::conditional_t.

Without this patch, we use "void" to trigger a compilation failure
downstream when sizeof(bool) != 1, which is not very friendly.  This
patch instead uses static_assert to catch the case where the user
chooses to use bool but sizeof(bool) != 1.
