### PR TITLE
[clang-format][NFC] Simplify AlignMacroMatches

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -656,7 +656,6 @@ void WhitespaceManager::alignConsecutiveMacros() {
 
   auto AlignMacrosMatches = [](const Change &C) {
     const FormatToken *Current = C.Tok;
-    unsigned SpacesRequiredBefore = 1;
 
     if (Current->SpacesRequiredBefore == 0 || !Current->Previous)
       return false;
@@ -665,22 +664,21 @@ void WhitespaceManager::alignConsecutiveMacros() {
 
     // If token is a ")", skip over the parameter list, to the
     // token that precedes the "("
-    if (Current->is(tok::r_paren) && Current->MatchingParen) {
-      Current = Current->MatchingParen->Previous;
-      SpacesRequiredBefore = 0;
+    if (const auto *MatchingParen = Current->MatchingParen;
+        Current->is(tok::r_paren) && MatchingParen) {
+      // For a macro function, 0 spaces are required between the
+      // identifier and the lparen that opens the parameter list.
+      if (MatchingParen->SpacesRequiredBefore > 0)
+        return false;
+      Current = MatchingParen->Previous;
+    } else if (Current->Next->SpacesRequiredBefore != 1) {
+      // For a simple macro, 1 space is required between the
+      // identifier and the first token of the defined value.
+      return false;
     }
 
-    if (!Current || Current->isNot(tok::identifier))
-      return false;
-
-    if (!Current->Previous || Current->Previous->isNot(tok::pp_define))
-      return false;
-
-    // For a macro function, 0 spaces are required between the
-    // identifier and the lparen that opens the parameter list.
-    // For a simple macro, 1 space is required between the
-    // identifier and the first token of the defined value.
-    return Current->Next->SpacesRequiredBefore == SpacesRequiredBefore;
+    return Current && Current->is(tok::identifier) && Current->Previous &&
+           Current->Previous->is(tok::pp_define);
   };
 
   unsigned MinColumn = 0;

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -656,6 +656,7 @@ void WhitespaceManager::alignConsecutiveMacros() {
 
   auto AlignMacrosMatches = [](const Change &C) {
     const FormatToken *Current = C.Tok;
+    assert(Current);
 
     if (Current->SpacesRequiredBefore == 0 || !Current->Previous)
       return false;

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -664,12 +664,14 @@ void WhitespaceManager::alignConsecutiveMacros() {
 
     // If token is a ")", skip over the parameter list, to the
     // token that precedes the "("
-    if (const auto *MatchingParen = Current->MatchingParen;
-        Current->is(tok::r_paren) && MatchingParen) {
+    if (Current->is(tok::r_paren)) {
+      const auto *MatchingParen = Current->MatchingParen;
       // For a macro function, 0 spaces are required between the
       // identifier and the lparen that opens the parameter list.
-      if (MatchingParen->SpacesRequiredBefore > 0)
+      if (!MatchingParen || MatchingParen->SpacesRequiredBefore > 0 ||
+          !MatchingParen->Previous) {
         return false;
+      }
       Current = MatchingParen->Previous;
     } else if (Current->Next->SpacesRequiredBefore != 1) {
       // For a simple macro, 1 space is required between the
@@ -677,8 +679,7 @@ void WhitespaceManager::alignConsecutiveMacros() {
       return false;
     }
 
-    return Current && Current->is(tok::identifier) && Current->Previous &&
-           Current->Previous->is(tok::pp_define);
+    return Current->endsSequence(tok::identifier, tok::pp_define);
   };
 
   unsigned MinColumn = 0;


### PR DESCRIPTION
Just return early based on the SpacedRequiredBefore.