### PR TITLE
Remove non-standard use of `std::exception` in `compiler-rt/test/asan/TestCases/Windows/basic_exception_handling.cpp`

### DIFF
--- a/compiler-rt/test/asan/TestCases/Windows/basic_exception_handling.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/basic_exception_handling.cpp
@@ -7,13 +7,14 @@
 // This code is based on the repro in https://github.com/google/sanitizers/issues/749
 #include <cstdio>
 #include <exception>
+#include <stdexcept>
 
-void throwInFunction() { throw std::exception("test2"); }
+void throwInFunction() { throw std::runtime_error("test2"); }
 
 int main() {
   // case 1: direct throw
   try {
-    throw std::exception("test1");
+    throw std::runtime_error("test1");
   } catch (const std::exception &ex) {
     puts(ex.what());
     // CHECK: test1


### PR DESCRIPTION
**Follow up to:** #159618

**Context**

The linked PR ^ introduced a new test to ensure that ASan on Windows no longer instruments catch-parameters. This test used a non-standard constructor of `std::exception`,one that accepted strings as their input, which _somehow_ passed the PR CI but would fail to compile on mingw with libc++.

This was originally reported by @mstorsjo, in this comment:
```
This testcase fails to compile in mingw environments, with libc++ as a C++ standard library - https://github.com/mstorsjo/llvm-mingw/actions/runs/18608410056/job/53074081871:

D:\a\llvm-mingw\llvm-mingw\llvm-project\compiler-rt\test\asan\TestCases\Windows\basic_exception_handling.cpp:11:32: error: no matching conversion for functional-style cast from 'const char[6]' to 'std::exception'
   11 | void throwInFunction() { throw std::exception("test2"); }
      |                                ^~~~~~~~~~~~~~~~~~~~~~~
C:/llvm-mingw/include/c++/v1/__exception/exception.h:75:25: note: candidate constructor not viable: no known conversion from 'const char[6]' to 'const exception' for 1st argument
   75 |   _LIBCPP_HIDE_FROM_ABI exception(const exception&) _NOEXCEPT            = default;
      |                         ^         ~~~~~~~~~~~~~~~~
C:/llvm-mingw/include/c++/v1/__exception/exception.h:74:25: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
   74 |   _LIBCPP_HIDE_FROM_ABI exception() _NOEXCEPT {}
      |                         ^
D:\a\llvm-mingw\llvm-mingw\llvm-project\compiler-rt\test\asan\TestCases\Windows\basic_exception_handling.cpp:16:11: error: no matching conversion for functional-style cast from 'const char[6]' to 'std::exception'
   16 |     throw std::exception("test1");
      |           ^~~~~~~~~~~~~~~~~~~~~~~
C:/llvm-mingw/include/c++/v1/__exception/exception.h:75:25: note: candidate constructor not viable: no known conversion from 'const char[6]' to 'const exception' for 1st argument
   75 |   _LIBCPP_HIDE_FROM_ABI exception(const exception&) _NOEXCEPT            = default;
      |                         ^         ~~~~~~~~~~~~~~~~
C:/llvm-mingw/include/c++/v1/__exception/exception.h:74:25: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
   74 |   _LIBCPP_HIDE_FROM_ABI exception() _NOEXCEPT {}
      |                         ^
2 errors generated.
Looking at https://en.cppreference.com/w/cpp/error/exception/exception.html, I don't see any std::exception constructor taking a const char* parameter.
```

_from:_ https://github.com/llvm/llvm-project/pull/159618#issuecomment-3418802209

**This PR** adjusts the faulty test case to rely on `std::runtime_error`, which contains a standard constructor accepting a string. This should suffice to make the test pass on mingw. I tested this on godbolt: https://godbolt.org/z/M4hPv5Wvx