### PR TITLE
[ADT] Use static_assert in PackedVector

### DIFF
--- a/llvm/include/llvm/ADT/PackedVector.h
+++ b/llvm/include/llvm/ADT/PackedVector.h
@@ -29,6 +29,8 @@ namespace llvm {
 /// an assertion.
 template <typename T, unsigned BitNum, typename BitVectorTy = BitVector>
 class PackedVector {
+  static_assert(BitNum > 0, "BitNum must be > 0");
+
   BitVectorTy Bits;
   // Keep track of the number of elements on our own.
   // We always maintain Bits.size() == NumElements * BitNum.
@@ -132,9 +134,6 @@ public:
   const BitVectorTy &raw_bits() const { return Bits; }
   BitVectorTy &raw_bits() { return Bits; }
 };
-
-// Leave BitNum=0 undefined.
-template <typename T> class PackedVector<T, 0>;
 
 } // end namespace llvm
 


### PR DESCRIPTION
This patch replaces an intentionally undefined template
specialization:

  template <typename T> class PackedVector<T, 0>;

with:

  static_assert(BitNum > 0, "BitNum must be > 0");

This way, the compiler diagnostic on a use of PackedVector<T, 0>
improves from:

  error: implicit instantiation of undefined template
  'llvm::PackedVector<unsigned int, 0>'

to:

  error: static assertion failed due to requirement '0U > 0': BitNum
  must be > 0
