### PR TITLE
[ADT] Add C++20-style llvm::identity_cxx20

### DIFF
--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -19,6 +19,7 @@
 
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 namespace llvm {
 
@@ -116,6 +117,15 @@ struct detector<std::void_t<Op<Args...>>, Op, Args...> {
 ///   bool fooHasCopyAssign = is_detected<has_copy_assign_t, FooClass>::value;
 template <template <class...> class Op, class... Args>
 using is_detected = typename detail::detector<void, Op, Args...>::value_t;
+
+struct identity_cxx20 // NOLINT(readability-identifier-naming)
+{
+  using is_transparent = void;
+
+  template <typename T> constexpr T &&operator()(T &&self) const noexcept {
+    return std::forward<T>(self);
+  }
+};
 
 //===----------------------------------------------------------------------===//
 //     Features from C++23

--- a/llvm/unittests/ADT/STLForwardCompatTest.cpp
+++ b/llvm/unittests/ADT/STLForwardCompatTest.cpp
@@ -184,4 +184,26 @@ TEST(TransformTest, ToUnderlying) {
   static_assert(llvm::to_underlying(E3::B3) == 0);
 }
 
+TEST(STLForwardCompatTest, IdentityCxx20) {
+  llvm::identity_cxx20 identity;
+
+  // Test with an lvalue.
+  int X = 42;
+  int &Y = identity(X);
+  EXPECT_EQ(&X, &Y);
+
+  // Test with a const lvalue.
+  const int CX = 10;
+  const int &CY = identity(CX);
+  EXPECT_EQ(&CX, &CY);
+
+  // Test with an rvalue.
+  EXPECT_EQ(identity(123), 123);
+
+  // Test perfect forwarding.
+  static_assert(std::is_same_v<int &, decltype(identity(X))>);
+  static_assert(std::is_same_v<const int &, decltype(identity(CX))>);
+  static_assert(std::is_same_v<int &&, decltype(identity(int(5)))>);
+}
+
 } // namespace


### PR DESCRIPTION
Currently, our llvm::identity<T> is not quite like std::identity from
C++20.  Ours is a template struct while std::identity is a
non-template struct with templatized operator().  This difference
means that we cannot mechanically replace llvm::identity with
std::identity when we switch to C++20 in the future.

This patch implements llvm::identity_cxx20, which behaves exactly like
std::identity.

Once this patch lands, I'm planning to migrate users of llvm::identity
to the new style.  There aren't that many:

- 4 instances of SparseSet<...>
- 3 instances of SparseMultiSet<...>
- about 50 instances of IndexedMap<...>
