### PR TITLE
[clang-tools-extra][Unittest] Fix wrong reference to CMake configuration variable

### DIFF
--- a/clang-tools-extra/clangd/unittests/lit.cfg.py
+++ b/clang-tools-extra/clangd/unittests/lit.cfg.py
@@ -24,7 +24,7 @@ elif platform.system() == "Windows":
 else:
     shlibpath_var = "LD_LIBRARY_PATH"
 config.environment[shlibpath_var] = os.path.pathsep.join(
-    ("@SHLIBDIR@", "@LLVM_LIBS_DIR@", config.environment.get(shlibpath_var, ""))
+    (config.shlibdir, config.llvm_libs_dir, config.environment.get(shlibpath_var, ""))
 )
 
 # It is not realistically possible to account for all options that could

--- a/clang-tools-extra/include-cleaner/test/Unit/lit.cfg.py
+++ b/clang-tools-extra/include-cleaner/test/Unit/lit.cfg.py
@@ -16,7 +16,7 @@ elif platform.system() == "Windows":
 else:
     shlibpath_var = "LD_LIBRARY_PATH"
 config.environment[shlibpath_var] = os.path.pathsep.join(
-    ("@SHLIBDIR@", "@LLVM_LIBS_DIR@", config.environment.get(shlibpath_var, ""))
+    (config.shlibdir, config.llvm_libs_dir, config.environment.get(shlibpath_var, ""))
 )
 
 # It is not realistically possible to account for all options that could


### PR DESCRIPTION
`@SHLIBDIR@` is replaced by CMake's configuration function, so it must be in `lit.site.cfg.py.in` but not `lit.cfg.py`. `lit.cfg.py` must reference variables in generated `lit.site.cfg.py`.

We didn't notice this problem because it only affects Windows (including MinGW and Cygwin) that are configured with either LLVM_LINK_LLVM_DYLIB=ON or BUILD_SHARED=ON.