### PR TITLE
[Clang][NFC] Fix a warning in TransformNestedRequirement

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -2864,9 +2864,9 @@ TemplateInstantiator::TransformNestedRequirement(
         TemplateArgs, Constraint->getSourceRange(), Satisfaction,
         /*TopLevelConceptId=*/nullptr, &NewConstraint);
 
-    assert(!Success || !Trap.hasErrorOccurred() &&
-                           "Substitution failures must be handled "
-                           "by CheckConstraintSatisfaction.");
+    assert((!Success || !Trap.hasErrorOccurred()) &&
+           "Substitution failures must be handled "
+           "by CheckConstraintSatisfaction.");
   }
 
   if (!Success || Satisfaction.HasSubstitutionFailure())


### PR DESCRIPTION
The logical or expression should be parenthesized.

Fixes https://github.com/llvm/llvm-project/issues/164104