### PR TITLE
[CIR] Add VTable class name for array types

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -941,9 +941,7 @@ const char *vTableClassNameForType(const CIRGenModule &cgm, const Type *ty) {
   case Type::ConstantArray:
   case Type::IncompleteArray:
   case Type::VariableArray:
-    cgm.errorNYI("VTableClassNameForType: __array_type_info");
-    break;
-
+    return "_ZTVN10__cxxabiv117__array_type_infoE";
   case Type::FunctionNoProto:
   case Type::FunctionProto:
     cgm.errorNYI("VTableClassNameForType: __function_type_info");


### PR DESCRIPTION
This PR adds the VTable name `_ZTVN10__cxxabiv117__array_type_infoE` for `Type::ConstantArray`, `Type::IncompleteArray` and `Type::VariableArray` in `ItaniumRTTIBuilder::BuildVTablePointer`.

issue #163601 