### PR TITLE
[lldb] Show signal number description

### DIFF
--- a/lldb/include/lldb/Target/UnixSignals.h
+++ b/lldb/include/lldb/Target/UnixSignals.h
@@ -31,6 +31,8 @@ public:
 
   llvm::StringRef GetSignalAsStringRef(int32_t signo) const;
 
+  llvm::StringRef GetSignalNoDescription(int32_t signo) const;
+
   std::string
   GetSignalDescription(int32_t signo,
                        std::optional<int32_t> code = std::nullopt,

--- a/lldb/include/lldb/Target/UnixSignals.h
+++ b/lldb/include/lldb/Target/UnixSignals.h
@@ -31,7 +31,7 @@ public:
 
   llvm::StringRef GetSignalAsStringRef(int32_t signo) const;
 
-  llvm::StringRef GetSignalNoDescription(int32_t signo) const;
+  llvm::StringRef GetSignalNumberDescription(int32_t signo) const;
 
   std::string
   GetSignalDescription(int32_t signo,

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1603,8 +1603,8 @@ public:
   Options *GetOptions() override { return &m_options; }
 
   void PrintSignalHeader(Stream &str) {
-    str.Printf("NAME         PASS   STOP   NOTIFY\n");
-    str.Printf("===========  =====  =====  ======\n");
+    str.Printf("NAME         PASS   STOP   NOTIFY  DESCRIPTION\n");
+    str.Printf("===========  =====  =====  ======  ===================\n");
   }
 
   void PrintSignal(Stream &str, int32_t signo, llvm::StringRef sig_name,
@@ -1616,8 +1616,15 @@ public:
     str.Format("{0, -11}  ", sig_name);
     if (signals_sp->GetSignalInfo(signo, suppress, stop, notify)) {
       bool pass = !suppress;
-      str.Printf("%s  %s  %s", (pass ? "true " : "false"),
+      str.Printf("%s  %s  %s  ", (pass ? "true " : "false"),
                  (stop ? "true " : "false"), (notify ? "true " : "false"));
+
+      llvm::StringRef sig_description =
+          signals_sp->GetSignalNoDescription(signo);
+      if (!sig_description.empty()) {
+        str.PutCString(" ");
+        str.PutCString(sig_description);
+      }
     }
     str.Printf("\n");
   }

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1620,7 +1620,7 @@ public:
                  (stop ? "true " : "false"), (notify ? "true " : "false"));
 
       llvm::StringRef sig_description =
-          signals_sp->GetSignalNoDescription(signo);
+          signals_sp->GetSignalNumberDescription(signo);
       if (!sig_description.empty()) {
         str.PutCString(" ");
         str.PutCString(sig_description);

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1615,14 +1615,14 @@ public:
 
     str.Format("{0, -11}  ", sig_name);
     if (signals_sp->GetSignalInfo(signo, suppress, stop, notify)) {
-      bool pass = !suppress;
-      str.Printf("%s  %s  %s  ", (pass ? "true " : "false"),
+      const bool pass = !suppress;
+      str.Printf("%s  %s  %s", (pass ? "true " : "false"),
                  (stop ? "true " : "false"), (notify ? "true " : "false"));
 
-      llvm::StringRef sig_description =
+      const llvm::StringRef sig_description =
           signals_sp->GetSignalNumberDescription(signo);
       if (!sig_description.empty()) {
-        str.PutCString(" ");
+        str.PutCString("   ");
         str.PutCString(sig_description);
       }
     }

--- a/lldb/source/Target/UnixSignals.cpp
+++ b/lldb/source/Target/UnixSignals.cpp
@@ -137,7 +137,7 @@ llvm::StringRef UnixSignals::GetSignalAsStringRef(int32_t signo) const {
   return pos->second.m_name;
 }
 
-llvm::StringRef UnixSignals::GetSignalNoDescription(int32_t signo) const {
+llvm::StringRef UnixSignals::GetSignalNumberDescription(int32_t signo) const {
   const auto pos = m_signals.find(signo);
   if (pos == m_signals.end())
     return {};

--- a/lldb/source/Target/UnixSignals.cpp
+++ b/lldb/source/Target/UnixSignals.cpp
@@ -137,6 +137,13 @@ llvm::StringRef UnixSignals::GetSignalAsStringRef(int32_t signo) const {
   return pos->second.m_name;
 }
 
+llvm::StringRef UnixSignals::GetSignalNoDescription(int32_t signo) const {
+  const auto pos = m_signals.find(signo);
+  if (pos == m_signals.end())
+    return {};
+  return pos->second.m_description;
+}
+
 std::string UnixSignals::GetSignalDescription(
     int32_t signo, std::optional<int32_t> code,
     std::optional<lldb::addr_t> addr, std::optional<lldb::addr_t> lower,

--- a/lldb/unittests/Signals/UnixSignalsTest.cpp
+++ b/lldb/unittests/Signals/UnixSignalsTest.cpp
@@ -148,6 +148,18 @@ TEST(UnixSignalsTest, GetAsString) {
             signals.GetSignalDescription(16, 3, 0x1233, 0x1234, 0x5678));
 }
 
+TEST(UnixSignalsTest, GetNumberDescription) {
+  TestSignals signals;
+
+  ASSERT_EQ("DESC2", signals.GetSignalNumberDescription(2));
+  ASSERT_EQ("DESC4", signals.GetSignalNumberDescription(4));
+  ASSERT_EQ("DESC8", signals.GetSignalNumberDescription(8));
+  ASSERT_EQ("DESC16", signals.GetSignalNumberDescription(16));
+
+  // Unknown signal number.
+  ASSERT_EQ("", signals.GetSignalNumberDescription(100));
+}
+
 TEST(UnixSignalsTest, VersionChange) {
   TestSignals signals;
 


### PR DESCRIPTION
show information about the signal when the user presses `process handle <unix-signal>`  i.e 

```sh
(lldb) process handle SIGWINCH 
NAME         PASS   STOP   NOTIFY  DESCRIPTION
===========  =====  =====  ======  ===================
SIGWINCH     true   false  false   window size changes
```

Wanted to use the existing `GetSignalDescription` but it is expected behaviour to return the signal name if no signal code is passed. It is used in stop info. 

https://github.com/llvm/llvm-project/blob/65c895dfe084860847e9e220ff9f1b283ebcb289/lldb/source/Target/StopInfo.cpp#L1192-L1195