### PR TITLE
[clang][analyzer] Mark `lstrcatA`, `lstrcpyA`, and `_strdup` as insecure on Windows in `SecuritySyntaxChecker`

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -870,14 +870,14 @@ def getpw : Checker<"getpw">,
   Documentation<HasDocumentation>;
 
 def lstrcatA : Checker<"lstrcatA">,
-  HelpText<"Warn on uses of the 'lstrcatA' function">,
-  Dependencies<[SecuritySyntaxChecker]>,
-  Documentation<HasDocumentation>;
+               HelpText<"Warn on uses of the 'lstrcatA' function">,
+               Dependencies<[SecuritySyntaxChecker]>,
+               Documentation<HasDocumentation>;
 
 def lstrcpyA : Checker<"lstrcpyA">,
-  HelpText<"Warn on uses of the 'lstrcpyA' function">,
-  Dependencies<[SecuritySyntaxChecker]>,
-  Documentation<HasDocumentation>;
+               HelpText<"Warn on uses of the 'lstrcpyA' function">,
+               Dependencies<[SecuritySyntaxChecker]>,
+               Documentation<HasDocumentation>;
 
 def mktemp : Checker<"mktemp">,
   HelpText<"Warn on uses of the 'mktemp' function">,
@@ -901,9 +901,9 @@ def strcpy : Checker<"strcpy">,
   Documentation<HasDocumentation>;
 
 def strdup : Checker<"strdup">,
-  HelpText<"Warn on uses of the '_strdup' function">,
-  Dependencies<[SecuritySyntaxChecker]>,
-  Documentation<HasDocumentation>;
+             HelpText<"Warn on uses of the '_strdup' function">,
+             Dependencies<[SecuritySyntaxChecker]>,
+             Documentation<HasDocumentation>;
 
 def vfork : Checker<"vfork">,
   HelpText<"Warn on uses of the 'vfork' function">,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -869,6 +869,16 @@ def getpw : Checker<"getpw">,
   Dependencies<[SecuritySyntaxChecker]>,
   Documentation<HasDocumentation>;
 
+def lstrcatA : Checker<"lstrcatA">,
+  HelpText<"Warn on uses of the 'lstrcatA' function">,
+  Dependencies<[SecuritySyntaxChecker]>,
+  Documentation<HasDocumentation>;
+
+def lstrcpyA : Checker<"lstrcpyA">,
+  HelpText<"Warn on uses of the 'lstrcpyA' function">,
+  Dependencies<[SecuritySyntaxChecker]>,
+  Documentation<HasDocumentation>;
+
 def mktemp : Checker<"mktemp">,
   HelpText<"Warn on uses of the 'mktemp' function">,
   Dependencies<[SecuritySyntaxChecker]>,
@@ -887,6 +897,11 @@ def rand : Checker<"rand">,
 
 def strcpy : Checker<"strcpy">,
   HelpText<"Warn on uses of the 'strcpy' and 'strcat' functions">,
+  Dependencies<[SecuritySyntaxChecker]>,
+  Documentation<HasDocumentation>;
+
+def strdup : Checker<"strdup">,
+  HelpText<"Warn on uses of the '_strdup' function">,
   Dependencies<[SecuritySyntaxChecker]>,
   Documentation<HasDocumentation>;
 


### PR DESCRIPTION
Addresses issue #103038.

Some of the functions mentioned in that issue are already covered or do not exist under the specified names. Therefore, this patch adds only the three functions listed above.

There is a separate commit for `clang-format` style changes since they seem to be inconsistent with the rest of `Checkers.td` file.

PR #164184 addresses the other part of the issue, which is making the list of insecure functions extensible.