### PR TITLE
[clang][NFC] Simplify implementation of `IgnoreExprNodes`

### DIFF
--- a/clang/include/clang/AST/IgnoreExpr.h
+++ b/clang/include/clang/AST/IgnoreExpr.h
@@ -17,16 +17,6 @@
 #include "clang/AST/ExprCXX.h"
 
 namespace clang {
-namespace detail {
-/// Given an expression E and functions Fn_1,...,Fn_n : Expr * -> Expr *,
-/// Return Fn_n(...(Fn_1(E)))
-inline Expr *IgnoreExprNodesImpl(Expr *E) { return E; }
-template <typename FnTy, typename... FnTys>
-Expr *IgnoreExprNodesImpl(Expr *E, FnTy &&Fn, FnTys &&... Fns) {
-  return IgnoreExprNodesImpl(std::forward<FnTy>(Fn)(E),
-                             std::forward<FnTys>(Fns)...);
-}
-} // namespace detail
 
 /// Given an expression E and functions Fn_1,...,Fn_n : Expr * -> Expr *,
 /// Recursively apply each of the functions to E until reaching a fixed point.
@@ -35,7 +25,7 @@ template <typename... FnTys> Expr *IgnoreExprNodes(Expr *E, FnTys &&... Fns) {
   Expr *LastE = nullptr;
   while (E != LastE) {
     LastE = E;
-    E = detail::IgnoreExprNodesImpl(E, std::forward<FnTys>(Fns)...);
+    ((E = std::forward<FnTys>(Fns)(E)), ...);
   }
   return E;
 }


### PR DESCRIPTION
Using a fold instead of template recursion.