### PR TITLE
[clang-tidy][NFC] Remove unused parameter in function

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyCheck.cpp
@@ -90,12 +90,10 @@ ClangTidyCheck::OptionsView::getLocalOrGlobal(StringRef LocalName) const {
   return std::nullopt;
 }
 
-static std::optional<bool> getAsBool(StringRef Value,
-                                     const llvm::Twine &LookupName) {
-
+static std::optional<bool> getAsBool(StringRef Value) {
   if (std::optional<bool> Parsed = llvm::yaml::parseBool(Value))
     return Parsed;
-  // To maintain backwards compatability, we support parsing numbers as
+  // To maintain backwards compatibility, we support parsing numbers as
   // booleans, even though its not supported in YAML.
   long long Number = 0;
   if (!Value.getAsInteger(10, Number))
@@ -107,7 +105,7 @@ template <>
 std::optional<bool>
 ClangTidyCheck::OptionsView::get<bool>(StringRef LocalName) const {
   if (std::optional<StringRef> ValueOr = get(LocalName)) {
-    if (auto Result = getAsBool(*ValueOr, NamePrefix + LocalName))
+    if (auto Result = getAsBool(*ValueOr))
       return Result;
     diagnoseBadBooleanOption(NamePrefix + LocalName, *ValueOr);
   }
@@ -119,7 +117,7 @@ std::optional<bool>
 ClangTidyCheck::OptionsView::getLocalOrGlobal<bool>(StringRef LocalName) const {
   auto Iter = findPriorityOption(CheckOptions, NamePrefix, LocalName, Context);
   if (Iter != CheckOptions.end()) {
-    if (auto Result = getAsBool(Iter->getValue().Value, Iter->getKey()))
+    if (auto Result = getAsBool(Iter->getValue().Value))
       return Result;
     diagnoseBadBooleanOption(Iter->getKey(), Iter->getValue().Value);
   }


### PR DESCRIPTION
82289aa refactored this function to not need this parameter.