### PR TITLE
[clang][bytecode] Fix a crash when redeclaring extern globals

### DIFF
--- a/clang/lib/AST/ByteCode/Program.cpp
+++ b/clang/lib/AST/ByteCode/Program.cpp
@@ -226,7 +226,10 @@ UnsignedOrNone Program::createGlobal(const ValueDecl *VD, const Expr *Init) {
         Globals[PIdx] = NewGlobal;
         // All pointers pointing to the previous extern decl now point to the
         // new decl.
-        RedeclBlock->movePointersTo(NewGlobal->block());
+        // A previous iteration might've already fixed up the pointers for this
+        // global.
+        if (RedeclBlock != NewGlobal->block())
+          RedeclBlock->movePointersTo(NewGlobal->block());
       }
     }
     PIdx = *Idx;

--- a/clang/test/AST/ByteCode/extern.cpp
+++ b/clang/test/AST/ByteCode/extern.cpp
@@ -1,8 +1,10 @@
 // RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify=both,expected %s
-// RUN: %clang_cc1 -verify=both,ref %s
-
+// RUN: %clang_cc1                                         -verify=both,ref      %s
 
 // both-no-diagnostics
+
+extern const double Num;
+extern const double Num = 12;
 
 extern const int E;
 constexpr int getE() {


### PR DESCRIPTION
One iteration of this loop might've already fixed up the pointers of coming globals, so check for that explicitly.

Fixes https://github.com/llvm/llvm-project/issues/164151