### PR TITLE
[clang-tidy][NFC] Devirtualize `GlobList` and don't heap allocate it

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -238,9 +238,8 @@ static bool parseFileExtensions(llvm::ArrayRef<std::string> AllFileExtensions,
 void ClangTidyContext::setCurrentFile(StringRef File) {
   CurrentFile = std::string(File);
   CurrentOptions = getOptionsForFile(CurrentFile);
-  CheckFilter = std::make_unique<CachedGlobList>(*getOptions().Checks);
-  WarningAsErrorFilter =
-      std::make_unique<CachedGlobList>(*getOptions().WarningsAsErrors);
+  CheckFilter = {*getOptions().Checks};
+  WarningAsErrorFilter = {*getOptions().WarningsAsErrors};
   if (!parseFileExtensions(*getOptions().HeaderFileExtensions,
                            HeaderFileExtensions))
     this->configurationDiag("Invalid header file extensions");
@@ -284,13 +283,11 @@ ClangTidyContext::getProfileStorageParams() const {
 }
 
 bool ClangTidyContext::isCheckEnabled(StringRef CheckName) const {
-  assert(CheckFilter != nullptr);
-  return CheckFilter->contains(CheckName);
+  return CheckFilter.contains(CheckName);
 }
 
 bool ClangTidyContext::treatAsError(StringRef CheckName) const {
-  assert(WarningAsErrorFilter != nullptr);
-  return WarningAsErrorFilter->contains(CheckName);
+  return WarningAsErrorFilter.contains(CheckName);
 }
 
 std::string ClangTidyContext::getCheckName(unsigned DiagnosticID) const {

--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
@@ -12,6 +12,7 @@
 #include "ClangTidyOptions.h"
 #include "ClangTidyProfiling.h"
 #include "FileExtensionsSet.h"
+#include "GlobList.h"
 #include "NoLintDirectiveHandler.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Tooling/Core/Diagnostic.h"
@@ -27,7 +28,6 @@ class ASTContext;
 class SourceManager;
 
 namespace tidy {
-class CachedGlobList;
 
 /// A detected error complete with information to display diagnostic and
 /// automatic fix.
@@ -247,8 +247,8 @@ private:
   std::string CurrentFile;
   ClangTidyOptions CurrentOptions;
 
-  std::unique_ptr<CachedGlobList> CheckFilter;
-  std::unique_ptr<CachedGlobList> WarningAsErrorFilter;
+  CachedGlobList CheckFilter;
+  CachedGlobList WarningAsErrorFilter;
 
   FileExtensionsSet HeaderFileExtensions;
   FileExtensionsSet ImplementationFileExtensions;

--- a/clang-tools-extra/clang-tidy/GlobList.h
+++ b/clang-tools-extra/clang-tidy/GlobList.h
@@ -24,7 +24,7 @@ namespace clang::tidy {
 /// them in the order of appearance in the list.
 class GlobList {
 public:
-  virtual ~GlobList() = default;
+  GlobList() = default;
 
   /// \p Globs is a comma-separated list of globs (only the '*' metacharacter is
   /// supported) with an optional '-' prefix to denote exclusion.
@@ -38,7 +38,7 @@ public:
 
   /// Returns \c true if the pattern matches \p S. The result is the last
   /// matching glob's Positive flag.
-  virtual bool contains(StringRef S) const;
+  bool contains(StringRef S) const;
 
 private:
   struct GlobListItem {
@@ -54,12 +54,12 @@ public:
 
 /// A \p GlobList that caches search results, so that search is performed only
 /// once for the same query.
-class CachedGlobList final : public GlobList {
+class CachedGlobList : public GlobList {
 public:
   using GlobList::GlobList;
 
   /// \see GlobList::contains
-  bool contains(StringRef S) const override;
+  bool contains(StringRef S) const;
 
 private:
   mutable llvm::StringMap<bool> Cache;


### PR DESCRIPTION
`GlobList` is a polymorphic class, but we don't use it polymorphically anywhere, so we seem to be paying that cost unnecessarily.