### PR TITLE
[llvm][dwarfdump] Pretty-print DW_AT_language_version

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -178,7 +178,7 @@ static void dumpAttribute(raw_ostream &OS, const DWARFDie &Die,
 
   llvm::StringRef PrettyVersionName =
       prettyLanguageVersionString(AttrValue, Die);
-  const bool ShouldDumpRawLanguageVersion =
+  bool ShouldDumpRawLanguageVersion =
       Attr == DW_AT_language_version &&
       (DumpOpts.Verbose || PrettyVersionName.empty());
 

--- a/llvm/test/DebugInfo/Generic/compileunit-source-language-name.ll
+++ b/llvm/test/DebugInfo/Generic/compileunit-source-language-name.ll
@@ -1,11 +1,11 @@
 ; AIX doesn't have support for DWARF 6 DW_AT_language_name
 ; XFAIL: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
-; RUN: %llc_dwarf -filetype=obj -O0 < %s | llvm-dwarfdump -debug-info - | FileCheck %s --implicit-check-not "DW_AT_language"
+; RUN: %llc_dwarf -filetype=obj -O0 < %s | llvm-dwarfdump -debug-info -v - | FileCheck %s --implicit-check-not "DW_AT_language"
 
-; CHECK:     DW_AT_language_name (DW_LNAME_ObjC_plus_plus)
-; CHECK:     DW_AT_language_name (DW_LNAME_C_plus_plus)
-; CHECK:     DW_AT_language_version (201100)
-; CHECK:     DW_AT_language_name (DW_LNAME_Rust)
+; CHECK:     DW_AT_language_name [DW_FORM_data2] (DW_LNAME_ObjC_plus_plus)
+; CHECK:     DW_AT_language_name [DW_FORM_data2] (DW_LNAME_C_plus_plus)
+; CHECK:     DW_AT_language_version [DW_FORM_data4] (201100)
+; CHECK:     DW_AT_language_name [DW_FORM_data2] (DW_LNAME_Rust)
 ; CHECK-NOT: DW_AT_language_version
 
 @x = global i32 0, align 4, !dbg !0

--- a/llvm/test/DebugInfo/Generic/compileunit-source-language-name.ll
+++ b/llvm/test/DebugInfo/Generic/compileunit-source-language-name.ll
@@ -4,7 +4,7 @@
 
 ; CHECK:     DW_AT_language_name [DW_FORM_data2] (DW_LNAME_ObjC_plus_plus)
 ; CHECK:     DW_AT_language_name [DW_FORM_data2] (DW_LNAME_C_plus_plus)
-; CHECK:     DW_AT_language_version [DW_FORM_data4] (201100)
+; CHECK:     DW_AT_language_version [DW_FORM_data4] (201100 C++11)
 ; CHECK:     DW_AT_language_name [DW_FORM_data2] (DW_LNAME_Rust)
 ; CHECK-NOT: DW_AT_language_version
 

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version-pretty.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version-pretty.s
@@ -1,10 +1,15 @@
 # Demonstrate dumping DW_AT_language_version in human-readable form.
-# RUN: llvm-mc -triple=x86_64--linux -filetype=obj < %s | \
-# RUN:     llvm-dwarfdump - | FileCheck %s --implicit-check-not "DW_AT_language_version"
+# RUN: llvm-mc -triple=x86_64--linux -filetype=obj -o %t.o < %s
+# RUN: llvm-dwarfdump %t.o -v | FileCheck %s --check-prefix=VERBOSE
+# RUN: llvm-dwarfdump %t.o | FileCheck %s --check-prefix=NO-VERBOSE
 
-# CHECK: .debug_info contents:
-# CHECK: DW_AT_language_name (DW_LNAME_C)
-# CHECK: DW_AT_language_version (C11)
+# VERBOSE: .debug_info contents:
+# VERBOSE: DW_AT_language_name [DW_FORM_data2] (DW_LNAME_C)
+# VERBOSE: DW_AT_language_version [DW_FORM_data4] (201112 C11)
+
+# NO-VERBOSE: .debug_info contents:
+# NO-VERBOSE: DW_AT_language_name (DW_LNAME_C)
+# NO-VERBOSE: DW_AT_language_version (C11)
 
         .section        .debug_abbrev,"",@progbits
         .byte   1                       # Abbreviation Code

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version-pretty.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version-pretty.s
@@ -6,10 +6,14 @@
 # VERBOSE: .debug_info contents:
 # VERBOSE: DW_AT_language_name [DW_FORM_data2] (DW_LNAME_C)
 # VERBOSE: DW_AT_language_version [DW_FORM_data4] (201112 C11)
+# VERBOSE: DW_AT_language_name [DW_FORM_data2] (0x0000)
+# VERBOSE: DW_AT_language_version [DW_FORM_data4] (12 Unknown)
 
 # NO-VERBOSE: .debug_info contents:
 # NO-VERBOSE: DW_AT_language_name (DW_LNAME_C)
 # NO-VERBOSE: DW_AT_language_version (C11)
+# NO-VERBOSE: DW_AT_language_name (0x0000)
+# NO-VERBOSE: DW_AT_language_version (Unknown)
 
         .section        .debug_abbrev,"",@progbits
         .byte   1                       # Abbreviation Code
@@ -33,5 +37,8 @@
         .byte   1                       # Abbrev [1] DW_TAG_compile_unit
         .short  3                       # DW_AT_language_name
         .long   201112                  # DW_AT_language_version
+        .byte   1                       # Abbrev [1] DW_TAG_compile_unit
+        .short  0                       # DW_AT_language_name
+        .long   12                      # DW_AT_language_version
         .byte   0 
 .Ldebug_info_end0:

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version-pretty.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version-pretty.s
@@ -1,27 +1,19 @@
-# Demonstrate dumping DW_AT_language_version.
-# RUN: llvm-mc -triple=x86_64--linux -filetype=obj -o %t.o < %s
-# RUN: llvm-dwarfdump -v %t.o | FileCheck %s --check-prefix=VERBOSE
-# RUN: llvm-dwarfdump %t.o | FileCheck %s --check-prefix=NO-VERBOSE
+# Demonstrate dumping DW_AT_language_version in human-readable form.
+# RUN: llvm-mc -triple=x86_64--linux -filetype=obj < %s | \
+# RUN:     llvm-dwarfdump - | FileCheck %s --implicit-check-not "DW_AT_language_version"
 
-# VERBOSE: .debug_abbrev contents:
-# VERBOSE: DW_AT_language_version DW_FORM_data4
-# VERBOSE: DW_AT_language_version DW_FORM_data2
-# VERBOSE: .debug_info contents:
-# VERBOSE: DW_AT_language_version [DW_FORM_data4] (201402)
-# VERBOSE: DW_AT_language_version [DW_FORM_data2] (0)
-
-# NO-VERBOSE: .debug_info contents:
-# NO-VERBOSE: DW_AT_language_version (201402)
-# NO-VERBOSE: DW_AT_language_version (0)
+# CHECK: .debug_info contents:
+# CHECK: DW_AT_language_name (DW_LNAME_C)
+# CHECK: DW_AT_language_version (C11)
 
         .section        .debug_abbrev,"",@progbits
         .byte   1                       # Abbreviation Code
         .byte   17                      # DW_TAG_compile_unit
         .byte   1                       # DW_CHILDREN_no 
+        .ascii  "\220\001"              # DW_AT_language_name
+        .byte   5                       # DW_FORM_data2
         .ascii  "\221\001"              # DW_AT_language_version
         .byte   6                       # DW_FORM_data4
-        .ascii  "\221\001"              # DW_AT_language_version
-        .byte   5                       # DW_FORM_data2
         .byte   0                       # EOM(1)
         .byte   0                       # EOM(2)
         .byte   0                       # EOM(3)
@@ -34,7 +26,7 @@
         .byte   8                       # Address Size (in bytes)
         .long   .debug_abbrev           # Offset Into Abbrev. Section
         .byte   1                       # Abbrev [1] DW_TAG_compile_unit
-        .long   201402                  # DW_AT_language_version
-        .short  0                       # DW_AT_language_version
+        .short  3                       # DW_AT_language_name
+        .long   201112                  # DW_AT_language_version
         .byte   0 
 .Ldebug_info_end0:

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_AT_language_version.s
@@ -1,4 +1,5 @@
-# Demonstrate dumping DW_AT_language_version.
+# Demonstrate dumping DW_AT_language_version without an
+# accompanying DW_AT_language_name.
 # RUN: llvm-mc -triple=x86_64--linux -filetype=obj -o %t.o < %s
 # RUN: llvm-dwarfdump -v %t.o | FileCheck %s --check-prefix=VERBOSE
 # RUN: llvm-dwarfdump %t.o | FileCheck %s --check-prefix=NO-VERBOSE


### PR DESCRIPTION
In both verbose and non-verbose mode we will now use the `llvm::dwarf::LanguageDescription` to turn the version into a human readable string. In verbose mode we also display the raw version code (similar to how we display addresses in verbose mode). To make the version code and prettified easier to distinguish, we print the prettified name in colour (if available), which is consistent with how `DW_AT_language` is printed in colour.

Before:
```
0x0000000c: DW_TAG_compile_unit                                                                           
              DW_AT_language_name       (DW_LNAME_C)                                                      
              DW_AT_language_version    (201112)             
```
After:
```
0x0000000c: DW_TAG_compile_unit                                                                           
              DW_AT_language_name       (DW_LNAME_C)                                                      
              DW_AT_language_version    (201112 C11)                                                             
```