### PR TITLE
Fix libclang finding the wrong resource paths

### DIFF
--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -4445,7 +4445,11 @@ enum CXErrorCode clang_parseTranslationUnit2(
     unsigned options, CXTranslationUnit *out_TU) {
   noteBottomOfStack();
   SmallVector<const char *, 4> Args;
-  Args.push_back("clang");
+
+  CIndexer *CXXIdx = static_cast<CIndexer *>(CIdx);
+  auto library_path = CXXIdx->getLibClangPath();
+  Args.push_back(library_path.c_str());
+
   Args.append(command_line_args, command_line_args + num_command_line_args);
   return clang_parseTranslationUnit2FullArgv(
       CIdx, source_filename, Args.data(), Args.size(), unsaved_files,

--- a/clang/tools/libclang/CIndexer.cpp
+++ b/clang/tools/libclang/CIndexer.cpp
@@ -97,7 +97,21 @@ const std::string &CIndexer::getClangResourcesPath() {
   if (!ResourcesPath.empty())
     return ResourcesPath;
 
-  SmallString<128> LibClangPath;
+  if (CachedLibClangPath.empty())
+    getLibClangPath();
+
+  // Cache our result.
+  ResourcesPath = GetResourcesPath(CachedLibClangPath);
+  return ResourcesPath;
+}
+
+const std::string &CIndexer::getLibClangPath()
+{
+  // Did we already compute the path?
+  if (!CachedLibClangPath.empty())
+    return CachedLibClangPath;
+
+  SmallString<128> ResultPath;
 
   // Find the location where this library lives (libclang.dylib).
 #ifdef _WIN32
@@ -107,9 +121,9 @@ const std::string &CIndexer::getClangResourcesPath() {
                sizeof(mbi));
   GetModuleFileNameA((HINSTANCE)mbi.AllocationBase, path, MAX_PATH);
 
-  LibClangPath += path;
+  ResultPath += path;
 #elif defined(_AIX)
-  getClangResourcesPathImplAIX(LibClangPath);
+  getClangResourcesPathImplAIX(ResultPath);
 #else
   bool PathFound = false;
 #if defined(CLANG_HAVE_DLFCN_H) && defined(CLANG_HAVE_DLADDR)
@@ -117,7 +131,7 @@ const std::string &CIndexer::getClangResourcesPath() {
   // This silly cast below avoids a C++ warning.
   if (dladdr((void *)(uintptr_t)clang_createTranslationUnit, &info) != 0) {
     // We now have the CIndex directory, locate clang relative to it.
-    LibClangPath += info.dli_fname;
+    ResultPath += info.dli_fname;
     PathFound = true;
   }
 #endif
@@ -127,19 +141,19 @@ const std::string &CIndexer::getClangResourcesPath() {
       // If we can't get the path using dladdr, try to get the main executable
       // path. This may be needed when we're statically linking libclang with
       // musl libc, for example.
-      LibClangPath += Path;
+      ResultPath += Path;
     } else {
       // It's rather unlikely we end up here. But it could happen, so report an
       // error instead of crashing.
-      llvm::report_fatal_error("could not locate Clang resource path");
+      llvm::report_fatal_error("could not locate libclang path");
     }
   }
 
 #endif
 
   // Cache our result.
-  ResourcesPath = GetResourcesPath(LibClangPath);
-  return ResourcesPath;
+  CachedLibClangPath = std::string(ResultPath);
+  return CachedLibClangPath;
 }
 
 StringRef CIndexer::getClangToolchainPath() {

--- a/clang/tools/libclang/CIndexer.h
+++ b/clang/tools/libclang/CIndexer.h
@@ -37,6 +37,7 @@ class CIndexer {
   bool StorePreamblesInMemory = false;
   unsigned Options; // CXGlobalOptFlags.
 
+  std::string CachedLibClangPath;
   std::string ResourcesPath;
   std::shared_ptr<PCHContainerOperations> PCHContainerOps;
 
@@ -76,6 +77,9 @@ public:
 
   /// Get the path of the clang resource files.
   const std::string &getClangResourcesPath();
+
+  /// Get the path of libclang.
+  const std::string &getLibClangPath();
 
   StringRef getClangToolchainPath();
 


### PR DESCRIPTION
Fix libclang finding the wrong resource paths by giving `clang_parseTranslationUnit2()` the path to libclang instead of just 'clang'.

Seems related to https://github.com/llvm/llvm-project/issues/18150 and https://github.com/llvm/llvm-project/issues/51256

Minimal example repo: https://github.com/Lachlan-Frawley/libclang-resource-path-minimal-example

Having thought about this a bit, I've considered it might be the wrong approach to solve the problem, but it does work.

Before fix is applied (showing bad resource paths):
```
clang version 22.0.0git (https://github.com/Lachlan-Frawley/llvm-project.git 5b5eacc5790365b90878a79893325bfae00ed693)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir:
Found candidate GCC installation: /../lib/gcc/x86_64-linux-gnu/11
Found candidate GCC installation: /../lib/gcc/x86_64-linux-gnu/12
Selected GCC installation: /../lib/gcc/x86_64-linux-gnu/12
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Candidate multilib: x32;@mx32
Selected multilib: .;@m64
ignoring nonexistent directory "lib/clang/22/include"
ignoring nonexistent directory "/../lib/gcc/x86_64-linux-gnu/12/../../../../x86_64-linux-gnu/include"
ignoring nonexistent directory "/include"
#include "..." search starts here:
#include <...> search starts here:
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include
End of search list.
my-cpp-header.h:4:10: fatal error: 'cstdint' file not found
MY_CONSTEXPR_VALUE -> 0
```

After changes here are applied (correct resource paths):
```
clang version 22.0.0git (https://github.com/Lachlan-Frawley/llvm-project.git 5b5eacc5790365b90878a79893325bfae00ed693)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/workspace/clang-mre/llvm-project/build/lib
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/11
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/12
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/12
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Candidate multilib: x32;@mx32
Selected multilib: .;@m64
ignoring nonexistent directory "/usr/lib/gcc/x86_64-linux-gnu/12/../../../../x86_64-linux-gnu/include"
ignoring nonexistent directory "/include"
#include "..." search starts here:
#include <...> search starts here:
 /home/workspace/clang-mre/llvm-project/build/lib/../include/x86_64-unknown-linux-gnu/c++/v1
 /home/workspace/clang-mre/llvm-project/build/lib/../include/c++/v1
 /home/workspace/clang-mre/llvm-project/build/lib/clang/22/include
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include
End of search list.
MY_CONSTEXPR_VALUE -> 6
```