### PR TITLE
[NFC][SPIRV] Use hasLocalLinkage instead of hasInternalLinkage or hasPrivateLinkage

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -4350,8 +4350,7 @@ bool SPIRVInstructionSelector::selectGlobalValue(
   if (hasInitializer(GlobalVar) && !Init)
     return true;
 
-  bool HasLnkTy = !GV->hasInternalLinkage() && !GV->hasPrivateLinkage() &&
-                  !GV->hasHiddenVisibility();
+  bool HasLnkTy = !GV->hasLocalLinkage() && !GV->hasHiddenVisibility();
   SPIRV::LinkageType::LinkageType LnkType =
       GV->isDeclarationForLinker()
           ? SPIRV::LinkageType::Import


### PR DESCRIPTION
Internally, hasLocalLinkage is implemented as:
```cpp
static bool isLocalLinkage(LinkageTypes Linkage) {
  return isInternalLinkage(Linkage) || isPrivateLinkage(Linkage);
}
```