### PR TITLE
[SPIRV][NFC] Use DenseMap's lookup instead of find

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -169,9 +169,7 @@ struct ModuleAnalysisInfo {
 
   MCRegister getFuncReg(const Function *F) {
     assert(F && "Function is null");
-    auto FuncPtrRegPair = FuncMap.find(F);
-    return FuncPtrRegPair == FuncMap.end() ? MCRegister()
-                                           : FuncPtrRegPair->second;
+    return FuncMap.lookup(F);
   }
   MCRegister getExtInstSetReg(unsigned SetNum) { return ExtInstSetMap[SetNum]; }
   InstrList &getMSInstrs(unsigned MSType) { return MS[MSType]; }


### PR DESCRIPTION
[lookup](https://llvm.org/doxygen/classllvm_1_1DenseMapBase.html#a0b2ca98dc28c61793ff5c90d23e5f14e) does a find and returns the default if no matching element was found. Its implementation is:

```cpp
/// lookup - Return the entry for the specified key, or a default
/// constructed value if no such entry exists.
[[nodiscard]] ValueT lookup(const_arg_type_t<KeyT> Val) const {
  if (const BucketT *Bucket = doFind(Val))
    return Bucket->getSecond();
  return ValueT();
}
```