### PR TITLE
[lldb][ValueObject][NFC] Remove unused SyntheticChildrenFrontEnd member

### DIFF
--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -29,8 +29,7 @@ protected:
   ValueObject &m_backend;
 
 public:
-  SyntheticChildrenFrontEnd(ValueObject &backend)
-      : m_backend(backend) {}
+  SyntheticChildrenFrontEnd(ValueObject &backend) : m_backend(backend) {}
 
   virtual ~SyntheticChildrenFrontEnd() = default;
 

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -28,13 +28,9 @@ class SyntheticChildrenFrontEnd {
 protected:
   ValueObject &m_backend;
 
-  void SetValid(bool valid) { m_valid = valid; }
-
-  bool IsValid() { return m_valid; }
-
 public:
   SyntheticChildrenFrontEnd(ValueObject &backend)
-      : m_backend(backend), m_valid(true) {}
+      : m_backend(backend) {}
 
   virtual ~SyntheticChildrenFrontEnd() = default;
 
@@ -100,7 +96,6 @@ protected:
                                                 CompilerType type);
 
 private:
-  bool m_valid;
   SyntheticChildrenFrontEnd(const SyntheticChildrenFrontEnd &) = delete;
   const SyntheticChildrenFrontEnd &
   operator=(const SyntheticChildrenFrontEnd &) = delete;


### PR DESCRIPTION
These `IsValid`/`SetValid` APIs are only ever used from 1 data-formatter in the Swift LLDB fork. Since all the APIs on
`SyntheticChildrenFrontEnd` are meant to be overriden, there is no good way to enforce calling `IsValid` from the base. And we should just let that 1 data-formatter manage its own `IsValid` state.