### PR TITLE
[lldb] Fix StdUnorderedMapSynthProvider for GCC

### DIFF
--- a/lldb/examples/synthetic/gnu_libstdcpp.py
+++ b/lldb/examples/synthetic/gnu_libstdcpp.py
@@ -63,11 +63,8 @@ class StdUnorderedMapSynthProvider:
         self.count = None
 
     def extract_type(self):
-        type = self.valobj.GetType()
-        # The last template argument is the allocator type.
-        template_arg_num = type.GetNumberOfTemplateArguments() - 1
-        allocator_type = type.GetTemplateArgumentType(template_arg_num)
-        data_type = allocator_type.GetTemplateArgumentType(0)
+        head_type = self.head.GetType().GetCanonicalType()
+        data_type = head_type.GetTemplateArgumentType(1)
         return data_type
 
     def update(self):


### PR DESCRIPTION
This patch adds small workaround for [issue](https://github.com/llvm/llvm-project/issues/152504). It looks like code compiled with gcc has lack of some important debug information (e.g. DW_TAG_template_type_parameter for allocator).

Example code:
```cpp
#include <unordered_map>

int main() {
    std::unordered_map<int, int> map = {
        {1, 2}
    };
    return 0;
}
```

Output from `llvm-dwarfdump` for code compiled by GCC or Clang. I used system GCC (13.3.0) and Clang (18.1.3) on Ubuntu 24.04 (WSL).

GCC:
```
0x00001fcd:     DW_TAG_class_type
                  DW_AT_name	("allocator<std::pair<int const, int> >")
                  DW_AT_byte_size	(0x01)
                  DW_AT_decl_file	("/usr/include/c++/13/bits/allocator.h")
                  DW_AT_decl_line	(130)
                  DW_AT_decl_column	(11)
                  DW_AT_sibling	(0x0000207c)

0x00001fda:       DW_TAG_inheritance
                    DW_AT_type	(0x00001d0a "std::__new_allocator<std::pair<int const, int> >")
                    DW_AT_data_member_location	(0)
                    DW_AT_accessibility	(DW_ACCESS_public)

0x00001fe0:       DW_TAG_subprogram
                    DW_AT_external	(true)
                    DW_AT_name	("allocator")
                    DW_AT_decl_file	("/usr/include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(163)
                    DW_AT_decl_column	(7)
                    DW_AT_linkage_name	("_ZNSaISt4pairIKiiEEC4Ev")
                    DW_AT_accessibility	(DW_ACCESS_public)
                    DW_AT_declaration	(true)
                    DW_AT_object_pointer	(0x00001ff4)
                    DW_AT_sibling	(0x00001ffa)

0x00001ff4:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004eb9 "std::allocator<std::pair<int const, int> > *")
                      DW_AT_artificial	(true)

0x00001ff9:         NULL

0x00001ffa:       DW_TAG_subprogram
                    DW_AT_external	(true)
                    DW_AT_name	("allocator")
                    DW_AT_decl_file	("/usr/include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(167)
                    DW_AT_decl_column	(7)
                    DW_AT_linkage_name	("_ZNSaISt4pairIKiiEEC4ERKS2_")
                    DW_AT_accessibility	(DW_ACCESS_public)
                    DW_AT_declaration	(true)
                    DW_AT_object_pointer	(0x0000200e)
                    DW_AT_sibling	(0x00002019)

0x0000200e:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004eb9 "std::allocator<std::pair<int const, int> > *")
                      DW_AT_artificial	(true)

0x00002013:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004ec3 "const std::allocator<std::pair<int const, int> > &")

0x00002018:         NULL

0x00002019:       DW_TAG_subprogram
                    DW_AT_external	(true)
                    DW_AT_name	("operator=")
                    DW_AT_decl_file	("/usr/include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(172)
                    DW_AT_decl_column	(18)
                    DW_AT_linkage_name	("_ZNSaISt4pairIKiiEEaSERKS2_")
                    DW_AT_type	(0x00004ec8 "std::allocator<std::pair<int const, int> > &")
                    DW_AT_accessibility	(DW_ACCESS_public)
                    DW_AT_declaration	(true)
                    DW_AT_defaulted	(DW_DEFAULTED_in_class)
                    DW_AT_object_pointer	(0x00002031)
                    DW_AT_sibling	(0x0000203c)

0x00002031:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004eb9 "std::allocator<std::pair<int const, int> > *")
                      DW_AT_artificial	(true)

0x00002036:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004ec3 "const std::allocator<std::pair<int const, int> > &")

0x0000203b:         NULL

0x0000203c:       DW_TAG_subprogram
                    DW_AT_external	(true)
                    DW_AT_name	("~allocator")
                    DW_AT_decl_file	("/usr/include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(184)
                    DW_AT_decl_column	(7)
                    DW_AT_linkage_name	("_ZNSaISt4pairIKiiEED4Ev")
                    DW_AT_accessibility	(DW_ACCESS_public)
                    DW_AT_declaration	(true)
                    DW_AT_object_pointer	(0x00002050)
                    DW_AT_sibling	(0x0000205b)

0x00002050:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004eb9 "std::allocator<std::pair<int const, int> > *")
                      DW_AT_artificial	(true)

0x00002055:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00004cab "int")
                      DW_AT_artificial	(true)

0x0000205a:         NULL
```

Clang:
```
0x00001a6e:     DW_TAG_class_type
                  DW_AT_calling_convention	(DW_CC_pass_by_reference)
                  DW_AT_name	("allocator<std::pair<const int, int> >")
                  DW_AT_byte_size	(0x01)
                  DW_AT_decl_file	("/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h")
                  DW_AT_decl_line	(130)

0x00001a74:       DW_TAG_template_type_parameter
                    DW_AT_type	(0x00000dec "std::pair<const int, int>")
                    DW_AT_name	("_Tp")

0x00001a7a:       DW_TAG_inheritance
                    DW_AT_type	(0x00001ad5 "std::__allocator_base<std::pair<const int, int> >")
                    DW_AT_data_member_location	(0x00)
                    DW_AT_accessibility	(DW_ACCESS_public)

0x00001a81:       DW_TAG_subprogram
                    DW_AT_name	("allocator")
                    DW_AT_decl_file	("/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(163)
                    DW_AT_declaration	(true)
                    DW_AT_external	(true)
                    DW_AT_accessibility	(DW_ACCESS_public)

0x00001a86:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00002dd1 "std::allocator<std::pair<const int, int> > *")
                      DW_AT_artificial	(true)

0x00001a8b:         NULL

0x00001a8c:       DW_TAG_subprogram
                    DW_AT_name	("allocator")
                    DW_AT_decl_file	("/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(167)
                    DW_AT_declaration	(true)
                    DW_AT_external	(true)
                    DW_AT_accessibility	(DW_ACCESS_public)

0x00001a91:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00002dd1 "std::allocator<std::pair<const int, int> > *")
                      DW_AT_artificial	(true)

0x00001a96:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00002dd6 "const std::allocator<std::pair<const int, int> > &")

0x00001a9b:         NULL

0x00001a9c:       DW_TAG_subprogram
                    DW_AT_linkage_name	("_ZNSaISt4pairIKiiEEaSERKS2_")
                    DW_AT_name	("operator=")
                    DW_AT_decl_file	("/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(172)
                    DW_AT_type	(0x00002de0 "std::allocator<std::pair<const int, int> > &")
                    DW_AT_declaration	(true)
                    DW_AT_external	(true)
                    DW_AT_accessibility	(DW_ACCESS_public)

0x00001aa6:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00002dd1 "std::allocator<std::pair<const int, int> > *")
                      DW_AT_artificial	(true)

0x00001aab:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00002dd6 "const std::allocator<std::pair<const int, int> > &")

0x00001ab0:         NULL

0x00001ab1:       DW_TAG_subprogram
                    DW_AT_name	("~allocator")
                    DW_AT_decl_file	("/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h")
                    DW_AT_decl_line	(184)
                    DW_AT_declaration	(true)
                    DW_AT_external	(true)
                    DW_AT_accessibility	(DW_ACCESS_public)

0x00001ab6:         DW_TAG_formal_parameter
                      DW_AT_type	(0x00002dd1 "std::allocator<std::pair<const int, int> > *")
                      DW_AT_artificial	(true)

0x00001abb:         NULL
```

I propose to add fallback implementation based on type of `_M_h`.