### PR TITLE
[flang] Fix dumping type names for clang in DumpEvExpr

### DIFF
--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -46,7 +46,11 @@ private:
       std::string_view v(__PRETTY_FUNCTION__);
       // Extract the "xyz" from the "pretty function" string:
       // "... [with T = xyz; std::string_view = ...]"
-      std::string_view front("with T = ");
+#ifdef __clang__
+      std::string_view front("[T = ");
+#else
+      std::string_view front("[with T = ");
+#endif
       std::string_view back("; std::string_view =");
 
 #elif defined(_MSC_VER)
@@ -69,7 +73,6 @@ private:
         }
       }
 #endif
-
       return "";
     }
 


### PR DESCRIPTION
The gcc/clang implementation uses \_\_PRETTY_FUNCTION\_\_ to generate the full function name, and then extracts the type name from it. GCC emits the type name in the form of
`[with T = <type-name>...]`
whereas clang uses
`[T = <type-name>...]`
The current code looked for "with T =" to get the location of the type name, which did not work in clang-generated code.