### PR TITLE
[ADT] Deprecate StringSwitch Cases with 4+ args. NFC.

### DIFF
--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -98,11 +98,13 @@ public:
     return CasesImpl({S0, S1, S2}, Value);
   }
 
+  [[deprecated("Pass cases in std::initializer_list instead")]]
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, T Value) {
     return CasesImpl({S0, S1, S2, S3}, Value);
   }
 
+  [[deprecated("Pass cases in std::initializer_list instead")]]
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                       StringLiteral S3, StringLiteral S4, T Value) {
     return CasesImpl({S0, S1, S2, S3, S4}, Value);
@@ -179,11 +181,13 @@ public:
     return CasesLowerImpl({S0, S1, S2}, Value);
   }
 
+  [[deprecated("Pass cases in std::initializer_list instead")]]
   StringSwitch &CasesLower(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                            StringLiteral S3, T Value) {
     return CasesLowerImpl({S0, S1, S2, S3}, Value);
   }
 
+  [[deprecated("Pass cases in std::initializer_list instead")]]
   StringSwitch &CasesLower(StringLiteral S0, StringLiteral S1, StringLiteral S2,
                            StringLiteral S3, StringLiteral S4, T Value) {
     return CasesLowerImpl({S0, S1, S2, S3, S4}, Value);


### PR DESCRIPTION
Suggest the `initializer_list` overload instead.

4+ args is an arbitrary number that allows for incremental depreciation without having to update too many call sites.

For more context, see https://github.com/llvm/llvm-project/pull/163117.