### PR TITLE
[libc++] Add benchmark for `std::exception_ptr`

### DIFF
--- a/libcxx/test/benchmarks/exception_ptr.bench.cpp
+++ b/libcxx/test/benchmarks/exception_ptr.bench.cpp
@@ -18,4 +18,49 @@ void bm_make_exception_ptr(benchmark::State& state) {
 }
 BENCHMARK(bm_make_exception_ptr)->ThreadRange(1, 8);
 
+static bool exception_ptr_moves_copies_swap(std::exception_ptr p1) {
+  // Taken from https://github.com/llvm/llvm-project/issues/44892
+  std::exception_ptr p2(p1);            // Copy constructor
+  std::exception_ptr p3(std::move(p2)); // Move constructor
+  p2 = std::move(p1);                   // Move assignment
+  p1 = p2;                              // Copy assignment
+  swap(p1, p2);                         // Swap
+  // Comparisons against nullptr. The overhead from creating temporary `exception_ptr`
+  // instances should be optimized out.
+  bool is_null  = p1 == nullptr && nullptr == p2;
+  bool is_equal = p1 == p2; // Comparison
+  return is_null && is_equal;
+}
+
+void bm_nonnull_exception_ptr(benchmark::State& state) {
+  std::exception_ptr excptr = std::make_exception_ptr(42);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(excptr);
+    benchmark::DoNotOptimize(exception_ptr_moves_copies_swap(excptr));
+  }
+}
+BENCHMARK(bm_nonnull_exception_ptr);
+
+void bm_null_exception_ptr(benchmark::State& state) {
+  std::exception_ptr excptr;
+  for (auto _ : state) {
+    // All of the `exception_ptr_noops` are no-ops but the optimizer
+    // cannot optimize them away, because the `DoNotOptimize` calls
+    // prevent the optimizer from doing so.
+    benchmark::DoNotOptimize(excptr);
+    benchmark::DoNotOptimize(exception_ptr_moves_copies_swap(excptr));
+  }
+}
+BENCHMARK(bm_null_exception_ptr);
+
+void bm_optimized_null_exception_ptr(benchmark::State& state) {
+  for (auto _ : state) {
+    // All of the `exception_ptr_noops` are no-ops because
+    // the exception_ptr is empty. Hence, the compiler should
+    // be able to optimize them very aggressively.
+    benchmark::DoNotOptimize(exception_ptr_moves_copies_swap(std::exception_ptr{nullptr}));
+  }
+}
+BENCHMARK(bm_optimized_null_exception_ptr);
+
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/exception_ptr.bench.cpp
+++ b/libcxx/test/benchmarks/exception_ptr.bench.cpp
@@ -19,7 +19,7 @@ void bm_make_exception_ptr(benchmark::State& state) {
 BENCHMARK(bm_make_exception_ptr)->ThreadRange(1, 8);
 
 static bool exception_ptr_moves_copies_swap(std::exception_ptr p1) {
-  // Taken from https://github.com/llvm/llvm-project/issues/44892
+  // Taken from https://llvm.org/PR45547
   std::exception_ptr p2(p1);            // Copy constructor
   std::exception_ptr p3(std::move(p2)); // Move constructor
   p2 = std::move(p1);                   // Move assignment

--- a/libcxx/test/benchmarks/exception_ptr.bench.cpp
+++ b/libcxx/test/benchmarks/exception_ptr.bench.cpp
@@ -21,7 +21,6 @@ BENCHMARK(bm_make_exception_ptr)->ThreadRange(1, 8);
 void bm_exception_ptr_copy_ctor_nonnull(benchmark::State& state) {
   std::exception_ptr excptr = std::make_exception_ptr(42);
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
     benchmark::DoNotOptimize(std::exception_ptr(excptr));
   }
 }
@@ -30,12 +29,13 @@ BENCHMARK(bm_exception_ptr_copy_ctor_nonnull);
 void bm_exception_ptr_copy_ctor_null(benchmark::State& state) {
   std::exception_ptr excptr = nullptr;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
-    benchmark::DoNotOptimize(std::exception_ptr(excptr));
+    std::exception_ptr excptr_copy(excptr);
+    benchmark::DoNotOptimize(excptr_copy);
+    // The compiler should be able to constant-fold the comparison
+    benchmark::DoNotOptimize(excptr_copy == nullptr);
   }
 }
 BENCHMARK(bm_exception_ptr_copy_ctor_null);
-
 
 void bm_exception_ptr_move_ctor_nonnull(benchmark::State& state) {
   std::exception_ptr excptr = std::make_exception_ptr(42);
@@ -43,7 +43,6 @@ void bm_exception_ptr_move_ctor_nonnull(benchmark::State& state) {
     // Need to copy, such that the `excptr` is not moved from and
     // empty after the first loop iteration.
     std::exception_ptr excptr_copy(excptr);
-    benchmark::DoNotOptimize(excptr_copy);
     benchmark::DoNotOptimize(std::exception_ptr(std::move(excptr_copy)));
   }
 }
@@ -52,8 +51,10 @@ BENCHMARK(bm_exception_ptr_move_ctor_nonnull);
 void bm_exception_ptr_move_ctor_null(benchmark::State& state) {
   std::exception_ptr excptr = nullptr;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
-    benchmark::DoNotOptimize(std::exception_ptr(std::move(excptr)));
+    std::exception_ptr new_excptr(std::move(excptr));
+    benchmark::DoNotOptimize(new_excptr);
+    // The compiler should be able to constant-fold the comparison
+    benchmark::DoNotOptimize(new_excptr == nullptr);
   }
 }
 BENCHMARK(bm_exception_ptr_move_ctor_null);
@@ -61,7 +62,6 @@ BENCHMARK(bm_exception_ptr_move_ctor_null);
 void bm_exception_ptr_copy_assign_nonnull(benchmark::State& state) {
   std::exception_ptr excptr = std::make_exception_ptr(42);
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
     std::exception_ptr new_excptr;
     new_excptr = excptr;
     benchmark::DoNotOptimize(new_excptr);
@@ -72,14 +72,14 @@ BENCHMARK(bm_exception_ptr_copy_assign_nonnull);
 void bm_exception_ptr_copy_assign_null(benchmark::State& state) {
   std::exception_ptr excptr = nullptr;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
     std::exception_ptr new_excptr;
     new_excptr = excptr;
     benchmark::DoNotOptimize(new_excptr);
+    // The compiler should be able to constant-fold the comparison
+    benchmark::DoNotOptimize(new_excptr == nullptr);
   }
 }
 BENCHMARK(bm_exception_ptr_copy_assign_null);
-
 
 void bm_exception_ptr_move_assign_nonnull(benchmark::State& state) {
   std::exception_ptr excptr = std::make_exception_ptr(42);
@@ -87,7 +87,6 @@ void bm_exception_ptr_move_assign_nonnull(benchmark::State& state) {
     // Need to copy, such that the `excptr` is not moved from and
     // empty after the first loop iteration.
     std::exception_ptr excptr_copy(excptr);
-    benchmark::DoNotOptimize(excptr_copy);
     std::exception_ptr new_excptr;
     new_excptr = std::move(excptr_copy);
     benchmark::DoNotOptimize(new_excptr);
@@ -98,84 +97,39 @@ BENCHMARK(bm_exception_ptr_move_assign_nonnull);
 void bm_exception_ptr_move_assign_null(benchmark::State& state) {
   std::exception_ptr excptr = nullptr;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
     std::exception_ptr new_excptr;
     new_excptr = std::move(excptr);
     benchmark::DoNotOptimize(new_excptr);
+    // The compiler should be able to constant-fold the comparison
+    benchmark::DoNotOptimize(new_excptr == nullptr);
   }
 }
 BENCHMARK(bm_exception_ptr_move_assign_null);
 
 void bm_exception_ptr_swap_nonnull(benchmark::State& state) {
-  std::exception_ptr excptr = std::make_exception_ptr(41);
+  std::exception_ptr excptr1 = std::make_exception_ptr(41);
   std::exception_ptr excptr2 = std::make_exception_ptr(42);
   for (auto _ : state) {
-    swap(excptr, excptr2);
-    benchmark::DoNotOptimize(excptr);
+    swap(excptr1, excptr2);
+    benchmark::DoNotOptimize(excptr1);
     benchmark::DoNotOptimize(excptr2);
   }
 }
 BENCHMARK(bm_exception_ptr_swap_nonnull);
 
 void bm_exception_ptr_swap_null(benchmark::State& state) {
-  std::exception_ptr excptr = nullptr;
+  std::exception_ptr excptr1 = nullptr;
   std::exception_ptr excptr2 = nullptr;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
-    swap(excptr, excptr2);
+    swap(excptr1, excptr2);
+    benchmark::DoNotOptimize(excptr1);
     benchmark::DoNotOptimize(excptr2);
+    // The compiler should be able to constant-fold those comparisons
+    benchmark::DoNotOptimize(excptr1 == nullptr);
+    benchmark::DoNotOptimize(excptr2 == nullptr);
+    benchmark::DoNotOptimize(excptr1 == excptr2);
   }
 }
 BENCHMARK(bm_exception_ptr_swap_null);
-
-// A chain of moves, copies and swaps.
-// In contrast to the previous benchmarks of individual operations,
-// this benchmark performs a chain of operations. It thereby
-// specifically stresses the information available to the compiler
-// for optimizations from the header itself.
-static bool exception_ptr_move_copy_swap(std::exception_ptr p1) {
-  // Taken from https://llvm.org/PR45547
-  std::exception_ptr p2(p1);
-  std::exception_ptr p3(std::move(p2));
-  p2 = std::move(p1);
-  p1 = p2;
-  swap(p1, p2);
-  // Comparisons against nullptr. The overhead from creating temporary `exception_ptr`
-  // instances should be optimized out.
-  bool is_null  = p1 == nullptr && nullptr == p2;
-  bool is_equal = p1 == p2;
-  return is_null && is_equal;
-}
-
-// Benchmark copies, moves and comparisons of a non-null exception_ptr.
-void bm_exception_ptr_move_copy_swap_nonnull(benchmark::State& state) {
-  std::exception_ptr excptr = std::make_exception_ptr(42);
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
-    benchmark::DoNotOptimize(exception_ptr_move_copy_swap(excptr));
-  }
-}
-BENCHMARK(bm_exception_ptr_move_copy_swap_nonnull);
-
-// Benchmark copies, moves and comparisons of a nullptr exception_ptr
-// where the compiler cannot prove that the exception_ptr is always
-// a nullptr and needs to emit runtime checks.
-void bm_exception_ptr_move_copy_swap_null(benchmark::State& state) {
-  std::exception_ptr excptr;
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(excptr);
-    benchmark::DoNotOptimize(exception_ptr_move_copy_swap(excptr));
-  }
-}
-BENCHMARK(bm_exception_ptr_move_copy_swap_null);
-
-// Benchmark copies, moves and comparisons of a nullptr exception_ptr
-// where the compiler can proof that the exception_ptr is always a nullptr.
-void bm_exception_ptr_move_copy_swap_null_optimized(benchmark::State& state) {
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(exception_ptr_move_copy_swap(std::exception_ptr{nullptr}));
-  }
-}
-BENCHMARK(bm_exception_ptr_move_copy_swap_null_optimized);
 
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/exception_ptr.bench.cpp
+++ b/libcxx/test/benchmarks/exception_ptr.bench.cpp
@@ -20,15 +20,15 @@ BENCHMARK(bm_make_exception_ptr)->ThreadRange(1, 8);
 
 static bool exception_ptr_moves_copies_swap(std::exception_ptr p1) {
   // Taken from https://llvm.org/PR45547
-  std::exception_ptr p2(p1);            // Copy constructor
-  std::exception_ptr p3(std::move(p2)); // Move constructor
-  p2 = std::move(p1);                   // Move assignment
-  p1 = p2;                              // Copy assignment
-  swap(p1, p2);                         // Swap
+  std::exception_ptr p2(p1);
+  std::exception_ptr p3(std::move(p2));
+  p2 = std::move(p1);
+  p1 = p2;
+  swap(p1, p2);
   // Comparisons against nullptr. The overhead from creating temporary `exception_ptr`
   // instances should be optimized out.
   bool is_null  = p1 == nullptr && nullptr == p2;
-  bool is_equal = p1 == p2; // Comparison
+  bool is_equal = p1 == p2;
   return is_null && is_equal;
 }
 

--- a/libcxx/test/benchmarks/exception_ptr.bench.cpp
+++ b/libcxx/test/benchmarks/exception_ptr.bench.cpp
@@ -32,6 +32,7 @@ static bool exception_ptr_moves_copies_swap(std::exception_ptr p1) {
   return is_null && is_equal;
 }
 
+// Benchmark copies, moves and comparisons of a non-null exception_ptr.
 void bm_nonnull_exception_ptr(benchmark::State& state) {
   std::exception_ptr excptr = std::make_exception_ptr(42);
   for (auto _ : state) {
@@ -41,23 +42,22 @@ void bm_nonnull_exception_ptr(benchmark::State& state) {
 }
 BENCHMARK(bm_nonnull_exception_ptr);
 
+// Benchmark copies, moves and comparisons of a nullptr exception_ptr
+// where the compiler cannot prove that the exception_ptr is always
+// a nullptr and needs to emit runtime checks.
 void bm_null_exception_ptr(benchmark::State& state) {
   std::exception_ptr excptr;
   for (auto _ : state) {
-    // All of the `exception_ptr_noops` are no-ops but the optimizer
-    // cannot optimize them away, because the `DoNotOptimize` calls
-    // prevent the optimizer from doing so.
     benchmark::DoNotOptimize(excptr);
     benchmark::DoNotOptimize(exception_ptr_moves_copies_swap(excptr));
   }
 }
 BENCHMARK(bm_null_exception_ptr);
 
+// Benchmark copies, moves and comparisons of a nullptr exception_ptr
+// where the compiler can proof that the exception_ptr is always a nullptr.
 void bm_optimized_null_exception_ptr(benchmark::State& state) {
   for (auto _ : state) {
-    // All of the `exception_ptr_noops` are no-ops because
-    // the exception_ptr is empty. Hence, the compiler should
-    // be able to optimize them very aggressively.
     benchmark::DoNotOptimize(exception_ptr_moves_copies_swap(std::exception_ptr{nullptr}));
   }
 }

--- a/libcxx/test/benchmarks/exception_ptr.bench.cpp
+++ b/libcxx/test/benchmarks/exception_ptr.bench.cpp
@@ -30,9 +30,9 @@ void bm_exception_ptr_copy_ctor_null(benchmark::State& state) {
   std::exception_ptr excptr = nullptr;
   for (auto _ : state) {
     std::exception_ptr excptr_copy(excptr);
-    benchmark::DoNotOptimize(excptr_copy);
     // The compiler should be able to constant-fold the comparison
     benchmark::DoNotOptimize(excptr_copy == nullptr);
+    benchmark::DoNotOptimize(excptr_copy);
   }
 }
 BENCHMARK(bm_exception_ptr_copy_ctor_null);
@@ -52,9 +52,9 @@ void bm_exception_ptr_move_ctor_null(benchmark::State& state) {
   std::exception_ptr excptr = nullptr;
   for (auto _ : state) {
     std::exception_ptr new_excptr(std::move(excptr));
-    benchmark::DoNotOptimize(new_excptr);
     // The compiler should be able to constant-fold the comparison
     benchmark::DoNotOptimize(new_excptr == nullptr);
+    benchmark::DoNotOptimize(new_excptr);
   }
 }
 BENCHMARK(bm_exception_ptr_move_ctor_null);
@@ -74,9 +74,9 @@ void bm_exception_ptr_copy_assign_null(benchmark::State& state) {
   for (auto _ : state) {
     std::exception_ptr new_excptr;
     new_excptr = excptr;
-    benchmark::DoNotOptimize(new_excptr);
     // The compiler should be able to constant-fold the comparison
     benchmark::DoNotOptimize(new_excptr == nullptr);
+    benchmark::DoNotOptimize(new_excptr);
   }
 }
 BENCHMARK(bm_exception_ptr_copy_assign_null);
@@ -99,9 +99,9 @@ void bm_exception_ptr_move_assign_null(benchmark::State& state) {
   for (auto _ : state) {
     std::exception_ptr new_excptr;
     new_excptr = std::move(excptr);
-    benchmark::DoNotOptimize(new_excptr);
     // The compiler should be able to constant-fold the comparison
     benchmark::DoNotOptimize(new_excptr == nullptr);
+    benchmark::DoNotOptimize(new_excptr);
   }
 }
 BENCHMARK(bm_exception_ptr_move_assign_null);
@@ -122,8 +122,6 @@ void bm_exception_ptr_swap_null(benchmark::State& state) {
   std::exception_ptr excptr2 = nullptr;
   for (auto _ : state) {
     swap(excptr1, excptr2);
-    benchmark::DoNotOptimize(excptr1);
-    benchmark::DoNotOptimize(excptr2);
     // The compiler should be able to constant-fold those comparisons
     benchmark::DoNotOptimize(excptr1 == nullptr);
     benchmark::DoNotOptimize(excptr2 == nullptr);


### PR DESCRIPTION
This commit adds benchmarks for `std::exception_ptr` to set a baseline in preparation for follow-up optimizations.