### PR TITLE
[clang-format] Add xxxMaxDigitsNoSeparator

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4767,7 +4767,12 @@ the configuration (without a prefix: ``Auto``).
 
   You can also specify a minimum number of digits (``BinaryMinDigits``,
   ``DecimalMinDigits``, and ``HexMinDigits``) the integer literal must
-  have in order for the separators to be inserted.
+  have in order for the separators to be inserted, and a maximum number of
+  digits (``BinaryMaxDigitsNoSeparator``, ``DecimalMaxDigitsNoSeparator``,
+  and ``HexMaxDigitsNoSeparator``) until the separators are removed. This
+  divides the literals in 3 regions, always without separator (up until
+  including ``xxxMaxDigitsNoSeparator``), maybe with, or without separators
+  (up until excluding ``xxxMinDigits``), and finally always with separators.
 
   * ``int8_t Binary`` Format separators in binary literals.
 
@@ -4787,6 +4792,19 @@ the configuration (without a prefix: ``Auto``).
       b1 = 0b101101;
       b2 = 0b1'101'101;
 
+  * ``int8_t BinaryMaxDigitsNoSeparator`` Remove separators in binary literals with a maximum number of digits.
+
+    .. code-block:: text
+
+      // Binary: 3
+      // BinaryMinDigits: 7
+      // BinaryMaxDigitsNoSeparator: 4
+      b0 = 0b1011; // Always removed.
+      b1 = 0b101101; // Not added.
+      b2 = 0b101'101; // Not removed.
+      b3 = 0b1'101'101; // Always added.
+      b4 = 0b10'1101; // Corrected to 0b101'101.
+
   * ``int8_t Decimal`` Format separators in decimal literals.
 
     .. code-block:: text
@@ -4803,6 +4821,19 @@ the configuration (without a prefix: ``Auto``).
       // DecimalMinDigits: 5
       d1 = 2023;
       d2 = 10'000;
+
+  * ``int8_t DecimalMaxDigitsNoSeparator`` Remove separators in decimal literals with a maximum number of digits.
+
+    .. code-block:: text
+
+      // Decimal: 3
+      // DecimalMinDigits: 7
+      // DecimalMaxDigitsNoSeparator: 4
+      d0 = 2023; // Always removed.
+      d1 = 123456; // Not added.
+      d2 = 123'456; // Not removed.
+      d3 = 5'000'000; // Always added.
+      d4 = 1'23'45; // Corrected to 12'345.
 
   * ``int8_t Hex`` Format separators in hexadecimal literals.
 
@@ -4821,6 +4852,20 @@ the configuration (without a prefix: ``Auto``).
       // HexMinDigits: 6
       h1 = 0xABCDE;
       h2 = 0xAB'CD'EF;
+
+  * ``int8_t HexMaxDigitsNoSeparator`` Remove separators in hexadecimal literals with a maximum number of
+    digits.
+
+    .. code-block:: text
+
+      // Hex: 2
+      // HexMinDigits: 6
+      // HexMaxDigitsNoSeparator: 4
+      h0 = 0xAFFE; // Always removed.
+      h1 = 0xABCDE; // Not added.
+      h2 = 0xA'BC'DE; // Not removed.
+      h3 = 0xAB'CD'EF; // Always added.
+      h4 = 0xABCD'E; // Corrected to 0xA'BC'DE.
 
 
 .. _JavaImportGroups:

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4765,14 +4765,21 @@ the configuration (without a prefix: ``Auto``).
       Decimal: 3
       Hex: -1
 
-  You can also specify a minimum number of digits (``BinaryMinDigits``,
-  ``DecimalMinDigits``, and ``HexMinDigits``) the integer literal must
-  have in order for the separators to be inserted, and a maximum number of
-  digits (``BinaryMaxDigitsNoSeparator``, ``DecimalMaxDigitsNoSeparator``,
-  and ``HexMaxDigitsNoSeparator``) until the separators are removed. This
-  divides the literals in 3 regions, always without separator (up until
-  including ``xxxMaxDigitsNoSeparator``), maybe with, or without separators
-  (up until excluding ``xxxMinDigits``), and finally always with separators.
+  You can also specify a minimum number of digits
+  (``BinaryMinDigitsInsert``, ``DecimalMinDigitsInsert``, and
+  ``HexMinDigitsInsert``) the integer literal must have in order for the
+  separators to be inserted, and a maximum number of digits
+  (``BinaryMaxDigitsRemove``, ``DecimalMaxDigitsRemove``, and
+  ``HexMaxDigitsRemove``) until the separators are removed. This divides the
+  literals in 3 regions, always without separator (up until including
+  ``xxxMaxDigitsRemove``), maybe with, or without separators (up until
+  excluding ``xxxMinDigitsInsert``), and finally always with separators.
+
+  .. note::
+
+   ``BinaryMinDigits``, ``DecimalMinDigits``, and ``HexMinDigits`` are
+   deprecated and renamed to ``BinaryMinDigitsInsert``,
+   ``DecimalMinDigitsInsert``, and ``HexMinDigitsInsert``, respectively.
 
   * ``int8_t Binary`` Format separators in binary literals.
 
@@ -4783,25 +4790,25 @@ the configuration (without a prefix: ``Auto``).
       /*  3: */ b = 0b100'111'101'101;
       /*  4: */ b = 0b1001'1110'1101;
 
-  * ``int8_t BinaryMinDigits`` Format separators in binary literals with a minimum number of digits.
+  * ``int8_t BinaryMinDigitsInsert`` Format separators in binary literals with a minimum number of digits.
 
     .. code-block:: text
 
       // Binary: 3
-      // BinaryMinDigits: 7
+      // BinaryMinDigitsInsert: 7
       b1 = 0b101101;
       b2 = 0b1'101'101;
 
-  * ``int8_t BinaryMaxDigitsNoSeparator`` Remove separators in binary literals with a maximum number of digits.
+  * ``int8_t BinaryMaxDigitsRemove`` Remove separators in binary literals with a maximum number of digits.
 
     .. code-block:: text
 
       // Binary: 3
-      // BinaryMinDigits: 7
-      // BinaryMaxDigitsNoSeparator: 4
+      // BinaryMinDigitsInsert: 7
+      // BinaryMaxDigitsRemove: 4
       b0 = 0b1011; // Always removed.
       b1 = 0b101101; // Not added.
-      b2 = 0b101'101; // Not removed.
+      b2 = 0b1'01'101; // Not removed, not corrected.
       b3 = 0b1'101'101; // Always added.
       b4 = 0b10'1101; // Corrected to 0b101'101.
 
@@ -4813,25 +4820,25 @@ the configuration (without a prefix: ``Auto``).
       /*  0: */ d = 184467'440737'0'95505'92ull;
       /*  3: */ d = 18'446'744'073'709'550'592ull;
 
-  * ``int8_t DecimalMinDigits`` Format separators in decimal literals with a minimum number of digits.
+  * ``int8_t DecimalMinDigitsInsert`` Format separators in decimal literals with a minimum number of digits.
 
     .. code-block:: text
 
       // Decimal: 3
-      // DecimalMinDigits: 5
+      // DecimalMinDigitsInsert: 5
       d1 = 2023;
       d2 = 10'000;
 
-  * ``int8_t DecimalMaxDigitsNoSeparator`` Remove separators in decimal literals with a maximum number of digits.
+  * ``int8_t DecimalMaxDigitsRemove`` Remove separators in decimal literals with a maximum number of digits.
 
     .. code-block:: text
 
       // Decimal: 3
-      // DecimalMinDigits: 7
-      // DecimalMaxDigitsNoSeparator: 4
+      // DecimalMinDigitsInsert: 7
+      // DecimalMaxDigitsRemove: 4
       d0 = 2023; // Always removed.
       d1 = 123456; // Not added.
-      d2 = 123'456; // Not removed.
+      d2 = 1'23'456; // Not removed, not corrected.
       d3 = 5'000'000; // Always added.
       d4 = 1'23'45; // Corrected to 12'345.
 
@@ -4843,27 +4850,27 @@ the configuration (without a prefix: ``Auto``).
       /*  0: */ h = 0xDEAD'BEEF'DE'AD'BEE'Fuz;
       /*  2: */ h = 0xDE'AD'BE'EF'DE'AD'BE'EFuz;
 
-  * ``int8_t HexMinDigits`` Format separators in hexadecimal literals with a minimum number of
+  * ``int8_t HexMinDigitsInsert`` Format separators in hexadecimal literals with a minimum number of
     digits.
 
     .. code-block:: text
 
       // Hex: 2
-      // HexMinDigits: 6
+      // HexMinDigitsInsert: 6
       h1 = 0xABCDE;
       h2 = 0xAB'CD'EF;
 
-  * ``int8_t HexMaxDigitsNoSeparator`` Remove separators in hexadecimal literals with a maximum number of
+  * ``int8_t HexMaxDigitsRemove`` Remove separators in hexadecimal literals with a maximum number of
     digits.
 
     .. code-block:: text
 
       // Hex: 2
-      // HexMinDigits: 6
-      // HexMaxDigitsNoSeparator: 4
+      // HexMinDigitsInsert: 6
+      // HexMaxDigitsRemove: 4
       h0 = 0xAFFE; // Always removed.
       h1 = 0xABCDE; // Not added.
-      h2 = 0xA'BC'DE; // Not removed.
+      h2 = 0xABC'DE; // Not removed, not corrected.
       h3 = 0xAB'CD'EF; // Always added.
       h4 = 0xABCD'E; // Corrected to 0xA'BC'DE.
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -687,6 +687,9 @@ clang-format
   ``AlignAfterOpenBracket`` option, and make ``AlignAfterOpenBracket`` a
   ``bool`` type.
 - Add ``AlignPPAndNotPP`` suboption to ``AlignTrailingComments``.
+- Rename ``(Binary|Decimal|Hex)MinDigits`` to ``...MinDigitsInsert`` and  add
+  ``(Binary|Decimal|Hex)MaxDigitsSeparator`` suboptions to
+  ``IntegerLiteralSeparator``.
 
 libclang
 --------

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3275,9 +3275,15 @@ struct FormatStyle {
   ///     Hex: -1
   /// \endcode
   ///
-  /// You can also specify a minimum number of digits (``BinaryMinDigits``,
-  /// ``DecimalMinDigits``, and ``HexMinDigits``) the integer literal must
-  /// have in order for the separators to be inserted.
+  /// You can also specify a minimum number of digits
+  /// (``BinaryMinDigitsInsert``, ``DecimalMinDigitsInsert``, and
+  /// ``HexMinDigitsInsert``) the integer literal must have in order for the
+  /// separators to be inserted, and a maximum number of digits
+  /// (``BinaryMaxDigitsRemove``, ``DecimalMaxDigitsRemove``, and
+  /// ``HexMaxDigitsRemove``) until the separators are removed. This divides the
+  /// literals in 3 regions, always without separator (up until including
+  /// ``xxxMaxDigitsRemove``), maybe with, or without separators (up until
+  /// excluding ``xxxMinDigitsInsert``), and finally always with separators.
   struct IntegerLiteralSeparatorStyle {
     /// Format separators in binary literals.
     /// \code{.text}
@@ -3290,11 +3296,23 @@ struct FormatStyle {
     /// Format separators in binary literals with a minimum number of digits.
     /// \code{.text}
     ///   // Binary: 3
-    ///   // BinaryMinDigits: 7
+    ///   // BinaryMinDigitsInsert: 7
     ///   b1 = 0b101101;
     ///   b2 = 0b1'101'101;
     /// \endcode
-    int8_t BinaryMinDigits;
+    int8_t BinaryMinDigitsInsert;
+    /// Remove separators in binary literals with a maximum number of digits.
+    /// \code{.text}
+    ///   // Binary: 3
+    ///   // BinaryMinDigitsInsert: 7
+    ///   // BinaryMaxDigitsRemove: 4
+    ///   b0 = 0b1011; // Always removed.
+    ///   b1 = 0b101101; // Not added.
+    ///   b2 = 0b1'01'101; // Not removed, not corrected.
+    ///   b3 = 0b1'101'101; // Always added.
+    ///   b4 = 0b10'1101; // Corrected to 0b101'101.
+    /// \endcode
+    int8_t BinaryMaxDigitsRemove;
     /// Format separators in decimal literals.
     /// \code{.text}
     ///   /* -1: */ d = 18446744073709550592ull;
@@ -3305,11 +3323,23 @@ struct FormatStyle {
     /// Format separators in decimal literals with a minimum number of digits.
     /// \code{.text}
     ///   // Decimal: 3
-    ///   // DecimalMinDigits: 5
+    ///   // DecimalMinDigitsInsert: 5
     ///   d1 = 2023;
     ///   d2 = 10'000;
     /// \endcode
-    int8_t DecimalMinDigits;
+    int8_t DecimalMinDigitsInsert;
+    /// Remove separators in decimal literals with a maximum number of digits.
+    /// \code{.text}
+    ///   // Decimal: 3
+    ///   // DecimalMinDigitsInsert: 7
+    ///   // DecimalMaxDigitsRemove: 4
+    ///   d0 = 2023; // Always removed.
+    ///   d1 = 123456; // Not added.
+    ///   d2 = 1'23'456; // Not removed, not corrected.
+    ///   d3 = 5'000'000; // Always added.
+    ///   d4 = 1'23'45; // Corrected to 12'345.
+    /// \endcode
+    int8_t DecimalMaxDigitsRemove;
     /// Format separators in hexadecimal literals.
     /// \code{.text}
     ///   /* -1: */ h = 0xDEADBEEFDEADBEEFuz;
@@ -3321,15 +3351,36 @@ struct FormatStyle {
     /// digits.
     /// \code{.text}
     ///   // Hex: 2
-    ///   // HexMinDigits: 6
+    ///   // HexMinDigitsInsert: 6
     ///   h1 = 0xABCDE;
     ///   h2 = 0xAB'CD'EF;
     /// \endcode
-    int8_t HexMinDigits;
+    int8_t HexMinDigitsInsert;
+    /// Remove separators in hexadecimal literals with a maximum number of
+    /// digits.
+    /// \code{.text}
+    ///   // Hex: 2
+    ///   // HexMinDigitsInsert: 6
+    ///   // HexMaxDigitsRemove: 4
+    ///   h0 = 0xAFFE; // Always removed.
+    ///   h1 = 0xABCDE; // Not added.
+    ///   h2 = 0xABC'DE; // Not removed, not corrected.
+    ///   h3 = 0xAB'CD'EF; // Always added.
+    ///   h4 = 0xABCD'E; // Corrected to 0xA'BC'DE.
+    /// \endcode
+    int8_t HexMaxDigitsRemove;
     bool operator==(const IntegerLiteralSeparatorStyle &R) const {
-      return Binary == R.Binary && BinaryMinDigits == R.BinaryMinDigits &&
-             Decimal == R.Decimal && DecimalMinDigits == R.DecimalMinDigits &&
-             Hex == R.Hex && HexMinDigits == R.HexMinDigits;
+      return Binary == R.Binary &&
+             BinaryMinDigitsInsert == R.BinaryMinDigitsInsert &&
+             BinaryMaxDigitsRemove == R.BinaryMaxDigitsRemove &&
+             Decimal == R.Decimal &&
+             DecimalMinDigitsInsert == R.DecimalMinDigitsInsert &&
+             DecimalMaxDigitsRemove == R.DecimalMaxDigitsRemove &&
+             Hex == R.Hex && HexMinDigitsInsert == R.HexMinDigitsInsert &&
+             HexMaxDigitsRemove == R.HexMaxDigitsRemove;
+    }
+    bool operator!=(const IntegerLiteralSeparatorStyle &R) const {
+      return !operator==(R);
     }
   };
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3284,6 +3284,11 @@ struct FormatStyle {
   /// literals in 3 regions, always without separator (up until including
   /// ``xxxMaxDigitsRemove``), maybe with, or without separators (up until
   /// excluding ``xxxMinDigitsInsert``), and finally always with separators.
+  /// \note
+  ///  ``BinaryMinDigits``, ``DecimalMinDigits``, and ``HexMinDigits`` are
+  ///  deprecated and renamed to ``BinaryMinDigitsInsert``,
+  ///  ``DecimalMinDigitsInsert``, and ``HexMinDigitsInsert``, respectively.
+  /// \endnote
   struct IntegerLiteralSeparatorStyle {
     /// Format separators in binary literals.
     /// \code{.text}

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -405,11 +405,19 @@ struct ScalarEnumerationTraits<FormatStyle::IndentExternBlockStyle> {
 template <> struct MappingTraits<FormatStyle::IntegerLiteralSeparatorStyle> {
   static void mapping(IO &IO, FormatStyle::IntegerLiteralSeparatorStyle &Base) {
     IO.mapOptional("Binary", Base.Binary);
-    IO.mapOptional("BinaryMinDigits", Base.BinaryMinDigits);
+    IO.mapOptional("BinaryMinDigitsInsert", Base.BinaryMinDigitsInsert);
+    IO.mapOptional("BinaryMaxDigitsRemove", Base.BinaryMaxDigitsRemove);
     IO.mapOptional("Decimal", Base.Decimal);
-    IO.mapOptional("DecimalMinDigits", Base.DecimalMinDigits);
+    IO.mapOptional("DecimalMinDigitsInsert", Base.DecimalMinDigitsInsert);
+    IO.mapOptional("DecimalMaxDigitsRemove", Base.DecimalMaxDigitsRemove);
     IO.mapOptional("Hex", Base.Hex);
-    IO.mapOptional("HexMinDigits", Base.HexMinDigits);
+    IO.mapOptional("HexMinDigitsInsert", Base.HexMinDigitsInsert);
+    IO.mapOptional("HexMaxDigitsRemove", Base.HexMaxDigitsRemove);
+
+    // For backward compatibility.
+    IO.mapOptional("BinaryMinDigits", Base.BinaryMinDigitsInsert);
+    IO.mapOptional("DecimalMinDigits", Base.DecimalMinDigitsInsert);
+    IO.mapOptional("HexMinDigits", Base.HexMinDigitsInsert);
   }
 };
 
@@ -1758,10 +1766,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.InsertBraces = false;
   LLVMStyle.InsertNewlineAtEOF = false;
   LLVMStyle.InsertTrailingCommas = FormatStyle::TCS_None;
-  LLVMStyle.IntegerLiteralSeparator = {
-      /*Binary=*/0,  /*BinaryMinDigits=*/0,
-      /*Decimal=*/0, /*DecimalMinDigits=*/0,
-      /*Hex=*/0,     /*HexMinDigits=*/0};
+  LLVMStyle.IntegerLiteralSeparator = {};
   LLVMStyle.JavaScriptQuotes = FormatStyle::JSQS_Leave;
   LLVMStyle.JavaScriptWrapImports = true;
   LLVMStyle.KeepEmptyLines = {
@@ -2183,7 +2188,7 @@ FormatStyle getClangFormatStyle() {
   Style.InsertBraces = true;
   Style.InsertNewlineAtEOF = true;
   Style.IntegerLiteralSeparator.Decimal = 3;
-  Style.IntegerLiteralSeparator.DecimalMinDigits = 5;
+  Style.IntegerLiteralSeparator.DecimalMinDigitsInsert = 5;
   Style.LineEnding = FormatStyle::LE_LF;
   Style.RemoveBracesLLVM = true;
   Style.RemoveEmptyLinesInUnwrappedLines = true;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1164,6 +1164,36 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               FormatStyle::BLS_Block);
   CHECK_PARSE("Cpp11BracedListStyle: true", Cpp11BracedListStyle,
               FormatStyle::BLS_AlignFirstComment);
+
+  constexpr FormatStyle::IntegerLiteralSeparatorStyle
+      ExpectedIntegerLiteralSeparatorStyle{/*Binary=*/2,
+                                           /*BinaryMinDigitInsert=*/5,
+                                           /*BinaryMaxDigitRemove=*/2,
+                                           /*Decimal=*/6,
+                                           /*DecimalMinDigitInsert=*/6,
+                                           /*DecimalMaxDigitRemove=*/3,
+                                           /*Hex=*/4,
+                                           /*HexMinDigitInsert=*/2,
+                                           /*HexMaxDigitRemove=*/1};
+  CHECK_PARSE("IntegerLiteralSeparator:\n"
+              "  Binary: 2\n"
+              "  BinaryMinDigitsInsert: 5\n"
+              "  BinaryMaxDigitsRemove: 2\n"
+              "  Decimal: 6\n"
+              "  DecimalMinDigitsInsert: 6\n"
+              "  DecimalMaxDigitsRemove: 3\n"
+              "  Hex: 4\n"
+              "  HexMinDigitsInsert: 2\n"
+              "  HexMaxDigitsRemove: 1",
+              IntegerLiteralSeparator, ExpectedIntegerLiteralSeparatorStyle);
+
+  // Backward compatibility:
+  CHECK_PARSE_NESTED_VALUE("BinaryMinDigits: 6", IntegerLiteralSeparator,
+                           BinaryMinDigitsInsert, 6);
+  CHECK_PARSE_NESTED_VALUE("DecimalMinDigits: 5", IntegerLiteralSeparator,
+                           DecimalMinDigitsInsert, 5);
+  CHECK_PARSE_NESTED_VALUE("HexMinDigits: 5", IntegerLiteralSeparator,
+                           HexMinDigitsInsert, 5);
 }
 
 TEST(ConfigParseTest, ParsesConfigurationWithLanguages) {

--- a/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
+++ b/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
@@ -137,34 +137,34 @@ TEST_F(IntegerLiteralSeparatorTest, UnderscoreAsSeparator) {
   verifyFormat("o = 0o400000000000000003n;", Style);
 }
 
-TEST_F(IntegerLiteralSeparatorTest, MinDigits) {
+TEST_F(IntegerLiteralSeparatorTest, MinDigitsInsert) {
   FormatStyle Style = getLLVMStyle();
   Style.IntegerLiteralSeparator.Binary = 3;
   Style.IntegerLiteralSeparator.Decimal = 3;
   Style.IntegerLiteralSeparator.Hex = 2;
 
-  Style.IntegerLiteralSeparator.BinaryMinDigits = 7;
+  Style.IntegerLiteralSeparator.BinaryMinDigitsInsert = 7;
   verifyFormat("b1 = 0b101101;\n"
                "b2 = 0b1'101'101;",
                "b1 = 0b101'101;\n"
                "b2 = 0b1101101;",
                Style);
 
-  Style.IntegerLiteralSeparator.DecimalMinDigits = 5;
+  Style.IntegerLiteralSeparator.DecimalMinDigitsInsert = 5;
   verifyFormat("d1 = 2023;\n"
                "d2 = 10'000;",
                "d1 = 2'023;\n"
                "d2 = 100'00;",
                Style);
 
-  Style.IntegerLiteralSeparator.DecimalMinDigits = 3;
+  Style.IntegerLiteralSeparator.DecimalMinDigitsInsert = 3;
   verifyFormat("d1 = 123;\n"
                "d2 = 1'234;",
                "d1 = 12'3;\n"
                "d2 = 12'34;",
                Style);
 
-  Style.IntegerLiteralSeparator.HexMinDigits = 6;
+  Style.IntegerLiteralSeparator.HexMinDigitsInsert = 6;
   verifyFormat("h1 = 0xABCDE;\n"
                "h2 = 0xAB'CD'EF;",
                "h1 = 0xA'BC'DE;\n"
@@ -240,6 +240,22 @@ TEST_F(IntegerLiteralSeparatorTest, FloatingPoint) {
                "F = 1234F;\n"
                "d = 5678d;\n"
                "M = 9012M",
+               Style);
+}
+
+TEST_F(IntegerLiteralSeparatorTest, MaxDigitsRemove) {
+  auto Style = getLLVMStyle();
+  Style.IntegerLiteralSeparator.Decimal = 3;
+  Style.IntegerLiteralSeparator.DecimalMaxDigitsRemove = 4;
+  Style.IntegerLiteralSeparator.DecimalMinDigitsInsert = 7;
+  verifyFormat("d0 = 2023;\n"
+               "d1 = 123456;\n"
+               "d2 = 1234'56;\n"
+               "d3 = 5'000'000;",
+               "d0 = 20'2'3;\n"
+               "d1 = 123456;\n"
+               "d2 = 1234'56;\n"
+               "d3 = 5000000;",
                Style);
 }
 

--- a/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
+++ b/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
@@ -248,13 +248,14 @@ TEST_F(IntegerLiteralSeparatorTest, MaxDigitsRemove) {
   Style.IntegerLiteralSeparator.Decimal = 3;
   Style.IntegerLiteralSeparator.DecimalMaxDigitsRemove = 4;
   Style.IntegerLiteralSeparator.DecimalMinDigitsInsert = 7;
+
+  verifyFormat("d1 = 123456;\n"
+               "d2 = 1234'56;",
+               Style);
+
   verifyFormat("d0 = 2023;\n"
-               "d1 = 123456;\n"
-               "d2 = 1234'56;\n"
                "d3 = 5'000'000;",
                "d0 = 20'2'3;\n"
-               "d1 = 123456;\n"
-               "d2 = 1234'56;\n"
                "d3 = 5000000;",
                Style);
 }


### PR DESCRIPTION
This basically adds a Leave option for a specific range of literals.