### PR TITLE
[VPlan] Strip stale comment for SCEVToExpansion (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -4164,8 +4164,6 @@ class VPlan {
   SmallVector<VPValue *, 16> VPLiveIns;
 
   /// Mapping from SCEVs to the VPValues representing their expansions.
-  /// NOTE: This mapping is temporary and will be removed once all users have
-  /// been modeled in VPlan directly.
   DenseMap<const SCEV *, VPValue *> SCEVToExpansion;
 
   /// Blocks allocated and owned by the VPlan. They will be deleted once the


### PR DESCRIPTION
ExpandSCEV recipes are expanded late, and SCEVToExpansion is just a cache that is not scheduled for removal.