### PR TITLE
[VPlan] Strip dead code in replaceSymbolicStrides (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2909,6 +2909,8 @@ void VPlanTransforms::canonicalizeEVLLoops(VPlan &Plan) {
 void VPlanTransforms::replaceSymbolicStrides(
     VPlan &Plan, PredicatedScalarEvolution &PSE,
     const DenseMap<Value *, const SCEV *> &StridesMap) {
+  // Replace VPValues for known constant strides guaranteed by predicate scalar
+  // evolution.
   ValueToSCEVMapTy RewriteMap;
   for (const SCEV *Stride : StridesMap.values()) {
     using namespace SCEVPatternMatch;


### PR DESCRIPTION
CanUseVersionedStride is checking that the value is modeled in VPlan, but we can use replaceAllUsesWith unconditionally for this.