### PR TITLE
[Flang][Driver] Emit module summary for Full LTO

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1019,11 +1019,15 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
 
   // Create the pass manager.
   llvm::ModulePassManager mpm;
+  // The module summary should be emitted by default for regular LTO
+  // except for ld64 targets.
+  bool emitSummary = (opts.PrepareForThinLTO || opts.PrepareForFullLTO) &&
+                     (triple.getVendor() != llvm::Triple::Apple);
+
+  if (emitSummary && !opts.PrepareForThinLTO)
+    llvmModule->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
+
   if (opts.PrepareForFatLTO) {
-    // The module summary should be emitted by default for regular LTO
-    // except for ld64 targets.
-    bool emitSummary = opts.PrepareForThinLTO || opts.PrepareForFullLTO ||
-                       triple.getVendor() != llvm::Triple::Apple;
     mpm = pb.buildFatLTODefaultPipeline(level, opts.PrepareForThinLTO,
                                         emitSummary);
   } else if (opts.PrepareForFullLTO)
@@ -1034,9 +1038,11 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
     mpm = pb.buildPerModuleDefaultPipeline(level);
 
   if (action == BackendActionTy::Backend_EmitBC)
-    mpm.addPass(llvm::BitcodeWriterPass(os));
+    mpm.addPass(llvm::BitcodeWriterPass(
+        os, /*ShouldPreserveUseListOrder=*/false, emitSummary));
   else if (action == BackendActionTy::Backend_EmitLL)
-    mpm.addPass(llvm::PrintModulePass(os));
+    mpm.addPass(llvm::PrintModulePass(
+        os, /*Banner=*/"", /*ShouldPreserveUseListOrder=*/false, emitSummary));
 
   // FIXME: This should eventually be replaced by a first-class driver option.
   // This should be done for both flang and clang simultaneously.

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1021,7 +1021,8 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
   llvm::ModulePassManager mpm;
   // The module summary should be emitted by default for regular LTO
   // except for ld64 targets.
-  bool emitSummary = opts.PrepareForFullLTO && (triple.getVendor() != llvm::Triple::Apple);
+  bool emitSummary =
+      opts.PrepareForFullLTO && (triple.getVendor() != llvm::Triple::Apple);
   if (opts.PrepareForFatLTO)
     mpm = pb.buildFatLTODefaultPipeline(level, opts.PrepareForThinLTO,
                                         emitSummary);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1021,8 +1021,7 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
   llvm::ModulePassManager mpm;
   // The module summary should be emitted by default for regular LTO
   // except for ld64 targets.
-  bool emitSummary = (opts.PrepareForThinLTO || opts.PrepareForFullLTO) &&
-                     (triple.getVendor() != llvm::Triple::Apple);
+  bool emitSummary = opts.PrepareForFullLTO && (triple.getVendor() != llvm::Triple::Apple);
   if (opts.PrepareForFatLTO)
     mpm = pb.buildFatLTODefaultPipeline(level, opts.PrepareForThinLTO,
                                         emitSummary);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1027,10 +1027,10 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
   if (emitSummary && !opts.PrepareForThinLTO)
     llvmModule->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
 
-  if (opts.PrepareForFatLTO) {
+  if (opts.PrepareForFatLTO)
     mpm = pb.buildFatLTODefaultPipeline(level, opts.PrepareForThinLTO,
                                         emitSummary);
-  } else if (opts.PrepareForFullLTO)
+  else if (opts.PrepareForFullLTO)
     mpm = pb.buildLTOPreLinkDefaultPipeline(level);
   else if (opts.PrepareForThinLTO)
     mpm = pb.buildThinLTOPreLinkDefaultPipeline(level);

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -72,6 +72,7 @@ if (NOT FLANG_STANDALONE_BUILD)
     FileCheck
     count
     not
+    llvm-bcanalyzer
     llvm-dis
     llvm-objcopy
     llvm-objdump

--- a/flang/test/Driver/lto-bc.f90
+++ b/flang/test/Driver/lto-bc.f90
@@ -13,6 +13,9 @@
 
 ! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=THIN
 ! THIN-NOT: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
+! THIN-NOT: ^{{.*}} = module:
+! THIN-NOT: ^{{.*}} = gv: (name:
+! THIN-NOT: ^{{.*}} = blockcount:
 
 ! RUN: %flang -flto %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=FULL
 ! FULL: define void @_QQmain()

--- a/flang/test/Driver/lto-bc.f90
+++ b/flang/test/Driver/lto-bc.f90
@@ -1,5 +1,5 @@
 ! Test that the output is LLVM bitcode for LTO and not a native objectfile by
-! disassembling it to LLVM IR. Also tests module summaries are emitted for LTO
+! disassembling it to LLVM IR. Also tests that module summaries are emitted for LTO
 
 ! RUN: %flang %s -c -o - | not llvm-dis -o %t
 ! RUN: %flang_fc1 %s -emit-llvm-bc -o - | llvm-dis -o - | FileCheck %s
@@ -11,7 +11,7 @@
 ! CHECK-NOT: ^{{.*}} = gv: (name:
 ! CHECK-NOT: ^{{.*}} = blockcount:
 
-! RUN: %flang -flto %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=FULL
+! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=THIN
 ! THIN: define void @_QQmain()
 ! THIN-NEXT:  ret void
 ! THIN-NEXT: }
@@ -20,7 +20,7 @@
 ! THIN: ^{{.*}} = gv: (name:
 ! THIN: ^{{.*}} = blockcount:
 
-! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=THIN
+! RUN: %flang -flto %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=FULL
 ! FULL: define void @_QQmain()
 ! FULL-NEXT:  ret void
 ! FULL-NEXT: }

--- a/flang/test/Driver/lto-bc.f90
+++ b/flang/test/Driver/lto-bc.f90
@@ -12,13 +12,7 @@
 ! CHECK-NOT: ^{{.*}} = blockcount:
 
 ! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=THIN
-! THIN: define void @_QQmain()
-! THIN-NEXT:  ret void
-! THIN-NEXT: }
 ! THIN-NOT: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
-! THIN: ^{{.*}} = module:
-! THIN: ^{{.*}} = gv: (name:
-! THIN: ^{{.*}} = blockcount:
 
 ! RUN: %flang -flto %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=FULL
 ! FULL: define void @_QQmain()

--- a/flang/test/Driver/lto-bc.f90
+++ b/flang/test/Driver/lto-bc.f90
@@ -12,6 +12,9 @@
 ! CHECK-NOT: ^{{.*}} = blockcount:
 
 ! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=THIN
+! THIN: define void @_QQmain()
+! THIN-NEXT:  ret void
+! THIN-NEXT: }
 ! THIN-NOT: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
 ! THIN-NOT: ^{{.*}} = module:
 ! THIN-NOT: ^{{.*}} = gv: (name:

--- a/flang/test/Driver/lto-bc.f90
+++ b/flang/test/Driver/lto-bc.f90
@@ -1,21 +1,35 @@
 ! Test that the output is LLVM bitcode for LTO and not a native objectfile by
-! disassembling it to LLVM IR.
-! Right now there is nothing special about it and it is similar to non-lto IR,
-! more work is needed to add things like module summaries.
+! disassembling it to LLVM IR. Also tests module summaries are emitted for LTO
 
 ! RUN: %flang %s -c -o - | not llvm-dis -o %t
 ! RUN: %flang_fc1 %s -emit-llvm-bc -o - | llvm-dis -o - | FileCheck %s
-
-! RUN: %flang -flto %s -c -o - | llvm-dis -o - | FileCheck %s
-! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s
-
 ! CHECK: define void @_QQmain()
 ! CHECK-NEXT:  ret void
 ! CHECK-NEXT: }
+! CHECK-NOT: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
+! CHECK-NOT: ^{{.*}} = module:
+! CHECK-NOT: ^{{.*}} = gv: (name:
+! CHECK-NOT: ^{{.*}} = blockcount:
 
-! CHECK-NOT: ^0 = module:
-! CHECK-NOT: ^1 = gv: (name:
-! CHECK-NOT: ^2 = flags:
-! CHECK-NOT: ^3 = blockcount:
+! RUN: %flang -flto %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=FULL
+! THIN: define void @_QQmain()
+! THIN-NEXT:  ret void
+! THIN-NEXT: }
+! THIN-NOT: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
+! THIN: ^{{.*}} = module:
+! THIN: ^{{.*}} = gv: (name:
+! THIN: ^{{.*}} = blockcount:
 
+! RUN: %flang -flto=thin %s -c -o - | llvm-dis -o - | FileCheck %s --check-prefix=THIN
+! FULL: define void @_QQmain()
+! FULL-NEXT:  ret void
+! FULL-NEXT: }
+! FULL: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
+! FULL: ^{{.*}} = module:
+! FULL: ^{{.*}} = gv: (name:
+! FULL: ^{{.*}} = blockcount:
+
+! RUN: %flang_fc1 -flto -emit-llvm-bc %s -o - | llvm-bcanalyzer -dump| FileCheck --check-prefix=MOD-SUMM %s
+! MOD-SUMM: FULL_LTO_GLOBALVAL_SUMMARY_BLOCK
+program main
 end program


### PR DESCRIPTION
This PR enables module summary for Full LTO. Module summaries are enabled by default for Full LTO in clang, this change makes the flang behaviour consistent. Reference PR: https://reviews.llvm.org/D34156