### PR TITLE
[flang] Fix standalone build regression from #161179

### DIFF
--- a/flang/lib/Optimizer/Dialect/MIF/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/MIF/CMakeLists.txt
@@ -3,18 +3,22 @@ add_flang_library(MIFDialect
   MIFOps.cpp
 
   DEPENDS
-  MLIRIR
   MIFOpsIncGen
 
   LINK_LIBS
   FIRDialect
   FIRDialectSupport
   FIRSupport
-  MLIRIR
-  MLIRTargetLLVMIRExport
 
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_DEPS
+  MLIRIR
+
+  MLIR_LIBS
+  MLIRIR
+  MLIRTargetLLVMIRExport
 )


### PR DESCRIPTION
Fix incorrect linking and dependencies introduced in #161179 that break standalone builds of Flang.