### PR TITLE
[clang-doc] fix overlapping navbar

### DIFF
--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -396,7 +396,7 @@ body, html {
 
 .sidebar {
     width: 250px;
-    top: 0;
+    top: 60px;
     left: 0;
     height: 100%;
     position: fixed;


### PR DESCRIPTION
The navbar has a height of 60px, but the sidebar didn't have any top
padding so it began underneath the navbar. Now the sidebar has a top
padding of 60px.