### PR TITLE
[ADT] Document C++20 migration path for llvm::is_detected

### DIFF
--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -115,6 +115,13 @@ struct detector<std::void_t<Op<Args...>>, Op, Args...> {
 ///   using has_copy_assign_t = decltype(std::declval<T&>()
 ///                                                 = std::declval<const T&>());
 ///   bool fooHasCopyAssign = is_detected<has_copy_assign_t, FooClass>::value;
+///
+/// NOTE: The C++20 standard has adopted concepts and requires clauses as a
+/// superior alternative to std::is_detected.
+///
+/// This utility is placed in STLForwardCompat.h as a reminder
+/// to migrate usages of llvm::is_detected to concepts and 'requires'
+/// clauses when the codebase adopts C++20.
 template <template <class...> class Op, class... Args>
 using is_detected = typename detail::detector<void, Op, Args...>::value_t;
 


### PR DESCRIPTION
The C++20 standard has adopted concepts and requires clauses as a
superior alternative to std::is_detected.

This patch adds a comment for llvm::is_detected to document this
relationship.  The utility is kept in STLForwardCompat.h to serve as a
marker to migrate usages of llvm::is_detected to concepts and
requires clauses when the codebase adopts C++20.
