### PR TITLE
[Orc] Migrate ExecutorAddr::rawPtr to llvm::identity_cxx20 (NFC)

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h
@@ -14,7 +14,7 @@
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_EXECUTORADDRESS_H
 
 #include "llvm/ADT/DenseMapInfo.h"
-#include "llvm/ADT/identity.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
@@ -34,7 +34,7 @@ using ExecutorAddrDiff = uint64_t;
 class ExecutorAddr {
 public:
   /// A wrap/unwrap function that leaves pointers unmodified.
-  template <typename T> using rawPtr = llvm::identity<T *>;
+  using rawPtr = llvm::identity_cxx20;
 
 #if __has_feature(ptrauth_calls)
   template <typename T> class PtrauthSignDefault {
@@ -63,10 +63,10 @@ public:
 #else
 
   /// Default wrap function to use on this host.
-  template <typename T> using defaultWrap = rawPtr<T>;
+  template <typename T> using defaultWrap = rawPtr;
 
   /// Default unwrap function to use on this host.
-  template <typename T> using defaultUnwrap = rawPtr<T>;
+  template <typename T> using defaultUnwrap = rawPtr;
 
 #endif
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h
@@ -33,8 +33,8 @@ public:
     JITSymbolFlags Flags = BaseFlags;
     if (std::is_function_v<T>)
       Flags |= JITSymbolFlags::Callable;
-    return ExecutorSymbolDef(
-        ExecutorAddr::fromPtr(UP, ExecutorAddr::rawPtr<T>()), Flags);
+    return ExecutorSymbolDef(ExecutorAddr::fromPtr(UP, ExecutorAddr::rawPtr()),
+                             Flags);
   }
 
   /// Cast this ExecutorSymbolDef to a pointer of the given type.


### PR DESCRIPTION
This patch updates ExecutorAddr::rawPtr to use llvm::identity_cxx20 to
better align with C++20.

Note that llvm::identity is a templated struct, while
llvm::identity_cxx20 is a non-templated struct with a templated
operator().

This patch makes rawPtr a non-templated type alias and adjusts use
sites.
