### PR TITLE
[clang][bytecode] Add support for (toplevel) array fillers.

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -42,27 +42,27 @@ static bool CheckArrayInitialized(InterpState &S, SourceLocation Loc,
 
   if (ElemType->isRecordType()) {
     const Record *R = BasePtr.getElemRecord();
-    for (size_t I = 0; I != NumElems; ++I) {
+    for (size_t I = 0; I != BasePtr.getNumAllocatedElems(); ++I) {
       Pointer ElemPtr = BasePtr.atIndex(I).narrow();
       Result &= CheckFieldsInitialized(S, Loc, ElemPtr, R);
     }
   } else if (const auto *ElemCAT = dyn_cast<ConstantArrayType>(ElemType)) {
-    for (size_t I = 0; I != NumElems; ++I) {
+
+    for (size_t I = 0; I != BasePtr.getNumAllocatedElems(); ++I) {
       Pointer ElemPtr = BasePtr.atIndex(I).narrow();
       Result &= CheckArrayInitialized(S, Loc, ElemPtr, ElemCAT);
     }
   } else {
     // Primitive arrays.
     if (S.getContext().canClassify(ElemType)) {
-      if (BasePtr.allElementsInitialized()) {
+      if (BasePtr.allElementsInitialized())
         return true;
-      } else {
-        DiagnoseUninitializedSubobject(S, Loc, BasePtr.getField());
-        return false;
-      }
+
+      DiagnoseUninitializedSubobject(S, Loc, BasePtr.getField());
+      return false;
     }
 
-    for (size_t I = 0; I != NumElems; ++I) {
+    for (size_t I = 0; I != BasePtr.getNumAllocatedElems(); ++I) {
       if (!BasePtr.isElementInitialized(I)) {
         DiagnoseUninitializedSubobject(S, Loc, BasePtr.getField());
         Result = false;

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1597,6 +1597,8 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
   if (!Func->isFullyCompiled())
     compileFunction(S, Func);
 
+  // Func->dump();
+
   if (!CheckCallable(S, OpPC, Func))
     return cleanup();
 

--- a/clang/lib/AST/ByteCode/InterpBlock.h
+++ b/clang/lib/AST/ByteCode/InterpBlock.h
@@ -142,8 +142,11 @@ public:
     IsInitialized = false;
   }
 
+  void moveArrayData(Block *To) const { Desc->moveArrayData(this, To); }
+
   void dump() const { dump(llvm::errs()); }
   void dump(llvm::raw_ostream &OS) const;
+  void dumpContents() const;
 
   bool isAccessible() const { return AccessFlags == 0; }
 

--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -11,6 +11,7 @@
 #include "Context.h"
 #include "Floating.h"
 #include "Integral.h"
+#include "InterpHelpers.h"
 #include "InterpState.h"
 #include "MemberPointer.h"
 #include "Pointer.h"
@@ -265,6 +266,8 @@ bool clang::interp::readPointerToBuffer(const Context &Ctx,
   Endian TargetEndianness =
       ASTCtx.getTargetInfo().isLittleEndian() ? Endian::Little : Endian::Big;
 
+  ensureArraySize(Ctx.getProgram(), FromPtr);
+
   return enumeratePointerFields(
       FromPtr, Ctx, Buffer.size(),
       [&](const Pointer &P, PrimType T, Bits BitOffset, Bits FullBitWidth,
@@ -383,6 +386,8 @@ bool clang::interp::DoBitCastPtr(InterpState &S, CodePtr OpPC,
   BitcastBuffer Buffer(Bytes(Size).toBits());
   readPointerToBuffer(S.getContext(), FromPtr, Buffer,
                       /*ReturnOnUninit=*/false);
+
+  ensureArraySize(S.P, ToPtr);
 
   // Now read the values out of the buffer again and into ToPtr.
   Endian TargetEndianness =

--- a/clang/lib/AST/ByteCode/InterpHelpers.cpp
+++ b/clang/lib/AST/ByteCode/InterpHelpers.cpp
@@ -1,0 +1,58 @@
+
+
+#include "InterpHelpers.h"
+#include "Descriptor.h"
+#include "InterpBlock.h"
+#include "Program.h"
+
+namespace clang {
+namespace interp {
+
+void ensureArraySize(Program &P, const Pointer &Ptr, unsigned RequestedIndex) {
+  if (!Ptr.isBlockPointer())
+    return;
+
+  assert(Ptr.getFieldDesc());
+  assert(Ptr.getDeclDesc());
+  if (!Ptr.getDeclDesc()->isArray())
+    return;
+
+  // No fillers for these.
+  if (!Ptr.isStatic() || Ptr.isUnknownSizeArray() || Ptr.block()->isDynamic())
+    return;
+
+  assert(Ptr.getFieldDesc()->isArray());
+
+  bool NeedsRealloc = RequestedIndex >= Ptr.getNumAllocatedElems() &&
+                      RequestedIndex < Ptr.getCapacity();
+
+  // llvm::errs() << "NeedsRealloc: " << NeedsRealloc << '\n';
+  if (!NeedsRealloc)
+    return;
+
+  assert(Ptr.getFieldDesc()->hasArrayFiller());
+  unsigned RequestedSize = RequestedIndex + 1;
+  assert(RequestedSize <= Ptr.getNumElems());
+
+  const Descriptor *D = Ptr.getFieldDesc();
+  ArraySize NewArraySize = ArraySize::getNextSize(RequestedSize, D->Capacity);
+
+  const Descriptor *NewDesc = nullptr;
+  if (D->isPrimitiveArray()) {
+    NewDesc = P.allocateDescriptor(D->Source, D->getPrimType(),
+                                   Descriptor::GlobalMD, NewArraySize,
+                                   D->IsConst, D->IsTemporary, D->IsMutable);
+  } else if (D->isCompositeArray()) {
+    NewDesc = P.allocateDescriptor(D->Source, D->SourceType, D->ElemDesc,
+                                   Descriptor::GlobalMD, NewArraySize,
+                                   D->IsConst, D->IsTemporary, D->IsMutable);
+  } else {
+    llvm_unreachable("Should be either a primitive or composite array");
+  }
+
+  assert(NewDesc);
+  P.reallocGlobal(const_cast<Block *>(Ptr.block()), NewDesc);
+}
+
+} // namespace interp
+} // namespace clang

--- a/clang/lib/AST/ByteCode/InterpHelpers.h
+++ b/clang/lib/AST/ByteCode/InterpHelpers.h
@@ -1,0 +1,14 @@
+
+#include "Pointer.h"
+
+namespace clang {
+namespace interp {
+void ensureArraySize(Program &P, const Pointer &Ptr, unsigned RequestedIndex);
+
+inline void ensureArraySize(Program &P, const Pointer &Ptr) {
+  if (!Ptr.getFieldDesc()->isArray())
+    return;
+  ensureArraySize(P, Ptr, Ptr.getNumElems() - 1);
+}
+} // namespace interp
+} // namespace clang

--- a/clang/lib/AST/ByteCode/Opcodes.td
+++ b/clang/lib/AST/ByteCode/Opcodes.td
@@ -381,6 +381,8 @@ def CopyArray : Opcode {
   let HasGroup = 1;
 }
 
+def SetArrayFillerPtr : Opcode { let Args = [ArgUint32]; }
+
 //===----------------------------------------------------------------------===//
 // Direct field accessors
 //===----------------------------------------------------------------------===//

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -596,6 +596,33 @@ public:
   unsigned getNumElems() const {
     if (!isBlockPointer())
       return ~0u;
+    // return getFieldDesc()->getNumElemsWithoutFiller();
+    // return getSize() / elemSize();
+    return getCapacity();
+  }
+
+  unsigned getNumAllocatedElems() const {
+    if (!isBlockPointer())
+      return ~0u;
+
+    assert(getFieldDesc()->isArray());
+    // return getSize() / elemSize();
+    return getFieldDesc()->getNumElemsWithoutFiller();
+  }
+
+  unsigned getNumAllocatedElemsWithFiller() const {
+    if (!isBlockPointer())
+      return ~0u;
+
+    assert(getFieldDesc()->isArray());
+    return getFieldDesc()->getNumElems(); // XXX WITH FILLER
+  }
+
+  unsigned getCapacity() const {
+    if (!isBlockPointer())
+      return ~0u;
+    if (getFieldDesc()->IsArray)
+      return getFieldDesc()->Capacity;
     return getSize() / elemSize();
   }
 
@@ -636,6 +663,15 @@ public:
     if (isUnknownSizeArray())
       return false;
 
+    if (isPastEnd())
+      return true;
+
+    return getIndex() == getNumElems();
+
+    // if (getFieldDesc()->IsArray && getIndex() >=
+    // getFieldDesc()->getNumElems() && getIndex() < getFieldDesc()->Capacity)
+    // return false;
+
     return isPastEnd() || (getSize() == getOffset());
   }
 
@@ -643,6 +679,10 @@ public:
   bool isPastEnd() const {
     if (isIntegralPointer())
       return false;
+
+    // if (getFieldDesc()->IsArray && getIndex() >=
+    // getFieldDesc()->getNumElems() && getIndex() < getFieldDesc()->Capacity)
+    // return false;
 
     return !isZero() && Offset > BS.Pointee->getSize();
   }
@@ -682,7 +722,7 @@ public:
     assert(BS.Pointee);
     assert(isDereferencable());
     assert(getFieldDesc()->isPrimitiveArray());
-    assert(I < getFieldDesc()->getNumElems());
+    // assert(I < getFieldDesc()->getNumElems());
 
     unsigned ElemByteOffset = I * getFieldDesc()->getElemSize();
     unsigned ReadOffset = BS.Base + sizeof(InitMapPtr) + ElemByteOffset;

--- a/clang/lib/AST/ByteCode/Program.h
+++ b/clang/lib/AST/ByteCode/Program.h
@@ -161,6 +161,12 @@ public:
       return std::nullopt;
     return CurrentDeclaration;
   }
+  /// Creates a new descriptor.
+  template <typename... Ts> Descriptor *allocateDescriptor(Ts &&...Args) {
+    return new (Allocator) Descriptor(std::forward<Ts>(Args)...);
+  }
+
+  void reallocGlobal(Block *Prev, const Descriptor *NewDesc);
 
 private:
   friend class DeclScope;
@@ -204,6 +210,10 @@ private:
     Block *block() { return &B; }
     const Block *block() const { return &B; }
 
+    GlobalInlineDescriptor getInlineDesc() const {
+      return *reinterpret_cast<const GlobalInlineDescriptor *>(B.rawData());
+    }
+
   private:
     /// Required metadata - does not actually track pointers.
     Block B;
@@ -222,11 +232,6 @@ private:
 
   /// Dummy parameter to generate pointers from.
   llvm::DenseMap<const void *, unsigned> DummyVariables;
-
-  /// Creates a new descriptor.
-  template <typename... Ts> Descriptor *allocateDescriptor(Ts &&...Args) {
-    return new (Allocator) Descriptor(std::forward<Ts>(Args)...);
-  }
 
   /// No declaration ID.
   static constexpr unsigned NoDeclaration = ~0u;

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -82,6 +82,7 @@ add_clang_library(clangAST
   ByteCode/EvaluationResult.cpp
   ByteCode/DynamicAllocator.cpp
   ByteCode/Interp.cpp
+  ByteCode/InterpHelpers.cpp
   ByteCode/InterpBlock.cpp
   ByteCode/InterpFrame.cpp
   ByteCode/InterpStack.cpp

--- a/clang/test/AST/ByteCode/array-fillers.cpp
+++ b/clang/test/AST/ByteCode/array-fillers.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 %s -std=c++20 -verify=both,expected -fexperimental-new-constant-interpreter
+
+// both-no-diagnostics
+
+
+constexpr int F[100] = {1,2};
+static_assert(F[98] == 0);
+static_assert(F[99] == 0);
+static_assert(F[0] == 1);
+static_assert(F[1] == 2);
+static_assert(F[2] == 0);
+
+constexpr _Complex double Doubles[4] = {{1.0, 2.0}};
+static_assert(__real(Doubles[0]) == 1.0, "");
+static_assert(__imag(Doubles[0]) == 2.0, "");
+
+static_assert(__real(Doubles[1]) == 0.0, "");
+static_assert(__imag(Doubles[1]) == 0.0, "");
+
+static_assert(__real(Doubles[2]) == 0.0, "");
+static_assert(__imag(Doubles[2]) == 0.0, "");
+static_assert(__real(Doubles[3]) == 0.0, "");
+static_assert(__imag(Doubles[3]) == 0.0, "");
+
+static_assert(__real(Doubles[0]) == 1.0, "");
+static_assert(__imag(Doubles[0]) == 2.0, "");
+
+struct S {
+  int x = 20;
+};
+constexpr S s[20] = {};
+static_assert(s[0].x == 20);
+static_assert(s[1].x == 20);
+static_assert(s[2].x == 20);
+static_assert(s[3].x == 20);
+static_assert(s[4].x == 20);
+
+constexpr int test() {
+  int a[4] = {};
+  int r = a[2];
+  return r;
+}
+static_assert(test() == 0);
+
+constexpr int test2() {
+  char buff[2] = {};
+  buff[0] = 'B';
+  return buff[1] == '\0' && buff[0] == 'B';
+}
+static_assert(test2());


### PR DESCRIPTION
This adds support for array fillers, for global, toplevel descriptors.

Toplevel meaning that this gets an array filler:
```c++
constexpr int foo[200] = {1};
```

But this does not:
```c++
struct S { int i[10] = {3}; };
constexpr S s{};
```

For multidimensional arrays, only the topmost dimension gets an array filler:
```c++
constexpr float arr_f[3][5] = {
    {1, 2, 3, 4, 5},
};
```

This means that this patch fixes e.g.
`test/SemaCXX/large-array-init`, but does not fix
`test/CodeGenCXX/cxx11-initializer-aggregate.cpp`, as that contains arrays such as:
```c++
  struct B { int n; int arr[1024 * 1024 * 1024 * 2u]; } b = {1, {2}};
  // ...
  unsigned char data_3[1024][1024][1024] = {{{0}}};
  // ...
  unsigned char data_12[1024][1024][1024] = {{{1}}};
```

additionally, adding array fillers regresses performance in the common case of no array fillers:
https://llvm-compile-time-tracker.com/compare.php?from=02052caa09b27b422c452a2e1be2e3bfed710156&to=5b654212c1442d814aa8ed1c8de960432e479cdd&stat=instructions:u