### PR TITLE
[SPIRV] Emit LinkageType for function with hidden visibility

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -1042,7 +1042,7 @@ getFirstValidInstructionInsertPoint(MachineBasicBlock &BB) {
 
 std::optional<SPIRV::LinkageType::LinkageType>
 getSpirvLinkageTypeFor(const SPIRVSubtarget &ST, const GlobalValue &GV) {
-  if (GV.hasLocalLinkage() || GV.hasHiddenVisibility())
+  if (GV.hasLocalLinkage())
     return std::nullopt;
 
   if (GV.isDeclarationForLinker())

--- a/llvm/test/CodeGen/SPIRV/linkage/link-hidden.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/link-hidden.ll
@@ -1,6 +1,9 @@
-; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-unknown %s -o - 2>&1 | FileCheck %s
-; CHECK: LLVM ERROR: Unknown function in:
-; CHECK-SAME: OpFunctionCall %{{[0-9]+}}:type, @bar
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpName %[[BAR:[0-9]+]] "bar"
+; CHECK: OpDecorate %[[BAR]] LinkageAttributes "bar" Import
+; CHECK: %[[BAR]] = OpFunction
 
 define hidden spir_kernel void @foo() addrspace(4) {
 entry:

--- a/llvm/test/CodeGen/SPIRV/linkage/link-hidden.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/link-hidden.ll
@@ -1,0 +1,11 @@
+; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-unknown %s -o - 2>&1 | FileCheck %s
+; CHECK: LLVM ERROR: Unknown function in:
+; CHECK-SAME: OpFunctionCall %{{[0-9]+}}:type, @bar
+
+define hidden spir_kernel void @foo() addrspace(4) {
+entry:
+  call spir_func addrspace(4) void @bar()
+  ret void
+}
+
+declare hidden spir_func void @bar() addrspace(4)


### PR DESCRIPTION
This patch allows emitting linkage decoration for global values with hidden linkage.

I don't think the "visibility" concept is covered in the SPIRV standard, so I'm not sure if this should rely on a target-triple specific hook.

The translator ignores the visibility, and this patch moves the SPIRV backend closer to the translator's behavior.

"hidden" visibility is different from "internal/private" linkage types. A global variable or function with hidden public linkage should still be visible to other compilation units in the same "shared object".

For the test `link-hidden.ll` with the triple `spirv--` the translator generates:
```asm
; SPIR-V
; Version: 1.0
; Generator: Khronos LLVM/SPIR-V Translator; 14
; Bound: 11
; Schema: 0
               OpCapability Addresses
               OpCapability Linkage
               OpCapability Kernel
          %1 = OpExtInstImport "OpenCL.std"
               OpMemoryModel Physical64 OpenCL
               OpEntryPoint Kernel %8 "foo"
               OpExecutionMode %8 ContractionOff
               OpSource Unknown 0
               OpName %bar "bar"
               OpName %foo "foo"
               OpName %entry "entry"
               OpDecorate %bar LinkageAttributes "bar" Import
               OpDecorate %foo LinkageAttributes "foo" Export
       %void = OpTypeVoid
          %3 = OpTypeFunction %void
        %bar = OpFunction %void None %3
               OpFunctionEnd
        %foo = OpFunction %void None %3
      %entry = OpLabel
          %7 = OpFunctionCall %void %bar
               OpReturn
               OpFunctionEnd
          %8 = OpFunction %void None %3
          %9 = OpLabel
         %10 = OpFunctionCall %void %foo
               OpReturn
               OpFunctionEnd
```