### PR TITLE
[clang][bytecode] Don't emit checkNull for function pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6633,7 +6633,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     if (!this->visit(SubExpr))
       return false;
 
-    if (!this->emitCheckNull(E))
+    if (!SubExpr->getType()->isFunctionPointerType() && !this->emitCheckNull(E))
       return false;
 
     if (classifyPrim(SubExpr) == PT_Ptr)

--- a/clang/test/AST/ByteCode/cxx14.cpp
+++ b/clang/test/AST/ByteCode/cxx14.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -std=c++14 -verify=both,expected %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++14 -verify=both,ref      %s
+
+
+
+constexpr int(*null_ptr)() = nullptr;
+constexpr int test4 = (*null_ptr)(); // both-error {{must be initialized by a constant expression}} \
+                                     // both-note {{evaluates to a null function pointer}}
+


### PR DESCRIPTION
Diagnose them later when we try to call the function pointer.