### PR TITLE
[llvm-c] Add LLVMConstFPFromBits() API

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -153,6 +153,7 @@ Changes to the C API
 
 * Add `LLVMGetOrInsertFunction` to get or insert a function, replacing the combination of `LLVMGetNamedFunction` and `LLVMAddFunction`.
 * Allow `LLVMGetVolatile` to work with any kind of Instruction.
+* Add `LLVMConstFPFromBits` to get a constant floating-point value from an array of 64 bit values.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2341,6 +2341,8 @@ LLVM_C_ABI LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy,
 
 /**
  * Obtain a constant for a floating point value from array of 64 bit values.
+ * The length of the array N must be ceildiv(bits, 64), where bits is the
+ * scalar size in bits of the floating-point type.
  */
 
 LLVM_C_ABI LLVMValueRef LLVMConstFPFromBits(LLVMTypeRef Ty, const uint64_t N[]);

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2340,11 +2340,10 @@ LLVM_C_ABI LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy,
                                                      unsigned SLen);
 
 /**
- * Obtain a constant for a floating point FP128 value from 2 64 bit values.
- * Only the LLVMFP128Type or LLVMPPCFP128Type are accepted.
+ * Obtain a constant for a floating point value from array of 64 bit values.
  */
 
-LLVM_C_ABI LLVMValueRef LLVMConstFP128(LLVMTypeRef Ty, const uint64_t N[2]);
+LLVM_C_ABI LLVMValueRef LLVMConstFPFromBits(LLVMTypeRef Ty, const uint64_t N[]);
 
 /**
  * Obtain the zero extended value for an integer constant value.

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2341,7 +2341,7 @@ LLVM_C_ABI LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy,
 
 /**
  * Obtain a constant for a floating point FP128 value from 2 64 bit values.
- * Only the LLVMFP128Type or LLVMPPCFP128Type are accepted. 
+ * Only the LLVMFP128Type or LLVMPPCFP128Type are accepted.
  */
 
 LLVM_C_ABI LLVMValueRef LLVMConstFP128(LLVMTypeRef Ty, const uint64_t N[2]);

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2340,6 +2340,13 @@ LLVM_C_ABI LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy,
                                                      unsigned SLen);
 
 /**
+ * Obtain a constant for a floating point FP128 value from 2 64 bit values.
+ * (112 bit mantissa)
+ */
+
+LLVMValueRef LLVMConstFP128(LLVMContextRef C, const uint64_t N[2]);
+
+/**
  * Obtain the zero extended value for an integer constant value.
  *
  * @see llvm::ConstantInt::getZExtValue()

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2341,10 +2341,10 @@ LLVM_C_ABI LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy,
 
 /**
  * Obtain a constant for a floating point FP128 value from 2 64 bit values.
- * (112 bit mantissa)
+ * Only the LLVMFP128Type or LLVMPPCFP128Type are accepted. 
  */
 
-LLVMValueRef LLVMConstFP128(LLVMContextRef C, const uint64_t N[2]);
+LLVM_C_ABI LLVMValueRef LLVMConstFP128(LLVMTypeRef Ty, const uint64_t N[2]);
 
 /**
  * Obtain the zero extended value for an integer constant value.

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1573,10 +1573,9 @@ LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy, const char Str[],
   return wrap(ConstantFP::get(unwrap(RealTy), StringRef(Str, SLen)));
 }
 
-LLVMValueRef LLVMConstFP128(LLVMTypeRef Ty, const uint64_t N[2]) {
+LLVMValueRef LLVMConstFPFromBits(LLVMTypeRef Ty, const uint64_t N[]) {
   Type *T = unwrap(Ty);
   unsigned SB = T->getScalarSizeInBits();
-  assert(SB == 128 && "Ty size should be 128");
   APInt AI(SB, ArrayRef<uint64_t>(N, divideCeil(SB, 64)));
   APFloat Quad(T->getFltSemantics(), AI);
   return wrap(ConstantFP::get(T, Quad));

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1573,11 +1573,12 @@ LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy, const char Str[],
   return wrap(ConstantFP::get(unwrap(RealTy), StringRef(Str, SLen)));
 }
 
-LLVMValueRef LLVMConstFP128(LLVMContextRef C, const uint64_t N[2]) {
-  Type *Ty = Type::getFP128Ty(*unwrap(C));
+LLVMValueRef LLVMConstFP128(LLVMTypeRef Ty, const uint64_t N[2]) {
+  Type *T = unwrap(Ty);
+  assert(T->getPrimitiveSizeInBits() == 128 && "Ty size should be 128");
   APInt AI(128, ArrayRef<uint64_t>(N, 2));
-  APFloat Quad(APFloat::IEEEquad(), AI);
-  return wrap(ConstantFP::get(Ty, Quad));
+  APFloat Quad(T->getFltSemantics(), AI);
+  return wrap(ConstantFP::get(T, Quad));
 }
 
 unsigned long long LLVMConstIntGetZExtValue(LLVMValueRef ConstantVal) {

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1573,6 +1573,13 @@ LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy, const char Str[],
   return wrap(ConstantFP::get(unwrap(RealTy), StringRef(Str, SLen)));
 }
 
+LLVMValueRef LLVMConstFP128(LLVMContextRef C, const uint64_t N[2]) {
+  Type *Ty = Type::getFP128Ty(*unwrap(C));
+  APInt AI(128, ArrayRef<uint64_t>(N, 2));
+  APFloat Quad(APFloat::IEEEquad(), AI);
+  return wrap(ConstantFP::get(Ty, Quad));
+}
+
 unsigned long long LLVMConstIntGetZExtValue(LLVMValueRef ConstantVal) {
   return unwrap<ConstantInt>(ConstantVal)->getZExtValue();
 }

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1575,8 +1575,9 @@ LLVMValueRef LLVMConstRealOfStringAndSize(LLVMTypeRef RealTy, const char Str[],
 
 LLVMValueRef LLVMConstFP128(LLVMTypeRef Ty, const uint64_t N[2]) {
   Type *T = unwrap(Ty);
-  assert(T->getPrimitiveSizeInBits() == 128 && "Ty size should be 128");
-  APInt AI(128, ArrayRef<uint64_t>(N, 2));
+  unsigned SB = T->getScalarSizeInBits();
+  assert(SB == 128 && "Ty size should be 128");
+  APInt AI(SB, ArrayRef<uint64_t>(N, divideCeil(SB, 64)));
   APFloat Quad(T->getFltSemantics(), AI);
   return wrap(ConstantFP::get(T, Quad));
 }

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -836,11 +836,12 @@ TEST(ConstantsTest, BlockAddressCAPITest) {
 }
 
 TEST(ConstantsTest, Float128Test) {
-  LLVMTypeRef Ty128 = LLVMFP128TypeInContext(LLVMGetGlobalContext());
-  LLVMTypeRef TyPPC128 = LLVMPPCFP128TypeInContext(LLVMGetGlobalContext());
-  LLVMTypeRef TyFloat = LLVMFloatTypeInContext(LLVMGetGlobalContext());
-  LLVMTypeRef TyDouble = LLVMDoubleTypeInContext(LLVMGetGlobalContext());
-  LLVMTypeRef TyHalf = LLVMHalfTypeInContext(LLVMGetGlobalContext());
+  LLVMContextRef C = LLVMContextCreate();
+  LLVMTypeRef Ty128 = LLVMFP128TypeInContext(C);
+  LLVMTypeRef TyPPC128 = LLVMPPCFP128TypeInContext(C);
+  LLVMTypeRef TyFloat = LLVMFloatTypeInContext(C);
+  LLVMTypeRef TyDouble = LLVMDoubleTypeInContext(C);
+  LLVMTypeRef TyHalf = LLVMHalfTypeInContext(C);
   LLVMBuilderRef Builder = LLVMCreateBuilder();
   uint64_t n[2] = {0x4000000000000000, 0x0}; //+2
   uint64_t m[2] = {0xC000000000000000, 0x0}; //-2
@@ -861,6 +862,7 @@ TEST(ConstantsTest, Float128Test) {
   uint64_t r[1] = {0x0000000000003c00}; //+1
   LLVMValueRef val7 = LLVMConstFPFromBits(TyHalf, r);
   EXPECT_TRUE(val7 != nullptr);
+  LLVMContextDispose(C);
 }
 
 } // end anonymous namespace

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -855,10 +855,10 @@ TEST(ConstantsTest, Float128Test) {
   EXPECT_TRUE(val4 != nullptr);
   uint64_t p[1] = {0x0000000040000000}; //+2
   LLVMValueRef val5 = LLVMConstFPFromBits(TyFloat, p);
-  EXPECT_TRUE(val5 != nullptr);
+  EXPECT_EQ(APFloat(2.0f), unwrap<ConstantFP>(val5)->getValue());
   uint64_t q[1] = {0x4000000000000000}; //+2
   LLVMValueRef val6 = LLVMConstFPFromBits(TyDouble, q);
-  EXPECT_TRUE(val6 != nullptr);
+  EXPECT_EQ(APFloat(2.0), unwrap<ConstantFP>(val6)->getValue());
   uint64_t r[1] = {0x0000000000003c00}; //+1
   LLVMValueRef val7 = LLVMConstFPFromBits(TyHalf, r);
   EXPECT_TRUE(val7 != nullptr);

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -838,15 +838,29 @@ TEST(ConstantsTest, BlockAddressCAPITest) {
 TEST(ConstantsTest, Float128Test) {
   LLVMTypeRef Ty128 = LLVMFP128TypeInContext(LLVMGetGlobalContext());
   LLVMTypeRef TyPPC128 = LLVMPPCFP128TypeInContext(LLVMGetGlobalContext());
+  LLVMTypeRef TyFloat = LLVMFloatTypeInContext(LLVMGetGlobalContext());
+  LLVMTypeRef TyDouble = LLVMDoubleTypeInContext(LLVMGetGlobalContext());
+  LLVMTypeRef TyHalf = LLVMHalfTypeInContext(LLVMGetGlobalContext());
   LLVMBuilderRef Builder = LLVMCreateBuilder();
   uint64_t n[2] = {0x4000000000000000, 0x0}; //+2
   uint64_t m[2] = {0xC000000000000000, 0x0}; //-2
-  LLVMValueRef val1 = LLVMConstFP128(Ty128, n);
-  LLVMValueRef val2 = LLVMConstFP128(Ty128, m);
+  LLVMValueRef val1 = LLVMConstFPFromBits(Ty128, n);
+  EXPECT_TRUE(val1 != nullptr);
+  LLVMValueRef val2 = LLVMConstFPFromBits(Ty128, m);
+  EXPECT_TRUE(val2 != nullptr);
   LLVMValueRef val3 = LLVMBuildFAdd(Builder, val1, val2, "test");
   EXPECT_TRUE(val3 != nullptr);
-  LLVMValueRef val4 = LLVMConstFP128(TyPPC128, n);
+  LLVMValueRef val4 = LLVMConstFPFromBits(TyPPC128, n);
   EXPECT_TRUE(val4 != nullptr);
+  uint64_t p[1] = {0x0000000040000000}; //+2
+  LLVMValueRef val5 = LLVMConstFPFromBits(TyFloat, p);
+  EXPECT_TRUE(val5 != nullptr);
+  uint64_t q[1] = {0x4000000000000000}; //+2
+  LLVMValueRef val6 = LLVMConstFPFromBits(TyDouble, q);
+  EXPECT_TRUE(val6 != nullptr);
+  uint64_t r[1] = {0x0000000000003c00}; //+1
+  LLVMValueRef val7 = LLVMConstFPFromBits(TyHalf, r);
+  EXPECT_TRUE(val7 != nullptr);
 }
 
 } // end anonymous namespace

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -835,5 +835,19 @@ TEST(ConstantsTest, BlockAddressCAPITest) {
   EXPECT_EQ(&BB, OutBB);
 }
 
+TEST(ConstantsTest, Float128Test) {
+  LLVMTypeRef Ty128 = LLVMFP128TypeInContext(LLVMGetGlobalContext());
+  LLVMTypeRef TyPPC128 = LLVMPPCFP128TypeInContext(LLVMGetGlobalContext());
+  LLVMBuilderRef Builder = LLVMCreateBuilder();
+  uint64_t n[2] = {0x4000000000000000, 0x0}; //+2
+  uint64_t m[2] = {0xC000000000000000, 0x0}; //-2
+  LLVMValueRef val1 = LLVMConstFP128(Ty128, n);
+  LLVMValueRef val2 = LLVMConstFP128(Ty128, m);
+  LLVMValueRef val3 = LLVMBuildFAdd(Builder, val1, val2, "test");
+  EXPECT_TRUE(val3 != nullptr);
+  LLVMValueRef val4 = LLVMConstFP128(TyPPC128, n);
+  EXPECT_TRUE(val4 != nullptr);
+}
+
 } // end anonymous namespace
 } // end namespace llvm


### PR DESCRIPTION
This change adds the ability to create a 128 bit floating point value from 2 64 bit integer values.
Some language frontends have already parsed a floating point string into a proper 128 bit quad value
and need to get the llvm value directly.