### PR TITLE
[lld][test] Fix AArch64 build attribute test cleanup

### DIFF
--- a/lld/test/ELF/aarch64-build-attributes.s
+++ b/lld/test/ELF/aarch64-build-attributes.s
@@ -1,4 +1,5 @@
 // REQUIRES: aarch64
+// RUN: rm -rf %t %t.o %t.so %t2.o
 // RUN: llvm-mc -triple=aarch64 %s -filetype=obj -o %t.o
 // RUN: ld.lld %t.o --shared -o %t.so
 // RUN: llvm-readelf --sections %t.so | FileCheck %s


### PR DESCRIPTION
This test has been reported to fail on a release bot, but nothing in the content of the test on the release branch should cause this problem:
ld.lld: error: cannot open output file /home/buildbot/as-worker-92/clang-with-thin-lto-ubuntu-rel/build/stage1/tools/lld/test/ELF/Output/aarch64-build-attributes.s.tmp: Is a directory

The reason this is happening is that if the same builder happened to run the extended version of this test, from a build of main, it would create a directory with that name. The test on main seemingly intends to stash files in that temporary directory (though not for all files, see #164396), but regardless, it creates the directory.

$ tree tools/lld/test/
tools/lld/test/
├── CMakeFiles
├── ELF
│   └── Output
│       ├── aarch64-build-attributes.s.tmp <<< This directory
│       │   ├── pauth-bti-gcs.s
│       │   └── pauth-bti-pac.s
│       ├── aarch64-build-attributes.s.tmp.merged.o
│       ├── aarch64-build-attributes.s.tmp1.o
│       ├── aarch64-build-attributes.s.tmp2.o
│       └── aarch64-build-attributes.s.tmp3.o
├── Unit
│   └── lit.site.cfg.py
├── cmake_install.cmake
└── lit.site.cfg.py

If you then had a 21.x build run, it would find that pre-existing directory and try to write to it as if it were a file.

ld.lld: error: cannot open output file /home/david.spickett/build-llvm-aarch64/tools/lld/test/ELF/Output/aarch64-build-attributes.s.tmp: Is a directory

To fix this, remove the file or directory names we're going to use, before the test starts.

(if this were main I'd put all the files in one direcory, but in the interest of keeping release changes small I'm just adding the rm line)