### PR TITLE
[llvm][docs] Remove guidance on adding release:reviewed label

### DIFF
--- a/llvm/docs/HowToReleaseLLVM.rst
+++ b/llvm/docs/HowToReleaseLLVM.rst
@@ -311,10 +311,10 @@ This section describes how to triage bug reports:
    to backport.  You should also review the bug yourself to ensure that it
    meets the requirements for committing to the release branch.
 
-#. Once a bug has been reviewed, add the release:reviewed label and update the
-   issue's status to "Needs Merge".  Check the pull request associated with the
-   issue.  If all the tests pass, then the pull request can be merged.  If not,
-   then add a comment on the issue asking someone to take a look at the failures.
+#. Once a bug has been reviewed, update the status to "Needs Merge". Check the
+   pull request associated with the issue. If all the tests pass, then the pull
+   request can be merged. If not, then add a comment on the issue asking
+   someone to take a look at the failures.
 
 
 Release Patch Rules


### PR DESCRIPTION
"How To Release LLVM To The Public" [1] mentions to add the release:reviewed label once a bug has been reviewed, but looking at the label [2] it seems this hasn't been followed for quite a long time, so I propose we remove it.

[1] https://llvm.org/docs/HowToReleaseLLVM.html#triaging-bug-reports-for-releases
[2] https://github.com/llvm/llvm-project/issues?q=label%3Arelease%3Areviewed