### PR TITLE
[lld][test] Fix file cleanup in aarch64-build-attributes.s

### DIFF
--- a/lld/test/ELF/aarch64-build-attributes.s
+++ b/lld/test/ELF/aarch64-build-attributes.s
@@ -1,11 +1,11 @@
 // REQUIRES: aarch64
 // RUN: rm -rf %t && split-file %s %t && cd %t
 
-// RUN: llvm-mc -triple=aarch64 -filetype=obj %s -o %t1.o
-// RUN: llvm-mc -triple=aarch64 -filetype=obj pauth-bti-gcs.s -o %t2.o
-// RUN: llvm-mc -triple=aarch64 -filetype=obj pauth-bti-pac.s -o %t3.o
-// RUN: ld.lld -r %t1.o %t2.o %t3.o -o %t.merged.o
-// RUN: llvm-readelf -n %t.merged.o | FileCheck %s --check-prefix=NOTE
+// RUN: llvm-mc -triple=aarch64 -filetype=obj %s -o 1.o
+// RUN: llvm-mc -triple=aarch64 -filetype=obj pauth-bti-gcs.s -o 2.o
+// RUN: llvm-mc -triple=aarch64 -filetype=obj pauth-bti-pac.s -o 3.o
+// RUN: ld.lld -r 1.o 2.o 3.o -o merged.o
+// RUN: llvm-readelf -n merged.o | FileCheck %s --check-prefix=NOTE
 
 /// This test merges three object files with AArch64 build attributes.
 /// All contain identical PAuth ABI info (platform/version), which must be preserved.


### PR DESCRIPTION
This test seems to have taken the lit documentation at its word:
https://llvm.org/docs/CommandGuide/lit.html#substitutions

"%t temporary file name unique to the test"

%t is in fact the **path** of a file. As suggested by the line below that describing %basename_t.

This test (I assume) assumed it was just the filename itself and so left a layout of:
```
$ tree tools/lld/test/
tools/lld/test/
├── CMakeFiles
├── ELF
│   └── Output
│       ├── aarch64-build-attributes.s.tmp
│       │   ├── pauth-bti-gcs.s
│       │   └── pauth-bti-pac.s
│       ├── aarch64-build-attributes.s.tmp.merged.o
│       ├── aarch64-build-attributes.s.tmp1.o
│       ├── aarch64-build-attributes.s.tmp2.o
│       └── aarch64-build-attributes.s.tmp3.o
├── Unit
│   └── lit.site.cfg.py
├── cmake_install.cmake
└── lit.site.cfg.py
```

Note how the 2 .s files are in the temp dir but the .o files are not. This is fine, it works, but it's going to cost someone time to unpick when this test actually does fail.

To fix this, remove %t from all the temp file names so they are created in the temp dir, which is cleaned before each run.

New layout:
```
$ tree tools/lld/test/
tools/lld/test/
├── CMakeFiles
├── ELF
│   └── Output
│       └── aarch64-build-attributes.s.tmp
│           ├── 1.o
│           ├── 2.o
│           ├── 3.o
│           ├── merged.o
│           ├── pauth-bti-gcs.s
│           └── pauth-bti-pac.s
├── Unit
│   └── lit.site.cfg.py
├── cmake_install.cmake
└── lit.site.cfg.py
```