### PR TITLE
[llvm][docs] Correct description of %t lit substitution

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -628,7 +628,7 @@ TestRunner.py:
  %{fs-src-root}          root component of file system paths pointing to the LLVM checkout
  %{fs-tmp-root}          root component of file system paths pointing to the test's temporary directory
  %{fs-sep}               file system path separator
- %t                      temporary file name unique to the test
+ %t                      the path of a temporary file unique to the test
  %basename_t             The last path component of %t but without the ``.tmp`` extension (deprecated, use ``%{t:stem}`` instead)
  %%                      %
  %/s                     %s but ``\`` is replaced by ``/``

--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -628,7 +628,7 @@ TestRunner.py:
  %{fs-src-root}          root component of file system paths pointing to the LLVM checkout
  %{fs-tmp-root}          root component of file system paths pointing to the test's temporary directory
  %{fs-sep}               file system path separator
- %t                      the path of a temporary file unique to the test
+ %t                      a path unique to the test (which may be used to make files or directories)
  %basename_t             The last path component of %t but without the ``.tmp`` extension (deprecated, use ``%{t:stem}`` instead)
  %%                      %
  %/s                     %s but ``\`` is replaced by ``/``


### PR DESCRIPTION
%t is currently documented as:
temporary file name unique to the test

https://llvm.org/docs/CommandGuide/lit.html#substitutions

Which I take to mean if the path is a/b/c/tempfile, then %t would be tempfile. It is not, it's the whole path.

(which is hinted at by %basename_t, but why would you read that if you didn't need to use it)

As seen in #164396 this can create confusion when people use it as if it were just the file name.

Make it clear in the docs that this is a unique path, which can be used to make files or folders.