### PR TITLE
[Modules] Fix LLVM_ENABLE_MODULES build (NFC)

### DIFF
--- a/llvm/include/llvm/CAS/FileOffset.h
+++ b/llvm/include/llvm/CAS/FileOffset.h
@@ -15,7 +15,7 @@
 #ifndef LLVM_CAS_FILEOFFSET_H
 #define LLVM_CAS_FILEOFFSET_H
 
-#include <cstdlib>
+#include <cstdint>
 
 namespace llvm::cas {
 


### PR DESCRIPTION
FileOffset.h uses `uint64_t` but only includes `<cstdlib>`, which is not specified to provide the `uint64_t` type.
This happens to work without `LLVM_ENABLE_MODULES` enabled due to transitive includes from `<cstdlib>`.
With `LLVM_ENABLE_MODULES` enabled, declarations from transitive includes are not visible by default, and the build fails.

This fixes `LLVM_ENABLE_MODULES` builds by including the proper header, `<cstdint>`, instead.