### PR TITLE
[libc] Capture 'POLY_COEFFS' by reference in asinpi_polyeval lambda.

### DIFF
--- a/libc/src/math/generic/asinpif16.cpp
+++ b/libc/src/math/generic/asinpif16.cpp
@@ -77,7 +77,7 @@ LLVM_LIBC_FUNCTION(float16, asinpif16, (float16 x)) {
   };
   // polynomial evaluation using horner's method
   // work only for |x| in [0, 0.5]
-  auto asinpi_polyeval = [](double x) -> double {
+  auto asinpi_polyeval = [&](double x) -> double {
     return x * fputil::polyeval(x * x, POLY_COEFFS[0], POLY_COEFFS[1],
                                 POLY_COEFFS[2], POLY_COEFFS[3], POLY_COEFFS[4],
                                 POLY_COEFFS[5], POLY_COEFFS[6], POLY_COEFFS[7]);


### PR DESCRIPTION
Closes #164403

GCC fails to compile libc currently. This PR fixes this by capturing 'POLY_COEFFS' by reference