### PR TITLE
[LLDB][NativePDB] Require `target-windows` for `func-symbols.test`

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/func-symbols.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/func-symbols.test
@@ -1,4 +1,4 @@
-# REQUIRES: lld
+# REQUIRES: lld, target-windows
 
 # Test that functions have the correct types.
 # This uses the same input as SymbolFile/PDB/func-symbols.test. However, DIA 


### PR DESCRIPTION
The test builds files for Windows, so the target has to be required. I didn't add this in #163733.

Fixes the failure from https://github.com/llvm/llvm-project/pull/163733#issuecomment-3426275296.