### PR TITLE
[ORC] Fix compile error

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
@@ -19,6 +19,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
+#include <vector>
 
 namespace llvm::orc::detail {
 


### PR DESCRIPTION
This fixes the following error we're getting internally, perhaps only with the latest clang:

llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h:136:24: error: missing '#include <__fwd/vector.h>'; default argument of 'vector' must be defined before it is used

This is a fix for #164340.