### PR TITLE
[lldb] Added a warning in case of instruction decode failure

### DIFF
--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -157,7 +157,8 @@ static lldb::offset_t DumpInstructions(const DataExtractor &DE, Stream *s,
         exe_scope->CalculateExecutionContext(exe_ctx);
         disassembler_sp->GetInstructionList().Dump(
             s, show_address, show_bytes, show_control_flow_kind, &exe_ctx);
-      }
+      } else if (number_of_instructions)
+        s->Printf("failed to decode instructions at 0x%" PRIx64 ".", addr);
     }
   } else
     s->Printf("invalid target");

--- a/lldb/test/API/commands/memory/read/TestMemoryRead.py
+++ b/lldb/test/API/commands/memory/read/TestMemoryRead.py
@@ -41,6 +41,18 @@ class MemoryReadTestCase(TestBase):
             " Consider increasing the maximum read length.",
         )
 
+    @skipIf(archs=no_match("^(riscv|aarch64).*"))
+    def test_memory_read_instruction_decode_failure(self):
+        """Test the 'memory read' command with instruction format."""
+        self.build_run_stop()
+
+        # assume that 0xffffff is invalid instruction in RISC-V and AArch64,
+        # so decoding it will fail
+        self.expect(
+            "memory read --format instruction `&my_insns[0]` `&my_insns[3]`",
+            substrs=["failed to decode instructions at"],
+        )
+
     def test_memory_read(self):
         """Test the 'memory read' command with plain and vector formats."""
         self.build_run_stop()

--- a/lldb/test/API/commands/memory/read/main.c
+++ b/lldb/test/API/commands/memory/read/main.c
@@ -5,5 +5,8 @@ int main(int argc, const char *argv[]) {
   double my_double = 1234.5678;
   int my_ints[] = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22};
   uint64_t my_uint64s[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  // assume that 0xffffff is invalid instruction in RISC-V and AArch64,
+  // so decoding it will fail
+  char my_insns[] = {0xff, 0xff, 0xff};
   return 0; // break here
 }


### PR DESCRIPTION
While testing baremetal lldb, I came across a situation that if an instruction could not be disassembled, lldb will print nothing as an output which might be a bit strange. I added at least printing warning in this case.