### PR TITLE
[LLVM][CodeGen][SVE] Fix typo in PPR_p8to15's DecoderMethod.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -993,7 +993,7 @@ def PPR_3b : PPRClass<0, 7> { // Restricted 3 bit SVE predicate register class.
   let DecoderMethod = "DecodeSimpleRegisterClass<AArch64::PPRRegClassID, 0, 8>";
 }
 def PPR_p8to15 : PPRClass<8, 15> {
-  let DecoderMethod = "DecodeSimpleRegisterClass<AArch64::PNRRegClassID, 8, 8>";
+  let DecoderMethod = "DecodeSimpleRegisterClass<AArch64::PPRRegClassID, 8, 8>";
 }
 
 def PPRMul2 : PPRClass<0, 14, 2>;


### PR DESCRIPTION
I think this is effectively an NFC patch (or at least I haven't found a way to trigger a bug from it) because PPR_p8to15 is not used by any instruction operands.  If preferred I can instead remove the DecoderMethod assignment, but I figured that would cause work for if it ever starts being used.