### PR TITLE
[Clang] Make the AS of llvm.compiler.used & llvm.used elements addrspace(0)

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3331,18 +3331,18 @@ static void emitUsed(CodeGenModule &CGM, StringRef Name,
   if (List.empty())
     return;
 
+  llvm::PointerType *UnqualPtr =
+      llvm::PointerType::getUnqual(CGM.getLLVMContext());
+
   // Convert List to what ConstantArray needs.
   SmallVector<llvm::Constant*, 8> UsedArray;
   UsedArray.resize(List.size());
   for (unsigned i = 0, e = List.size(); i != e; ++i) {
-    UsedArray[i] =
-        llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
-            cast<llvm::Constant>(&*List[i]), CGM.Int8PtrTy);
+    UsedArray[i] = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
+        cast<llvm::Constant>(&*List[i]), UnqualPtr);
   }
 
-  if (UsedArray.empty())
-    return;
-  llvm::ArrayType *ATy = llvm::ArrayType::get(CGM.Int8PtrTy, UsedArray.size());
+  llvm::ArrayType *ATy = llvm::ArrayType::get(UnqualPtr, UsedArray.size());
 
   auto *GV = new llvm::GlobalVariable(
       CGM.getModule(), ATy, false, llvm::GlobalValue::AppendingLinkage,

--- a/clang/test/CodeGen/embed-bitcode-marker-with-nonzero-as.c
+++ b/clang/test/CodeGen/embed-bitcode-marker-with-nonzero-as.c
@@ -3,6 +3,6 @@
 
 // CHECK: @llvm.embedded.module = private addrspace(1) constant [0 x i8] zeroinitializer, section ".llvmbc", align 1
 // CHECK-NEXT: @llvm.cmdline = private addrspace(1) constant [{{[0-9]+}} x i8] c"{{.*}}", section ".llvmcmd", align 1
-// CHECK-NEXT: @llvm.compiler.used = appending addrspace(1) global [5 x ptr addrspace(4)] [ptr addrspace(4) addrspacecast (ptr addrspace(1) @foo.managed to ptr addrspace(4)), ptr addrspace(4) addrspacecast (ptr addrspace(1) @foo to ptr addrspace(4)), ptr addrspace(4) addrspacecast (ptr addrspace(1) @__hip_cuid_ to ptr addrspace(4)), ptr addrspace(4) addrspacecast (ptr addrspace(1) @llvm.embedded.module to ptr addrspace(4)), ptr addrspace(4) addrspacecast (ptr addrspace(1) @llvm.cmdline to ptr addrspace(4))], section "llvm.metadata"
+// CHECK-NEXT: @llvm.compiler.used = appending addrspace(1) global [5 x ptr] [ptr addrspacecast (ptr addrspace(1) @foo.managed to ptr), ptr addrspacecast (ptr addrspace(1) @foo to ptr), ptr addrspacecast (ptr addrspace(1) @__hip_cuid_ to ptr), ptr addrspacecast (ptr addrspace(1) @llvm.embedded.module to ptr), ptr addrspacecast (ptr addrspace(1) @llvm.cmdline to ptr)], section "llvm.metadata"
 
 __attribute__((managed)) int foo = 42;

--- a/clang/test/CodeGen/llvm_compiler_used_elements_are_unqual.c
+++ b/clang/test/CodeGen/llvm_compiler_used_elements_are_unqual.c
@@ -1,38 +1,64 @@
-// RUN: %clang_cc1 -triple x86_64-- -emit-llvm -x c %s -o - \
+// RUN: %clang_cc1 -x c -triple x86_64-- -emit-llvm -x c %s -o - \
 // RUN:   | FileCheck %s --check-prefix=X86
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN: %clang_cc1 -x c -triple amdgcn-amd-amdhsa -emit-llvm -x c %s -o - \
 // RUN:   | FileCheck %s --check-prefix=AMDGCN
-// RUN: %clang_cc1 -triple spirv64-- -emit-llvm -x c %s -o - \
+// RUN: %clang_cc1 -x c -triple spirv64-- -emit-llvm -x c %s -o - \
 // RUN:   | FileCheck %s --check-prefix=SPIRV
-// RUN: %clang_cc1 -triple spirv64-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN: %clang_cc1 -x c -triple spirv64-amd-amdhsa -emit-llvm -x c %s -o - \
 // RUN:   | FileCheck %s --check-prefix=SPIRV_AMD
+// RUN: %clang_cc1 -x cl -cl-std=CL1.2 -triple x86_64-- -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=X86
+// RUN: %clang_cc1 -x cl -cl-std=CL1.2 -triple amdgcn-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=AMDGCN
+// RUN: %clang_cc1 -x cl -cl-std=CL1.2 -triple spirv64-- -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SPIRV_CL
+// RUN: %clang_cc1 -x cl -cl-std=CL1.2 -triple spirv64-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SPIRV_AMD_CL
+// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple x86_64-- -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=X86
+// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple amdgcn-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=AMDGCN
+// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spirv64-- -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SPIRV_CL
+// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spirv64-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SPIRV_AMD_CL
 
-static __attribute__((__used__)) int foo = 42;
+#ifndef __OPENCL_C_VERSION__
+#define __constant const
+#endif
+
+static __constant __attribute__((__used__)) int foo = 42;
 
 
-// X86: @foo = internal global i32 42, align 4
+// X86: @foo = internal constant i32 42
 // X86: @llvm.compiler.used = appending global [2 x ptr] [ptr @foo, ptr @bar], section "llvm.metadata"
-//.
-// AMDGCN: @foo = internal addrspace(1) global i32 42, align 4
-// AMDGCN: @llvm.compiler.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(1) @foo to ptr), ptr @bar], section "llvm.metadata"
-//.
-// SPIRV: @foo = internal global i32 42, align 4
+//
+// AMDGCN: @foo = internal addrspace(4) constant i32 42
+// AMDGCN: @llvm.compiler.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(4) @foo to ptr), ptr @bar], section "llvm.metadata"
+//
+// SPIRV: @foo = internal constant i32 42
 // SPIRV: @llvm.used = appending addrspace(1) global [2 x ptr] [ptr @foo, ptr @bar], section "llvm.metadata"
-//.
-// SPIRV_AMD: @foo = internal addrspace(1) global i32 42, align 4
+//
+// SPIRV_CL: @foo = internal addrspace(2) constant i32 42
+// SPIRV_CL: @llvm.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(2) @foo to ptr), ptr @bar], section "llvm.metadata"
+//
+// SPIRV_AMD: @foo = internal addrspace(1) constant i32 42
 // SPIRV_AMD: @llvm.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(1) @foo to ptr), ptr addrspacecast (ptr addrspace(4) @bar to ptr)], section "llvm.metadata"
-//.
-// X86-LABEL: define internal void @bar(
-// X86-SAME: ) #[[ATTR0:[0-9]+]] {
 //
-// AMDGCN-LABEL: define internal void @bar(
-// AMDGCN-SAME: ) #[[ATTR0:[0-9]+]] {
+// SPIRV_AMD_CL: @foo = internal addrspace(2) constant i32 42
+// SPIRV_AMD_CL: @llvm.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(2) @foo to ptr), ptr addrspacecast (ptr addrspace(4) @bar to ptr)], section "llvm.metadata"
 //
-// SPIRV-LABEL: define internal spir_func void @bar(
-// SPIRV-SAME: ) #[[ATTR0:[0-9]+]] {
+// X86: define internal void @bar() #{{[0-9]}} {
 //
-// SPIRV_AMD-LABEL: define internal spir_func void @bar(
-// SPIRV_AMD-SAME: ) addrspace(4) #[[ATTR0:[0-9]+]] {
+// AMDGCN: define internal void @bar() #{{[0-9]}} {
+//
+// SPIRV: define internal spir_func void @bar() #{{[0-9]}} {
+//
+// SPIRV_CL: define internal spir_func void @bar() #{{[0-9]}} {
+//
+// SPIRV_AMD: define internal spir_func void @bar() addrspace(4) #{{[0-9]}} {
+//
+// SPIRV_AMD_CL: define internal spir_func void @bar() addrspace(4) #{{[0-9]}} {
 //
 static void __attribute__((__used__)) bar() {
 }

--- a/clang/test/CodeGen/llvm_compiler_used_elements_are_unqual.c
+++ b/clang/test/CodeGen/llvm_compiler_used_elements_are_unqual.c
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -triple x86_64-- -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=X86
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=AMDGCN
+// RUN: %clang_cc1 -triple spirv64-- -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SPIRV
+// RUN: %clang_cc1 -triple spirv64-amd-amdhsa -emit-llvm -x c %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SPIRV_AMD
+
+static __attribute__((__used__)) int foo = 42;
+
+
+// X86: @foo = internal global i32 42, align 4
+// X86: @llvm.compiler.used = appending global [2 x ptr] [ptr @foo, ptr @bar], section "llvm.metadata"
+//.
+// AMDGCN: @foo = internal addrspace(1) global i32 42, align 4
+// AMDGCN: @llvm.compiler.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(1) @foo to ptr), ptr @bar], section "llvm.metadata"
+//.
+// SPIRV: @foo = internal global i32 42, align 4
+// SPIRV: @llvm.used = appending addrspace(1) global [2 x ptr] [ptr @foo, ptr @bar], section "llvm.metadata"
+//.
+// SPIRV_AMD: @foo = internal addrspace(1) global i32 42, align 4
+// SPIRV_AMD: @llvm.used = appending addrspace(1) global [2 x ptr] [ptr addrspacecast (ptr addrspace(1) @foo to ptr), ptr addrspacecast (ptr addrspace(4) @bar to ptr)], section "llvm.metadata"
+//.
+// X86-LABEL: define internal void @bar(
+// X86-SAME: ) #[[ATTR0:[0-9]+]] {
+//
+// AMDGCN-LABEL: define internal void @bar(
+// AMDGCN-SAME: ) #[[ATTR0:[0-9]+]] {
+//
+// SPIRV-LABEL: define internal spir_func void @bar(
+// SPIRV-SAME: ) #[[ATTR0:[0-9]+]] {
+//
+// SPIRV_AMD-LABEL: define internal spir_func void @bar(
+// SPIRV_AMD-SAME: ) addrspace(4) #[[ATTR0:[0-9]+]] {
+//
+static void __attribute__((__used__)) bar() {
+}


### PR DESCRIPTION
By convention the AS of the elements of `llvm.compiler.used` & `llvm.used` is 0. However, the AS of `CGM.Int8PtrTy` is not always 0.

This leaves some LLVM helpers (`appendToUsed/appendToCompilerUsed/removeFromUsedLists`) unusable.

This patch makes the AS of the elements of these variables to be 0.

This PR is related to https://github.com/llvm/llvm-project/pull/162660