### PR TITLE
[clang] Improve efficiency of CGDebugInfo by using PresumedLoc.

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1250,6 +1250,21 @@ public:
     return getSpellingLocSlowCase(Loc);
   }
 
+  /// Given a SourceLocation object, return the refined spelling
+  /// location referenced by the ID.
+  ///
+  /// The key difference to \ref getSpellingLoc is that the source location
+  /// for macro body is resolved to the expansion site.
+  ///
+  /// This is the place where the characters that make up the lexed token
+  /// can be found.
+  SourceLocation getRefinedSpellingLoc(SourceLocation Loc) const {
+    // Handle the non-mapped case inline, defer to out of line code to handle
+    // expansions.
+    if (Loc.isFileID()) return Loc;
+    return getRefinedSpellingLocSlowCase(Loc);
+  }
+
   /// Given a SourceLocation object, return the spelling location
   /// referenced by the ID.
   ///
@@ -1977,6 +1992,7 @@ private:
 
   SourceLocation getExpansionLocSlowCase(SourceLocation Loc) const;
   SourceLocation getSpellingLocSlowCase(SourceLocation Loc) const;
+  SourceLocation getRefinedSpellingLocSlowCase(SourceLocation Loc) const;
   SourceLocation getFileLocSlowCase(SourceLocation Loc) const;
 
   FileIDAndOffset

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1261,7 +1261,8 @@ public:
   SourceLocation getRefinedSpellingLoc(SourceLocation Loc) const {
     // Handle the non-mapped case inline, defer to out of line code to handle
     // expansions.
-    if (Loc.isFileID()) return Loc;
+    if (Loc.isFileID())
+      return Loc;
     return getRefinedSpellingLocSlowCase(Loc);
   }
 

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1977,7 +1977,6 @@ private:
 
   SourceLocation getExpansionLocSlowCase(SourceLocation Loc) const;
   SourceLocation getSpellingLocSlowCase(SourceLocation Loc) const;
-  SourceLocation getRefinedSpellingLocSlowCase(SourceLocation Loc) const;
   SourceLocation getFileLocSlowCase(SourceLocation Loc) const;
 
   FileIDAndOffset

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1250,22 +1250,6 @@ public:
     return getSpellingLocSlowCase(Loc);
   }
 
-  /// Given a SourceLocation object, return the refined spelling
-  /// location referenced by the ID.
-  ///
-  /// The key difference to \ref getSpellingLoc is that the source location
-  /// for macro body is resolved to the expansion site.
-  ///
-  /// This is the place where the characters that make up the lexed token
-  /// can be found.
-  SourceLocation getRefinedSpellingLoc(SourceLocation Loc) const {
-    // Handle the non-mapped case inline, defer to out of line code to handle
-    // expansions.
-    if (Loc.isFileID())
-      return Loc;
-    return getRefinedSpellingLocSlowCase(Loc);
-  }
-
   /// Given a SourceLocation object, return the spelling location
   /// referenced by the ID.
   ///

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -918,13 +918,13 @@ SourceLocation SourceManager::getSpellingLocSlowCase(SourceLocation Loc) const {
 SourceLocation
 SourceManager::getRefinedSpellingLocSlowCase(SourceLocation Loc) const {
   do {
-    const SLocEntry &E = getSLocEntry(getFileID(Loc));
-    const ExpansionInfo &Exp = E.getExpansion();
-    if (Exp.isMacroArgExpansion()) {
-      Loc = Exp.getSpellingLoc().getLocWithOffset(Loc.getOffset() -
-                                                  E.getOffset());
+    const SLocEntry &Entry = getSLocEntry(getFileID(Loc));
+    const ExpansionInfo &ExpInfo = Entry.getExpansion();
+    if (ExpInfo.isMacroArgExpansion()) {
+      Loc = ExpInfo.getSpellingLoc().getLocWithOffset(Loc.getOffset() -
+                                                      Entry.getOffset());
     } else {
-      Loc = Exp.getExpansionLocStart();
+      Loc = ExpInfo.getExpansionLocStart();
     }
   } while (!Loc.isFileID());
   return Loc;

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -915,6 +915,20 @@ SourceLocation SourceManager::getSpellingLocSlowCase(SourceLocation Loc) const {
   return Loc;
 }
 
+SourceLocation
+SourceManager::getRefinedSpellingLocSlowCase(SourceLocation Loc) const {
+  do {
+    FileIDAndOffset LocInfo = getDecomposedLoc(Loc);
+    const ExpansionInfo &Expansion = getSLocEntry(LocInfo.first).getExpansion();
+    if (Expansion.isMacroArgExpansion()) {
+      Loc = Expansion.getSpellingLoc().getLocWithOffset(LocInfo.second);
+    } else {
+      Loc = Expansion.getExpansionLocStart();
+    }
+  } while (!Loc.isFileID());
+  return Loc;
+}
+
 SourceLocation SourceManager::getFileLocSlowCase(SourceLocation Loc) const {
   do {
     if (isMacroArgExpansion(Loc))

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -918,12 +918,13 @@ SourceLocation SourceManager::getSpellingLocSlowCase(SourceLocation Loc) const {
 SourceLocation
 SourceManager::getRefinedSpellingLocSlowCase(SourceLocation Loc) const {
   do {
-    FileIDAndOffset LocInfo = getDecomposedLoc(Loc);
-    const ExpansionInfo &Expansion = getSLocEntry(LocInfo.first).getExpansion();
-    if (Expansion.isMacroArgExpansion()) {
-      Loc = Expansion.getSpellingLoc().getLocWithOffset(LocInfo.second);
+    const SLocEntry &E = getSLocEntry(getFileID(Loc));
+    const ExpansionInfo &Exp = E.getExpansion();
+    if (Exp.isMacroArgExpansion()) {
+      Loc = Exp.getSpellingLoc().getLocWithOffset(Loc.getOffset() -
+                                                  E.getOffset());
     } else {
-      Loc = Expansion.getExpansionLocStart();
+      Loc = Exp.getExpansionLocStart();
     }
   } while (!Loc.isFileID());
   return Loc;

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -915,8 +915,7 @@ SourceLocation SourceManager::getSpellingLocSlowCase(SourceLocation Loc) const {
   return Loc;
 }
 
-SourceLocation
-SourceManager::getRefinedSpellingLocSlowCase(SourceLocation Loc) const {
+SourceLocation SourceManager::getFileLocSlowCase(SourceLocation Loc) const {
   do {
     const SLocEntry &Entry = getSLocEntry(getFileID(Loc));
     const ExpansionInfo &ExpInfo = Entry.getExpansion();
@@ -926,16 +925,6 @@ SourceManager::getRefinedSpellingLocSlowCase(SourceLocation Loc) const {
     } else {
       Loc = ExpInfo.getExpansionLocStart();
     }
-  } while (!Loc.isFileID());
-  return Loc;
-}
-
-SourceLocation SourceManager::getFileLocSlowCase(SourceLocation Loc) const {
-  do {
-    if (isMacroArgExpansion(Loc))
-      Loc = getImmediateSpellingLoc(Loc);
-    else
-      Loc = getImmediateExpansionRange(Loc).getBegin();
   } while (!Loc.isFileID());
   return Loc;
 }

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -5531,8 +5531,7 @@ void CGDebugInfo::EmitDeclareOfBlockDeclRefVariable(
       Ty = CreateSelfType(VD->getType(), Ty);
 
   // Get location information.
-  const unsigned Line =
-      getLineNumber(Loc.isValid() ? Loc : CurLoc);
+  const unsigned Line = getLineNumber(Loc.isValid() ? Loc : CurLoc);
   unsigned Column = getColumnNumber(Loc);
 
   const llvm::DataLayout &target = CGM.getDataLayout();
@@ -5641,7 +5640,8 @@ void CGDebugInfo::EmitDeclareOfBlockLiteralArgVariable(const CGBlockInfo &block,
   const BlockDecl *blockDecl = block.getBlockDecl();
 
   // Collect some general information about the block's location.
-  SourceLocation loc = getRefinedSpellingLocation(blockDecl->getCaretLocation());
+  SourceLocation loc =
+      getRefinedSpellingLocation(blockDecl->getCaretLocation());
   llvm::DIFile *tunit = getOrCreateFile(loc);
   unsigned line = getLineNumber(loc);
   unsigned column = getColumnNumber(loc);
@@ -6172,8 +6172,8 @@ void CGDebugInfo::EmitGlobalVariable(const ValueDecl *VD, const APValue &Init) {
     }
 
   GV.reset(DBuilder.createGlobalVariableExpression(
-      DContext, Name, StringRef(), Unit, getLineNumber(Loc), Ty,
-      true, true, InitExpr, getOrCreateStaticDataMemberDeclarationOrNull(VarD),
+      DContext, Name, StringRef(), Unit, getLineNumber(Loc), Ty, true, true,
+      InitExpr, getOrCreateStaticDataMemberDeclarationOrNull(VarD),
       TemplateParameters, Align));
 }
 
@@ -6192,8 +6192,8 @@ void CGDebugInfo::EmitExternalVariable(llvm::GlobalVariable *Var,
   llvm::DIScope *DContext = getDeclContextDescriptor(D);
   llvm::DIGlobalVariableExpression *GVE =
       DBuilder.createGlobalVariableExpression(
-          DContext, Name, StringRef(), Unit, getLineNumber(Loc),
-          Ty, false, false, nullptr, nullptr, nullptr, Align);
+          DContext, Name, StringRef(), Unit, getLineNumber(Loc), Ty, false,
+          false, nullptr, nullptr, nullptr, Align);
   Var->addDebugInfo(GVE);
 }
 
@@ -6289,8 +6289,8 @@ void CGDebugInfo::AddStringLiteralDebugInfo(llvm::GlobalVariable *GV,
   llvm::DIFile *File = getOrCreateFile(Loc);
   llvm::DIGlobalVariableExpression *Debug =
       DBuilder.createGlobalVariableExpression(
-          nullptr, StringRef(), StringRef(), File,
-          getLineNumber(Loc), getOrCreateType(S->getType(), File), true);
+          nullptr, StringRef(), StringRef(), File, getLineNumber(Loc),
+          getOrCreateType(S->getType(), File), true);
   GV->addDebugInfo(Debug);
 }
 

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -545,7 +545,8 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
     FileName = TheCU->getFile()->getFilename();
     CSInfo = TheCU->getFile()->getChecksum();
   } else {
-    PresumedLoc PLoc = SM.getPresumedLoc(SM.getRefinedSpellingLoc(Loc));
+    assert(Loc.isFileID());
+    PresumedLoc PLoc = SM.getPresumedLoc(Loc);
     FileName = PLoc.getFilename();
 
     if (FileName.empty()) {
@@ -627,7 +628,8 @@ unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  return SM.getPresumedLoc(SM.getRefinedSpellingLoc(Loc)).getLine();
+  assert(Loc.isFileID());
+  return SM.getPresumedLoc(Loc).getLine();
 }
 
 unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
@@ -639,8 +641,8 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc =
-      SM.getPresumedLoc(Loc.isValid() ? SM.getRefinedSpellingLoc(Loc) : CurLoc);
+  assert(Loc.isFileID());
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc);
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 
@@ -1393,9 +1395,9 @@ CGDebugInfo::getOrCreateRecordFwdDecl(const RecordType *Ty,
   const RecordDecl *RD = Ty->getDecl()->getDefinitionOrSelf();
   if (llvm::DIType *T = getTypeOrNull(QualType(Ty, 0)))
     return cast<llvm::DICompositeType>(T);
-  llvm::DIFile *DefUnit = getOrCreateFile(RD->getLocation());
-  const unsigned Line =
-      getLineNumber(RD->getLocation().isValid() ? RD->getLocation() : CurLoc);
+  SourceLocation Loc = getRefinedSpellingLocation(RD->getLocation());
+  llvm::DIFile *DefUnit = getOrCreateFile(Loc);
+  const unsigned Line = getLineNumber(Loc.isValid() ? Loc : CurLoc);
   StringRef RDName = getClassName(RD);
 
   uint64_t Size = 0;
@@ -1622,7 +1624,7 @@ llvm::DIType *CGDebugInfo::CreateType(const TemplateSpecializationType *Ty,
   auto PP = getPrintingPolicy();
   Ty->getTemplateName().print(OS, PP, TemplateName::Qualified::None);
 
-  SourceLocation Loc = AliasDecl->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(AliasDecl->getLocation());
 
   if (CGM.getCodeGenOpts().DebugTemplateAlias) {
     auto ArgVector = ::GetTemplateArgs(TD, Ty);
@@ -1691,7 +1693,7 @@ llvm::DIType *CGDebugInfo::CreateType(const TypedefType *Ty,
 
   // We don't set size information, but do specify where the typedef was
   // declared.
-  SourceLocation Loc = Ty->getDecl()->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(Ty->getDecl()->getLocation());
 
   uint32_t Align = getDeclAlignIfRequired(Ty->getDecl(), CGM.getContext());
   // Typedefs are derived from some other type.
@@ -1825,7 +1827,7 @@ CGDebugInfo::createBitFieldType(const FieldDecl *BitFieldDecl,
   QualType Ty = BitFieldDecl->getType();
   if (BitFieldDecl->hasAttr<PreferredTypeAttr>())
     Ty = BitFieldDecl->getAttr<PreferredTypeAttr>()->getType();
-  SourceLocation Loc = BitFieldDecl->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(BitFieldDecl->getLocation());
   llvm::DIFile *VUnit = getOrCreateFile(Loc);
   llvm::DIType *DebugType = getOrCreateType(Ty, VUnit);
 
@@ -1903,7 +1905,8 @@ llvm::DIDerivedType *CGDebugInfo::createBitFieldSeparatorIfNeeded(
     return nullptr;
 
   QualType Ty = PreviousBitfield->getType();
-  SourceLocation Loc = PreviousBitfield->getLocation();
+  SourceLocation Loc =
+      getRefinedSpellingLocation(PreviousBitfield->getLocation());
   llvm::DIFile *VUnit = getOrCreateFile(Loc);
   llvm::DIType *DebugType = getOrCreateType(Ty, VUnit);
   llvm::DIScope *RecordTy = BitFieldDI->getScope();
@@ -2022,6 +2025,7 @@ void CGDebugInfo::CollectRecordLambdaFields(
       continue;
     }
 
+    Loc = getRefinedSpellingLocation(Loc);
     llvm::DIFile *VUnit = getOrCreateFile(Loc);
 
     elements.push_back(createFieldType(
@@ -2036,10 +2040,11 @@ CGDebugInfo::CreateRecordStaticField(const VarDecl *Var, llvm::DIType *RecordTy,
   // Create the descriptor for the static variable, with or without
   // constant initializers.
   Var = Var->getCanonicalDecl();
-  llvm::DIFile *VUnit = getOrCreateFile(Var->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(Var->getLocation());
+  llvm::DIFile *VUnit = getOrCreateFile(Loc);
   llvm::DIType *VTy = getOrCreateType(Var->getType(), VUnit);
 
-  unsigned LineNumber = getLineNumber(Var->getLocation());
+  unsigned LineNumber = getLineNumber(Loc);
   StringRef VName = Var->getName();
 
   // FIXME: to avoid complications with type merging we should
@@ -2087,9 +2092,10 @@ void CGDebugInfo::CollectRecordNormalField(
   } else {
     auto Align = getDeclAlignIfRequired(field, CGM.getContext());
     llvm::DINodeArray Annotations = CollectBTFDeclTagAnnotations(field);
-    FieldType =
-        createFieldType(name, type, field->getLocation(), field->getAccess(),
-                        OffsetInBits, Align, tunit, RecordTy, RD, Annotations);
+    FieldType = createFieldType(
+        name, type, getRefinedSpellingLocation(field->getLocation()),
+        field->getAccess(), OffsetInBits, Align, tunit, RecordTy, RD,
+        Annotations);
   }
 
   elements.push_back(FieldType);
@@ -2103,7 +2109,7 @@ void CGDebugInfo::CollectRecordNestedType(
   // instead?
   if (isa<InjectedClassNameType>(Ty))
     return;
-  SourceLocation Loc = TD->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(TD->getLocation());
   if (llvm::DIType *nestedType = getOrCreateType(Ty, getOrCreateFile(Loc)))
     elements.push_back(nestedType);
 }
@@ -2307,8 +2313,9 @@ llvm::DISubprogram *CGDebugInfo::CreateCXXMemberFunction(
   llvm::DIFile *MethodDefUnit = nullptr;
   unsigned MethodLine = 0;
   if (!Method->isImplicit()) {
-    MethodDefUnit = getOrCreateFile(Method->getLocation());
-    MethodLine = getLineNumber(Method->getLocation());
+    SourceLocation Loc = getRefinedSpellingLocation(Method->getLocation());
+    MethodDefUnit = getOrCreateFile(Loc);
+    MethodLine = getLineNumber(Loc);
   }
 
   // Collect virtual method info.
@@ -2759,7 +2766,7 @@ void CGDebugInfo::emitVTableSymbol(llvm::GlobalVariable *VTable,
 
   ASTContext &Context = CGM.getContext();
   StringRef SymbolName = "_vtable$";
-  SourceLocation Loc;
+  SourceLocation InvalidLoc;
   QualType VoidPtr = Context.getPointerType(Context.VoidTy);
 
   // We deal with two different contexts:
@@ -2771,7 +2778,7 @@ void CGDebugInfo::emitVTableSymbol(llvm::GlobalVariable *VTable,
   // placed inside the scope of the C++ class/structure.
   llvm::DIScope *DContext = getContextDescriptor(RD, TheCU);
   auto *Ctxt = cast<llvm::DICompositeType>(DContext);
-  llvm::DIFile *Unit = getOrCreateFile(Loc);
+  llvm::DIFile *Unit = getOrCreateFile(InvalidLoc);
   llvm::DIType *VTy = getOrCreateType(VoidPtr, Unit);
   llvm::DINode::DIFlags Flags = getAccessFlag(AccessSpecifier::AS_private, RD) |
                                 llvm::DINode::FlagArtificial;
@@ -2908,6 +2915,7 @@ void CGDebugInfo::CollectVTableInfo(const CXXRecordDecl *RD, llvm::DIFile *Unit,
 llvm::DIType *CGDebugInfo::getOrCreateRecordType(QualType RTy,
                                                  SourceLocation Loc) {
   assert(CGM.getCodeGenOpts().hasReducedDebugInfo());
+  Loc = getRefinedSpellingLocation(Loc);
   llvm::DIType *T = getOrCreateType(RTy, getOrCreateFile(Loc));
   return T;
 }
@@ -2921,6 +2929,7 @@ llvm::DIType *CGDebugInfo::getOrCreateStandaloneType(QualType D,
                                                      SourceLocation Loc) {
   assert(CGM.getCodeGenOpts().hasReducedDebugInfo());
   assert(!D.isNull() && "null type");
+  Loc = getRefinedSpellingLocation(Loc);
   llvm::DIType *T = getOrCreateType(D, getOrCreateFile(Loc));
   assert(T && "could not create debug info for type");
 
@@ -2938,7 +2947,8 @@ void CGDebugInfo::addHeapAllocSiteMetadata(llvm::CallBase *CI,
   if (AllocatedTy->isVoidType())
     node = llvm::MDNode::get(CGM.getLLVMContext(), {});
   else
-    node = getOrCreateType(AllocatedTy, getOrCreateFile(Loc));
+    node = getOrCreateType(AllocatedTy,
+                           getOrCreateFile(getRefinedSpellingLocation(Loc)));
 
   CI->setMetadata("heapallocsite", node);
 }
@@ -3171,8 +3181,9 @@ std::pair<llvm::DIType *, llvm::DIType *>
 CGDebugInfo::CreateTypeDefinition(const RecordType *Ty) {
   RecordDecl *RD = Ty->getDecl()->getDefinitionOrSelf();
 
+  SourceLocation Loc = getRefinedSpellingLocation(RD->getLocation());
   // Get overall information about the record type for the debug info.
-  llvm::DIFile *DefUnit = getOrCreateFile(RD->getLocation());
+  llvm::DIFile *DefUnit = getOrCreateFile(Loc);
 
   // Records and classes and unions can all be recursive.  To handle them, we
   // first generate a debug descriptor for the struct as a forward declaration.
@@ -3240,7 +3251,7 @@ llvm::DIType *CGDebugInfo::CreateType(const ObjCObjectType *Ty,
 llvm::DIType *CGDebugInfo::CreateType(const ObjCTypeParamType *Ty,
                                       llvm::DIFile *Unit) {
   // Ignore protocols.
-  SourceLocation Loc = Ty->getDecl()->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(Ty->getDecl()->getLocation());
 
   // Use Typedefs to represent ObjCTypeParamType.
   return DBuilder.createTypedef(
@@ -3291,9 +3302,10 @@ llvm::DIType *CGDebugInfo::CreateType(const ObjCInterfaceType *Ty,
         llvm::dwarf::DW_TAG_structure_type, ID->getName(),
         getDeclContextDescriptor(ID), Unit, 0, RuntimeLang);
 
+  SourceLocation Loc = getRefinedSpellingLocation(ID->getLocation());
   // Get overall information about the record type for the debug info.
-  llvm::DIFile *DefUnit = getOrCreateFile(ID->getLocation());
-  unsigned Line = getLineNumber(ID->getLocation());
+  llvm::DIFile *DefUnit = getOrCreateFile(Loc);
+  unsigned Line = getLineNumber(Loc);
 
   // If this is just a forward declaration return a special forward-declaration
   // debug type since we won't be able to lay out the entire type.
@@ -3414,8 +3426,9 @@ llvm::DIModule *CGDebugInfo::getOrCreateModuleRef(ASTSourceDescriptor Mod,
 llvm::DIType *CGDebugInfo::CreateTypeDefinition(const ObjCInterfaceType *Ty,
                                                 llvm::DIFile *Unit) {
   ObjCInterfaceDecl *ID = Ty->getDecl();
-  llvm::DIFile *DefUnit = getOrCreateFile(ID->getLocation());
-  unsigned Line = getLineNumber(ID->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(ID->getLocation());
+  llvm::DIFile *DefUnit = getOrCreateFile(Loc);
+  unsigned Line = getLineNumber(Loc);
 
   unsigned RuntimeLang = TheCU->getSourceLanguage().getUnversionedName();
 
@@ -3510,9 +3523,10 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const ObjCInterfaceType *Ty,
     if (FieldName.empty())
       continue;
 
+    SourceLocation Loc = getRefinedSpellingLocation(Field->getLocation());
     // Get the location for the field.
-    llvm::DIFile *FieldDefUnit = getOrCreateFile(Field->getLocation());
-    unsigned FieldLine = getLineNumber(Field->getLocation());
+    llvm::DIFile *FieldDefUnit = getOrCreateFile(Loc);
+    unsigned FieldLine = getLineNumber(Loc);
     QualType FType = Field->getType();
     uint64_t FieldSize = 0;
     uint32_t FieldAlign = 0;
@@ -3557,7 +3571,7 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const ObjCInterfaceType *Ty,
       if (ObjCPropertyImplDecl *PImpD =
               ImpD->FindPropertyImplIvarDecl(Field->getIdentifier())) {
         if (ObjCPropertyDecl *PD = PImpD->getPropertyDecl()) {
-          SourceLocation Loc = PD->getLocation();
+          SourceLocation Loc = getRefinedSpellingLocation(PD->getLocation());
           llvm::DIFile *PUnit = getOrCreateFile(Loc);
           unsigned PLine = getLineNumber(Loc);
           ObjCMethodDecl *Getter = PImpD->getGetterMethodDecl();
@@ -3839,11 +3853,12 @@ llvm::DIType *CGDebugInfo::CreateEnumType(const EnumType *Ty) {
     // FwdDecl with the second and then replace the second with
     // complete type.
     llvm::DIScope *EDContext = getDeclContextDescriptor(ED);
-    llvm::DIFile *DefUnit = getOrCreateFile(ED->getLocation());
+    SourceLocation Loc = getRefinedSpellingLocation(ED->getLocation());
+    llvm::DIFile *DefUnit = getOrCreateFile(Loc);
     llvm::TempDIScope TmpContext(DBuilder.createReplaceableCompositeType(
         llvm::dwarf::DW_TAG_enumeration_type, "", TheCU, DefUnit, 0));
 
-    unsigned Line = getLineNumber(ED->getLocation());
+    unsigned Line = getLineNumber(Loc);
     StringRef EDName = ED->getName();
     llvm::DIType *RetTy = DBuilder.createReplaceableCompositeType(
         llvm::dwarf::DW_TAG_enumeration_type, EDName, EDContext, DefUnit, Line,
@@ -3876,8 +3891,9 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const EnumType *Ty) {
   // Return a CompositeType for the enum itself.
   llvm::DINodeArray EltArray = DBuilder.getOrCreateArray(Enumerators);
 
-  llvm::DIFile *DefUnit = getOrCreateFile(ED->getLocation());
-  unsigned Line = getLineNumber(ED->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(ED->getLocation());
+  llvm::DIFile *DefUnit = getOrCreateFile(Loc);
+  unsigned Line = getLineNumber(Loc);
   llvm::DIScope *EnumContext = getDeclContextDescriptor(ED);
   llvm::DIType *ClassTy = getOrCreateType(ED->getIntegerType(), DefUnit);
   return DBuilder.createEnumerationType(
@@ -3895,8 +3911,10 @@ llvm::DIMacro *CGDebugInfo::CreateMacro(llvm::DIMacroFile *Parent,
 llvm::DIMacroFile *CGDebugInfo::CreateTempMacroFile(llvm::DIMacroFile *Parent,
                                                     SourceLocation LineLoc,
                                                     SourceLocation FileLoc) {
-  llvm::DIFile *FName = getOrCreateFile(FileLoc);
-  unsigned Line = LineLoc.isInvalid() ? 0 : getLineNumber(LineLoc);
+  llvm::DIFile *FName = getOrCreateFile(getRefinedSpellingLocation(FileLoc));
+  unsigned Line = LineLoc.isInvalid()
+                      ? 0
+                      : getLineNumber(getRefinedSpellingLocation(LineLoc));
   return DBuilder.createTempMacroFile(Parent, Line, FName);
 }
 
@@ -4219,7 +4237,7 @@ llvm::DICompositeType *CGDebugInfo::CreateLimitedType(const RecordType *Ty) {
 
   // Get overall information about the record type for the debug info.
   StringRef RDName = getClassName(RD);
-  const SourceLocation Loc = RD->getLocation();
+  const SourceLocation Loc = getRefinedSpellingLocation(RD->getLocation());
   llvm::DIFile *DefUnit = nullptr;
   unsigned Line = 0;
   if (Loc.isValid()) {
@@ -4333,7 +4351,8 @@ void CGDebugInfo::CollectContainingType(const CXXRecordDecl *RD,
         break;
     }
     CanQualType T = CGM.getContext().getCanonicalTagType(PBase);
-    ContainingType = getOrCreateType(T, getOrCreateFile(RD->getLocation()));
+    SourceLocation Loc = getRefinedSpellingLocation(RD->getLocation());
+    ContainingType = getOrCreateType(T, getOrCreateFile(Loc));
   } else if (RD->isDynamicClass())
     ContainingType = RealDecl;
 
@@ -4404,10 +4423,11 @@ void CGDebugInfo::collectVarDeclProps(const VarDecl *VD, llvm::DIFile *&Unit,
                                       StringRef &Name, StringRef &LinkageName,
                                       llvm::MDTuple *&TemplateParameters,
                                       llvm::DIScope *&VDContext) {
-  Unit = getOrCreateFile(VD->getLocation());
-  LineNo = getLineNumber(VD->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(VD->getLocation());
+  Unit = getOrCreateFile(Loc);
+  LineNo = getLineNumber(Loc);
 
-  setLocation(VD->getLocation());
+  setLocation(Loc);
 
   T = VD->getType();
   if (T->isIncompleteArrayType()) {
@@ -4460,7 +4480,7 @@ llvm::DISubprogram *CGDebugInfo::getFunctionFwdDeclOrStub(GlobalDecl GD,
   StringRef Name, LinkageName;
   llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
   llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::SPFlagZero;
-  SourceLocation Loc = GD.getDecl()->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(GD.getDecl()->getLocation());
   llvm::DIFile *Unit = getOrCreateFile(Loc);
   llvm::DIScope *DContext = Unit;
   unsigned Line = getLineNumber(Loc);
@@ -4515,7 +4535,7 @@ llvm::DIGlobalVariable *
 CGDebugInfo::getGlobalVariableForwardDeclaration(const VarDecl *VD) {
   QualType T;
   StringRef Name, LinkageName;
-  SourceLocation Loc = VD->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(VD->getLocation());
   llvm::DIFile *Unit = getOrCreateFile(Loc);
   llvm::DIScope *DContext = Unit;
   unsigned Line = getLineNumber(Loc);
@@ -4541,7 +4561,8 @@ llvm::DINode *CGDebugInfo::getDeclarationOrDefinition(const Decl *D) {
   // in unlimited debug info)
   if (const auto *TD = dyn_cast<TypeDecl>(D)) {
     QualType Ty = CGM.getContext().getTypeDeclType(TD);
-    return getOrCreateType(Ty, getOrCreateFile(TD->getLocation()));
+    SourceLocation Loc = getRefinedSpellingLocation(TD->getLocation());
+    return getOrCreateType(Ty, getOrCreateFile(Loc));
   }
   auto I = DeclCache.find(D->getCanonicalDecl());
 
@@ -4587,7 +4608,8 @@ llvm::DISubprogram *CGDebugInfo::getFunctionDeclaration(const Decl *D) {
   auto MI = SPCache.find(FD->getCanonicalDecl());
   if (MI == SPCache.end()) {
     if (const auto *MD = dyn_cast<CXXMethodDecl>(FD->getCanonicalDecl())) {
-      return CreateCXXMemberFunction(MD, getOrCreateFile(MD->getLocation()),
+      SourceLocation Loc = getRefinedSpellingLocation(MD->getLocation());
+      return CreateCXXMemberFunction(MD, getOrCreateFile(Loc),
                                      cast<llvm::DICompositeType>(S));
     }
   }
@@ -4749,6 +4771,7 @@ void CGDebugInfo::emitFunctionStart(GlobalDecl GD, SourceLocation Loc,
 
   const Decl *D = GD.getDecl();
   bool HasDecl = (D != nullptr);
+  Loc = getRefinedSpellingLocation(Loc);
 
   llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
   llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::SPFlagZero;
@@ -4817,7 +4840,7 @@ void CGDebugInfo::emitFunctionStart(GlobalDecl GD, SourceLocation Loc,
       SPFlags | llvm::DISubprogram::SPFlagDefinition;
 
   const unsigned LineNo = getLineNumber(Loc.isValid() ? Loc : CurLoc);
-  unsigned ScopeLine = getLineNumber(ScopeLoc);
+  unsigned ScopeLine = getLineNumber(getRefinedSpellingLocation(ScopeLoc));
   llvm::DISubroutineType *DIFnType = getOrCreateFunctionType(D, FnType, Unit);
   llvm::DISubprogram *Decl = nullptr;
   llvm::DINodeArray Annotations = nullptr;
@@ -4865,6 +4888,7 @@ void CGDebugInfo::EmitFunctionDecl(GlobalDecl GD, SourceLocation Loc,
     return GetName(D, true);
   });
 
+  Loc = getRefinedSpellingLocation(Loc);
   llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
   llvm::DIFile *Unit = getOrCreateFile(Loc);
   bool IsDeclForCallSite = Fn ? true : false;
@@ -4992,6 +5016,10 @@ void CGDebugInfo::CreateLexicalBlock(SourceLocation Loc) {
       getColumnNumber(CurLoc)));
 }
 
+SourceLocation CGDebugInfo::getRefinedSpellingLocation(SourceLocation Loc) const {
+  return CGM.getContext().getSourceManager().getRefinedSpellingLoc(Loc);
+}
+
 void CGDebugInfo::AppendAddressSpaceXDeref(
     unsigned AddressSpace, SmallVectorImpl<uint64_t> &Expr) const {
   std::optional<unsigned> DWARFAddressSpace =
@@ -5008,6 +5036,7 @@ void CGDebugInfo::AppendAddressSpaceXDeref(
 void CGDebugInfo::EmitLexicalBlockStart(CGBuilderTy &Builder,
                                         SourceLocation Loc) {
   // Set our current location.
+  Loc = getRefinedSpellingLocation(Loc);
   setLocation(Loc);
 
   // Emit a line table change for the current location inside the new scope.
@@ -5060,7 +5089,8 @@ CGDebugInfo::EmitTypeForVarWithBlocksAttr(const VarDecl *VD,
   uint64_t FieldSize, FieldOffset;
   uint32_t FieldAlign;
 
-  llvm::DIFile *Unit = getOrCreateFile(VD->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(VD->getLocation());
+  llvm::DIFile *Unit = getOrCreateFile(Loc);
   QualType Type = VD->getType();
 
   FieldOffset = 0;
@@ -5136,8 +5166,9 @@ llvm::DILocalVariable *CGDebugInfo::EmitDeclare(const VarDecl *VD,
   const bool VarIsArtificial = IsArtificial(VD);
 
   llvm::DIFile *Unit = nullptr;
+  SourceLocation Loc = getRefinedSpellingLocation(VD->getLocation());
   if (!VarIsArtificial)
-    Unit = getOrCreateFile(VD->getLocation());
+    Unit = getOrCreateFile(Loc);
   llvm::DIType *Ty;
   uint64_t XOffset = 0;
   if (VD->hasAttr<BlocksAttr>())
@@ -5154,8 +5185,8 @@ llvm::DILocalVariable *CGDebugInfo::EmitDeclare(const VarDecl *VD,
   unsigned Line = 0;
   unsigned Column = 0;
   if (!VarIsArtificial) {
-    Line = getLineNumber(VD->getLocation());
-    Column = getColumnNumber(VD->getLocation());
+    Line = getLineNumber(Loc);
+    Column = getColumnNumber(Loc);
   }
   SmallVector<uint64_t, 13> Expr;
   llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
@@ -5321,7 +5352,8 @@ llvm::DILocalVariable *CGDebugInfo::EmitDeclare(const BindingDecl *BD,
   if (isa<DeclRefExpr>(BD->getBinding()))
     return nullptr;
 
-  llvm::DIFile *Unit = getOrCreateFile(BD->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(BD->getLocation());
+  llvm::DIFile *Unit = getOrCreateFile(Loc);
   llvm::DIType *Ty = getOrCreateType(BD->getType(), Unit);
 
   // If there is no debug info for this type then do not emit debug info
@@ -5344,8 +5376,8 @@ llvm::DILocalVariable *CGDebugInfo::EmitDeclare(const BindingDecl *BD,
     Expr.push_back(llvm::dwarf::DW_OP_deref);
   }
 
-  unsigned Line = getLineNumber(BD->getLocation());
-  unsigned Column = getColumnNumber(BD->getLocation());
+  unsigned Line = getLineNumber(Loc);
+  unsigned Column = getColumnNumber(Loc);
   StringRef Name = BD->getName();
   auto *Scope = cast<llvm::DIScope>(LexicalBlockStack.back());
   // Create the descriptor for the variable.
@@ -5439,11 +5471,12 @@ void CGDebugInfo::EmitLabel(const LabelDecl *D, CGBuilderTy &Builder) {
     return;
 
   auto *Scope = cast<llvm::DIScope>(LexicalBlockStack.back());
-  llvm::DIFile *Unit = getOrCreateFile(D->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(D->getLocation());
+  llvm::DIFile *Unit = getOrCreateFile(Loc);
 
   // Get location information.
-  unsigned Line = getLineNumber(D->getLocation());
-  unsigned Column = getColumnNumber(D->getLocation());
+  unsigned Line = getLineNumber(Loc);
+  unsigned Column = getColumnNumber(Loc);
 
   StringRef Name = D->getName();
 
@@ -5482,7 +5515,8 @@ void CGDebugInfo::EmitDeclareOfBlockDeclRefVariable(
   bool isByRef = VD->hasAttr<BlocksAttr>();
 
   uint64_t XOffset = 0;
-  llvm::DIFile *Unit = getOrCreateFile(VD->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(VD->getLocation());
+  llvm::DIFile *Unit = getOrCreateFile(Loc);
   llvm::DIType *Ty;
   if (isByRef)
     Ty = EmitTypeForVarWithBlocksAttr(VD, &XOffset).WrappedType;
@@ -5497,8 +5531,8 @@ void CGDebugInfo::EmitDeclareOfBlockDeclRefVariable(
 
   // Get location information.
   const unsigned Line =
-      getLineNumber(VD->getLocation().isValid() ? VD->getLocation() : CurLoc);
-  unsigned Column = getColumnNumber(VD->getLocation());
+      getLineNumber(Loc.isValid() ? Loc : CurLoc);
+  unsigned Column = getColumnNumber(Loc);
 
   const llvm::DataLayout &target = CGM.getDataLayout();
 
@@ -5606,7 +5640,7 @@ void CGDebugInfo::EmitDeclareOfBlockLiteralArgVariable(const CGBlockInfo &block,
   const BlockDecl *blockDecl = block.getBlockDecl();
 
   // Collect some general information about the block's location.
-  SourceLocation loc = blockDecl->getCaretLocation();
+  SourceLocation loc = getRefinedSpellingLocation(blockDecl->getCaretLocation());
   llvm::DIFile *tunit = getOrCreateFile(loc);
   unsigned line = getLineNumber(loc);
   unsigned column = getColumnNumber(loc);
@@ -6077,8 +6111,9 @@ void CGDebugInfo::EmitGlobalVariable(const ValueDecl *VD, const APValue &Init) {
   });
 
   auto Align = getDeclAlignIfRequired(VD, CGM.getContext());
+  SourceLocation Loc = getRefinedSpellingLocation(VD->getLocation());
   // Create the descriptor for the variable.
-  llvm::DIFile *Unit = getOrCreateFile(VD->getLocation());
+  llvm::DIFile *Unit = getOrCreateFile(Loc);
   StringRef Name = VD->getName();
   llvm::DIType *Ty = getOrCreateType(VD->getType(), Unit);
 
@@ -6136,7 +6171,7 @@ void CGDebugInfo::EmitGlobalVariable(const ValueDecl *VD, const APValue &Init) {
     }
 
   GV.reset(DBuilder.createGlobalVariableExpression(
-      DContext, Name, StringRef(), Unit, getLineNumber(VD->getLocation()), Ty,
+      DContext, Name, StringRef(), Unit, getLineNumber(Loc), Ty,
       true, true, InitExpr, getOrCreateStaticDataMemberDeclarationOrNull(VarD),
       TemplateParameters, Align));
 }
@@ -6148,14 +6183,15 @@ void CGDebugInfo::EmitExternalVariable(llvm::GlobalVariable *Var,
     return;
 
   auto Align = getDeclAlignIfRequired(D, CGM.getContext());
-  llvm::DIFile *Unit = getOrCreateFile(D->getLocation());
+  SourceLocation Loc = getRefinedSpellingLocation(D->getLocation());
+  llvm::DIFile *Unit = getOrCreateFile(Loc);
   StringRef Name = D->getName();
   llvm::DIType *Ty = getOrCreateType(D->getType(), Unit);
 
   llvm::DIScope *DContext = getDeclContextDescriptor(D);
   llvm::DIGlobalVariableExpression *GVE =
       DBuilder.createGlobalVariableExpression(
-          DContext, Name, StringRef(), Unit, getLineNumber(D->getLocation()),
+          DContext, Name, StringRef(), Unit, getLineNumber(Loc),
           Ty, false, false, nullptr, nullptr, nullptr, Align);
   Var->addDebugInfo(GVE);
 }
@@ -6233,7 +6269,7 @@ void CGDebugInfo::EmitGlobalAlias(const llvm::GlobalValue *GV,
     return;
 
   llvm::DIScope *DContext = getDeclContextDescriptor(D);
-  auto Loc = D->getLocation();
+  SourceLocation Loc = getRefinedSpellingLocation(D->getLocation());
 
   llvm::DIImportedEntity *ImportDI = DBuilder.createImportedDeclaration(
       DContext, DI, getOrCreateFile(Loc), getLineNumber(Loc), D->getName());
@@ -6244,16 +6280,15 @@ void CGDebugInfo::EmitGlobalAlias(const llvm::GlobalValue *GV,
 
 void CGDebugInfo::AddStringLiteralDebugInfo(llvm::GlobalVariable *GV,
                                             const StringLiteral *S) {
-  SourceLocation Loc = S->getStrTokenLoc(0);
-  SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(SM.getRefinedSpellingLoc(Loc));
+  SourceLocation Loc = getRefinedSpellingLocation(S->getStrTokenLoc(0));
+  PresumedLoc PLoc = CGM.getContext().getSourceManager().getPresumedLoc(Loc);
   if (!PLoc.isValid())
     return;
 
   llvm::DIFile *File = getOrCreateFile(Loc);
   llvm::DIGlobalVariableExpression *Debug =
       DBuilder.createGlobalVariableExpression(
-          nullptr, StringRef(), StringRef(), getOrCreateFile(Loc),
+          nullptr, StringRef(), StringRef(), File,
           getLineNumber(Loc), getOrCreateType(S->getType(), File), true);
   GV->addDebugInfo(Debug);
 }
@@ -6271,7 +6306,7 @@ void CGDebugInfo::EmitUsingDirective(const UsingDirectiveDecl &UD) {
   const NamespaceDecl *NSDecl = UD.getNominatedNamespace();
   if (!NSDecl->isAnonymousNamespace() ||
       CGM.getCodeGenOpts().DebugExplicitImport) {
-    auto Loc = UD.getLocation();
+    SourceLocation Loc = getRefinedSpellingLocation(UD.getLocation());
     if (!Loc.isValid())
       Loc = CurLoc;
     DBuilder.createImportedModule(
@@ -6283,7 +6318,7 @@ void CGDebugInfo::EmitUsingDirective(const UsingDirectiveDecl &UD) {
 void CGDebugInfo::EmitUsingShadowDecl(const UsingShadowDecl &USD) {
   if (llvm::DINode *Target =
           getDeclarationOrDefinition(USD.getUnderlyingDecl())) {
-    auto Loc = USD.getLocation();
+    SourceLocation Loc = getRefinedSpellingLocation(USD.getLocation());
     DBuilder.createImportedDeclaration(
         getCurrentContextDescriptor(cast<Decl>(USD.getDeclContext())), Target,
         getOrCreateFile(Loc), getLineNumber(Loc));
@@ -6331,7 +6366,7 @@ void CGDebugInfo::EmitImportDecl(const ImportDecl &ID) {
     return;
   if (Module *M = ID.getImportedModule()) {
     auto Info = ASTSourceDescriptor(*M);
-    auto Loc = ID.getLocation();
+    auto Loc = getRefinedSpellingLocation(ID.getLocation());
     DBuilder.createImportedDeclaration(
         getCurrentContextDescriptor(cast<Decl>(ID.getDeclContext())),
         getOrCreateModuleRef(Info, DebugTypeExtRefs), getOrCreateFile(Loc),
@@ -6347,7 +6382,7 @@ CGDebugInfo::EmitNamespaceAlias(const NamespaceAliasDecl &NA) {
   if (VH)
     return cast<llvm::DIImportedEntity>(VH);
   llvm::DIImportedEntity *R;
-  auto Loc = NA.getLocation();
+  auto Loc = getRefinedSpellingLocation(NA.getLocation());
   if (const auto *Underlying =
           dyn_cast<NamespaceAliasDecl>(NA.getAliasedNamespace()))
     // This could cache & dedup here rather than relying on metadata deduping.
@@ -6479,6 +6514,7 @@ llvm::DebugLoc CGDebugInfo::SourceLocToDebugLoc(SourceLocation Loc) {
   if (LexicalBlockStack.empty())
     return llvm::DebugLoc();
 
+  Loc = getRefinedSpellingLocation(Loc);
   llvm::MDNode *Scope = LexicalBlockStack.back();
   return llvm::DILocation::get(CGM.getLLVMContext(), getLineNumber(Loc),
                                getColumnNumber(Loc), Scope);

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -110,6 +110,34 @@ static bool IsArtificial(VarDecl const *VD) {
                               cast<Decl>(VD->getDeclContext())->isImplicit());
 }
 
+/// If the given source location resides in a macro argument, this function
+/// recursively resolves through macro argument expansions to return a source
+/// location that points to where the argument was spelled in the macro
+/// invocation. This is necessary for generating correct debug information for
+/// code inside macro arguments, as we want to point to user-written code.
+static SourceLocation resolveSpellingLocation(SourceManager &SM,
+                                              SourceLocation Loc) {
+  SourceLocation ParentLoc = Loc;
+
+  while (SM.isMacroArgExpansion(ParentLoc)) {
+    ParentLoc = SM.getImmediateMacroCallerLoc(ParentLoc);
+  }
+
+  if (ParentLoc.isMacroID()) {
+    return ParentLoc;
+  }
+  return SM.getSpellingLoc(Loc);
+}
+
+/// Returns the presumed location for a given source location, resolving
+/// through macro arguments first. This ensures that file, line, and column
+/// information points to where a macro argument was spelled, rather than where
+/// it was expanded.
+static PresumedLoc getPresumedSpellingLoc(SourceManager &SM,
+                                          SourceLocation Loc) {
+  return SM.getPresumedLoc(resolveSpellingLocation(SM, Loc));
+}
+
 CGDebugInfo::CGDebugInfo(CodeGenModule &CGM)
     : CGM(CGM), DebugKind(CGM.getCodeGenOpts().getDebugInfo()),
       DebugTypeExtRefs(CGM.getCodeGenOpts().DebugTypeExtRefs),
@@ -318,7 +346,8 @@ void CGDebugInfo::setLocation(SourceLocation Loc) {
   if (Loc.isInvalid())
     return;
 
-  CurLoc = CGM.getContext().getSourceManager().getExpansionLoc(Loc);
+  SourceManager &SM = CGM.getContext().getSourceManager();
+  CurLoc = SM.getExpansionLoc(resolveSpellingLocation(SM, Loc));
 
   // If we've changed files in the middle of a lexical scope go ahead
   // and create a new lexical scope with file node if it's different
@@ -326,7 +355,6 @@ void CGDebugInfo::setLocation(SourceLocation Loc) {
   if (LexicalBlockStack.empty())
     return;
 
-  SourceManager &SM = CGM.getContext().getSourceManager();
   auto *Scope = cast<llvm::DIScope>(LexicalBlockStack.back());
   PresumedLoc PCLoc = SM.getPresumedLoc(CurLoc);
   if (PCLoc.isInvalid() || Scope->getFile() == getOrCreateFile(CurLoc))
@@ -545,7 +573,7 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
     FileName = TheCU->getFile()->getFilename();
     CSInfo = TheCU->getFile()->getChecksum();
   } else {
-    PresumedLoc PLoc = SM.getPresumedLoc(Loc);
+    PresumedLoc PLoc = getPresumedSpellingLoc(SM, Loc);
     FileName = PLoc.getFilename();
 
     if (FileName.empty()) {
@@ -627,7 +655,7 @@ unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  return SM.getPresumedLoc(Loc).getLine();
+  return getPresumedSpellingLoc(SM, Loc).getLine();
 }
 
 unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
@@ -639,7 +667,8 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc);
+  PresumedLoc PLoc = Loc.isValid() ? getPresumedSpellingLoc(SM, Loc)
+                                   : SM.getPresumedLoc(CurLoc);
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 
@@ -6244,7 +6273,8 @@ void CGDebugInfo::EmitGlobalAlias(const llvm::GlobalValue *GV,
 void CGDebugInfo::AddStringLiteralDebugInfo(llvm::GlobalVariable *GV,
                                             const StringLiteral *S) {
   SourceLocation Loc = S->getStrTokenLoc(0);
-  PresumedLoc PLoc = CGM.getContext().getSourceManager().getPresumedLoc(Loc);
+  PresumedLoc PLoc =
+      getPresumedSpellingLoc(CGM.getContext().getSourceManager(), Loc);
   if (!PLoc.isValid())
     return;
 

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -110,34 +110,6 @@ static bool IsArtificial(VarDecl const *VD) {
                               cast<Decl>(VD->getDeclContext())->isImplicit());
 }
 
-/// If the given source location resides in a macro argument, this function
-/// recursively resolves through macro argument expansions to return a source
-/// location that points to where the argument was spelled in the macro
-/// invocation. This is necessary for generating correct debug information for
-/// code inside macro arguments, as we want to point to user-written code.
-static SourceLocation resolveSpellingLocation(SourceManager &SM,
-                                              SourceLocation Loc) {
-  SourceLocation ParentLoc = Loc;
-
-  while (SM.isMacroArgExpansion(ParentLoc)) {
-    ParentLoc = SM.getImmediateMacroCallerLoc(ParentLoc);
-  }
-
-  if (ParentLoc.isMacroID()) {
-    return ParentLoc;
-  }
-  return SM.getSpellingLoc(Loc);
-}
-
-/// Returns the presumed location for a given source location, resolving
-/// through macro arguments first. This ensures that file, line, and column
-/// information points to where a macro argument was spelled, rather than where
-/// it was expanded.
-static PresumedLoc getPresumedSpellingLoc(SourceManager &SM,
-                                          SourceLocation Loc) {
-  return SM.getPresumedLoc(resolveSpellingLocation(SM, Loc));
-}
-
 CGDebugInfo::CGDebugInfo(CodeGenModule &CGM)
     : CGM(CGM), DebugKind(CGM.getCodeGenOpts().getDebugInfo()),
       DebugTypeExtRefs(CGM.getCodeGenOpts().DebugTypeExtRefs),
@@ -347,7 +319,7 @@ void CGDebugInfo::setLocation(SourceLocation Loc) {
     return;
 
   SourceManager &SM = CGM.getContext().getSourceManager();
-  CurLoc = SM.getExpansionLoc(resolveSpellingLocation(SM, Loc));
+  CurLoc = SM.getRefinedSpellingLoc(Loc);
 
   // If we've changed files in the middle of a lexical scope go ahead
   // and create a new lexical scope with file node if it's different
@@ -573,7 +545,7 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
     FileName = TheCU->getFile()->getFilename();
     CSInfo = TheCU->getFile()->getChecksum();
   } else {
-    PresumedLoc PLoc = getPresumedSpellingLoc(SM, Loc);
+    PresumedLoc PLoc = SM.getPresumedLoc(SM.getRefinedSpellingLoc(Loc));
     FileName = PLoc.getFilename();
 
     if (FileName.empty()) {
@@ -655,7 +627,7 @@ unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  return getPresumedSpellingLoc(SM, Loc).getLine();
+  return SM.getPresumedLoc(SM.getRefinedSpellingLoc(Loc)).getLine();
 }
 
 unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
@@ -667,8 +639,8 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = Loc.isValid() ? getPresumedSpellingLoc(SM, Loc)
-                                   : SM.getPresumedLoc(CurLoc);
+  PresumedLoc PLoc =
+      SM.getPresumedLoc(Loc.isValid() ? SM.getRefinedSpellingLoc(Loc) : CurLoc);
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 
@@ -6273,8 +6245,8 @@ void CGDebugInfo::EmitGlobalAlias(const llvm::GlobalValue *GV,
 void CGDebugInfo::AddStringLiteralDebugInfo(llvm::GlobalVariable *GV,
                                             const StringLiteral *S) {
   SourceLocation Loc = S->getStrTokenLoc(0);
-  PresumedLoc PLoc =
-      getPresumedSpellingLoc(CGM.getContext().getSourceManager(), Loc);
+  SourceManager &SM = CGM.getContext().getSourceManager();
+  PresumedLoc PLoc = SM.getPresumedLoc(SM.getRefinedSpellingLoc(Loc));
   if (!PLoc.isValid())
     return;
 

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -5016,7 +5016,16 @@ void CGDebugInfo::CreateLexicalBlock(SourceLocation Loc) {
       getColumnNumber(CurLoc)));
 }
 
-SourceLocation CGDebugInfo::getRefinedSpellingLocation(SourceLocation Loc) const {
+// All locations handled by CGDebugInfo are refined locations because this
+// is more suitable for debugging than pure spelling or expansion locations.
+// Refined locations do not point into macro definitions. If a source
+// location is part of a macro argument expansion, its refined location is
+// the spelling location of the argument. If a source location is part of a
+// macro body, its refined location is the expansion location.
+// This allows debuggers to show the macro invocation site or the argument
+// site, but not the macro definition body.
+SourceLocation
+CGDebugInfo::getRefinedSpellingLocation(SourceLocation Loc) const {
   return CGM.getContext().getSourceManager().getRefinedSpellingLoc(Loc);
 }
 

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -5016,14 +5016,6 @@ void CGDebugInfo::CreateLexicalBlock(SourceLocation Loc) {
       getColumnNumber(CurLoc)));
 }
 
-// All locations handled by CGDebugInfo are refined locations because this
-// is more suitable for debugging than pure spelling or expansion locations.
-// Refined locations do not point into macro definitions. If a source
-// location is part of a macro argument expansion, its refined location is
-// the spelling location of the argument. If a source location is part of a
-// macro body, its refined location is the expansion location.
-// This allows debuggers to show the macro invocation site or the argument
-// site, but not the macro definition body.
 SourceLocation
 CGDebugInfo::getRefinedSpellingLocation(SourceLocation Loc) const {
   return CGM.getContext().getSourceManager().getRefinedSpellingLoc(Loc);

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -408,6 +408,16 @@ private:
   /// Create a new lexical block node and push it on the stack.
   void CreateLexicalBlock(SourceLocation Loc);
 
+  /// All locations handled by CGDebugInfo are refined locations because this
+  /// is more suitable for debugging than pure spelling or expansion locations.
+  ///
+  /// Refined locations do not point into macro definitions. If a source
+  /// location is part of a macro argument expansion, its refined location is
+  /// the spelling location of the argument. If a source location is part of a
+  /// macro body, its refined location is the expansion location.
+  ///
+  /// This allows debuggers to show the macro invocation site or the argument
+  /// site, but not the macro definition body.
   SourceLocation getRefinedSpellingLocation(SourceLocation Loc) const;
 
   /// If target-specific LLVM \p AddressSpace directly maps to target-specific

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -408,6 +408,8 @@ private:
   /// Create a new lexical block node and push it on the stack.
   void CreateLexicalBlock(SourceLocation Loc);
 
+  SourceLocation getRefinedSpellingLocation(SourceLocation Loc) const;
+
   /// If target-specific LLVM \p AddressSpace directly maps to target-specific
   /// DWARF address space, appends extended dereferencing mechanism to complex
   /// expression \p Expr. Otherwise, does nothing.

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -408,17 +408,15 @@ private:
   /// Create a new lexical block node and push it on the stack.
   void CreateLexicalBlock(SourceLocation Loc);
 
-  /// All locations handled by CGDebugInfo are refined locations because this
+  /// All locations handled by CGDebugInfo are file locations because this
   /// is more suitable for debugging than pure spelling or expansion locations.
-  ///
-  /// Refined locations do not point into macro definitions. If a source
-  /// location is part of a macro argument expansion, its refined location is
+  /// File locations do not point into macro definitions. If a source
+  /// location is part of a macro argument expansion, its file location is
   /// the spelling location of the argument. If a source location is part of a
-  /// macro body, its refined location is the expansion location.
-  ///
+  /// macro body, its file location is the expansion location.
   /// This allows debuggers to show the macro invocation site or the argument
   /// site, but not the macro definition body.
-  SourceLocation getRefinedSpellingLocation(SourceLocation Loc) const;
+  SourceLocation getFileLocation(SourceLocation Loc) const;
 
   /// If target-specific LLVM \p AddressSpace directly maps to target-specific
   /// DWARF address space, appends extended dereferencing mechanism to complex

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -68,7 +68,7 @@ class CGDebugInfo {
   llvm::DICompileUnit *TheCU = nullptr;
   ModuleMap *ClangModuleMap = nullptr;
   ASTSourceDescriptor PCHDescriptor;
-  SourceLocation CurLoc;
+  PresumedLoc CurPLoc;
   llvm::MDNode *CurInlinedAt = nullptr;
   llvm::DIType *VTablePtrType = nullptr;
   llvm::DIType *ClassTy = nullptr;
@@ -346,18 +346,18 @@ private:
   llvm::DINodeArray CollectBTFDeclTagAnnotations(const Decl *D);
 
   llvm::DIType *createFieldType(StringRef name, QualType type,
-                                SourceLocation loc, AccessSpecifier AS,
+                                const PresumedLoc &PLoc, AccessSpecifier AS,
                                 uint64_t offsetInBits, uint32_t AlignInBits,
                                 llvm::DIFile *tunit, llvm::DIScope *scope,
                                 const RecordDecl *RD = nullptr,
                                 llvm::DINodeArray Annotations = nullptr);
 
   llvm::DIType *createFieldType(StringRef name, QualType type,
-                                SourceLocation loc, AccessSpecifier AS,
+                                const PresumedLoc &PLoc, AccessSpecifier AS,
                                 uint64_t offsetInBits, llvm::DIFile *tunit,
                                 llvm::DIScope *scope,
                                 const RecordDecl *RD = nullptr) {
-    return createFieldType(name, type, loc, AS, offsetInBits, 0, tunit, scope,
+    return createFieldType(name, type, PLoc, AS, offsetInBits, 0, tunit, scope,
                            RD);
   }
 
@@ -406,7 +406,7 @@ private:
   /// @}
 
   /// Create a new lexical block node and push it on the stack.
-  void CreateLexicalBlock(SourceLocation Loc);
+  void CreateLexicalBlock(const PresumedLoc &PLoc);
 
   /// All locations handled by CGDebugInfo are file locations because this
   /// is more suitable for debugging than pure spelling or expansion locations.
@@ -416,7 +416,7 @@ private:
   /// macro body, its file location is the expansion location.
   /// This allows debuggers to show the macro invocation site or the argument
   /// site, but not the macro definition body.
-  SourceLocation getFileLocation(SourceLocation Loc) const;
+  PresumedLoc getFileLocation(SourceLocation Loc) const;
 
   /// If target-specific LLVM \p AddressSpace directly maps to target-specific
   /// DWARF address space, appends extended dereferencing mechanism to complex
@@ -439,9 +439,9 @@ private:
   /// A helper function to collect debug info for the default fields of a
   /// block.
   void collectDefaultFieldsForBlockLiteralDeclare(
-      const CGBlockInfo &Block, const ASTContext &Context, SourceLocation Loc,
-      const llvm::StructLayout &BlockLayout, llvm::DIFile *Unit,
-      SmallVectorImpl<llvm::Metadata *> &Fields);
+      const CGBlockInfo &Block, const ASTContext &Context,
+      const PresumedLoc &PLoc, const llvm::StructLayout &BlockLayout,
+      llvm::DIFile *Unit, SmallVectorImpl<llvm::Metadata *> &Fields);
 
 public:
   CGDebugInfo(CodeGenModule &CGM);
@@ -475,11 +475,11 @@ public:
 
   /// Update the current source location. If \arg loc is invalid it is
   /// ignored.
-  void setLocation(SourceLocation Loc);
+  void setLocation(const PresumedLoc &PLoc);
 
   /// Return the current source location. This does not necessarily correspond
   /// to the IRBuilder's current DebugLoc.
-  SourceLocation getLocation() const { return CurLoc; }
+  const PresumedLoc &getLocation() const { return CurPLoc; }
 
   /// Update the current inline scope. All subsequent calls to \p EmitLocation
   /// will create a location with this inlinedAt field.
@@ -495,6 +495,11 @@ public:
   /// the source file. If the location is invalid, the previous
   /// location will be reused.
   void EmitLocation(CGBuilderTy &Builder, SourceLocation Loc);
+
+  /// Emit metadata to indicate a change in line/column information in
+  /// the source file. If the location is invalid, the previous
+  /// location will be reused.
+  void EmitLocation(CGBuilderTy &Builder, const PresumedLoc &Loc);
 
   QualType getFunctionType(const FunctionDecl *FD, QualType RetTy,
                            const SmallVectorImpl<const VarDecl *> &Args);
@@ -753,7 +758,7 @@ private:
 
   /// Convenience function to get the file debug info descriptor for the input
   /// location.
-  llvm::DIFile *getOrCreateFile(SourceLocation Loc);
+  llvm::DIFile *getOrCreateFile(const PresumedLoc &PLoc);
 
   /// Create a file debug info descriptor for a source file.
   llvm::DIFile *
@@ -872,12 +877,12 @@ private:
 
   /// Get line number for the location. If location is invalid
   /// then use current location.
-  unsigned getLineNumber(SourceLocation Loc);
+  unsigned getLineNumber(const PresumedLoc &PLoc) const;
 
   /// Get column number for the location. If location is
   /// invalid then use current location.
   /// \param Force  Assume DebugColumnInfo option is true.
-  unsigned getColumnNumber(SourceLocation Loc, bool Force = false);
+  unsigned getColumnNumber(const PresumedLoc &PLoc, bool Force = false) const;
 
   /// Collect various properties of a FunctionDecl.
   /// \param GD  A GlobalDecl whose getDecl() must return a FunctionDecl.
@@ -920,9 +925,9 @@ private:
 /// location or preferred location of the specified Expr.
 class ApplyDebugLocation {
 private:
-  void init(SourceLocation TemporaryLocation, bool DefaultToEmpty = false);
+  void init(const PresumedLoc &TemporaryLocation, bool DefaultToEmpty = false);
   ApplyDebugLocation(CodeGenFunction &CGF, bool DefaultToEmpty,
-                     SourceLocation TemporaryLocation);
+                     const PresumedLoc &TemporaryLocation);
 
   llvm::DebugLoc OriginalLocation;
   CodeGenFunction *CGF;
@@ -959,7 +964,7 @@ public:
   /// SourceLocation to CGDebugInfo::setLocation() will result in the
   /// last valid location being reused.
   static ApplyDebugLocation CreateArtificial(CodeGenFunction &CGF) {
-    return ApplyDebugLocation(CGF, false, SourceLocation());
+    return ApplyDebugLocation(CGF, false, PresumedLoc());
   }
   /// Apply TemporaryLocation if it is valid. Otherwise switch
   /// to an artificial debug location that has a valid scope, but no
@@ -967,7 +972,7 @@ public:
   static ApplyDebugLocation
   CreateDefaultArtificial(CodeGenFunction &CGF,
                           SourceLocation TemporaryLocation) {
-    return ApplyDebugLocation(CGF, false, TemporaryLocation);
+    return ApplyDebugLocation(CGF, TemporaryLocation);
   }
 
   /// Set the IRBuilder to not attach debug locations.  Note that
@@ -976,13 +981,13 @@ public:
   /// all instructions that do not have a location at the beginning of
   /// a function are counted towards to function prologue.
   static ApplyDebugLocation CreateEmpty(CodeGenFunction &CGF) {
-    return ApplyDebugLocation(CGF, true, SourceLocation());
+    return ApplyDebugLocation(CGF, true, PresumedLoc());
   }
 };
 
 /// A scoped helper to set the current debug location to an inlined location.
 class ApplyInlineDebugLocation {
-  SourceLocation SavedLocation;
+  PresumedLoc SavedLocation;
   CodeGenFunction *CGF;
 
 public:

--- a/clang/test/DebugInfo/Generic/macro-info.c
+++ b/clang/test/DebugInfo/Generic/macro-info.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s
+#define ID(x) x
+
+// CHECK: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+3]]
+// CHECK: DIGlobalVariable({{.*}}line: [[@LINE+5]],{{.*}} type: [[TYPEID:![0-9]+]]
+ID(
+  int global = 42;
+
+  const char* s() {
+    return "1234567890";
+  }
+)
+
+#define SWAP(x,y) y; x
+
+// CHECK: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+4]]
+// CHECK: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE+2]]
+SWAP(
+  int global2 = 43,
+  int global3 = 44
+);

--- a/clang/test/DebugInfo/Generic/macro-info.c
+++ b/clang/test/DebugInfo/Generic/macro-info.c
@@ -1,21 +1,32 @@
 // RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s
-#define ID(x) x
 
-// CHECK: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+3]]
-// CHECK: DIGlobalVariable({{.*}}line: [[@LINE+5]],{{.*}} type: [[TYPEID:![0-9]+]]
-ID(
-  int global = 42;
+#define GLOBAL(num) global##num
+#define DECL_GLOBAL(x) int x
+#define SAME_ORDER(x, y) x; y
+#define SWAP_ORDER(x,y) y; x
 
+// CHECK: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+4]]
+// CHECK: DIGlobalVariable({{.*}}line: [[@LINE+6]],{{.*}} type: [[TYPEID:![0-9]+]]
+SAME_ORDER(
+  int
+    GLOBAL  // <- global
+      () = 42,
   const char* s() {
     return "1234567890";
   }
 )
-
-#define SWAP(x,y) y; x
-
-// CHECK: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+4]]
+// CHECK: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+6]]
 // CHECK: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE+2]]
-SWAP(
-  int global2 = 43,
-  int global3 = 44
+SWAP_ORDER(
+  int GLOBAL(  // <- global2
+    2) = 43,
+  DECL_GLOBAL(
+    GLOBAL(  // <- global3
+      3)) = 44
 );
+
+
+// CHECK: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE+2]]
+DECL_GLOBAL(
+  GLOBAL(  // <- global4
+    4));


### PR DESCRIPTION
CGDebugInfo used to store SourceLocation which was converted to PresumedLoc multiple times per call.
Now we perform convertion from SourceLocation to PresumedLoc just once and use it, which is more efficient.
It saves at least  2 conversions per single call (sometimes 3)  in the following methods:
`getOrCreateFile`, `getLineNumber`, `getColumnNumber`.