### PR TITLE
[Hexagon] Only enable insert-big.ll test with asserts

### DIFF
--- a/llvm/test/CodeGen/Hexagon/insert-big.ll
+++ b/llvm/test/CodeGen/Hexagon/insert-big.ll
@@ -1,3 +1,6 @@
+; HexagonGenInsert.cpp has custom debug output control, which is only enabled in builds with assertions.
+; REQUIRES: asserts
+
 ; Check that llc does not abort, which happened due to incorrect MIR.
 ; RUN: llc -O2 -mtriple=hexagon -insert-max-ifmap=1 < %s
 ; RUN: llc -O2 -mtriple=hexagon -insert-max-ifmap=2 < %s


### PR DESCRIPTION
The test fails because its debug output is only written with assertions.