### PR TITLE
[ORC] Fix unused variable warning

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/WaitingOnGraphTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/WaitingOnGraphTest.cpp
@@ -54,7 +54,9 @@ protected:
       return ContainerElementsMap();
 
     ContainerElementsMap Result = SNs[0]->defs();
+#ifndef NDEBUG
     const ContainerElementsMap &Deps = SNs[0]->deps();
+#endif // NDEBUG
 
     for (size_t I = 1; I != SNs.size(); ++I) {
       assert(!DepsMustMatch || SNs[I]->deps() == Deps);


### PR DESCRIPTION
This fixes a potentially unused variable that's only used in an assert.

This is a fix for #164340.