### PR TITLE
[clang-format] Align trailing comments for function parameters

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -507,7 +507,8 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
   };
 
   unsigned I = StartAt;
-  for (unsigned E = Changes.size(); I != E; ++I) {
+  unsigned E = Changes.size();
+  for (; I != E; ++I) {
     auto &CurrentChange = Changes[I];
     if (CurrentChange.indentAndNestingLevel() < IndentAndNestingLevel)
       break;
@@ -652,8 +653,8 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
 
   // Pass entire lines to the function so that it can update the state of all
   // tokens that move.
-  for (EndOfSequence = I; EndOfSequence < Changes.size() &&
-                          Changes[EndOfSequence].NewlinesBefore == 0;
+  for (EndOfSequence = I;
+       EndOfSequence < E && Changes[EndOfSequence].NewlinesBefore == 0;
        ++EndOfSequence) {
   }
   AlignCurrentSequence();

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -650,16 +650,15 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
     MatchedIndices.push_back(I);
   }
 
-  // Pass to the function entire lines, so it can update the state of all tokens
-  // that move.
-  EndOfSequence = I;
-  while (EndOfSequence < Changes.size() &&
-         Changes[EndOfSequence].NewlinesBefore == 0) {
-    ++EndOfSequence;
+  // Pass entire lines to the function so that it can update the state of all
+  // tokens that move.
+  for (EndOfSequence = I; EndOfSequence < Changes.size() &&
+                          Changes[EndOfSequence].NewlinesBefore == 0;
+       ++EndOfSequence) {
   }
   AlignCurrentSequence();
   // The return value should still be where the level ends. The rest of the line
-  // may contain stuff to be aligned within the parent level.
+  // may contain stuff to be aligned within an outer level.
   return I;
 }
 

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -399,6 +399,15 @@ AlignTokenSequence(const FormatStyle &Style, unsigned Start, unsigned End,
       }
     }
   }
+
+  // The scope to be aligned may not occupy entire lines. The rest of the line
+  // needs some book-keeping.
+  for (unsigned i = End; i < Changes.size() && Changes[i].NewlinesBefore == 0;
+       ++i) {
+    Changes[i].StartOfTokenColumn += Shift;
+    if (i + 1 != Changes.size())
+      Changes[i + 1].PreviousEndOfTokenColumn += Shift;
+  }
 }
 
 // Walk through a subset of the changes, starting at StartAt, and find

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -399,15 +399,6 @@ AlignTokenSequence(const FormatStyle &Style, unsigned Start, unsigned End,
       }
     }
   }
-
-  // The scope to be aligned may not occupy entire lines. The rest of the line
-  // needs some book-keeping.
-  for (unsigned i = End; i < Changes.size() && Changes[i].NewlinesBefore == 0;
-       ++i) {
-    Changes[i].StartOfTokenColumn += Shift;
-    if (i + 1 != Changes.size())
-      Changes[i + 1].PreviousEndOfTokenColumn += Shift;
-  }
 }
 
 // Walk through a subset of the changes, starting at StartAt, and find
@@ -659,8 +650,16 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
     MatchedIndices.push_back(I);
   }
 
+  // Pass to the function entire lines, so it can update the state of all tokens
+  // that move.
   EndOfSequence = I;
+  while (EndOfSequence < Changes.size() &&
+         Changes[EndOfSequence].NewlinesBefore == 0) {
+    ++EndOfSequence;
+  }
   AlignCurrentSequence();
+  // The return value should still be where the level ends. The rest of the line
+  // may contain stuff to be aligned within the parent level.
   return I;
 }
 

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -507,7 +507,7 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
   };
 
   unsigned I = StartAt;
-  unsigned E = Changes.size();
+  const auto E = Changes.size();
   for (; I != E; ++I) {
     auto &CurrentChange = Changes[I];
     if (CurrentChange.indentAndNestingLevel() < IndentAndNestingLevel)

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -19828,6 +19828,14 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
                "  Test &operator=(const Test &) = default;\n"
                "};",
                Alignment);
+
+  // The comment to the right should still align right.
+  verifyFormat("void foo(int   name, // name\n"
+               "         float name, // name\n"
+               "         int   name) // name\n"
+               "{}",
+               Alignment);
+
   unsigned OldColumnLimit = Alignment.ColumnLimit;
   // We need to set ColumnLimit to zero, in order to stress nested alignments,
   // otherwise the function parameters will be re-flowed onto a single line.


### PR DESCRIPTION
before

```C++
void foo(int   name, // name
         float name, // name
         int   name)   // name
{}
```

after

```C++
void foo(int   name, // name
         float name, // name
         int   name) // name
{}
```

Fixes #85123.

As the bug report explained, the procedure for aligning the function parameters previously failed to update `StartOfTokenColumn`.