### PR TITLE
[libc] Add macros definitions for <nl_types.h>

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -776,6 +776,7 @@ add_header_macro(
   ../libc/include/nl_types.yaml
   nl_types.h
   DEPENDS
+    .llvm-libc-macros.nl_types_macros
     .llvm-libc-types.nl_catd
   )
 

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -346,6 +346,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  nl_types_macros
+  HDR
+    nl-types-macros.h
+)
+
+add_macro_header(
   pthread_macros
   HDR
     pthread-macros.h

--- a/libc/include/llvm-libc-macros/nl-types-macros.h
+++ b/libc/include/llvm-libc-macros/nl-types-macros.h
@@ -1,0 +1,16 @@
+//===-- Definition of macros from nl_types.h ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_NL_TYPES_MACROS_H
+#define LLVM_LIBC_MACROS_NL_TYPES_MACROS_H
+
+#define NL_SETD 1
+#define NL_CAT_LOCALE 1
+
+#endif // LLVM_LIBC_MACROS_NL_TYPES_MACROS_H
+

--- a/libc/include/llvm-libc-macros/nl-types-macros.h
+++ b/libc/include/llvm-libc-macros/nl-types-macros.h
@@ -13,4 +13,3 @@
 #define NL_CAT_LOCALE 1
 
 #endif // LLVM_LIBC_MACROS_NL_TYPES_MACROS_H
-

--- a/libc/include/nl_types.yaml
+++ b/libc/include/nl_types.yaml
@@ -1,7 +1,11 @@
 header: nl_types.h
 standards:
   - posix
-macros: []
+macros:
+  - macro_name: NL_SETD
+    macro_header: nl-types-macros.h
+  - macro_name: NL_CAT_LOCALE
+    macro_header: nl-types-macros.h
 types:
   - type_name: nl_catd
 enums: []

--- a/libc/test/src/nl_types/CMakeLists.txt
+++ b/libc/test/src/nl_types/CMakeLists.txt
@@ -7,6 +7,7 @@ add_libc_test(
   SRCS
     nl_types_test.cpp
   DEPENDS
+    libc.include.llvm-libc-macros.nl_types_macros
     libc.include.llvm-libc-types.nl_catd
     libc.src.nl_types.catopen
     libc.src.nl_types.catclose

--- a/libc/test/src/nl_types/nl_types_test.cpp
+++ b/libc/test/src/nl_types/nl_types_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-macros/nl-types-macros.h"
 #include "include/llvm-libc-types/nl_catd.h"
 #include "src/nl_types/catclose.h"
 #include "src/nl_types/catgets.h"
@@ -15,7 +16,7 @@
 using LlvmLibcNlTypesTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcNlTypesTest, CatopenFails) {
-  ASSERT_EQ(LIBC_NAMESPACE::catopen("/somepath", 0),
+  ASSERT_EQ(LIBC_NAMESPACE::catopen("/somepath", NL_CAT_LOCALE),
             reinterpret_cast<nl_catd>(-1));
   ASSERT_ERRNO_EQ(EINVAL);
 }
@@ -28,6 +29,6 @@ TEST_F(LlvmLibcNlTypesTest, CatgetsFails) {
   const char *message = "message";
   // Note that we test for pointer equality here, since catgets
   // is expected to return the input argument as-is.
-  ASSERT_EQ(LIBC_NAMESPACE::catgets(nullptr, 0, 0, message),
+  ASSERT_EQ(LIBC_NAMESPACE::catgets(nullptr, NL_SETD, 1, message),
             const_cast<char *>(message));
 }


### PR DESCRIPTION
This PR adds required macro definitions to `<nl_types.h>` header, so that they're available to the code including it.

The header itself was added in 12abe8aed6dc724546cf93c94d7ff6abe864f28b, together with stub definitions of the three required functions.
