### PR TITLE
[HIP] Hack around CMake incorrectly parsing OpenMP support in HIP mode

### DIFF
--- a/clang/test/Driver/hip-toolchain-no-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-no-rdc.hip
@@ -214,3 +214,10 @@
 // AMDGCNSPIRV: {{".*clang-offload-bundler.*"}} "-type=o"
 // AMDGCNSPIRV-SAME: "-targets={{.*}}hipv4-spirv64-amd-amdhsa--amdgcnspirv,hipv4-amdgcn-amd-amdhsa--gfx900"
 // AMDGCNSPIRV-SAME: "-input=[[AMDGCNSPV_CO]]" "-input=[[GFX900_CO]]"
+
+// Check verbose printing with the new driver.
+// RUN: %clang -### --target=x86_64-linux-gnu -fno-gpu-rdc -nogpulib -nogpuinc \
+// RUN:   --offload-new-driver --offload-arch=gfx908 -v %s 2>&1 | FileCheck %s --check-prefix=VERBOSE
+// VERBOSE: clang-linker-wrapper
+// VERBOSE-NOT: --device-compiler=amdgcn-amd-amdhsa=-v
+// VERBOSE-NOT: --wrapper-verbose


### PR DESCRIPTION
Summary:
The new driver uses an embedded clang job to handle the device
compilation. This correctly returns the linker as being `ld.lld`. The
CMake parser to detect things like OpenMP support in the linker will
parse the output of `-v` for the linker job. If the user is also using
LLD for their linker, it will think this job is the linker and then fail
as it does not see the required libraries. For these special HIP
compilations, just print the linker wrapper invocation and nothing else.
This will still show users the steps used to generate the binary but it
will hack around this issue.
