### PR TITLE
[CAS] Fix msan failure attempt 2

### DIFF
--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -45,7 +45,7 @@ inline HashType digest(StringRef Data) {
 }
 
 inline ValueType valueFromString(StringRef S) {
-  ValueType Val;
+  ValueType Val = {};
   llvm::copy(S.substr(0, sizeof(Val)), Val.data());
   return Val;
 }

--- a/llvm/unittests/CAS/OnDiskKeyValueDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskKeyValueDBTest.cpp
@@ -65,7 +65,7 @@ TEST_F(OnDiskCASTest, OnDiskKeyValueDBTest) {
     // Insert a lot of entries.
     for (unsigned I = 0; I < 1024 * 100; ++I) {
       std::string Index = Twine(I).str();
-      ArrayRef<char> Val;
+      std::optional<ArrayRef<char>> Val;
       ASSERT_THAT_ERROR(
           DB->put(digest(Index), valueFromString(Index)).moveInto(Val),
           Succeeded());


### PR DESCRIPTION
Try to fix msan error again. Previously, the error wasn't correctly
identified as the uninitialized value is in a different function than
the line crashed. Make sure value return from hash generating function
is fully zero initialized.
