### PR TITLE
[lldb] add a warning if `dirname` is not in the PATH

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -74,6 +74,15 @@ else()
   endif()
 endif()
 
+find_program(LLDB_DIRNAME_PATH dirname)
+if(LLDB_DIRNAME_PATH)
+  message(STATUS "Found dirname: ${LLDB_DIRNAME_PATH}")
+else()
+  message(STATUS "Did not find 'dirname'.")
+  message(WARNING
+        "Many LLDB API tests require the 'dirname' tool. Please provide it in Path.")
+endif()
+
 if (TARGET clang)
   set(LLDB_DEFAULT_TEST_COMPILER "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")
 else()

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -80,7 +80,8 @@ if(LLDB_DIRNAME_PATH)
 else()
   message(STATUS "Could NOT find 'dirname'")
   message(WARNING
-        "Many LLDB API tests require the 'dirname' tool. Please provide it in Path.")
+        "Many LLDB API tests require the GNU coreutils tools. Please make "
+        "sure they are installed and in PATH.")
 endif()
 
 if (TARGET clang)

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -78,7 +78,7 @@ find_program(LLDB_DIRNAME_PATH dirname)
 if(LLDB_DIRNAME_PATH)
   message(STATUS "Found dirname: ${LLDB_DIRNAME_PATH}")
 else()
-  message(STATUS "Did not find 'dirname'.")
+  message(STATUS "Could NOT find 'dirname'")
   message(WARNING
         "Many LLDB API tests require the 'dirname' tool. Please provide it in Path.")
 endif()


### PR DESCRIPTION
This patch adds a check in lldb's API test CMakeLists file to ensure that `dirname` is in the PATH, which is not obvious on Windows.