### PR TITLE
[flang] Adjust needless warning

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1781,7 +1781,7 @@ void CheckHelper::CheckExternal(const Symbol &symbol) {
         if (auto previousChars{Characterize(previous)}) {
           std::string whyNot;
           if (!chars->IsCompatibleWith(*previousChars,
-                  /*ignoreImplicitVsExplicit=*/false, &whyNot)) {
+                  /*ignoreImplicitVsExplicit=*/true, &whyNot)) {
             if (auto *msg{Warn(common::UsageWarning::ExternalInterfaceMismatch,
                     "The external interface '%s' is not compatible with an earlier definition (%s)"_warn_en_US,
                     symbol.name(), whyNot)}) {

--- a/flang/test/Semantics/bug1491.f90
+++ b/flang/test/Semantics/bug1491.f90
@@ -1,0 +1,21 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1 -Werror -pedantic
+module m
+  interface
+    integer function foo1()
+    end function
+    integer function foo2(j)
+    end function
+    integer function foo3()
+    end function
+  end interface
+end module
+
+subroutine test()
+  integer, external :: foo1
+!WARNING: The external interface 'foo2' is not compatible with an earlier definition (distinct numbers of dummy arguments) [-Wexternal-interface-mismatch]
+  integer, external :: foo2
+  integer, external :: foo3
+  call bar(foo1())
+  call bar(foo2())
+  call baz(foo3)
+end subroutine

--- a/flang/test/Semantics/null-init.f90
+++ b/flang/test/Semantics/null-init.f90
@@ -37,7 +37,7 @@ end module
 
 module m7
   interface
-    !WARNING: The external interface 'null' is not compatible with an earlier definition (incompatible procedure attributes: ImplicitInterface) [-Wexternal-interface-mismatch]
+    !WARNING: The external interface 'null' is not compatible with an earlier definition (function results have incompatible attributes) [-Wexternal-interface-mismatch]
     function null() result(p)
       integer, pointer :: p
     end function


### PR DESCRIPTION
When an external procedure has an explicit interface in one scope, and an implicit interface in another, and there's at least one call to it from which dummy argument information can be inferred, don't emit a warning about potential incompatibility if the only difference in their characteristics is that one of their interfaces was implicit.