### PR TITLE
[DAGCombiner] Relax nsz constraint with fp->int->fp optimizations

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -19094,12 +19094,13 @@ static SDValue foldFPToIntToFP(SDNode *N, const SDLoc &DL, SelectionDAG &DAG,
   bool IsSigned = N->getOpcode() == ISD::SINT_TO_FP;
   assert(IsSigned || IsUnsigned);
 
-  bool IsSignedZeroSafe = DAG.getTarget().Options.NoSignedZerosFPMath;
+  bool IsSignedZeroSafe = DAG.getTarget().Options.NoSignedZerosFPMath ||
+                          DAG.canIgnoreSignBitOfZero(SDValue(N, 0));
   // For signed conversions: The optimization changes signed zero behavior.
   if (IsSigned && !IsSignedZeroSafe)
     return SDValue();
   // For unsigned conversions, we need FABS to canonicalize -0.0 to +0.0
-  // (unless NoSignedZerosFPMath is set).
+  // (unless outputting a signed zero is OK).
   if (IsUnsigned && !IsSignedZeroSafe && !TLI.isFAbsFree(VT))
     return SDValue();
 

--- a/llvm/test/CodeGen/AArch64/fp-to-int-to-fp.ll
+++ b/llvm/test/CodeGen/AArch64/fp-to-int-to-fp.ll
@@ -250,6 +250,72 @@ entry:
 }
 
 
+define i1 @test_fcmp(float %x) {
+; CHECK-LABEL: test_fcmp:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    frintz s0, s0
+; CHECK-NEXT:    fcmp s0, #0.0
+; CHECK-NEXT:    cset w0, eq
+; CHECK-NEXT:    ret
+  %conv1 = fptosi float %x to i32
+  %conv2 = sitofp i32 %conv1 to float
+  %cmp = fcmp oeq float %conv2, 0.0
+  ret i1 %cmp
+}
+
+define float @test_fabs(float %x) {
+; CHECK-LABEL: test_fabs:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    frintz s0, s0
+; CHECK-NEXT:    fabs s0, s0
+; CHECK-NEXT:    ret
+  %conv1 = fptosi float %x to i32
+  %conv2 = sitofp i32 %conv1 to float
+  %abs = call float @llvm.fabs.f32(float %conv2)
+  ret float %abs
+}
+
+define float @test_copysign(float %x, float %y) {
+; CHECK-LABEL: test_copysign:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    frintz s0, s0
+; CHECK-NEXT:    mvni v2.4s, #128, lsl #24
+; CHECK-NEXT:    // kill: def $s1 killed $s1 def $q1
+; CHECK-NEXT:    bif v0.16b, v1.16b, v2.16b
+; CHECK-NEXT:    // kill: def $s0 killed $s0 killed $q0
+; CHECK-NEXT:    ret
+  %conv1 = fptosi float %x to i32
+  %conv2 = sitofp i32 %conv1 to float
+  %combine = call float @llvm.copysign.f32(float %conv2, float %y)
+  ret float %combine
+}
+
+define float @test_fadd(float %x) {
+; CHECK-LABEL: test_fadd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    frintz s0, s0
+; CHECK-NEXT:    fmov s1, #1.00000000
+; CHECK-NEXT:    fadd s0, s0, s1
+; CHECK-NEXT:    ret
+  %conv1 = fptosi float %x to i32
+  %conv2 = sitofp i32 %conv1 to float
+  %add = fadd float %conv2, 1.0
+  ret float %add
+}
+
+define float @test_fsub(float %x) {
+; CHECK-LABEL: test_fsub:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    frintz s0, s0
+; CHECK-NEXT:    fmov s1, #-1.00000000
+; CHECK-NEXT:    fadd s0, s0, s1
+; CHECK-NEXT:    ret
+  %conv1 = fptosi float %x to i32
+  %conv2 = sitofp i32 %conv1 to float
+  %sub = fsub float %conv2, 1.0
+  ret float %sub
+}
+
 declare i32 @llvm.smin.i32(i32, i32)
 declare i32 @llvm.smax.i32(i32, i32)
 declare i32 @llvm.umin.i32(i32, i32)
@@ -258,3 +324,5 @@ declare <4 x i32> @llvm.smin.v4i32(<4 x i32>, <4 x i32>)
 declare <4 x i32> @llvm.smax.v4i32(<4 x i32>, <4 x i32>)
 declare <4 x i32> @llvm.umin.v4i32(<4 x i32>, <4 x i32>)
 declare <4 x i32> @llvm.umax.v4i32(<4 x i32>, <4 x i32>)
+declare float @llvm.fabs.f32(float)
+declare float @llvm.copysign.f32(float, float)

--- a/llvm/test/CodeGen/X86/setoeq.ll
+++ b/llvm/test/CodeGen/X86/setoeq.ll
@@ -18,8 +18,7 @@ define zeroext i8 @oeq_f64_i32(double %x) nounwind readnone {
 ; AVX-LABEL: oeq_f64_i32:
 ; AVX:       # %bb.0: # %entry
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vcvttpd2dq %xmm0, %xmm1
-; AVX-NEXT:    vcvtdq2pd %xmm1, %xmm1
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX-NEXT:    vcmpeqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
@@ -29,8 +28,7 @@ define zeroext i8 @oeq_f64_i32(double %x) nounwind readnone {
 ; AVX512-LABEL: oeq_f64_i32:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttpd2dq %xmm0, %xmm1
-; AVX512-NEXT:    vcvtdq2pd %xmm1, %xmm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpeqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
@@ -67,16 +65,7 @@ define zeroext i8 @oeq_f64_u32(double %x) nounwind readnone {
 ; AVX-LABEL: oeq_f64_u32:
 ; AVX:       # %bb.0: # %entry
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vcvttsd2si %xmm0, %eax
-; AVX-NEXT:    movl %eax, %ecx
-; AVX-NEXT:    sarl $31, %ecx
-; AVX-NEXT:    vsubsd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm1
-; AVX-NEXT:    vcvttsd2si %xmm1, %edx
-; AVX-NEXT:    andl %ecx, %edx
-; AVX-NEXT:    orl %eax, %edx
-; AVX-NEXT:    vmovd %edx, %xmm1
-; AVX-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}, %xmm1, %xmm1
-; AVX-NEXT:    vsubsd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm1, %xmm1
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX-NEXT:    vcmpeqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
@@ -86,8 +75,7 @@ define zeroext i8 @oeq_f64_u32(double %x) nounwind readnone {
 ; AVX512-LABEL: oeq_f64_u32:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttsd2usi %xmm0, %eax
-; AVX512-NEXT:    vcvtusi2sd %eax, %xmm7, %xmm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpeqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
@@ -131,35 +119,21 @@ define zeroext i8 @oeq_f64_i64(double %x) nounwind readnone {
 ;
 ; AVX-LABEL: oeq_f64_i64:
 ; AVX:       # %bb.0: # %entry
-; AVX-NEXT:    pushl %ebp
-; AVX-NEXT:    movl %esp, %ebp
-; AVX-NEXT:    andl $-8, %esp
-; AVX-NEXT:    subl $24, %esp
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vmovsd %xmm0, (%esp)
-; AVX-NEXT:    fldl (%esp)
-; AVX-NEXT:    fisttpll (%esp)
-; AVX-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
-; AVX-NEXT:    vmovlps %xmm1, {{[0-9]+}}(%esp)
-; AVX-NEXT:    fildll {{[0-9]+}}(%esp)
-; AVX-NEXT:    fstpl {{[0-9]+}}(%esp)
-; AVX-NEXT:    vcmpeqsd {{[0-9]+}}(%esp), %xmm0, %xmm0
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
+; AVX-NEXT:    vcmpeqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
 ; AVX-NEXT:    # kill: def $al killed $al killed $eax
-; AVX-NEXT:    movl %ebp, %esp
-; AVX-NEXT:    popl %ebp
 ; AVX-NEXT:    retl
 ;
 ; AVX512-LABEL: oeq_f64_i64:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttpd2qq %xmm0, %xmm1
-; AVX512-NEXT:    vcvtqq2pd %ymm1, %ymm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpeqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
-; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retl
 entry:
 	%0 = fptosi double %x to i64
@@ -216,48 +190,21 @@ define zeroext i8 @oeq_f64_u64(double %x) nounwind readnone {
 ;
 ; AVX-LABEL: oeq_f64_u64:
 ; AVX:       # %bb.0: # %entry
-; AVX-NEXT:    pushl %ebp
-; AVX-NEXT:    movl %esp, %ebp
-; AVX-NEXT:    andl $-8, %esp
-; AVX-NEXT:    subl $8, %esp
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vmovsd {{.*#+}} xmm1 = [9.2233720368547758E+18,0.0E+0]
-; AVX-NEXT:    vucomisd %xmm0, %xmm1
-; AVX-NEXT:    jbe .LBB3_2
-; AVX-NEXT:  # %bb.1: # %entry
-; AVX-NEXT:    vxorpd %xmm1, %xmm1, %xmm1
-; AVX-NEXT:  .LBB3_2: # %entry
-; AVX-NEXT:    vsubsd %xmm1, %xmm0, %xmm1
-; AVX-NEXT:    vmovsd %xmm1, (%esp)
-; AVX-NEXT:    fldl (%esp)
-; AVX-NEXT:    fisttpll (%esp)
-; AVX-NEXT:    setbe %al
-; AVX-NEXT:    movzbl %al, %eax
-; AVX-NEXT:    shll $31, %eax
-; AVX-NEXT:    xorl {{[0-9]+}}(%esp), %eax
-; AVX-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
-; AVX-NEXT:    vpinsrd $1, %eax, %xmm1, %xmm1
-; AVX-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],mem[0],xmm1[1],mem[1]
-; AVX-NEXT:    vsubpd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm1, %xmm1
-; AVX-NEXT:    vshufpd {{.*#+}} xmm2 = xmm1[1,0]
-; AVX-NEXT:    vaddsd %xmm1, %xmm2, %xmm1
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX-NEXT:    vcmpeqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
 ; AVX-NEXT:    # kill: def $al killed $al killed $eax
-; AVX-NEXT:    movl %ebp, %esp
-; AVX-NEXT:    popl %ebp
 ; AVX-NEXT:    retl
 ;
 ; AVX512-LABEL: oeq_f64_u64:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttpd2uqq %xmm0, %xmm1
-; AVX512-NEXT:    vcvtuqq2pd %ymm1, %ymm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpeqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
-; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retl
 entry:
 	%0 = fptoui double %x to i64
@@ -282,8 +229,7 @@ define zeroext i8 @une_f64_i32(double %x) nounwind readnone {
 ; AVX-LABEL: une_f64_i32:
 ; AVX:       # %bb.0: # %entry
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vcvttpd2dq %xmm0, %xmm1
-; AVX-NEXT:    vcvtdq2pd %xmm1, %xmm1
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX-NEXT:    vcmpneqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
@@ -293,8 +239,7 @@ define zeroext i8 @une_f64_i32(double %x) nounwind readnone {
 ; AVX512-LABEL: une_f64_i32:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttpd2dq %xmm0, %xmm1
-; AVX512-NEXT:    vcvtdq2pd %xmm1, %xmm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpneqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
@@ -331,16 +276,7 @@ define zeroext i8 @une_f64_u32(double %x) nounwind readnone {
 ; AVX-LABEL: une_f64_u32:
 ; AVX:       # %bb.0: # %entry
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vcvttsd2si %xmm0, %eax
-; AVX-NEXT:    movl %eax, %ecx
-; AVX-NEXT:    sarl $31, %ecx
-; AVX-NEXT:    vsubsd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm1
-; AVX-NEXT:    vcvttsd2si %xmm1, %edx
-; AVX-NEXT:    andl %ecx, %edx
-; AVX-NEXT:    orl %eax, %edx
-; AVX-NEXT:    vmovd %edx, %xmm1
-; AVX-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}, %xmm1, %xmm1
-; AVX-NEXT:    vsubsd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm1, %xmm1
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX-NEXT:    vcmpneqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
@@ -350,8 +286,7 @@ define zeroext i8 @une_f64_u32(double %x) nounwind readnone {
 ; AVX512-LABEL: une_f64_u32:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttsd2usi %xmm0, %eax
-; AVX512-NEXT:    vcvtusi2sd %eax, %xmm7, %xmm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpneqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
@@ -395,35 +330,21 @@ define zeroext i8 @une_f64_i64(double %x) nounwind readnone {
 ;
 ; AVX-LABEL: une_f64_i64:
 ; AVX:       # %bb.0: # %entry
-; AVX-NEXT:    pushl %ebp
-; AVX-NEXT:    movl %esp, %ebp
-; AVX-NEXT:    andl $-8, %esp
-; AVX-NEXT:    subl $24, %esp
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vmovsd %xmm0, (%esp)
-; AVX-NEXT:    fldl (%esp)
-; AVX-NEXT:    fisttpll (%esp)
-; AVX-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
-; AVX-NEXT:    vmovlps %xmm1, {{[0-9]+}}(%esp)
-; AVX-NEXT:    fildll {{[0-9]+}}(%esp)
-; AVX-NEXT:    fstpl {{[0-9]+}}(%esp)
-; AVX-NEXT:    vcmpneqsd {{[0-9]+}}(%esp), %xmm0, %xmm0
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
+; AVX-NEXT:    vcmpneqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
 ; AVX-NEXT:    # kill: def $al killed $al killed $eax
-; AVX-NEXT:    movl %ebp, %esp
-; AVX-NEXT:    popl %ebp
 ; AVX-NEXT:    retl
 ;
 ; AVX512-LABEL: une_f64_i64:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttpd2qq %xmm0, %xmm1
-; AVX512-NEXT:    vcvtqq2pd %ymm1, %ymm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpneqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
-; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retl
 entry:
 	%0 = fptosi double %x to i64
@@ -480,48 +401,21 @@ define zeroext i8 @une_f64_u64(double %x) nounwind readnone {
 ;
 ; AVX-LABEL: une_f64_u64:
 ; AVX:       # %bb.0: # %entry
-; AVX-NEXT:    pushl %ebp
-; AVX-NEXT:    movl %esp, %ebp
-; AVX-NEXT:    andl $-8, %esp
-; AVX-NEXT:    subl $8, %esp
 ; AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX-NEXT:    vmovsd {{.*#+}} xmm1 = [9.2233720368547758E+18,0.0E+0]
-; AVX-NEXT:    vucomisd %xmm0, %xmm1
-; AVX-NEXT:    jbe .LBB7_2
-; AVX-NEXT:  # %bb.1: # %entry
-; AVX-NEXT:    vxorpd %xmm1, %xmm1, %xmm1
-; AVX-NEXT:  .LBB7_2: # %entry
-; AVX-NEXT:    vsubsd %xmm1, %xmm0, %xmm1
-; AVX-NEXT:    vmovsd %xmm1, (%esp)
-; AVX-NEXT:    fldl (%esp)
-; AVX-NEXT:    fisttpll (%esp)
-; AVX-NEXT:    setbe %al
-; AVX-NEXT:    movzbl %al, %eax
-; AVX-NEXT:    shll $31, %eax
-; AVX-NEXT:    xorl {{[0-9]+}}(%esp), %eax
-; AVX-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
-; AVX-NEXT:    vpinsrd $1, %eax, %xmm1, %xmm1
-; AVX-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],mem[0],xmm1[1],mem[1]
-; AVX-NEXT:    vsubpd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm1, %xmm1
-; AVX-NEXT:    vshufpd {{.*#+}} xmm2 = xmm1[1,0]
-; AVX-NEXT:    vaddsd %xmm1, %xmm2, %xmm1
+; AVX-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX-NEXT:    vcmpneqsd %xmm0, %xmm1, %xmm0
 ; AVX-NEXT:    vmovd %xmm0, %eax
 ; AVX-NEXT:    andl $1, %eax
 ; AVX-NEXT:    # kill: def $al killed $al killed $eax
-; AVX-NEXT:    movl %ebp, %esp
-; AVX-NEXT:    popl %ebp
 ; AVX-NEXT:    retl
 ;
 ; AVX512-LABEL: une_f64_u64:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
-; AVX512-NEXT:    vcvttpd2uqq %xmm0, %xmm1
-; AVX512-NEXT:    vcvtuqq2pd %ymm1, %ymm1
+; AVX512-NEXT:    vroundsd $11, %xmm0, %xmm0, %xmm1
 ; AVX512-NEXT:    vcmpneqsd %xmm0, %xmm1, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
-; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retl
 entry:
 	%0 = fptoui double %x to i64


### PR DESCRIPTION
`NoSignedZerosFPMath` isn't a hard requirements and in some contexts we can still apply the truncation without worrying. For example, in cases where the users of this sequence are overwriting the sign-bit (fabs) or simply ignoring it (fcmp).
I think the same logic can be applied elsewhere for other DAG optimizations.

Based on top of https://github.com/llvm/llvm-project/pull/164502.