### PR TITLE
[PAC][clang] Do not attempt to get definition of non-instantiated template

### DIFF
--- a/clang/test/SemaCXX/ptrauth-template-instantiation-aborted.cpp
+++ b/clang/test/SemaCXX/ptrauth-template-instantiation-aborted.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -fptrauth-intrinsics -fsyntax-only -ferror-limit 1 -verify -std=c++03 %s
+
+/// Force two errors so we hit the error limit leading to skip of template instantiation
+# "" // expected-error {{invalid preprocessing directive}}
+# ""
+// expected-error@* {{too many errors emitted}}
+
+template <typename>
+struct a {};
+
+struct b {
+  b(int) {}
+  void c() {
+    /// Trigger the following call stack:
+    ///   ...
+    ///   clang::ASTContext::findPointerAuthContent(clang::QualType) const /path/to/llvm-project/clang/lib/AST/ASTContext.cpp
+    ///   clang::ASTContext::containsAddressDiscriminatedPointerAuth(clang::QualType) const /path/to/llvm-project/clang/lib/AST/ASTContext.cpp
+    ///   clang::QualType::isCXX{11|98}PODType(clang::ASTContext const&) const /path/to/llvm-project/clang/lib/AST/Type.cpp
+    ///   clang::QualType::isPODType(clang::ASTContext const&) const /path/to/llvm-project/clang/lib/AST/Type.cpp
+    ///   SelfReferenceChecker /path/to/llvm-project/clang/lib/Sema/SemaDecl.cpp
+    ///   CheckSelfReference /path/to/llvm-project/clang/lib/Sema/SemaDecl.cpp
+    ///   clang::Sema::AddInitializerToDecl(clang::Decl*, clang::Expr*, bool) /path/to/llvm-project/clang/lib/Sema/SemaDecl.cpp
+    ///   ...
+    b d(0);
+  }
+  a<int> e;
+};
+


### PR DESCRIPTION
This patch fixes a crash which we hit after #154490. The reproducer is provided in a test case.

The root cause of the crash is as follows.
`primaryBaseHasAddressDiscriminatedVTableAuthentication` requires a non-null CXX record decl definition which might not be available if we are dealing with a non-instantiated template. It might be the case if the template was not instantiated due to a prior fatal error. See the corresponding check in the `Sema::InstantiatingTemplate` constructor.

Previously, we tried to call `isPolymorphic()` on a `CXXRecordDecl` with null `DefinitionData`, which led to a crash. With this patch, we abort execution of `ASTContext::findPointerAuthContent` before call to `primaryBaseHasAddressDiscriminatedVTableAuthentication` if we have a prior fatal error which might have led to non-instantiated templates.