### PR TITLE
[clang] OpenMP: fix variant template mismatch crash

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -7246,7 +7246,9 @@ void SemaOpenMP::ActOnStartOfFunctionDefinitionInOpenMPDeclareVariantScope(
     FunctionDecl *UDecl = nullptr;
     if (IsTemplated && isa<FunctionTemplateDecl>(CandidateDecl)) {
       auto *FTD = cast<FunctionTemplateDecl>(CandidateDecl);
-      if (FTD->getTemplateParameters()->size() == TemplateParamLists.size())
+      // FIXME: Should this compare the template parameter lists on all levels?
+      if (SemaRef.Context.isSameTemplateParameterList(
+              FTD->getTemplateParameters(), TemplateParamLists.back()))
         UDecl = FTD->getTemplatedDecl();
     } else if (!IsTemplated)
       UDecl = dyn_cast<FunctionDecl>(CandidateDecl);

--- a/clang/test/SemaOpenMP/openmp-begin-declare-variant_template.cpp
+++ b/clang/test/SemaOpenMP/openmp-begin-declare-variant_template.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple x86_64 -fopenmp -verify %s
+
+// FIXME: Is this supposed to work?
+
+#pragma omp begin declare variant match(implementation={extension(allow_templates)})
+template <class T> void f(T) {}
+// expected-note@-1 {{explicit instantiation refers here}}
+#pragma end
+template <int> struct A {};
+template <bool B> A<B> f() = delete;
+template void f<float>(float);
+// expected-error@-1 {{explicit instantiation of undefined function template 'f'}}


### PR DESCRIPTION
This ammends the fix commited in https://reviews.llvm.org/D109770 / 6cf6fa6ef1c28

Comparing the number of template parameter lists with the number of template parameters is obviously wrong.

Even then, the number of parameters being the same doesn't mean the templates are compatible.

This change compares if the template parameters are actually equivalent.

This fixes the crash, but I am not sure what is the design and intention here, this openmp template support looks too fragile.

The added test case still doesn't work, but at least we don't crash now.