### PR TITLE
[llvm-remarkutil] filter: Ignore whitespace in test

### DIFF
--- a/llvm/test/tools/llvm-remarkutil/filter.test
+++ b/llvm/test/tools/llvm-remarkutil/filter.test
@@ -1,8 +1,8 @@
-RUN: llvm-remarkutil filter %p/Inputs/filter.yaml | diff %p/Inputs/filter.yaml -
-RUN: llvm-remarkutil filter --rfunction=func %p/Inputs/filter.yaml | diff %p/Inputs/filter.yaml -
-RUN: llvm-remarkutil filter --rremark-name=Remark %p/Inputs/filter.yaml | diff %p/Inputs/filter.yaml -
-RUN: llvm-remarkutil filter --rpass-name=pass %p/Inputs/filter.yaml | diff %p/Inputs/filter.yaml -
-RUN: llvm-remarkutil filter --rfilter-arg-by=argval %p/Inputs/filter.yaml | diff %p/Inputs/filter.yaml -
+RUN: llvm-remarkutil filter %p/Inputs/filter.yaml | diff -w %p/Inputs/filter.yaml -
+RUN: llvm-remarkutil filter --rfunction=func %p/Inputs/filter.yaml | diff -w %p/Inputs/filter.yaml -
+RUN: llvm-remarkutil filter --rremark-name=Remark %p/Inputs/filter.yaml | diff -w %p/Inputs/filter.yaml -
+RUN: llvm-remarkutil filter --rpass-name=pass %p/Inputs/filter.yaml | diff -w %p/Inputs/filter.yaml -
+RUN: llvm-remarkutil filter --rfilter-arg-by=argval %p/Inputs/filter.yaml | diff -w %p/Inputs/filter.yaml -
 
 RUN: llvm-remarkutil filter --rfunction=unc1 %p/Inputs/filter.yaml | FileCheck %s --strict-whitespace --check-prefix=REMARK1
 RUN: llvm-remarkutil filter --rremark-name=ark3 %p/Inputs/filter.yaml | FileCheck %s --strict-whitespace --check-prefix=REMARK3


### PR DESCRIPTION
On Windows, the YAML files may or may not be in CRLF format, which can
cause `diff` to fail. Thus, ignore whitespace to make this more robust.
