### PR TITLE
[CI][Github] Install Clang in Windows container

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -100,7 +100,7 @@ RUN powershell -Command \
     rm actions-runner-win.zip
 
 # Set the LLVM_VERSION environment variable
-RUN powershell -Command [Environment]::SetEnvironmentVariable('LLVM_VERSION', '21.1.2', 'Machine')
+ENV LLVM_VERSION=21.1.2
 
 # Download and extract Clang compiler.
 # Create directories, download, extract, and clean up all in one layer

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -98,3 +98,37 @@ RUN powershell -Command \
     Add-Type -AssemblyName System.IO.Compression.FileSystem ; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('actions-runner-win.zip', $PWD) ;\
     rm actions-runner-win.zip
+
+# Download and extract Clang compiler.
+# Create directories, download, extract, and clean up all in one layer
+RUN powershell -Command \
+    # --- Setup directories --- \
+    Write-Host "Creating directories..."; \
+    New-Item -Path "C:\temp-download" -ItemType "Directory" -Force ; \
+    New-Item -Path "C:\xz-utils" -ItemType "Directory" -Force ; \
+    New-Item -Path "C:\clang" -ItemType "Directory" -Force ; \
+    # --- 1. Download and extract xz --- \
+    Set-Location C:\temp-download ; \
+    Write-Host "Downloading xz-utils..."; \
+    Invoke-WebRequest -Uri "http://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip" -OutFile "xz.zip"; \
+    Write-Host "Extracting xz-utils..."; \
+    Add-Type -AssemblyName "System.IO.Compression.FileSystem"; \
+    [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\temp-download\xz.zip', 'C:\xz-utils'); \ 
+    # --- 2. Download and decompress Clang --- \
+    Write-Host "Downloading Clang..."; \
+    Invoke-WebRequest -Uri "http://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.2/clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" -OutFile "clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" ; \
+    Write-Host "Decompressing clang.tar.xz using C:\xz-utils\bin_x86-64\xz.exe"; \
+    C:\xz-utils\bin_x86-64\xz.exe -d -qq clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz ; \
+    # --- 3. Extract clang --- \
+    Write-Host "Extracting clang.tar to C:\clang ..."; \
+    C:\Windows\System32\tar.exe -xf clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar -C C:\clang ; \
+    # --- 4. Clean up --- \
+    Write-Host "Cleaning up..." ; \
+    Set-Location C:\ ; \
+    Remove-Item C:\temp-download -Recurse -Force; \
+    Remove-Item C:\xz-utils -Recurse -Force; \
+    Write-Host "Download and extraction complete." ;
+
+RUN powershell -Command \
+    Set-Location C:\clang ; \
+    Rename-Item -Path "C:\clang\clang+llvm-21.1.2-x86_64-pc-windows-msvc" -NewName "C:\clang\clang-msvc" ;

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -124,9 +124,7 @@ RUN powershell -Command \
     Set-Location C:\ ; \
     Remove-Item C:\temp-download -Recurse -Force; \
     Remove-Item C:\xz-utils -Recurse -Force; \
-
-# Shorten path to clang files.
-RUN powershell -Command \
+    # -- 5. Shorten path to clang files & remove unnecessary files -- \
     Set-Location C:\clang ; \
     Rename-Item -Path "C:\clang\clang+llvm-21.1.2-x86_64-pc-windows-msvc" -NewName "C:\clang\clang-msvc" ; \
     Set-Location C:\clang\clang-msvc ; \

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -99,6 +99,9 @@ RUN powershell -Command \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('actions-runner-win.zip', $PWD) ;\
     rm actions-runner-win.zip
 
+# Set the LLVM_VERSION environment variable
+RUN powershell -Command [Environment]::SetEnvironmentVariable('LLVM_VERSION', '21.1.2', 'Machine')
+
 # Download and extract Clang compiler.
 # Create directories, download, extract, and clean up all in one layer
 RUN powershell -Command \
@@ -109,26 +112,31 @@ RUN powershell -Command \
     New-Item -Path "C:\clang" -ItemType "Directory" -Force ; \
     # --- 1. Download and extract xz --- \
     Set-Location C:\temp-download ; \
-    Write-Host "Downloading xz-utils..."; \
     Invoke-WebRequest -Uri "http://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip" -OutFile "xz.zip"; \
-    Write-Host "Extracting xz-utils..."; \
     Add-Type -AssemblyName "System.IO.Compression.FileSystem"; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\temp-download\xz.zip', 'C:\xz-utils'); \ 
     # --- 2. Download and decompress Clang --- \
-    Write-Host "Downloading Clang..."; \
     Invoke-WebRequest -Uri "http://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.2/clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" -OutFile "clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" ; \
-    Write-Host "Decompressing clang.tar.xz using C:\xz-utils\bin_x86-64\xz.exe"; \
     C:\xz-utils\bin_x86-64\xz.exe -d -qq clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz ; \
     # --- 3. Extract clang --- \
-    Write-Host "Extracting clang.tar to C:\clang ..."; \
     C:\Windows\System32\tar.exe -xf clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar -C C:\clang ; \
     # --- 4. Clean up --- \
-    Write-Host "Cleaning up..." ; \
     Set-Location C:\ ; \
     Remove-Item C:\temp-download -Recurse -Force; \
     Remove-Item C:\xz-utils -Recurse -Force; \
-    Write-Host "Download and extraction complete." ;
 
+# Shorten path to clang files.
 RUN powershell -Command \
     Set-Location C:\clang ; \
-    Rename-Item -Path "C:\clang\clang+llvm-21.1.2-x86_64-pc-windows-msvc" -NewName "C:\clang\clang-msvc" ;
+    Rename-Item -Path "C:\clang\clang+llvm-21.1.2-x86_64-pc-windows-msvc" -NewName "C:\clang\clang-msvc" ; \
+    Set-Location C:\clang\clang-msvc ; \
+    Remove-Item -Path C:\clang\clang-msvc\libexec -Recurse -Force ; \
+    Remove-Item -Path C:\clang\clang-msvc\share -Recurse -Force ; \
+    Rename-Item -Path "C:\clang\clang-msvc\bin" -NewName "C:\clang\clang-msvc\bin-full" ; \
+    New-Item -Path "C:\clang\clang-msvc\bin" -ItemType Directory -Force ; \
+    Set-Location C:\clang\clang-msvc\bin ; \
+    Copy-Item -Path C:\clang\clang-msvc\bin-full\*.dll -Destination C:\clang\clang-msvc\bin\. ; \
+    Copy-Item -Path C:\clang\clang-msvc\bin-full\clang-cl.exe -Destination C:\clang\clang-msvc\bin\. ; \
+    Copy-Item -Path C:\clang\clang-msvc\bin-full\lld-link.exe -Destination C:\clang\clang-msvc\bin\. ; \
+    Set-Location C:\clang\clang-msvc ; \
+    Remove-Item -Path C:\clang\clang-msvc\bin-full -Recurse -Force ;

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -113,10 +113,12 @@ RUN powershell -Command \
     # --- 1. Download and extract xz --- \
     Set-Location C:\temp-download ; \
     Invoke-WebRequest -Uri "http://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip" -OutFile "xz.zip"; \
+    (Get-FileHash -Path "C:\temp-download\xz.zip" -Algorithm MD5).Hash -eq 'c3c69fdce3e825cc0b76123b36b0bcc2' ; \
     Add-Type -AssemblyName "System.IO.Compression.FileSystem"; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\temp-download\xz.zip', 'C:\xz-utils'); \ 
     # --- 2. Download and decompress Clang --- \
     Invoke-WebRequest -Uri "http://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.2/clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" -OutFile "clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" ; \
+    (Get-FileHash -Path "C:\temp-download\clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" -Algorithm MD5).Hash -eq '0ae1d3effd9ab9d323f7fa595777f0a2' ; \
     C:\xz-utils\bin_x86-64\xz.exe -d -qq clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz ; \
     # --- 3. Extract clang --- \
     C:\Windows\System32\tar.exe -xf clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar -C C:\clang ; \


### PR DESCRIPTION
Downloads clang-for-windows from the LLVM releases website, decompresses and untars the images, and leave them in C:\clang\clang-msvc\...  Temporarily downloads the 'xz' utility to decompress the downloaded clang tarball image.