### PR TITLE
[NFC][SampleFDO] Use const& to avoid copies

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1072,7 +1072,7 @@ public:
     TypeCountMap &TypeCounts = getTypeSamplesAt(Loc);
     bool Overflowed = false;
 
-    for (const auto [Type, Count] : Other) {
+    for (const auto &[Type, Count] : Other) {
       FunctionId TypeId(Type);
       bool RowOverflow = false;
       TypeCounts[TypeId] = SaturatingMultiplyAdd(


### PR DESCRIPTION
Use const& in range-based for loop to avoid unnecessary copies