### PR TITLE
[compiler-rt] Fix building for arm64ec

### DIFF
--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -337,7 +337,8 @@
 #endif
 #endif
 
-#if defined(__ASSEMBLER__) && (defined(__i386__) || defined(__amd64__)) && !defined(__arm64ec__)
+#if defined(__ASSEMBLER__) && (defined(__i386__) || defined(__amd64__)) &&     \
+    !defined(__arm64ec__)
 .att_syntax
 #endif
 

--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -337,7 +337,7 @@
 #endif
 #endif
 
-#if defined(__ASSEMBLER__) && (defined(__i386__) || defined(__amd64__))
+#if defined(__ASSEMBLER__) && (defined(__i386__) || defined(__amd64__)) && !defined(__arm64ec__)
 .att_syntax
 #endif
 


### PR DESCRIPTION
c208a23643231d0b19c6f795895a16dfe6797340 added the directive `.att_syntax` when building for x86 architectures. However, when building for arm64ec (a Windows target, for an ABI compatible with x86_64), the defines for `__x86_64__` (and similar ones like `__amd64__`) are still defined, so we need to check for `__arm64ec__` here as well to skip it for such targets.

This matches similar existing ifdefs for x86_64/aarch64 in compiler-rt builtins.