### PR TITLE
[GlobalISel] Update the documentation of abd.

### DIFF
--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -504,7 +504,7 @@ undefined.
 G_ABDS, G_ABDU
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Compute the absolute difference (signed and unsigned), e.g. abs(x-y).
+Compute the absolute difference (signed and unsigned), e.g. trunc(abs(ext(x)-ext(y)).
 
 .. code-block:: none
 


### PR DESCRIPTION
The abd nodes do not perform the same as abs(x-y), although they are often mistaken to do so. They extend into a larger bit size before performing the sub / abs and so produce different results. Update the description of the instruction to avoid misunderstandings.