### PR TITLE
[libcxx] Fix freestanding build with filesystem disabled on Windows

### DIFF
--- a/libcxx/src/CMakeLists.txt
+++ b/libcxx/src/CMakeLists.txt
@@ -9,10 +9,7 @@ set(LIBCXX_SOURCES
   error_category.cpp
   exception.cpp
   expected.cpp
-  filesystem/filesystem_clock.cpp
-  filesystem/filesystem_error.cpp
   filesystem/path_parser.h
-  filesystem/path.cpp
   functional.cpp
   hash.cpp
   include/apple_availability.h
@@ -117,6 +114,9 @@ endif()
 
 if (LIBCXX_ENABLE_FILESYSTEM)
   list(APPEND LIBCXX_SOURCES
+    filesystem/filesystem_clock.cpp
+    filesystem/filesystem_error.cpp
+    filesystem/path.cpp
     filesystem/directory_entry.cpp
     filesystem/directory_iterator.cpp
     filesystem/file_descriptor.h

--- a/libcxx/src/print.cpp
+++ b/libcxx/src/print.cpp
@@ -13,8 +13,6 @@
 
 #include <__system_error/system_error.h>
 
-#include "filesystem/error.h"
-
 #if defined(_LIBCPP_WIN32API)
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
@@ -51,7 +49,11 @@ __write_to_windows_console([[maybe_unused]] FILE* __stream, [[maybe_unused]] wst
                     __view.size(),
                     nullptr,
                     nullptr) == 0) {
+#    if _LIBCPP_HAS_FILESYSTEM
     std::__throw_system_error(filesystem::detail::get_last_error(), "failed to write formatted output");
+#    else
+    std::__throw_system_error(error_code(GetLastError(), system_category()), "failed to write formatted output");
+#    endif
   }
 }
 #  endif // _LIBCPP_HAS_WIDE_CHARACTERS


### PR DESCRIPTION
Building libc++ for freestanding targets on Windows with LIBCXX_ENABLE_FILESYSTEM=OFF fails due to compilation errors.

The root cause is twofold:
1. path.cpp and filesystem_error.cpp are compiled even when filesystem is disabled. These files depend on wide character and localization support, which freestanding builds typically don't provide.
2. print.cpp transitively depends on filesystem headers for Windows error reporting, pulling in <filesystem> even when the feature is disabled.

This patch fixes both problems by:
- Guarding filesystem sources in src/CMakeLists.txt with LIBCXX_ENABLE_FILESYSTEM
- Making print.cpp call GetLastError() directly when filesystem support is unavailable

Fixes #164074