### PR TITLE
[SupportLSP] Add ShowMessageParams

### DIFF
--- a/llvm/include/llvm/Support/LSP/Protocol.h
+++ b/llvm/include/llvm/Support/LSP/Protocol.h
@@ -1244,6 +1244,23 @@ struct CodeAction {
 /// Add support for JSON serialization.
 llvm::json::Value toJSON(const CodeAction &);
 
+//===----------------------------------------------------------------------===//
+//  ShowMessageParams
+//===----------------------------------------------------------------------===//
+
+enum class MessageType { Error = 1, Warning = 2, Info = 3, Log = 4, Debug = 5 };
+
+struct ShowMessageParams {
+  ShowMessageParams(MessageType Type, std::string Message)
+      : type(Type), message(Message) {}
+  MessageType type;
+  /// The actual message.
+  std::string message;
+};
+
+/// Add support for JSON serialization.
+llvm::json::Value toJSON(const ShowMessageParams &Params);
+
 } // namespace lsp
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/LSP/Protocol.h
+++ b/llvm/include/llvm/Support/LSP/Protocol.h
@@ -1250,13 +1250,23 @@ llvm::json::Value toJSON(const CodeAction &);
 
 enum class MessageType { Error = 1, Warning = 2, Info = 3, Log = 4, Debug = 5 };
 
+struct MessageActionItem {
+  /// A short title like 'Retry', 'Open Log' etc.
+  std::string title;
+};
+
 struct ShowMessageParams {
   ShowMessageParams(MessageType Type, std::string Message)
       : type(Type), message(Message) {}
   MessageType type;
   /// The actual message.
   std::string message;
+  /// The message action items to present.
+  std::optional<std::vector<MessageActionItem>> actions;
 };
+
+/// Add support for JSON serialization.
+llvm::json::Value toJSON(const MessageActionItem &Params);
 
 /// Add support for JSON serialization.
 llvm::json::Value toJSON(const ShowMessageParams &Params);

--- a/llvm/lib/Support/LSP/Protocol.cpp
+++ b/llvm/lib/Support/LSP/Protocol.cpp
@@ -1041,3 +1041,14 @@ llvm::json::Value llvm::lsp::toJSON(const CodeAction &Value) {
     CodeAction["edit"] = *Value.edit;
   return std::move(CodeAction);
 }
+
+//===----------------------------------------------------------------------===//
+// ShowMessageParams
+//===----------------------------------------------------------------------===//
+
+llvm::json::Value llvm::lsp::toJSON(const ShowMessageParams &Params) {
+  return llvm::json::Object{
+      {"type", static_cast<int>(Params.type)},
+      {"message", Params.message},
+  };
+}

--- a/llvm/lib/Support/LSP/Protocol.cpp
+++ b/llvm/lib/Support/LSP/Protocol.cpp
@@ -1047,8 +1047,15 @@ llvm::json::Value llvm::lsp::toJSON(const CodeAction &Value) {
 //===----------------------------------------------------------------------===//
 
 llvm::json::Value llvm::lsp::toJSON(const ShowMessageParams &Params) {
-  return llvm::json::Object{
+  auto Out = llvm::json::Object{
       {"type", static_cast<int>(Params.type)},
       {"message", Params.message},
   };
+  if (Params.actions)
+    Out["actions"] = *Params.actions;
+  return Out;
+}
+
+llvm::json::Value llvm::lsp::toJSON(const MessageActionItem &Params) {
+  return llvm::json::Object{{"title", Params.title}};
 }


### PR DESCRIPTION
Adds ShowMessageParams to LSP support according to the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#showMessageRequestParams).
