### PR TITLE
[mlir][IR] Deprecate `OpBuilder::create` in favor of free functions

### DIFF
--- a/mlir/include/mlir/IR/Builders.h
+++ b/mlir/include/mlir/IR/Builders.h
@@ -502,6 +502,7 @@ private:
 public:
   /// Create an operation of specific op type at the current insertion point.
   template <typename OpTy, typename... Args>
+  [[deprecated("Use OpTy::create instead")]]
   OpTy create(Location location, Args &&...args) {
     OperationState state(location,
                          getCheckRegisteredInfo<OpTy>(location.getContext()));
@@ -517,9 +518,9 @@ public:
   /// the results of the operation.
   ///
   /// Note: This performs opportunistic eager folding during IR construction.
-  /// The folders are designed to operate efficiently on canonical IR, which 
+  /// The folders are designed to operate efficiently on canonical IR, which
   /// this API does not enforce. Complete folding isn't only expected in the
-  /// context of canonicalization which intertwine folders with pattern 
+  /// context of canonicalization which intertwine folders with pattern
   /// rewrites until fixed-point.
   template <typename OpTy, typename... Args>
   void createOrFold(SmallVectorImpl<Value> &results, Location location,


### PR DESCRIPTION
These have been soft-deprecated since July: https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339

Add a deprecation attribute to prevent new uses from creeping in.