### PR TITLE
[libc] Fix a couple issues in <wchar.h> header

### DIFF
--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -4,6 +4,7 @@ macros:
   - macro_name: NULL
     macro_header: null-macro.h
 types:
+  - type_name: FILE
   - type_name: size_t
   - type_name: wint_t
   - type_name: wchar_t
@@ -104,9 +105,9 @@ functions:
   - name: wmemset
     standards:
       - stdc
-    return_type: wchar_t*
+    return_type: wchar_t *
     arguments:
-      - type: wchar_t*
+      - type: wchar_t *
       - type: wchar_t
       - type: size_t
   - name: wcschr
@@ -246,7 +247,7 @@ functions:
       - type: const wchar_t **__restrict
       - type: size_t
       - type: size_t
-      - type: mbstate_t
+      - type: mbstate_t *__restrict
   - name: wcsrtombs
     standards:
       - stdc
@@ -255,7 +256,7 @@ functions:
       - type: char *__restrict
       - type: const wchar_t **__restrict
       - type: size_t
-      - type: mbstate_t
+      - type: mbstate_t *__restrict
   - name: wcrtomb
     standards:
       - stdc
@@ -299,7 +300,7 @@ functions:
     arguments:
       - type: wchar_t *__restrict
       - type: const wchar_t *__restrict
-      - type: wchar_t** __restrict
+      - type: wchar_t **__restrict
   - name: wcpcpy
     standards:
       - stdc

--- a/libc/src/wchar/wcsnrtombs.cpp
+++ b/libc/src/wchar/wcsnrtombs.cpp
@@ -22,7 +22,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(size_t, wcsnrtombs,
                    (char *__restrict s, const wchar_t **__restrict pwcs,
-                    size_t nwc, size_t len, mbstate_t *ps)) {
+                    size_t nwc, size_t len, mbstate_t *__restrict ps)) {
   LIBC_CRASH_ON_NULLPTR(pwcs);
   static internal::mbstate internal_mbstate;
   auto result = internal::wcsnrtombs(

--- a/libc/src/wchar/wcsnrtombs.h
+++ b/libc/src/wchar/wcsnrtombs.h
@@ -17,7 +17,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 size_t wcsnrtombs(char *__restrict s, const wchar_t **__restrict pwcs,
-                  size_t nwc, size_t len, mbstate_t *ps);
+                  size_t nwc, size_t len, mbstate_t *__restrict ps);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/wchar/wcsrtombs.cpp
+++ b/libc/src/wchar/wcsrtombs.cpp
@@ -22,7 +22,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(size_t, wcsrtombs,
                    (char *__restrict s, const wchar_t **__restrict pwcs,
-                    size_t n, mbstate_t *ps)) {
+                    size_t n, mbstate_t *__restrict ps)) {
   LIBC_CRASH_ON_NULLPTR(pwcs);
   static internal::mbstate internal_mbstate;
   auto result = internal::wcsnrtombs(

--- a/libc/src/wchar/wcsrtombs.h
+++ b/libc/src/wchar/wcsrtombs.h
@@ -17,7 +17,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 size_t wcsrtombs(char *__restrict s, const wchar_t **__restrict pwcs, size_t n,
-                 mbstate_t *ps);
+                 mbstate_t *__restrict ps);
 
 } // namespace LIBC_NAMESPACE_DECL
 


### PR DESCRIPTION
* Add FILE type declaration, as it should be presented in `<wchar.h>`, as well as in `<stdio.h>`
* Fix argument type in `wcsrtombs` / `wcsnrtombs` function - it should be restrict pointer to `mbstate_t`. Add restrict qualifier to internal implementation as well.

This brings us closer to being able to build libcxx with wide-character support against llvm-libc headers.