### PR TITLE
[flang][cuda] Do not consider function result as host array

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -131,6 +131,9 @@ struct FindHostArray
     return (*this)(x.base());
   }
   Result operator()(const Symbol &symbol) const {
+    if (symbol.IsFuncResult()) {
+      return nullptr;
+    }
     if (const auto *details{
             symbol.GetUltimate().detailsIf<semantics::ObjectEntityDetails>()}) {
       if (details->IsArray() &&

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -36,6 +36,12 @@ module m
     if (i .le. N) a(i) = m(i)
   end subroutine
 
+  attributes(device) function devfct(r1, r2) result(res)
+    real(4), intent(in) :: r1(3), r2(3)
+    real(4) :: res(3)
+    res = r1 - r2 ! Do not error on function result
+  end function
+
   attributes(global) subroutine hostparameter(a)
     integer :: a(*)
     i = threadIdx%x


### PR DESCRIPTION
The function result in a device function is not a host array. Avoid triggering the error `Host array 'res' cannot be present in device context` for this. 