### PR TITLE
[lit] Update shtest-ulimit.py to explicitly check default limits

### DIFF
--- a/llvm/utils/lit/tests/shtest-ulimit.py
+++ b/llvm/utils/lit/tests/shtest-ulimit.py
@@ -5,7 +5,11 @@
 # as well.
 # UNSUPPORTED: system-windows, system-solaris
 
-# RUN: not %{lit} -a -v %{inputs}/shtest-ulimit --order=lexical | FileCheck %s
+# RUN: %{python} %S/Inputs/shtest-ulimit/print_limits.py | grep RLIMIT_NOFILE \
+# RUN:   | sed -n -e 's/.*=//p' | tr -d '\n' > %t.nofile_limit
+
+# RUN: not %{lit} -a -v %{inputs}/shtest-ulimit --order=lexical \
+# RUN:   | FileCheck -DBASE_NOFILE_LIMIT=%{readfile:%t.nofile_limit} %s
 
 # CHECK: -- Testing: 3 tests{{.*}}
 
@@ -18,4 +22,4 @@
 # CHECK: RLIMIT_NOFILE=50
 
 # CHECK-LABEL: FAIL: shtest-ulimit :: ulimit_reset.txt ({{[^)]*}})
-# CHECK-NOT: RLIMIT_NOFILE=50
+# CHECK: RLIMIT_NOFILE=[[BASE_NOFILE_LIMIT]]


### PR DESCRIPTION
The recently added ulimit_reset.txt section in shtest-ulimit.py was failing on some builders if the default file descriptor limit started with 50. This patch fixes that by explicitly checking that the file descriptor limit is equal to the default value.