### PR TITLE
[clang-format] Allow line breaking with PointerAlignment configured

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1566,7 +1566,8 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
   }
 
   if (NextNonComment->isOneOf(TT_StartOfName, TT_PointerOrReference) ||
-      Previous.isOneOf(tok::coloncolon, tok::equal, TT_JsTypeColon)) {
+      Previous.isOneOf(TT_PointerOrReference, tok::coloncolon, tok::equal,
+                       TT_JsTypeColon)) {
     return ContinuationIndent;
   }
   if (PreviousNonComment && PreviousNonComment->is(tok::colon) &&

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -4343,7 +4343,7 @@ unsigned TokenAnnotator::splitPenalty(const AnnotatedLine &Line,
       return Style.PenaltyReturnTypeOnItsOwnLine;
     return 200;
   }
-  if (Right.is(TT_PointerOrReference))
+  if (Left.is(TT_PointerOrReference) || Right.is(TT_PointerOrReference))
     return 190;
   if (Right.is(TT_LambdaArrow))
     return 110;
@@ -6262,8 +6262,10 @@ bool TokenAnnotator::canBreakBefore(const AnnotatedLine &Line,
                     TT_ClassHeadName, TT_QtProperty, tok::kw_operator)) {
     return true;
   }
+  // It is fine to break the line when the * or & should be separate from the
+  // name according to the PointerAlignment config.
   if (Left.is(TT_PointerOrReference))
-    return false;
+    return Right.SpacesRequiredBefore;
   if (Right.isTrailingComment()) {
     // We rely on MustBreakBefore being set correctly here as we should not
     // change the "binding" behavior of a comment.

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -8646,11 +8646,6 @@ TEST_F(FormatTest, BreaksFunctionDeclarations) {
 
   Style.ColumnLimit = 70;
   verifyFormat(
-      "void foo( //\n"
-      "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName*\n"
-      "        const my_super_super_super_super_long_variable_name) {}",
-      Style);
-  verifyFormat(
       "void foo(const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName*\n"
       "             my_super_super_super_super_long_variable_name) {}",
       Style);
@@ -8660,11 +8655,6 @@ TEST_F(FormatTest, BreaksFunctionDeclarations) {
       Style);
 
   Style.PointerAlignment = FormatStyle::PAS_Middle;
-  verifyFormat(
-      "void foo( //\n"
-      "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName *\n"
-      "        const my_super_super_super_super_long_variable_name) {}",
-      Style);
   verifyFormat(
       "void foo(\n"
       "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName *\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -8644,6 +8644,38 @@ TEST_F(FormatTest, BreaksFunctionDeclarations) {
                "                 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}",
                Style);
 
+  Style.ColumnLimit = 70;
+  verifyFormat(
+      "void foo( //\n"
+      "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName*\n"
+      "        const my_super_super_super_super_long_variable_name) {}",
+      Style);
+  verifyFormat(
+      "void foo(const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName*\n"
+      "             my_super_super_super_super_long_variable_name) {}",
+      Style);
+  verifyFormat(
+      "void foo(const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName*\n"
+      "             const my_super_super_super_super_long_variable_name) {}",
+      Style);
+
+  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  verifyFormat(
+      "void foo( //\n"
+      "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName *\n"
+      "        const my_super_super_super_super_long_variable_name) {}",
+      Style);
+  verifyFormat(
+      "void foo(\n"
+      "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName *\n"
+      "        my_super_super_super_super_long_variable_name) {}",
+      Style);
+  verifyFormat(
+      "void foo(\n"
+      "    const MySuperSuperSuperSuperSuperSuperSuperSuperLongTypeName *\n"
+      "        const my_super_super_super_super_long_variable_name) {}",
+      Style);
+
   Style = getLLVMStyleWithColumns(45);
   Style.PenaltyReturnTypeOnItsOwnLine = 400;
   verifyFormat("template <bool abool, // a comment\n"


### PR DESCRIPTION
Fixes #139514.

Within a long declaration involving the pointer, the program has allowed breaking between the type and the star when the configuration specified that the star should stick to the variable.  Now it also allows breaking between the star and the variable when the configuration specified that the star should stick to the type.