### PR TITLE
[compiler-rt] Check if the compiler supports `__has_feature` first

### DIFF
--- a/compiler-rt/lib/builtins/gcc_personality_v0.c
+++ b/compiler-rt/lib/builtins/gcc_personality_v0.c
@@ -30,7 +30,13 @@ EXCEPTION_DISPOSITION _GCC_specific_handler(PEXCEPTION_RECORD, void *, PCONTEXT,
                                             _Unwind_Personality_Fn);
 #endif
 
+#if defined(__has_feature)
 #if __has_feature(ptrauth_calls)
+#define __compiler_rt_use_ptrauth
+#endif
+#endif
+
+#ifdef __compiler_rt_use_ptrauth
 #include <ptrauth.h>
 
 // `__ptrauth_restricted_intptr` is a feature of apple clang that predates
@@ -292,7 +298,7 @@ COMPILER_RT_ABI _Unwind_Reason_Code __gcc_personality_v0(
       _Unwind_SetGR(context, __builtin_eh_return_data_regno(1), 0);
       size_t __ptrauth_gcc_personality_lpad landingPad =
           funcStart + landingPadOffset;
-#if __has_feature(ptrauth_calls)
+#ifdef __compiler_rt_use_ptrauth
       uintptr_t stackPointer = _Unwind_GetGR(context, -2);
       const uintptr_t existingDiscriminator = ptrauth_blend_discriminator(
           &landingPad, __ptrauth_gcc_personality_lpad_disc);


### PR DESCRIPTION
This line of code was introduced by https://github.com/llvm/llvm-project/commit/e6a1aff5916447630e9ec0e8a90594ca1ee7a1be. 

This file fails to compile in some supported setups now, because `__has_feature` itself being a macro is not implemented in GCC until 14: https://godbolt.org/z/eM9Gff157

This fix should be simple, since ptrauth is only supported by apple clang, which should pass the `defined(__has_feature)` condition, all other compilers that don't pass this condition can just assume the feature not being supported. 