### PR TITLE
[flang][Driver] Enable -Os and -Oz in flang

### DIFF
--- a/flang/include/flang/Frontend/CodeGenOptions.def
+++ b/flang/include/flang/Frontend/CodeGenOptions.def
@@ -20,6 +20,8 @@ CODEGENOPT(Name, Bits, Default)
 #endif
 
 CODEGENOPT(OptimizationLevel, 2, 0) ///< The -O[0-3] option specified.
+/// The -Os (==1) or -Oz (==2) option is specified.
+CODEGENOPT(OptimizeSize, 2, 0) 
 
 CODEGENOPT(DebugPassManager, 1, 0) ///< Prints debug information for the new
                                    ///< pass manager.

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -602,7 +602,16 @@ mapToLevel(const Fortran::frontend::CodeGenOptions &opts) {
   case 1:
     return llvm::OptimizationLevel::O1;
   case 2:
-    return llvm::OptimizationLevel::O2;
+    switch (opts.OptimizeSize) {
+    default:
+      llvm_unreachable("Invalid optimization level for size!");
+    case 0:
+      return llvm::OptimizationLevel::O2;
+    case 1:
+      return llvm::OptimizationLevel::Os;
+    case 2:
+      return llvm::OptimizationLevel::Oz;
+    }
   case 3:
     return llvm::OptimizationLevel::O3;
   }

--- a/flang/test/Driver/default-optimization-pipelines.f90
+++ b/flang/test/Driver/default-optimization-pipelines.f90
@@ -14,9 +14,15 @@
 ! RUN: %flang_fc1 -S -O2 %s -flto=full -fdebug-pass-manager -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-O2-LTO
 ! RUN: %flang_fc1 -S -O2 %s -flto=thin -fdebug-pass-manager -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-O2-THINLTO
 
-! Verify that only the left-most `-O{n}` is used
+! Verify that only the right-most `-O{n}` is used
 ! RUN: %flang -S -O2 -O0 %s -Xflang -fdebug-pass-manager -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-O0
 ! RUN: %flang_fc1 -S -O2 -O0 %s -fdebug-pass-manager -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-O0
+
+! Verify that passing -Os/-Oz have the desired effect on the pass pipelines.
+! RUN: %flang -S -Os %s -Xflang -fdebug-pass-manager -o /dev/null 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK-OSIZE
+! RUN: %flang -S -Oz %s -Xflang -fdebug-pass-manager -o /dev/null 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK-OSIZE
 
 ! CHECK-O0-NOT: Running pass: SimplifyCFGPass on simple_loop_
 ! CHECK-O0: Running analysis: TargetLibraryAnalysis on simple_loop_
@@ -32,6 +38,12 @@
 ! CHECK-O2-THINLTO-NOT: Running pass: LoopVectorizePass
 ! CHECK-O2-THINLTO: Running pass: CanonicalizeAliasesPass on [module]
 ! CHECK-O2-THINLTO: Running pass: NameAnonGlobalPass on [module]
+
+! -Os/-Oz imply -O2, so check that a pass that runs on O2 is run. Then check
+! that passes like LibShrinkWrap, that should not be run when optimizing for
+! size, are not run (see llvm/lib/Passes/PassBuilderPipelines.cpp).
+! CHECK-OSIZE: Running pass: SimplifyCFGPass on simple_loop_
+! CHECK-OSIZE-NOT: Running pass: LibCallsShrinkWrapPass on simple_loop_
 
 subroutine simple_loop
   integer :: i

--- a/flang/test/Driver/mlir-pass-pipeline.f90
+++ b/flang/test/Driver/mlir-pass-pipeline.f90
@@ -1,173 +1,206 @@
-! Test the MLIR pass pipeline
-
-! RUN: %flang_fc1 -S -mmlir --mlir-pass-statistics -mmlir --mlir-pass-statistics-display=pipeline -o /dev/null %s 2>&1 | FileCheck --check-prefixes=ALL %s
-! -O0 is the default:
-! RUN: %flang_fc1 -S -mmlir --mlir-pass-statistics -mmlir --mlir-pass-statistics-display=pipeline %s -O0 -o /dev/null 2>&1 | FileCheck --check-prefixes=ALL %s
-! RUN: %flang_fc1 -S -mmlir --mlir-pass-statistics -mmlir --mlir-pass-statistics-display=pipeline %s -O2 -o /dev/null 2>&1 | FileCheck --check-prefixes=ALL,O2 %s
-
 ! REQUIRES: asserts
+!
+! Test the MLIR pass pipeline
+!
+! The table below summarizes the relationship between the optimization levels
+! -O<N> and the integer speedup and size levels.
+!
+!          .------------------------------.
+!          |  Level  |  Speedup  |  Size  |
+!          |------------------------------|
+!          |   -O0   |     0     |   0    |
+!          |   -O1   |     1     |   0    |
+!          |   -O2   |     2     |   0    |
+!          |   -O3   |     3     |   0    |
+!          |   -Os   |     2     |   1    |
+!          |   -Oz   |     2     |   2    |
+!          '------------------------------'
+!
+! Since the speedup level for -Os and -Oz is the same as that of -O2, most of
+! the passes that are run at -O2 are run at -Os and -Oz as well, except for any
+! passes that might increase the size of the code. The names of the FileCheck
+! prefixes in the RUN below lines indicate at which optimization levels the
+! corresponding output is expected. For instance:
+!
+!     ALL    O0, O1, O2, O3, Os, Oz (note that -O1 and -O3 are not explicitly
+!            tested here)
+!     O2     O2 only, but not Os or Oz
+!     O02    O0 and O2, but not Os or Oz
+!     O2SZ   O2, Os, and Oz
+!
+! NOTE: At the time of writing, the same set of MLIR passes is run for both
+! optimization level -Os and -Oz.
+!
+! RUN: %flang_fc1 -S -o /dev/null %s -mmlir --mlir-pass-statistics \
+! RUN:     -mmlir --mlir-pass-statistics-display=pipeline 2>&1 \
+! RUN:     | FileCheck --check-prefixes=ALL,O02 %s
+!
+! RUN: %flang_fc1 -O0 -S -o /dev/null %s -mmlir --mlir-pass-statistics \
+! RUN:     -mmlir --mlir-pass-statistics-display=pipeline 2>&1 \
+! RUN:     | FileCheck --check-prefixes=ALL,O02 %s
+!
+! RUN: %flang_fc1 -O2 -S -o /dev/null %s -mmlir --mlir-pass-statistics \
+! RUN:     -mmlir --mlir-pass-statistics-display=pipeline 2>&1 \
+! RUN:     | FileCheck --check-prefixes=ALL,O02,O2,O2SZ %s
+!
+! RUN: %flang_fc1 -Os -S -o /dev/null %s -mmlir --mlir-pass-statistics \
+! RUN:     -mmlir --mlir-pass-statistics-display=pipeline 2>&1 \
+! RUN:     | FileCheck --check-prefixes=ALL,O2 %s
+!
+! RUN: %flang_fc1 -Oz -S -o /dev/null %s -mmlir --mlir-pass-statistics \
+! RUN:     -mmlir --mlir-pass-statistics-display=pipeline 2>&1 \
+! RUN:     | FileCheck --check-prefixes=ALL,O2 %s
+!
+! Ideally, we need an output with only the pass names, but there is currently no
+! way to get that, so in order to guarantee that the passes are in the expected
+! order (i.e. use -NEXT) we have to check the statistics output as well.
+!
+! ALL:         Pass statistics report
+! ALL:         Fortran::lower::VerifierPass
+! ALL:         Pass statistics report
+! ALL:         Fortran::lower::VerifierPass
+! O2-NEXT:     Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
+! O2-NEXT:       'fir.global' Pipeline
+! O2-NEXT:         ExpressionSimplification
+! O2-NEXT:       'func.func' Pipeline
+! O2-NEXT:         ExpressionSimplification
+! O2-NEXT:       'omp.declare_reduction' Pipeline
+! O2-NEXT:         ExpressionSimplification
+! O2-NEXT:       'omp.private' Pipeline
+! O2-NEXT:         ExpressionSimplification
+! O2-NEXT:     Canonicalizer
+! ALL-NEXT:    Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
+! ALL-NEXT:      'fir.global' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O02-NEXT:        InlineElementals
+! ALL-NEXT:      'func.func' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O02-NEXT:        InlineElementals
+! ALL-NEXT:      'omp.declare_reduction' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O02-NEXT:        InlineElementals
+! ALL-NEXT:      'omp.private' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O02-NEXT:        InlineElementals
+! O2-NEXT:     Canonicalizer
+! O2-NEXT:     CSE
+! O2-NEXT:       (S) {{.*}} num-cse'd
+! O2-NEXT:       (S) {{.*}} num-dce'd
+! O2-NEXT:     Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
+! O2-NEXT:       'fir.global' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O2-NEXT:         PropagateFortranVariableAttributes
+! O2-NEXT:         OptimizedBufferization
+! O2SZ-NEXT:       InlineHLFIRAssign
+! O2-NEXT:       'func.func' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O2-NEXT:         PropagateFortranVariableAttributes
+! O2-NEXT:         OptimizedBufferization
+! O2SZ-NEXT:       InlineHLFIRAssign
+! O2-NEXT:       'omp.declare_reduction' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O2-NEXT:         PropagateFortranVariableAttributes
+! O2-NEXT:         OptimizedBufferization
+! O2SZ-NEXT:       InlineHLFIRAssign
+! O2-NEXT:       'omp.private' Pipeline
+! O2-NEXT:         SimplifyHLFIRIntrinsics
+! O2-NEXT:         PropagateFortranVariableAttributes
+! O2-NEXT:         OptimizedBufferization
+! O2SZ-NEXT:       InlineHLFIRAssign
+! ALL:         LowerHLFIROrderedAssignments
+! ALL-NEXT:    LowerHLFIRIntrinsics
+! ALL-NEXT:    BufferizeHLFIR
+! O2SZ-NEXT:   Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
+! O2SZ-NEXT:     'fir.global' Pipeline
+! O2SZ-NEXT:       InlineHLFIRAssign
+! O2SZ-NEXT:     'func.func' Pipeline
+! O2SZ-NEXT:       InlineHLFIRAssign
+! O2SZ-NEXT:     'omp.declare_reduction' Pipeline
+! O2SZ-NEXT:       InlineHLFIRAssign
+! O2SZ-NEXT:     'omp.private' Pipeline
+! O2SZ-NEXT:       InlineHLFIRAssign
+! ALL-NEXT:    ConvertHLFIRtoFIR
+! ALL-NEXT:    CSE
+! ALL-NEXT:      (S) 0 num-cse'd - Number of operations CSE'd
+! ALL-NEXT:      (S) 0 num-dce'd - Number of operations DCE'd
+! ALL-NEXT:    Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
+! ALL-NEXT:      'fir.global' Pipeline
+! ALL-NEXT:        CharacterConversion
+! ALL-NEXT:      'func.func' Pipeline
+! ALL-NEXT:        ArrayValueCopy
+! ALL-NEXT:        CharacterConversion
+! ALL-NEXT:      'omp.declare_reduction' Pipeline
+! ALL-NEXT:        CharacterConversion
+! ALL-NEXT:      'omp.private' Pipeline
+! ALL-NEXT:        CharacterConversion
+! ALL-NEXT:    Canonicalizer
+! ALL-NEXT:    SimplifyRegionLite
+! O2SZ-NEXT:   SimplifyIntrinsics
+! O2SZ-NEXT:   AlgebraicSimplification
+! ALL-NEXT:    CSE
+! ALL-NEXT:      (S) 0 num-cse'd - Number of operations CSE'd
+! ALL-NEXT:      (S) 0 num-dce'd - Number of operations DCE'd
+! ALL-NEXT:    'func.func' Pipeline
+! ALL-NEXT:      MemoryAllocationOpt
+! ALL-NEXT:    Inliner
+! ALL-NEXT:    SimplifyRegionLite
+! ALL-NEXT:    CSE
+! ALL-NEXT:      (S) 0 num-cse'd - Number of operations CSE'd
+! ALL-NEXT:      (S) 0 num-dce'd - Number of operations DCE'd
+! ALL-NEXT:    PolymorphicOpConversion
+! ALL-NEXT:    AssumedRankOpConversion
+! O2-NEXT:     'func.func' Pipeline
+! O2-NEXT:       OptimizeArrayRepacking
+! ALL-NEXT:    LowerRepackArraysPass
+! ALL-NEXT:    SimplifyFIROperations
+! ALL-NEXT:    Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
+! ALL-NEXT:      'fir.global' Pipeline
+! ALL-NEXT:        StackReclaim
+! ALL-NEXT:        CFGConversion
+! ALL-NEXT:      'func.func' Pipeline
+! ALL-NEXT:        StackReclaim
+! ALL-NEXT:        CFGConversion
+! ALL-NEXT:      'omp.declare_reduction' Pipeline
+! ALL-NEXT:        StackReclaim
+! ALL-NEXT:        CFGConversion
+! ALL-NEXT:      'omp.private' Pipeline
+! ALL-NEXT:        StackReclaim
+! ALL-NEXT:        CFGConversion
+! ALL-NEXT:    SCFToControlFlow
+! ALL-NEXT:    Canonicalizer
+! ALL-NEXT:    SimplifyRegionLite
+! ALL-NEXT:    ConvertComplexPow
+! ALL-NEXT:    CSE
+! ALL-NEXT:      (S) 0 num-cse'd - Number of operations CSE'd
+! ALL-NEXT:      (S) 0 num-dce'd - Number of operations DCE'd
+! O2-NEXT:     'func.func' Pipeline
+! O2-NEXT:       SetRuntimeCallAttributes
+! ALL-NEXT:    MIFOpConversion
+! ALL-NEXT:    BoxedProcedurePass
+! O2-NEXT:     AddAliasTags
+! ALL-NEXT:   Pipeline Collection : ['fir.global', 'func.func', 'gpu.module', 'omp.declare_reduction', 'omp.private']
+! ALL-NEXT:     'fir.global' Pipeline
+! ALL-NEXT:        AbstractResultOpt
+! ALL-NEXT:     'func.func' Pipeline
+! ALL-NEXT:        AbstractResultOpt
+! ALL-NEXT:     'gpu.module' Pipeline
+! ALL-NEXT:       Pipeline Collection : ['func.func', 'gpu.func']
+! ALL-NEXT:         'func.func' Pipeline
+! ALL-NEXT:           AbstractResultOpt
+! ALL-NEXT:         'gpu.func' Pipeline
+! ALL-NEXT:           AbstractResultOpt
+! ALL-NEXT:     'omp.declare_reduction' Pipeline
+! ALL-NEXT:       AbstractResultOpt
+! ALL-NEXT:     'omp.private' Pipeline
+! ALL-NEXT:       AbstractResultOpt
+! ALL-NEXT:    CodeGenRewrite
+! ALL-NEXT:      (S) 0 num-dce'd - Number of operations eliminated
+! ALL-NEXT:    ExternalNameConversion
+! ALL-NEXT:    TargetRewrite
+! ALL-NEXT:    CompilerGeneratedNamesConversion
+! ALL-NEXT:    'func.func' Pipeline
+! ALL-NEXT:      FunctionAttr
+! ALL-NEXT:    FIRToLLVMLowering
+! ALL-NOT:     LLVMIRLoweringPass
 
 end program
-
-! ALL: Pass statistics report
-! ALL: Fortran::lower::VerifierPass
-
-! ALL: Pass statistics report
-
-! ALL: Fortran::lower::VerifierPass
-! O2-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
-! O2-NEXT: 'fir.global' Pipeline
-! O2-NEXT:   ExpressionSimplification
-! O2-NEXT: 'func.func' Pipeline
-! O2-NEXT:   ExpressionSimplification
-! O2-NEXT: 'omp.declare_reduction' Pipeline
-! O2-NEXT:   ExpressionSimplification
-! O2-NEXT: 'omp.private' Pipeline
-! O2-NEXT:   ExpressionSimplification
-! O2-NEXT: Canonicalizer
-! ALL:     Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
-! ALL-NEXT:'fir.global' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! ALL:       InlineElementals
-! ALL-NEXT:'func.func' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! ALL:       InlineElementals
-! ALL-NEXT:'omp.declare_reduction' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! ALL:       InlineElementals
-! ALL-NEXT:'omp.private' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! ALL:       InlineElementals
-! O2-NEXT: Canonicalizer
-! O2-NEXT: CSE
-! O2-NEXT: (S) {{.*}} num-cse'd
-! O2-NEXT: (S) {{.*}} num-dce'd
-! O2-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
-! O2-NEXT: 'fir.global' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! O2-NEXT:   PropagateFortranVariableAttributes
-! O2-NEXT:   OptimizedBufferization
-! O2-NEXT:   InlineHLFIRAssign
-! O2-NEXT: 'func.func' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! O2-NEXT:   PropagateFortranVariableAttributes
-! O2-NEXT:   OptimizedBufferization
-! O2-NEXT:   InlineHLFIRAssign
-! O2-NEXT: 'omp.declare_reduction' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! O2-NEXT:   PropagateFortranVariableAttributes
-! O2-NEXT:   OptimizedBufferization
-! O2-NEXT:   InlineHLFIRAssign
-! O2-NEXT: 'omp.private' Pipeline
-! O2-NEXT:   SimplifyHLFIRIntrinsics
-! O2-NEXT:   PropagateFortranVariableAttributes
-! O2-NEXT:   OptimizedBufferization
-! O2-NEXT:   InlineHLFIRAssign
-! ALL: LowerHLFIROrderedAssignments
-! ALL-NEXT: LowerHLFIRIntrinsics
-! ALL-NEXT: BufferizeHLFIR
-! O2-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
-! O2-NEXT:   'fir.global' Pipeline
-! O2-NEXT:     InlineHLFIRAssign
-! O2-NEXT:   'func.func' Pipeline
-! O2-NEXT:     InlineHLFIRAssign
-! O2-NEXT:   'omp.declare_reduction' Pipeline
-! O2-NEXT:     InlineHLFIRAssign
-! O2-NEXT:   'omp.private' Pipeline
-! O2-NEXT:     InlineHLFIRAssign
-! ALL-NEXT: ConvertHLFIRtoFIR
-! ALL-NEXT: CSE
-! Ideally, we need an output with only the pass names, but
-! there is currently no way to get that, so in order to
-! guarantee that the passes are in the expected order
-! (i.e. use -NEXT) we have to check the statistics output as well.
-! ALL-NEXT:   (S) 0 num-cse'd - Number of operations CSE'd
-! ALL-NEXT:   (S) 0 num-dce'd - Number of operations DCE'd
-
-! ALL-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
-! ALL-NEXT: 'fir.global' Pipeline
-! ALL-NEXT:   CharacterConversion
-! ALL-NEXT: 'func.func' Pipeline
-! ALL-NEXT:   ArrayValueCopy
-! ALL-NEXT:   CharacterConversion
-! ALL-NEXT: 'omp.declare_reduction' Pipeline
-! ALL-NEXT:   CharacterConversion
-! ALL-NEXT: 'omp.private' Pipeline
-! ALL-NEXT:   CharacterConversion
-
-! ALL-NEXT: Canonicalizer
-! ALL-NEXT: SimplifyRegionLite
-!  O2-NEXT: SimplifyIntrinsics
-!  O2-NEXT: AlgebraicSimplification
-! ALL-NEXT: CSE
-! ALL-NEXT:   (S) 0 num-cse'd - Number of operations CSE'd
-! ALL-NEXT:   (S) 0 num-dce'd - Number of operations DCE'd
-
-! ALL-NEXT: 'func.func' Pipeline
-! ALL-NEXT:   MemoryAllocationOpt
-
-! ALL-NEXT: Inliner
-! ALL-NEXT: SimplifyRegionLite
-! ALL-NEXT: CSE
-! ALL-NEXT:   (S) 0 num-cse'd - Number of operations CSE'd
-! ALL-NEXT:   (S) 0 num-dce'd - Number of operations DCE'd
-
-! ALL-NEXT: PolymorphicOpConversion
-! ALL-NEXT: AssumedRankOpConversion
-! O2-NEXT:  'func.func' Pipeline
-! O2-NEXT:    OptimizeArrayRepacking
-! ALL-NEXT: LowerRepackArraysPass
-! ALL-NEXT: SimplifyFIROperations
-
-! ALL-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
-! ALL-NEXT:    'fir.global' Pipeline
-! ALL-NEXT:      StackReclaim
-! ALL-NEXT:      CFGConversion
-! ALL-NEXT:    'func.func' Pipeline
-! ALL-NEXT:      StackReclaim
-! ALL-NEXT:      CFGConversion
-! ALL-NEXT:   'omp.declare_reduction' Pipeline
-! ALL-NEXT:      StackReclaim
-! ALL-NEXT:      CFGConversion
-! ALL-NEXT:   'omp.private' Pipeline
-! ALL-NEXT:      StackReclaim
-! ALL-NEXT:      CFGConversion
-
-! ALL-NEXT: SCFToControlFlow
-! ALL-NEXT: Canonicalizer
-! ALL-NEXT: SimplifyRegionLite
-! ALL-NEXT: ConvertComplexPow
-! ALL-NEXT: CSE
-! ALL-NEXT:   (S) 0 num-cse'd - Number of operations CSE'd
-! ALL-NEXT:   (S) 0 num-dce'd - Number of operations DCE'd
-! O2-NEXT:  'func.func' Pipeline
-! O2-NEXT:    SetRuntimeCallAttributes
-! ALL-NEXT: MIFOpConversion 
-! ALL-NEXT: BoxedProcedurePass
-! O2-NEXT:  AddAliasTags
-
-! ALL-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'gpu.module', 'omp.declare_reduction', 'omp.private']
-! ALL-NEXT:   'fir.global' Pipeline
-! ALL-NEXT:    AbstractResultOpt
-! ALL-NEXT:  'func.func' Pipeline
-! ALL-NEXT:    AbstractResultOpt
-! ALL-NEXT:  'gpu.module' Pipeline
-! ALL-NEXT:   Pipeline Collection : ['func.func', 'gpu.func'] 
-! ALL-NEXT:   'func.func' Pipeline 
-! ALL-NEXT:   AbstractResultOpt
-! ALL-NEXT:   'gpu.func' Pipeline 
-! ALL-NEXT:   AbstractResultOpt
-! ALL-NEXT:  'omp.declare_reduction' Pipeline
-! ALL-NEXT:    AbstractResultOpt
-! ALL-NEXT:  'omp.private' Pipeline
-! ALL-NEXT:    AbstractResultOpt
-
-! ALL-NEXT: CodeGenRewrite
-! ALL-NEXT:   (S) 0 num-dce'd - Number of operations eliminated
-! ALL-NEXT: ExternalNameConversion
-! ALL-NEXT: TargetRewrite
-! ALL-NEXT: CompilerGeneratedNamesConversion
-! ALL-NEXT:  'func.func' Pipeline
-! ALL-NEXT:   FunctionAttr
-! ALL-NEXT: FIRToLLVMLowering
-! ALL-NOT: LLVMIRLoweringPass


### PR DESCRIPTION
For the LLVM passes, the implementation mirrors that in clang. A number of
FIR and MLIR passes that may result in an increase in code size are not run
when either of these options is provided. Explicit speedup and size levels are
used instead of isOptimizingForSize since the latter assumes that speedupLevel
is 0 if optimizing for size. However, optimizing for size implies that the
speedup level is 2

Fixes #62268 