### PR TITLE
[clang-tidy][NFC] Clarify switch-missing-default-case doc (#164699)

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/switch-missing-default-case.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/switch-missing-default-case.rst
@@ -9,8 +9,8 @@ on covering cases with non-enums where the compiler may not issue warnings.
 Switch statements without a default case can lead to unexpected
 behavior and incomplete handling of all possible cases. When a switch statement
 lacks a default case, if a value is encountered that does not match any of the
-specified cases, the program will continue execution without any defined
-behavior or handling.
+specified cases, the switch statement will do nothing and the program will
+continue execution without handling the value.
 
 This check helps identify switch statements that are missing a default case,
 allowing developers to ensure that all possible cases are handled properly.


### PR DESCRIPTION
Falling through a defaultless switch statement has well defined behavior. Fixes https://github.com/llvm/llvm-project/issues/164699.

Credit for noticing this problem goes to user "pozz" on comp.lang.c,
Message-ID: <10da67g$3q59f$1@dont-email.me>