### PR TITLE
[flang][mlir] Fix-forward heap use-after-free in #155348

### DIFF
--- a/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
+++ b/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
@@ -252,11 +252,11 @@ class PrepareForOMPOffloadPrivatizationPass
         // variable, rewrite all the uses of the original variable with
         // the heap-allocated variable.
         rewriter.setInsertionPoint(targetOp);
-        mapInfoOp = cloneModifyAndErase(mapInfoOp);
-        rewriter.setInsertionPoint(mapInfoOp);
+        auto clonedOp = cast<omp::MapInfoOp>(cloneModifyAndErase(mapInfoOp));
+        rewriter.setInsertionPoint(clonedOp);
 
         // Fix any members that may use varPtr to now use heapMem
-        for (auto member : mapInfoOp.getMembers()) {
+        for (auto member : clonedOp.getMembers()) {
           auto memberMapInfoOp = cast<omp::MapInfoOp>(member.getDefiningOp());
           if (!usesVarPtr(memberMapInfoOp))
             continue;
@@ -276,7 +276,7 @@ class PrepareForOMPOffloadPrivatizationPass
         // targetOp.
         if (isPrivatizedByValue) {
           rewriter.setInsertionPoint(targetOp);
-          auto newPrivVar = LLVM::LoadOp::create(rewriter, mapInfoOp.getLoc(),
+          auto newPrivVar = LLVM::LoadOp::create(rewriter, clonedOp.getLoc(),
                                                  varType, heapMem);
           newPrivVars.push_back(newPrivVar);
         }

--- a/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
+++ b/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
@@ -260,7 +260,8 @@ class PrepareForOMPOffloadPrivatizationPass
           auto memberMapInfoOp = cast<omp::MapInfoOp>(member.getDefiningOp());
           if (!usesVarPtr(memberMapInfoOp))
             continue;
-          memberMapInfoOp = cast<omp::MapInfoOp>(cloneModifyAndErase(memberMapInfoOp));
+          memberMapInfoOp =
+              cast<omp::MapInfoOp>(cloneModifyAndErase(memberMapInfoOp));
           rewriter.setInsertionPoint(memberMapInfoOp);
 
           if (memberMapInfoOp.getVarPtrPtr()) {

--- a/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
+++ b/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
@@ -252,7 +252,8 @@ class PrepareForOMPOffloadPrivatizationPass
         // variable, rewrite all the uses of the original variable with
         // the heap-allocated variable.
         rewriter.setInsertionPoint(targetOp);
-        rewriter.setInsertionPoint(cloneModifyAndErase(mapInfoOp));
+        mapInfoOp = cloneModifyAndErase(mapInfoOp);
+        rewriter.setInsertionPoint(mapInfoOp);
 
         // Fix any members that may use varPtr to now use heapMem
         for (auto member : mapInfoOp.getMembers()) {


### PR DESCRIPTION
`mapInfoOp.getMembers()` on line 258 is use-after-free, because cloneModifyAndErase (line 255) erased `mapInfoOp`. Fix the issue by replacing subsequent `mapInfoOp` usages with `clonedOp`.

Similarly, update `memberMapInfoOp` to avoid subsequent use-after-free.