### PR TITLE
[Compiler-rt] Fix wrong assignment in compiler_rt

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/x86.c
+++ b/compiler-rt/lib/builtins/cpu_model/x86.c
@@ -36,14 +36,14 @@ enum VendorSignatures {
   SIG_AMD = 0x68747541,   // Auth
 };
 
-enum ProcessorVendors {
+enum ProcessorVendors : unsigned int {
   VENDOR_INTEL = 1,
   VENDOR_AMD,
   VENDOR_OTHER,
   VENDOR_MAX
 };
 
-enum ProcessorTypes {
+enum ProcessorTypes : unsigned int {
   INTEL_BONNELL = 1,
   INTEL_CORE2,
   INTEL_COREI7,
@@ -322,8 +322,8 @@ static void detectX86FamilyModel(unsigned EAX, unsigned *Family,
 static const char *getIntelProcessorTypeAndSubtype(unsigned Family,
                                                    unsigned Model,
                                                    const unsigned *Features,
-                                                   unsigned *Type,
-                                                   unsigned *Subtype) {
+                                                   enum ProcessorTypes *Type,
+                                                   enum ProcessorSubtypes *Subtype) {
   // We select CPU strings to match the code in Host.cpp, but we don't use them
   // in compiler-rt.
   const char *CPU = 0;
@@ -616,8 +616,7 @@ static const char *getIntelProcessorTypeAndSubtype(unsigned Family,
     // Clearwaterforest:
     case 0xdd:
       CPU = "clearwaterforest";
-      *Type = INTEL_COREI7;
-      *Subtype = INTEL_CLEARWATERFOREST;
+      *Type = INTEL_CLEARWATERFOREST;
       break;
 
     case 0x57:
@@ -670,8 +669,8 @@ static const char *getIntelProcessorTypeAndSubtype(unsigned Family,
 static const char *getAMDProcessorTypeAndSubtype(unsigned Family,
                                                  unsigned Model,
                                                  const unsigned *Features,
-                                                 unsigned *Type,
-                                                 unsigned *Subtype) {
+                                                 enum ProcessorTypes *Type,
+                                                 enum ProcessorSubtypes *Subtype) {
   const char *CPU = 0;
 
   switch (Family) {
@@ -1162,10 +1161,12 @@ __attribute__((visibility("hidden")))
 #endif
 struct __processor_model {
   unsigned int __cpu_vendor;
-  unsigned int __cpu_type;
-  unsigned int __cpu_subtype;
+  enum ProcessorTypes  __cpu_type;
+  enum ProcessorSubtypes  __cpu_subtype;
   unsigned int __cpu_features[1];
 } __cpu_model = {0, 0, 0, {0}};
+
+static_assert(sizeof(__cpu_model) == 16, "Wrong size of __cpu_model will result in ABI break");
 
 #ifndef _WIN32
 __attribute__((visibility("hidden")))

--- a/compiler-rt/lib/builtins/cpu_model/x86.c
+++ b/compiler-rt/lib/builtins/cpu_model/x86.c
@@ -319,11 +319,9 @@ static void detectX86FamilyModel(unsigned EAX, unsigned *Family,
 
 #define testFeature(F) (Features[F / 32] & (1 << (F % 32))) != 0
 
-static const char *getIntelProcessorTypeAndSubtype(unsigned Family,
-                                                   unsigned Model,
-                                                   const unsigned *Features,
-                                                   enum ProcessorTypes *Type,
-                                                   enum ProcessorSubtypes *Subtype) {
+static const char *getIntelProcessorTypeAndSubtype(
+    unsigned Family, unsigned Model, const unsigned *Features,
+    enum ProcessorTypes *Type, enum ProcessorSubtypes *Subtype) {
   // We select CPU strings to match the code in Host.cpp, but we don't use them
   // in compiler-rt.
   const char *CPU = 0;
@@ -666,11 +664,9 @@ static const char *getIntelProcessorTypeAndSubtype(unsigned Family,
   return CPU;
 }
 
-static const char *getAMDProcessorTypeAndSubtype(unsigned Family,
-                                                 unsigned Model,
-                                                 const unsigned *Features,
-                                                 enum ProcessorTypes *Type,
-                                                 enum ProcessorSubtypes *Subtype) {
+static const char *getAMDProcessorTypeAndSubtype(
+    unsigned Family, unsigned Model, const unsigned *Features,
+    enum ProcessorTypes *Type, enum ProcessorSubtypes *Subtype) {
   const char *CPU = 0;
 
   switch (Family) {
@@ -1161,12 +1157,13 @@ __attribute__((visibility("hidden")))
 #endif
 struct __processor_model {
   unsigned int __cpu_vendor;
-  enum ProcessorTypes  __cpu_type;
-  enum ProcessorSubtypes  __cpu_subtype;
+  enum ProcessorTypes __cpu_type;
+  enum ProcessorSubtypes __cpu_subtype;
   unsigned int __cpu_features[1];
 } __cpu_model = {0, 0, 0, {0}};
 
-static_assert(sizeof(__cpu_model) == 16, "Wrong size of __cpu_model will result in ABI break");
+static_assert(sizeof(__cpu_model) == 16,
+              "Wrong size of __cpu_model will result in ABI break");
 
 #ifndef _WIN32
 __attribute__((visibility("hidden")))


### PR DESCRIPTION
The `INTEL_CLEARWATERFOREST` belonged to `ProcessorTypes` enum, but it was assigned to `Subtype` value, leading to cpu_specific/cpu_dispatch not recognizing CWF. The type for `Subtype` and `Type` are changed to respective enums to guard against these sort of errors in the future