### PR TITLE
[llvm-ir2vec] Build issue fix in AMD buildbot

### DIFF
--- a/llvm/tools/llvm-ir2vec/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsCodeGens
   AllTargetsDescs
   AllTargetsInfos
+  TargetParser
   )
 
 add_llvm_tool(llvm-ir2vec


### PR DESCRIPTION
Fixes the build issue in `openmp-offload-amdgpu-runtime-2` caused by #164025