### PR TITLE
[llvm-profdata] Reintroduce use of InitLLVM

### DIFF
--- a/llvm/test/tools/llvm-profdata/input-wildcard.test
+++ b/llvm/test/tools/llvm-profdata/input-wildcard.test
@@ -1,0 +1,15 @@
+# This test verifies that llvm-profdata will do wildcard expansion on its
+# arguments. The expansion is done by Windows-specific support in InitLLVM, so
+# we only expect this to work on Windows hosts.
+# REQUIRES: system-windows
+
+# Create two files to glob.
+RUN: echo '# empty profile 1' >  %t.prof1.proftxt
+RUN: echo '# empty profile 2' >> %t.prof2.proftxt
+
+# Prevent LIT itself from globbing by quoting the wildcard argument.
+RUN: llvm-profdata merge "%t.*.proftxt" -dump-input-file-list -o /dev/null | FileCheck %s
+
+# Verify that llvm-profdata expanded the wildcard argument.
+CHECK: 1,{{.*}}.prof1.proftxt
+CHECK-NEXT: 1,{{.*}}.prof2.proftxt

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -34,7 +34,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/LLVMDriver.h"
+#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -3465,6 +3465,7 @@ static int order_main() {
 }
 
 int main(int argc, const char *argv[]) {
+  InitLLVM X(argc, argv);
   StringRef ProgName(sys::path::filename(argv[0]));
 
   if (argc < 2) {


### PR DESCRIPTION
Before llvm-profdata participated in llvm-driver it directly called InitLLVM, which takes care of wildcard argument expansion for tools on Windows. When llvm-driver support was added to llvm-profdata this InitLLVM call was effectively moved into the common llvm-driver wrapper mechanism.

More recently, in #162191, llvm-driver support was temporarily backed out of llvm-profdata due to an issue with `cl::opt` handling. This change reintroduces the direct call to InitLLVM in order to restore wildcard expansion and also adds a test for the wildcard expansion on Windows.