### PR TITLE
[ExecutionEngine] Call hash_combine_range with a range (NFC)

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
@@ -186,9 +186,7 @@ private:
         SmallVector<ElementId> SortedElems(ContainerElems.begin(),
                                            ContainerElems.end());
         llvm::sort(SortedElems);
-        Hash = hash_combine(
-            Hash, Container,
-            hash_combine_range(SortedElems.begin(), SortedElems.end()));
+        Hash = hash_combine(Hash, Container, hash_combine_range(SortedElems));
       }
       return Hash;
     }


### PR DESCRIPTION
We can pass a range directly to hash_combine_range these days.
