### PR TITLE
[clang][DebugInfo] Disable objective-CXX tests on AIX and z/OS

### DIFF
--- a/clang/test/DebugInfo/ObjCXX/lit.local.cfg
+++ b/clang/test/DebugInfo/ObjCXX/lit.local.cfg
@@ -1,0 +1,5 @@
+# objective-CXX is not supported on AIX and zOS
+unsupported_platforms = [ "system-aix", "system-zos" ]
+
+if any(up in config.available_features for up in unsupported_platforms):
+    config.unsupported = True


### PR DESCRIPTION
These tests not supported on AIX and z/OS, disable them to get the clang-ppc64-aix green 