### PR TITLE
[ISel] Use CallBase instead of CallInst

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1978,9 +1978,9 @@ SDValue SelectionDAGBuilder::getValueImpl(const Value *V) {
     Register InReg = FuncInfo.InitializeRegForValue(Inst);
 
     std::optional<CallingConv::ID> CallConv;
-    auto *CI = dyn_cast<CallInst>(Inst);
-    if (CI && !CI->isInlineAsm())
-      CallConv = CI->getCallingConv();
+    auto *CB = dyn_cast<CallBase>(Inst);
+    if (CB && !CB->isInlineAsm())
+      CallConv = CB->getCallingConv();
 
     RegsForValue RFV(*DAG.getContext(), TLI, DAG.getDataLayout(), InReg,
                      Inst->getType(), CallConv);


### PR DESCRIPTION
This is to follow the discussion in https://github.com/llvm/llvm-project/pull/164565
CallBase can cover more call-like instructions which carry caling convention
flag.
