### PR TITLE
[lldb][test] skip Lua tests when the Lua interpreter is not found

### DIFF
--- a/lldb/cmake/modules/FindLuaAndSwig.cmake
+++ b/lldb/cmake/modules/FindLuaAndSwig.cmake
@@ -34,6 +34,7 @@ else()
                                     FOUND_VAR
                                       LUAANDSWIG_FOUND
                                     REQUIRED_VARS
+                                      LUA_EXECUTABLE
                                       LUA_LIBRARIES
                                       LUA_INCLUDE_DIR
                                       LUA_VERSION_MINOR

--- a/lldb/test/API/lua_api/TestLuaAPI.py
+++ b/lldb/test/API/lua_api/TestLuaAPI.py
@@ -158,7 +158,9 @@ class TestLuaAPI(TestBase):
         return tests
 
     def test_lua_api(self):
-        if "LUA_EXECUTABLE" not in os.environ or len(os.environ["LUA_EXECUTABLE"]) == 0:
+        if "LUA_EXECUTABLE" not in os.environ or not os.path.exists(
+            os.environ["LUA_EXECUTABLE"]
+        ):
             self.skipTest("Lua API tests could not find Lua executable.")
             return
         lua_executable = os.environ["LUA_EXECUTABLE"]


### PR DESCRIPTION
When Swig is installed but not any Lua interpreter, the cmake script in `lldb/cmake/modules/FindLuaAndSwig.cmake` will execute `find_program(LUA_EXECUTABLE, ...)` and this will set the `LUA_EXECUTABLE` variable to `LUA_EXECUTABLE-NOTFOUND`.

Ensure that in this case we are skipping the Lua tests requiring the interpreter.