### PR TITLE
[LoopCacheAnalysis] Drop incorrect nowrap flags from addrec

### DIFF
--- a/llvm/lib/Analysis/LoopCacheAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopCacheAnalysis.cpp
@@ -436,10 +436,9 @@ bool IndexedReference::delinearize(const LoopInfo &LI) {
       const SCEV *StepRec = AccessFnAR ? AccessFnAR->getStepRecurrence(SE) : nullptr;
 
       if (StepRec && SE.isKnownNegative(StepRec))
-        AccessFn = SE.getAddRecExpr(AccessFnAR->getStart(),
-                                    SE.getNegativeSCEV(StepRec),
-                                    AccessFnAR->getLoop(),
-                                    AccessFnAR->getNoWrapFlags());
+        AccessFn = SE.getAddRecExpr(
+            AccessFnAR->getStart(), SE.getNegativeSCEV(StepRec),
+            AccessFnAR->getLoop(), SCEV::NoWrapFlags::FlagAnyWrap);
       const SCEV *Div = SE.getUDivExactExpr(AccessFn, ElemSize);
       Subscripts.push_back(Div);
       Sizes.push_back(ElemSize);


### PR DESCRIPTION
This patch stops propagating nowrap flags unconditionally. In the modified part, when we have an addrec `{%a,+,%b}` where `%b` is known to be negative, we create a new addrec `{%a,+,(-1 * %b)}`. When creating it, the nowrap flags are transferred from the original addrec to the new one without any checks, which is generally incorrect. Since the nowrap property is not essential for this analysis, it would be better to drop it to avoid potential bugs.