### PR TITLE
[Clang] Reenable Tests on SystemZ/AIX Using env -u

### DIFF
--- a/clang/test/Driver/config-file3.c
+++ b/clang/test/Driver/config-file3.c
@@ -1,9 +1,5 @@
 // Needs symlinks
 // UNSUPPORTED: system-windows
-// env -u is not supported on AIX.
-// TODO(boomanaiden154): Remove this once we have switched over to lit's
-// internal shell which does support env -u.
-// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 // REQUIRES: x86-registered-target
 
 // RUN: rm -rf %t && mkdir %t

--- a/clang/test/Driver/config-zos.c
+++ b/clang/test/Driver/config-zos.c
@@ -1,9 +1,5 @@
 // Needs symlinks
 // UNSUPPORTED: system-windows
-// env -u is not supported on AIX.
-// TODO(boomanaiden154): Remove this once we have switched over to lit's
-// internal shell which does support env -u.
-// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 // REQUIRES: systemz-registered-target
 
 // RUN: rm -rf %t && mkdir %t

--- a/clang/test/Driver/config-zos1.c
+++ b/clang/test/Driver/config-zos1.c
@@ -1,8 +1,4 @@
 // UNSUPPORTED: system-windows
-// env -u is not supported on AIX.
-// TODO(boomanaiden154): Remove this once we have switched over to lit's
-// internal shell which does support env -u.
-// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 // REQUIRES: systemz-registered-target
 
 // RUN: export CLANG_CONFIG_PATH=%S/Inputs/config-zos

--- a/clang/test/Modules/crash-vfs-path-symlink-component.m
+++ b/clang/test/Modules/crash-vfs-path-symlink-component.m
@@ -1,9 +1,5 @@
 // Needs symlinks
 // UNSUPPORTED: system-windows
-// env -u is not supported on AIX.
-// TODO(boomanaiden154): Remove this once we have switched over to lit's
-// internal shell which does support env -u.
-// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 // REQUIRES: crash-recovery
 
 // FIXME: This XFAIL is cargo-culted from crash-report.c. Do we need it?

--- a/clang/test/Modules/crash-vfs-path-traversal.m
+++ b/clang/test/Modules/crash-vfs-path-traversal.m
@@ -2,10 +2,6 @@
 // UNSUPPORTED: ms-sdk, target={{.*-(ps4|ps5)}}
 // Some assertions in this test use Linux style (/) file paths.
 // UNSUPPORTED: system-windows
-// env -u is not supported on AIX.
-// TODO(boomanaiden154): Remove this once we have switched over to lit's
-// internal shell which does support env -u.
-// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 
 // FIXME: Canonicalizing paths to remove relative traversal components
 // currenty fails a unittest on windows and is disable by default.

--- a/clang/test/Modules/crash-vfs-relative-overlay.m
+++ b/clang/test/Modules/crash-vfs-relative-overlay.m
@@ -1,9 +1,5 @@
 // UNSUPPORTED: system-windows
 // REQUIRES: crash-recovery
-// env -u is not supported on AIX.
-// TODO(boomanaiden154): Remove this once we have switched over to lit's
-// internal shell which does support env -u.
-// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 
 // FIXME: This XFAIL is cargo-culted from crash-report.c. Do we need it?
 // XFAIL: target={{.*-windows-gnu}}


### PR DESCRIPTION
These were disabled when adjusting tests to work with the internal shell because the implementation on these systems of env did not support the -u option. Now that we have switched to the internal shell and env -u is implemented internally, these tests should work again.