### PR TITLE
[llvm][Support] Introduced scalar type names in YAMLGenerateSchema

### DIFF
--- a/llvm/include/llvm/Support/YAMLGenerateSchema.h
+++ b/llvm/include/llvm/Support/YAMLGenerateSchema.h
@@ -1,0 +1,400 @@
+//===- llvm/Support/YAMLGenerateSchema.h ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_YAMLGENERATE_SCHEMA_H
+#define LLVM_SUPPORT_YAMLGENERATE_SCHEMA_H
+
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/YAMLTraits.h"
+
+namespace llvm {
+
+namespace json {
+class Value;
+}
+
+namespace yaml {
+
+class GenerateSchema : public IO {
+public:
+  GenerateSchema(raw_ostream &RO);
+  ~GenerateSchema() override = default;
+
+  IOKind getKind() const override;
+  bool outputting() const override;
+  bool mapTag(StringRef, bool) override;
+  void beginMapping() override;
+  void endMapping() override;
+  bool preflightKey(StringRef, bool, bool, bool &, void *&) override;
+  void postflightKey(void *) override;
+  std::vector<StringRef> keys() override;
+  void beginFlowMapping() override;
+  void endFlowMapping() override;
+  unsigned beginSequence() override;
+  void endSequence() override;
+  bool preflightElement(unsigned, void *&) override;
+  void postflightElement(void *) override;
+  unsigned beginFlowSequence() override;
+  bool preflightFlowElement(unsigned, void *&) override;
+  void postflightFlowElement(void *) override;
+  void endFlowSequence() override;
+  void beginEnumScalar() override;
+  bool matchEnumScalar(StringRef, bool) override;
+  bool matchEnumFallback() override;
+  void endEnumScalar() override;
+  bool beginBitSetScalar(bool &) override;
+  bool bitSetMatch(StringRef, bool) override;
+  void endBitSetScalar() override;
+  void scalarString(StringRef &, QuotingType) override;
+  void blockScalarString(StringRef &) override;
+  void scalarTag(std::string &) override;
+  NodeKind getNodeKind() override;
+  void setError(const Twine &message) override;
+  std::error_code error() override;
+  bool canElideEmptySequence() override;
+
+  bool preflightDocument();
+  void postflightDocument();
+
+  class SchemaNode {
+  public:
+    virtual json::Value toJSON() const = 0;
+
+    virtual ~SchemaNode() = default;
+  };
+
+  enum class PropertyKind : uint8_t {
+    UserDefined,
+    Properties,
+    AdditionalProperties,
+    Required,
+    Optional,
+    Type,
+    Enum,
+    Items,
+    FlowStyle,
+  };
+
+  class SchemaProperty : public SchemaNode {
+    StringRef Name;
+    PropertyKind Kind;
+
+  public:
+    SchemaProperty(StringRef Name, PropertyKind Kind)
+        : Name(Name), Kind(Kind) {}
+
+    PropertyKind getKind() const { return Kind; }
+
+    StringRef getName() const { return Name; }
+  };
+
+  class Schema;
+
+  class UserDefinedProperty final : public SchemaProperty {
+    Schema *Value;
+
+  public:
+    UserDefinedProperty(StringRef Name, Schema *Value)
+        : SchemaProperty(Name, PropertyKind::UserDefined), Value(Value) {}
+
+    Schema *getSchema() const { return Value; }
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::UserDefined;
+    }
+  };
+
+  class PropertiesProperty final : public SchemaProperty,
+                                   SmallVector<UserDefinedProperty *, 8> {
+  public:
+    using BaseVector = SmallVector<UserDefinedProperty *, 8>;
+
+    PropertiesProperty()
+        : SchemaProperty("properties", PropertyKind::Properties) {}
+
+    using BaseVector::begin;
+    using BaseVector::emplace_back;
+    using BaseVector::end;
+    using BaseVector::size;
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::Properties;
+    }
+  };
+
+  class AdditionalPropertiesProperty final : public SchemaProperty {
+    Schema *Value;
+
+  public:
+    AdditionalPropertiesProperty(Schema *Value = nullptr)
+        : SchemaProperty("additionalProperties",
+                         PropertyKind::AdditionalProperties),
+          Value(Value) {}
+
+    Schema *getSchema() const { return Value; }
+
+    void setSchema(Schema *S) { Value = S; }
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::AdditionalProperties;
+    }
+  };
+
+  class RequiredProperty final : public SchemaProperty,
+                                 SmallVector<StringRef, 4> {
+  public:
+    using BaseVector = SmallVector<StringRef, 4>;
+
+    RequiredProperty() : SchemaProperty("required", PropertyKind::Required) {}
+
+    using BaseVector::begin;
+    using BaseVector::emplace_back;
+    using BaseVector::end;
+    using BaseVector::size;
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::Required;
+    }
+  };
+
+  class OptionalProperty final : public SchemaProperty,
+                                 SmallVector<StringRef, 4> {
+  public:
+    using BaseVector = SmallVector<StringRef, 4>;
+
+    OptionalProperty() : SchemaProperty("optional", PropertyKind::Optional) {}
+
+    using BaseVector::begin;
+    using BaseVector::emplace_back;
+    using BaseVector::end;
+    using BaseVector::size;
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::Optional;
+    }
+  };
+
+  class TypeProperty final : public SchemaProperty {
+    StringRef Value;
+
+  public:
+    TypeProperty(StringRef Value)
+        : SchemaProperty("type", PropertyKind::Type), Value(Value) {}
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::Type;
+    }
+  };
+
+  class EnumProperty final : public SchemaProperty, SmallVector<StringRef, 4> {
+  public:
+    using BaseVector = SmallVector<StringRef, 4>;
+
+    EnumProperty() : SchemaProperty("enum", PropertyKind::Enum) {}
+
+    using BaseVector::begin;
+    using BaseVector::emplace_back;
+    using BaseVector::end;
+    using BaseVector::size;
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::Enum;
+    }
+  };
+
+  class ItemsProperty final : public SchemaProperty {
+    Schema *Value;
+
+  public:
+    ItemsProperty(Schema *Value = nullptr)
+        : SchemaProperty("items", PropertyKind::Items), Value(Value) {}
+
+    Schema *getSchema() const { return Value; }
+
+    void setSchema(Schema *S) { Value = S; }
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::Items;
+    }
+  };
+
+  enum class FlowStyle : bool {
+    Block,
+    Flow,
+  };
+
+  class FlowStyleProperty final : public SchemaProperty {
+    FlowStyle Style;
+
+  public:
+    FlowStyleProperty(FlowStyle Style = FlowStyle::Block)
+        : SchemaProperty("flowStyle", PropertyKind::FlowStyle), Style(Style) {}
+
+    void setStyle(FlowStyle S) { Style = S; }
+
+    FlowStyle getStyle() const { return Style; }
+
+    json::Value toJSON() const override;
+
+    static bool classof(const SchemaProperty *Property) {
+      return Property->getKind() == PropertyKind::FlowStyle;
+    }
+  };
+
+  class Schema final : public SchemaNode, SmallVector<SchemaProperty *, 8> {
+  public:
+    using BaseVector = SmallVector<SchemaProperty *, 8>;
+
+    Schema() = default;
+
+    using BaseVector::begin;
+    using BaseVector::emplace_back;
+    using BaseVector::end;
+    using BaseVector::size;
+
+    json::Value toJSON() const override;
+  };
+
+private:
+  std::vector<std::unique_ptr<SchemaNode>> SchemaNodes;
+  SmallVector<Schema *, 8> Schemas;
+  raw_ostream &RO;
+  SchemaNode *Root = nullptr;
+
+  template <typename PropertyType, typename... PropertyArgs>
+  PropertyType *createProperty(PropertyArgs &&...Args) {
+    std::unique_ptr<PropertyType> UPtr =
+        std::make_unique<PropertyType>(std::forward<PropertyArgs>(Args)...);
+    PropertyType *Ptr = UPtr.get();
+    SchemaNodes.emplace_back(std::move(UPtr));
+    return Ptr;
+  }
+
+  template <typename PropertyType, typename... PropertyArgs>
+  PropertyType *getOrCreateProperty(Schema &S, PropertyArgs... Args) {
+    auto Found = std::find_if(S.begin(), S.end(), [](SchemaProperty *Property) {
+      return isa<PropertyType>(Property);
+    });
+    if (Found != S.end()) {
+      return cast<PropertyType>(*Found);
+    }
+    PropertyType *Created =
+        createProperty<PropertyType>(std::forward<PropertyArgs>(Args)...);
+    S.emplace_back(Created);
+    return Created;
+  }
+
+  Schema *createSchema() {
+    std::unique_ptr<Schema> UPtr = std::make_unique<Schema>();
+    Schema *Ptr = UPtr.get();
+    SchemaNodes.emplace_back(std::move(UPtr));
+    return Ptr;
+  }
+
+  Schema *getTopSchema() const {
+    return Schemas.empty() ? nullptr : Schemas.back();
+  }
+};
+
+// Define non-member operator<< so that Output can stream out document list.
+template <typename T>
+inline std::enable_if_t<has_DocumentListTraits<T>::value, GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &DocList) {
+  EmptyContext Ctx;
+  Gen.preflightDocument();
+  yamlize(Gen, DocumentListTraits<T>::element(Gen, DocList, 0), true, Ctx);
+  Gen.postflightDocument();
+  return Gen;
+}
+
+// Define non-member operator<< so that Output can stream out a map.
+template <typename T>
+inline std::enable_if_t<has_MappingTraits<T, EmptyContext>::value,
+                        GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &Map) {
+  EmptyContext Ctx;
+  Gen.preflightDocument();
+  yamlize(Gen, Map, true, Ctx);
+  Gen.postflightDocument();
+  return Gen;
+}
+
+// Define non-member operator<< so that Output can stream out a sequence.
+template <typename T>
+inline std::enable_if_t<has_SequenceTraits<T>::value, GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &Seq) {
+  EmptyContext Ctx;
+  Gen.preflightDocument();
+  yamlize(Gen, Seq, true, Ctx);
+  Gen.postflightDocument();
+  return Gen;
+}
+
+// Define non-member operator<< so that Output can stream out a block scalar.
+template <typename T>
+inline std::enable_if_t<has_BlockScalarTraits<T>::value, GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &Val) {
+  EmptyContext Ctx;
+  Gen.preflightDocument();
+  yamlize(Gen, Val, true, Ctx);
+  Gen.postflightDocument();
+  return Gen;
+}
+
+// Define non-member operator<< so that Output can stream out a string map.
+template <typename T>
+inline std::enable_if_t<has_CustomMappingTraits<T>::value, GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &Val) {
+  EmptyContext Ctx;
+  Gen.preflightDocument();
+  yamlize(Gen, Val, true, Ctx);
+  Gen.postflightDocument();
+  return Gen;
+}
+
+// Define non-member operator<< so that Output can stream out a polymorphic
+// type.
+template <typename T>
+inline std::enable_if_t<has_PolymorphicTraits<T>::value, GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &Val) {
+  EmptyContext Ctx;
+  Gen.preflightDocument();
+  yamlize(Gen, Val, true, Ctx);
+  Gen.postflightDocument();
+  return Gen;
+}
+
+// Provide better error message about types missing a trait specialization
+template <typename T>
+inline std::enable_if_t<missingTraits<T, EmptyContext>::value, GenerateSchema &>
+operator<<(GenerateSchema &Gen, T &seq) {
+  char missing_yaml_trait_for_type[sizeof(MissingTrait<T>)];
+  return Gen;
+}
+
+} // namespace yaml
+
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_YAMLGENERATE_SCHEMA_H

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -282,6 +282,7 @@ add_llvm_component_library(LLVMSupport
   WithColor.cpp
   YAMLParser.cpp
   YAMLTraits.cpp
+  YAMLGenerateSchema.cpp
   raw_os_ostream.cpp
   raw_ostream.cpp
   raw_ostream_proxy.cpp

--- a/llvm/lib/Support/YAMLGenerateSchema.cpp
+++ b/llvm/lib/Support/YAMLGenerateSchema.cpp
@@ -1,0 +1,285 @@
+//===- lib/Support/YAMLGenerateSchema.cpp ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/YAMLGenerateSchema.h"
+#include "llvm/Support/JSON.h"
+
+using namespace llvm;
+using namespace yaml;
+
+//===----------------------------------------------------------------------===//
+//  GenerateSchema
+//===----------------------------------------------------------------------===//
+
+GenerateSchema::GenerateSchema(raw_ostream &RO) : RO(RO) {}
+
+IOKind GenerateSchema::getKind() const { return IOKind::GeneratingSchema; }
+
+bool GenerateSchema::outputting() const { return false; }
+
+bool GenerateSchema::mapTag(StringRef, bool) { return false; }
+
+void GenerateSchema::beginMapping() {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  TypeProperty *Type = createProperty<TypeProperty>("object");
+  Top->emplace_back(Type);
+  FlowStyleProperty *FlowStyle = createProperty<FlowStyleProperty>();
+  Top->emplace_back(FlowStyle);
+}
+
+void GenerateSchema::endMapping() {}
+
+bool GenerateSchema::preflightKey(StringRef Key, bool Required,
+                                  bool SameAsDefault, bool &UseDefault,
+                                  void *&SaveInfo) {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  if (Key == "additionalProperties") {
+    AdditionalPropertiesProperty *Additional =
+        getOrCreateProperty<AdditionalPropertiesProperty>(*Top);
+    Schema *S = createSchema();
+    Additional->setSchema(S);
+    Schemas.push_back(S);
+    return true;
+  }
+
+  if (Required) {
+    RequiredProperty *Req = getOrCreateProperty<RequiredProperty>(*Top);
+    Req->emplace_back(Key);
+  } else {
+    OptionalProperty *Opt = getOrCreateProperty<OptionalProperty>(*Top);
+    Opt->emplace_back(Key);
+  }
+  PropertiesProperty *Properties =
+      getOrCreateProperty<PropertiesProperty>(*Top);
+  Schema *S = createSchema();
+  UserDefinedProperty *UserDefined =
+      createProperty<UserDefinedProperty>(Key, S);
+  Properties->emplace_back(UserDefined);
+  Schemas.push_back(S);
+  return true;
+}
+
+void GenerateSchema::postflightKey(void *) {
+  assert(!Schemas.empty());
+  Schemas.pop_back();
+}
+
+std::vector<StringRef> GenerateSchema::keys() { return {}; }
+
+void GenerateSchema::beginFlowMapping() {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  TypeProperty *Type = createProperty<TypeProperty>("object");
+  Top->emplace_back(Type);
+  FlowStyleProperty *FlowStyle =
+      createProperty<FlowStyleProperty>(FlowStyle::Flow);
+  Top->emplace_back(FlowStyle);
+}
+
+void GenerateSchema::endFlowMapping() {}
+
+unsigned GenerateSchema::beginSequence() {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  TypeProperty *Type = createProperty<TypeProperty>("array");
+  Top->emplace_back(Type);
+  ItemsProperty *Items = createProperty<ItemsProperty>();
+  Top->emplace_back(Items);
+  FlowStyleProperty *FlowStyle = createProperty<FlowStyleProperty>();
+  Top->emplace_back(FlowStyle);
+  return 1;
+}
+
+void GenerateSchema::endSequence() {}
+
+bool GenerateSchema::preflightElement(unsigned, void *&) {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  Schema *S = createSchema();
+  ItemsProperty *Items = getOrCreateProperty<ItemsProperty>(*Top);
+  Items->setSchema(S);
+  Schemas.push_back(S);
+  return true;
+}
+
+void GenerateSchema::postflightElement(void *) {
+  assert(!Schemas.empty());
+  Schemas.pop_back();
+}
+
+unsigned GenerateSchema::beginFlowSequence() {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  TypeProperty *Type = createProperty<TypeProperty>("array");
+  Top->emplace_back(Type);
+  ItemsProperty *Items = createProperty<ItemsProperty>();
+  Top->emplace_back(Items);
+  FlowStyleProperty *FlowStyle =
+      createProperty<FlowStyleProperty>(FlowStyle::Flow);
+  Top->emplace_back(FlowStyle);
+  return 1;
+}
+
+bool GenerateSchema::preflightFlowElement(unsigned Arg1, void *&Arg2) {
+  return preflightElement(Arg1, Arg2);
+}
+
+void GenerateSchema::postflightFlowElement(void *Arg1) {
+  postflightElement(Arg1);
+}
+
+void GenerateSchema::endFlowSequence() { endSequence(); }
+
+void GenerateSchema::beginEnumScalar() {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  TypeProperty *Type = createProperty<TypeProperty>("string");
+  Top->emplace_back(Type);
+  EnumProperty *Enum = createProperty<EnumProperty>();
+  Top->emplace_back(Enum);
+}
+
+bool GenerateSchema::matchEnumScalar(StringRef Val, bool) {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  EnumProperty *Enum = getOrCreateProperty<EnumProperty>(*Top);
+  Enum->emplace_back(Val);
+  return false;
+}
+
+bool GenerateSchema::matchEnumFallback() { return false; }
+
+void GenerateSchema::endEnumScalar() {}
+
+bool GenerateSchema::beginBitSetScalar(bool &) {
+  beginEnumScalar();
+  return true;
+}
+
+bool GenerateSchema::bitSetMatch(StringRef Val, bool Arg) {
+  return matchEnumScalar(Val, Arg);
+}
+
+void GenerateSchema::endBitSetScalar() { endEnumScalar(); }
+
+void GenerateSchema::scalarString(StringRef &Val, QuotingType) {
+  Schema *Top = getTopSchema();
+  assert(Top);
+  TypeProperty *Type = createProperty<TypeProperty>("string");
+  Top->emplace_back(Type);
+}
+
+void GenerateSchema::blockScalarString(StringRef &S) {
+  scalarString(S, QuotingType::None);
+}
+
+void GenerateSchema::scalarTag(std::string &val) {}
+
+NodeKind GenerateSchema::getNodeKind() { report_fatal_error("invalid call"); }
+
+void GenerateSchema::setError(const Twine &) {}
+
+std::error_code GenerateSchema::error() { return {}; }
+
+bool GenerateSchema::canElideEmptySequence() { return false; }
+
+// These are only used by operator<<. They could be private
+// if that templated operator could be made a friend.
+
+bool GenerateSchema::preflightDocument() {
+  Schema *S = createSchema();
+  Root = S;
+  Schemas.push_back(S);
+  return true;
+}
+
+void GenerateSchema::postflightDocument() {
+  assert(!Schemas.empty());
+  Schemas.pop_back();
+  json::Value JSONValue = Root->toJSON();
+  RO << llvm::formatv("{0:2}\n", JSONValue);
+}
+
+json::Value GenerateSchema::UserDefinedProperty::toJSON() const {
+  return Value->toJSON();
+}
+
+json::Value GenerateSchema::PropertiesProperty::toJSON() const {
+  json::Object JSONObject;
+  for (UserDefinedProperty *Property : *this) {
+    json::Value JSONValue = Property->toJSON();
+    JSONObject.try_emplace(Property->getName().data(), std::move(JSONValue));
+  }
+  return JSONObject;
+}
+
+json::Value GenerateSchema::AdditionalPropertiesProperty::toJSON() const {
+  return Value->toJSON();
+}
+
+json::Value GenerateSchema::RequiredProperty::toJSON() const {
+  json::Array JSONArray;
+  for (StringRef Value : *this) {
+    json::Value JSONValue(Value.data());
+    JSONArray.emplace_back(std::move(JSONValue));
+  }
+  return JSONArray;
+}
+
+json::Value GenerateSchema::OptionalProperty::toJSON() const {
+  json::Array JSONArray;
+  for (StringRef Value : *this) {
+    json::Value JSONValue(Value.data());
+    JSONArray.emplace_back(std::move(JSONValue));
+  }
+  return JSONArray;
+}
+
+json::Value GenerateSchema::TypeProperty::toJSON() const {
+  json::Value JSONValue(Value.data());
+  return JSONValue;
+}
+
+json::Value GenerateSchema::EnumProperty::toJSON() const {
+  json::Array JSONArray;
+  for (StringRef Value : *this) {
+    json::Value JSONValue(Value.data());
+    JSONArray.emplace_back(std::move(JSONValue));
+  }
+  return JSONArray;
+}
+
+json::Value GenerateSchema::ItemsProperty::toJSON() const {
+  return Value->toJSON();
+}
+
+json::Value GenerateSchema::FlowStyleProperty::toJSON() const {
+  StringRef Value;
+  switch (Style) {
+  case FlowStyle::Block:
+    Value = "block";
+    break;
+  case FlowStyle::Flow:
+    Value = "flow";
+    break;
+  }
+  json::Value JSONValue(Value.data());
+  return JSONValue;
+}
+
+json::Value GenerateSchema::Schema::toJSON() const {
+  json::Object JSONObject;
+  for (SchemaProperty *Value : *this) {
+    json::Value JSONValue = Value->toJSON();
+    StringRef Key = Value->getName();
+    JSONObject.try_emplace(Key.data(), std::move(JSONValue));
+  }
+  return JSONObject;
+}

--- a/llvm/lib/Support/YAMLGenerateSchema.cpp
+++ b/llvm/lib/Support/YAMLGenerateSchema.cpp
@@ -172,7 +172,7 @@ void GenerateSchema::endBitSetScalar() { endEnumScalar(); }
 void GenerateSchema::scalarString(StringRef &Val, QuotingType) {
   Schema *Top = getTopSchema();
   assert(Top);
-  TypeProperty *Type = createProperty<TypeProperty>("string");
+  TypeProperty *Type = createProperty<TypeProperty>(Val);
   Top->emplace_back(Type);
 }
 

--- a/llvm/lib/Support/YAMLTraits.cpp
+++ b/llvm/lib/Support/YAMLTraits.cpp
@@ -74,6 +74,8 @@ Input::~Input() = default;
 
 std::error_code Input::error() { return EC; }
 
+IOKind Input::getKind() const { return IOKind::Inputting; }
+
 bool Input::outputting() const {
   return false;
 }
@@ -484,6 +486,8 @@ Output::Output(raw_ostream &yout, void *context, int WrapColumn)
     : IO(context), Out(yout), WrapColumn(WrapColumn) {}
 
 Output::~Output() = default;
+
+IOKind Output::getKind() const { return IOKind::Outputting; }
 
 bool Output::outputting() const {
   return true;

--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -112,6 +112,7 @@ add_llvm_unittest(SupportTests
   VirtualOutputFileTest.cpp
   WithColorTest.cpp
   YAMLIOTest.cpp
+  YAMLGenerateSchemaTest.cpp
   YAMLParserTest.cpp
   buffer_ostream_test.cpp
   formatted_raw_ostream_test.cpp

--- a/llvm/unittests/Support/YAMLGenerateSchemaTest.cpp
+++ b/llvm/unittests/Support/YAMLGenerateSchemaTest.cpp
@@ -1,0 +1,124 @@
+//===- YAMLGenerateSchemaTest.cpp - Tests for Generating YAML Schema ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/YAMLGenerateSchema.h"
+#include "llvm/Support/YAMLTraits.h"
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+enum class ColorTy {
+  White,
+  Black,
+  Blue,
+};
+
+struct Baby {
+  std::string Name;
+  ColorTy Color;
+};
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(Baby)
+
+struct Animal {
+  std::string Name;
+  std::optional<int> Age;
+  std::vector<Baby> Babies;
+};
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(Animal)
+
+namespace llvm {
+namespace yaml {
+
+template <> struct ScalarEnumerationTraits<ColorTy> {
+  static void enumeration(IO &io, ColorTy &value) {
+    io.enumCase(value, "white", ColorTy::White);
+    io.enumCase(value, "black", ColorTy::Black);
+    io.enumCase(value, "blue", ColorTy::Blue);
+  }
+};
+
+template <> struct MappingTraits<Baby> {
+  static void mapping(IO &io, Baby &info) {
+    io.mapRequired("name", info.Name);
+    io.mapRequired("color", info.Color);
+  }
+};
+
+template <> struct MappingTraits<Animal> {
+  static void mapping(IO &io, Animal &info) {
+    io.mapRequired("name", info.Name);
+    io.mapOptional("age", info.Age);
+    io.mapOptional("babies", info.Babies);
+  }
+};
+
+} // namespace yaml
+} // namespace llvm
+
+TEST(ObjectYAMLGenerateSchema, SimpleSchema) {
+  std::string String;
+  raw_string_ostream OS(String);
+  std::vector<Animal> Animals;
+  yaml::GenerateSchema Gen(OS);
+  Gen << Animals;
+  StringRef YAMLSchema = R"({
+  "flowStyle": "block",
+  "items": {
+    "flowStyle": "block",
+    "optional": [
+      "age",
+      "babies"
+    ],
+    "properties": {
+      "age": {
+        "type": "string"
+      },
+      "babies": {
+        "flowStyle": "block",
+        "items": {
+          "flowStyle": "block",
+          "properties": {
+            "color": {
+              "enum": [
+                "white",
+                "black",
+                "blue"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "color"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "name": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  },
+  "type": "array"
+}
+)";
+  EXPECT_EQ(String.c_str(), YAMLSchema.str());
+}

--- a/llvm/unittests/Support/YAMLGenerateSchemaTest.cpp
+++ b/llvm/unittests/Support/YAMLGenerateSchemaTest.cpp
@@ -81,7 +81,7 @@ TEST(ObjectYAMLGenerateSchema, SimpleSchema) {
     ],
     "properties": {
       "age": {
-        "type": "string"
+        "type": "integer"
       },
       "babies": {
         "flowStyle": "block",

--- a/llvm/utils/gn/secondary/llvm/lib/Support/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Support/BUILD.gn
@@ -178,6 +178,7 @@ static_library("Support") {
     "WithColor.cpp",
     "YAMLParser.cpp",
     "YAMLTraits.cpp",
+    "YAMLGenerateSchema.cpp",
     "Z3Solver.cpp",
     "circular_raw_ostream.cpp",
     "raw_os_ostream.cpp",


### PR DESCRIPTION
Since now, when creating a YAML Schema, the type of all scalars is a 'string', this may be a bit strange. For example if you start typing number in IDE, it will complain that 'string' was expected. This patch fixes it by introducing new optional TypeNameTrait. Is is optional in order not to break backward compatibility.

This PR depends on https://github.com/llvm/llvm-project/pull/133284