### PR TITLE
[clang-tidy][readability-redundant-parentheses] add option to prevent widely used work around

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -62,7 +62,6 @@ void RedundantParenthesesCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *PE = Result.Nodes.getNodeAs<ParenExpr>("dup");
   if (auto *DRE = dyn_cast<DeclRefExpr>(PE->getSubExpr())) {
     const std::string Name = DRE->getDecl()->getQualifiedNameAsString();
-    llvm::errs() << Name << "\n";
     bool Allowed = llvm::any_of(AllowedDecls, [&Name](const llvm::Regex &NM) {
       return NM.isValid() && NM.match(Name);
     });

--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -62,9 +62,10 @@ void RedundantParenthesesCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *PE = Result.Nodes.getNodeAs<ParenExpr>("dup");
   if (auto *DRE = dyn_cast<DeclRefExpr>(PE->getSubExpr())) {
     const std::string Name = DRE->getDecl()->getQualifiedNameAsString();
-    bool Allowed = llvm::any_of(AllowedDecls, [&Name](const llvm::Regex &NM) {
-      return NM.isValid() && NM.match(Name);
-    });
+    const bool Allowed =
+        llvm::any_of(AllowedDecls, [&Name](const llvm::Regex &NM) {
+          return NM.isValid() && NM.match(Name);
+        });
     if (Allowed)
       return;
   }

--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.h
@@ -20,13 +20,16 @@ namespace clang::tidy::readability {
 /// https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-parentheses.html
 class RedundantParenthesesCheck : public ClangTidyCheck {
 public:
-  RedundantParenthesesCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  RedundantParenthesesCheck(StringRef Name, ClangTidyContext *Context);
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus | LangOpts.C99;
   }
+
+private:
+  const std::vector<StringRef> AllowedDecls;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
@@ -35,8 +35,7 @@ Options
 
   Semicolon-separated list of regular expressions matching names of declarations
   to ignore when the parentheses are around. Declarations can include variables
-  or functions.
-  The default is an `std::max;std::min`.
+  or functions. The default is an `std::max;std::min`.
   
   Some STL library functions may have the same name as widely used function-like
   macro. For example, ``std::max`` and ``max`` macro. A workaround to distinguish

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
@@ -33,10 +33,10 @@ Options
 
 .. option:: AllowedDecls
 
-  A semicolon-separated list of names of declarations included variables and
-  functions to ignore when the parenthese around it.
+  A semicolon-separated list of names of declarations to ignore when the
+  parentheses are around. Declarations can include variables or functions.
   The default is an `std::max;std::min`.
   
-  Some std library functions may have the same name as widely used function-like
-  macro. For example, ``std::max`` and ``max`` macro. A work around to distinguish
-  them is adding parenthese around functions to prevent function-like macro.
+  Some STL library functions may have the same name as widely used function-like
+  macro. For example, ``std::max`` and ``max`` macro. A workaround to distinguish
+  them is adding parentheses around functions to prevent function-like macro.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
@@ -33,8 +33,9 @@ Options
 
 .. option:: AllowedDecls
 
-  A semicolon-separated list of names of declarations to ignore when the
-  parentheses are around. Declarations can include variables or functions.
+  Semicolon-separated list of regular expressions matching names of declarations
+  to ignore when the parentheses are around. Declarations can include variables
+  or functions.
   The default is an `std::max;std::min`.
   
   Some STL library functions may have the same name as widely used function-like

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
@@ -27,3 +27,16 @@ affect the semantics.
 .. code-block:: c++
 
   int a = (1 * 2) + 3; // no warning
+
+Options
+-------
+
+.. option:: AllowedDecls
+
+  A semicolon-separated list of names of declarations included variables and
+  functions to ignore when the parenthese around it.
+  The default is an `std::max;std::min`.
+  
+  Some std library functions may have the same name as widely used function-like
+  macro. For example, ``std::max`` and ``max`` macro. A work around to distinguish
+  them is adding parenthese around functions to prevent function-like macro.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
@@ -62,3 +62,12 @@ void exceptions() {
   // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: redundant parentheses around expression [readability-redundant-parentheses]
   // CHECK-FIXES:    alignof(3);
 }
+
+namespace std {
+  template<class T> T max(T, T);
+  template<class T> T min(T, T);
+} // namespace std
+void ignoreStdMaxMin() {
+  (std::max)(1,2);
+  (std::min)(1,2);
+}


### PR DESCRIPTION
Part of #164125
Add a new option to ignore some decls.
