### PR TITLE
[NFC] Rename 'Expr' to 'RefExpr' to fix the build warnings

### DIFF
--- a/clang/include/clang/AST/StmtOpenACC.h
+++ b/clang/include/clang/AST/StmtOpenACC.h
@@ -821,7 +821,9 @@ public:
   struct StmtInfo {
     const Expr *V;
     const Expr *X;
-    const Expr *Expr;
+    // Listed as 'expr' in the standard, this is typically a generic expression
+    // as a component.
+    const Expr *RefExpr;
     // TODO: OpenACC: We should expand this as we're implementing the other
     // atomic construct kinds.
   };

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenACC.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenACC.cpp
@@ -346,7 +346,7 @@ CIRGenFunction::emitOpenACCAtomicConstruct(const OpenACCAtomicConstruct &s) {
   }
   case OpenACCAtomicKind::Write: {
     mlir::Value x = emitLValue(inf.X).getPointer();
-    mlir::Value expr = emitAnyExpr(inf.Expr).getValue();
+    mlir::Value expr = emitAnyExpr(inf.RefExpr).getValue();
     auto op = mlir::acc::AtomicWriteOp::create(builder, start, x, expr,
                                                /*ifCond=*/{});
     emitOpenACCClauses(op, s.getDirectiveKind(), s.getDirectiveLoc(),


### PR DESCRIPTION
I used 'expr' since that is what it is in the standard, but that obviously conflicts with our warnings on some build bots. This patch fixes that by renaming it.