### PR TITLE
[libc] add various macros relate to *ADDR*

### DIFF
--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -10,6 +10,7 @@
 #define LLVM_LIBC_MACROS_NETINET_IN_MACROS_H
 
 #include "../llvm-libc-types/in_addr_t.h"
+#include "__llvm-libc-common.h"
 
 #define IPPROTO_IP 0
 #define IPPROTO_ICMP 1

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIBC_MACROS_NETINET_IN_MACROS_H
 #define LLVM_LIBC_MACROS_NETINET_IN_MACROS_H
 
+#include "../llvm-libc-types/in_addr_t.h"
+
 #define IPPROTO_IP 0
 #define IPPROTO_ICMP 1
 #define IPPROTO_TCP 6
@@ -23,5 +25,11 @@
 #define IPV6_JOIN_GROUP 20
 #define IPV6_LEAVE_GROUP 21
 #define IPV6_V6ONLY 26
+
+#define INADDR_ANY __LLVM_LIBC_CAST(static_cast, in_addr_t, 0x00000000)
+#define INADDR_BROADCAST __LLVM_LIBC_CAST(static_cast, in_addr_t, 0xffffffff)
+
+#define INET_ADDRSTRLEN 16
+#define INET6_ADDRSTRLEN 46
 
 #endif // LLVM_LIBC_MACROS_NETINET_IN_MACROS_H


### PR DESCRIPTION
This patch adds 4 macros in the `netinet/in.h` header, as specified by POSIX standards.

Based on previous discussions, testing these unchanged values is redundant, so I did not add tests here. If there is a better way to test these, I would be happy to add them.