### PR TITLE
[flang][mlir] fix irreflexibility violation of strict weak ordering in #155348

### DIFF
--- a/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
+++ b/mlir/lib/Dialect/OpenMP/Transforms/OpenMPOffloadPrivatizationPrepare.cpp
@@ -189,7 +189,9 @@ class PrepareForOMPOffloadPrivatizationPass
 
         DominanceInfo dom;
         llvm::sort(chainOfOps, [&](Operation *l, Operation *r) {
-          return dom.dominates(l, r);
+          if (l == r)
+            return false;
+          return dom.properlyDominates(l, r);
         });
 
         rewriter.setInsertionPoint(chainOfOps.front());


### PR DESCRIPTION
This fixes strict weak ordering checks violations from #155348 when running these two tests:

    mlir/test/Dialect/OpenMP/omp-offload-privatization-prepare.mlir
    mlir/test/Dialect/OpenMP/omp-offload-privatization-prepare-by-value.mlir

Sample error:

    /stable/src/libcxx/include/__debug_utils/strict_weak_ordering_check.h:50: libc++ Hardening assertion !__comp(*(__first + __a), *(__first + __b)) failed: Your comparator is not a valid strict-weak ordering

This is because (x < x) should be false, not true, to meet the irreflexibility property. (Note that .dominates(x, x) returns true.)

I'm afraid that even after this commit we can't guarantee a strict weak ordering, because we can't guarantee transitivity of equivalence by sorting with a strict dominance function. However the tests are not failing anymore, and I am not at all familiar with this code so I will leave this concern up to the original author for consideration. (Ideas without any further context: I would consider a topological sort or walking a dominator tree.)

Reference on std::sort and strict weak ordering:
  https://danlark.org/2022/04/20/changing-stdsort-at-googles-scale-and-beyond/