### PR TITLE
[flang] Fix build on different of cores from #164630

### DIFF
--- a/flang/lib/Optimizer/Dialect/MIF/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/MIF/CMakeLists.txt
@@ -8,7 +8,6 @@ add_flang_library(MIFDialect
   LINK_LIBS
   FIRDialect
   FIRDialectSupport
-  FIRSupport
 
   LINK_COMPONENTS
   AsmParser

--- a/flang/lib/Optimizer/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Support/CMakeLists.txt
@@ -7,9 +7,11 @@ add_flang_library(FIRSupport
   DEPENDS
   FIROpsIncGen
   HLFIROpsIncGen
+  MIFOpsIncGen
 
   LINK_LIBS
   FIRDialect
+  MIFDialect
 
   LINK_COMPONENTS
   TargetParser


### PR DESCRIPTION
Normally fix incorrect linking introduced in [#161179](https://github.com/llvm/llvm-project/pull/161179) with build in parallel.