### PR TITLE
[lldb] fix lldb-server test failures on windows

### DIFF
--- a/lldb/test/Shell/lldb-server/TestPlatformErrorMessages.test
+++ b/lldb/test/Shell/lldb-server/TestPlatformErrorMessages.test
@@ -22,4 +22,4 @@ LOGFILE_MISSING: error: --log-file: missing argument
 RUN: %platformserver --log-channels 2>&1 | FileCheck --check-prefixes=LOGCHANNELS_MISSING,ALL %s
 LOGCHANNELS_MISSING: error: --log-channels: missing argument
 
-ALL: Use 'lldb-server {{p|platform}} --help' for a complete list of options.
+ALL: Use 'lldb-server{{(\.exe)?}} {{p|platform}} --help' for a complete list of options.

--- a/lldb/test/Shell/lldb-server/TestPlatformHelp.test
+++ b/lldb/test/Shell/lldb-server/TestPlatformHelp.test
@@ -5,9 +5,9 @@ RUN: %lldb-server p -h 2>&1 | FileCheck %s
 RUN: %lldb-server platform --help 2>&1 | FileCheck %s
 RUN: %lldb-server platform -h 2>&1 | FileCheck %s
 
-CHECK: OVERVIEW: lldb-server platform
+CHECK: OVERVIEW: lldb-server{{(\.exe)?}} platform
 
-CHECK: USAGE: lldb-server {{p|platform}} [options] --listen <[host]:port> {{\[}}[--] program args...]
+CHECK: USAGE: lldb-server{{(\.exe)?}} {{p|platform}} [options] --listen <[host]:port> {{\[}}[--] program args...]
 
 CHECK: CONNECTION OPTIONS:
 CHECK: --gdbserver-port <port>
@@ -33,8 +33,8 @@ CHECK: Acts as a platform server for remote debugging
 
 CHECK: EXAMPLES
 CHECK: # Listen on port 1234, exit after first connection
-CHECK: lldb-server platform --listen tcp://0.0.0.0:1234
+CHECK: lldb-server{{(\.exe)?}} platform --listen tcp://0.0.0.0:1234
 CHECK: # Listen on port 5555, accept multiple connections
-CHECK: lldb-server platform --server --listen tcp://localhost:5555
+CHECK: lldb-server{{(\.exe)?}} platform --server --listen tcp://localhost:5555
 CHECK: # Listen on Unix domain socket
-CHECK: lldb-server platform --listen unix:///tmp/lldb-server.sock
+CHECK: lldb-server{{(\.exe)?}} platform --listen unix:///tmp/lldb-server.sock


### PR DESCRIPTION
Fix windows test failures from https://github.com/llvm/llvm-project/pull/162730 by including and optional .exe on the lldb-server name. Still passes on linux, but should pass on windows now.

```
> bin/llvm-lit -v tools/lldb/test/Shell/lldb-server/
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/config.py:531: note: using clang: llvm-project/build/bin/clang
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/config.py:531: note: using ld.lld: /usr/bin/ld.lld
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/config.py:531: note: using lld-link: /usr/bin/lld-link
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/config.py:531: note: using ld64.lld: /usr/bin/ld64.lld
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/config.py:531: note: using wasm-ld: /usr/bin/wasm-ld
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/subst.py:126: note: Did not find obj2yaml in llvm-project/build/./bin:llvm-project/build/./bin
llvm-lit: llvm-project/llvm/utils/lit/lit/llvm/subst.py:126: note: Did not find llvm-objdump in llvm-project/build/./bin:llvm-project/build/./bin
llvm-lit: llvm-project/lldb/test/Shell/lit.cfg.py:125: warning: Could not set a default per-test timeout. Requires the Python psutil module but it could not be found. Try installing it via pip or via your operating system's package manager.
-- Testing: 4 tests, 4 workers --
PASS: lldb-shell :: lldb-server/TestGdbserverErrorMessages.test (1 of 4)
PASS: lldb-shell :: lldb-server/TestPlatformHelp.test (2 of 4)
PASS: lldb-shell :: lldb-server/TestPlatformErrorMessages.test (3 of 4)
PASS: lldb-shell :: lldb-server/TestPlatformSuccessfulStartup.test (4 of 4)

Testing Time: 1.10s

Total Discovered Tests: 4
  Passed: 4 (100.00%)

1 warning(s) in tests
```