### PR TITLE
[flang][OpenMP] Add missing forward declarations and includes

### DIFF
--- a/flang/include/flang/Semantics/openmp-utils.h
+++ b/flang/include/flang/Semantics/openmp-utils.h
@@ -28,6 +28,7 @@
 #include <utility>
 
 namespace Fortran::semantics {
+class Scope;
 class SemanticsContext;
 class Symbol;
 

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -26,7 +26,9 @@
 #include "flang/Parser/openmp-utils.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/expression.h"
+#include "flang/Semantics/scope.h"
 #include "flang/Semantics/semantics.h"
+#include "flang/Semantics/symbol.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
@@ -505,5 +507,4 @@ bool IsStrictlyStructuredBlock(const parser::Block &block) {
     return false;
   }
 }
-
 } // namespace Fortran::semantics::omp


### PR DESCRIPTION
Add declarations/includes of Scope and Symbol to Semantics/openmp-utils.