### PR TITLE
[HLSL] Adding DXIL Storage type into `TypedInfo`

### DIFF
--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -293,7 +293,7 @@ public:
 
   struct TypedInfo {
     dxil::ElementType ElementTy;
-    dxil::ElementType DXILTargetTy;
+    dxil::ElementType DXILStorageTy;
     uint32_t ElementCount;
 
     bool operator==(const TypedInfo &RHS) const {

--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -293,7 +293,6 @@ public:
 
   struct TypedInfo {
     dxil::ElementType ElementTy;
-    // Some 64 byte types are treated as 32 byte types in DXIL.
     dxil::ElementType DXILTargetTy;
     uint32_t ElementCount;
 

--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -293,6 +293,8 @@ public:
 
   struct TypedInfo {
     dxil::ElementType ElementTy;
+    // Some 64 byte types are treated as 32 byte types in DXIL.
+    dxil::ElementType DXILTargetTy;
     uint32_t ElementCount;
 
     bool operator==(const TypedInfo &RHS) const {

--- a/llvm/lib/Analysis/DXILResource.cpp
+++ b/llvm/lib/Analysis/DXILResource.cpp
@@ -207,7 +207,6 @@ static dxil::ElementType toDXILElementType(Type *Ty, bool IsSigned) {
 }
 
 static dxil::ElementType toDXILStorageType(dxil::ElementType ET) {
-  // TODO: Handle unorm and snorm.
   if (ET == dxil::ElementType::U64 || ET == dxil::ElementType::F64 ||
       ET == dxil::ElementType::I64 || ET == dxil::ElementType::SNormF64 ||
       ET == dxil::ElementType::UNormF64)
@@ -646,9 +645,10 @@ void ResourceTypeInfo::print(raw_ostream &OS, const DataLayout &DL) const {
       OS << "  Alignment: " << Struct.AlignLog2 << "\n";
     } else if (isTyped()) {
       TypedInfo Typed = getTyped();
-      OS << "  Element Type: " << getElementTypeName(Typed.ElementTy) << "\n"
-         << "  Storage Type: " << getElementTypeName(Typed.DXILStorageTy)
-         << "\n"
+      OS << "  Element Type: " << getElementTypeName(Typed.ElementTy);
+      if (Typed.ElementTy != Typed.DXILStorageTy)
+        OS << " (stored as " << getElementTypeName(Typed.DXILStorageTy) << ")";
+      OS << "\n"
          << "  Element Count: " << Typed.ElementCount << "\n";
     } else if (isFeedback())
       OS << "  Feedback Type: " << getSamplerFeedbackTypeName(getFeedbackType())

--- a/llvm/lib/Analysis/DXILResource.cpp
+++ b/llvm/lib/Analysis/DXILResource.cpp
@@ -206,12 +206,11 @@ static dxil::ElementType toDXILElementType(Type *Ty, bool IsSigned) {
   return ElementType::Invalid;
 }
 
-static dxil::ElementType toDXILTargetType(Type *Ty, bool IsSigned) {
+static dxil::ElementType toDXILTargetType(dxil::ElementType ET) {
   // TODO: Handle unorm, snorm, and packed.
-  Type *ScalarTy = Ty->getScalarType();
-  if (ScalarTy->isIntegerTy(64) || ScalarTy->isDoubleTy())
-    return ElementType::U32;
-  return toDXILElementType(Ty, IsSigned);
+  if (ET == dxil::ElementType::U64 || ET == dxil::ElementType::F64)
+    return dxil::ElementType::U32;
+  return ET;
 }
 
 ResourceTypeInfo::ResourceTypeInfo(TargetExtType *HandleTy,
@@ -577,7 +576,7 @@ ResourceTypeInfo::TypedInfo ResourceTypeInfo::getTyped() const {
 
   auto [ElTy, IsSigned] = getTypedElementType(Kind, HandleTy);
   dxil::ElementType ET = toDXILElementType(ElTy, IsSigned);
-  dxil::ElementType DXILTargetTy = toDXILTargetType(ElTy, IsSigned);
+  dxil::ElementType DXILTargetTy = toDXILTargetType(ET);
   uint32_t Count = 1;
   if (auto *VTy = dyn_cast<FixedVectorType>(ElTy))
     Count = VTy->getNumElements();

--- a/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
@@ -49,7 +49,7 @@ static StringRef getRCPrefix(dxil::ResourceClass RC) {
 
 static StringRef getFormatName(const dxil::ResourceTypeInfo &RI) {
   if (RI.isTyped()) {
-    switch (RI.getTyped().DXILTargetTy) {
+    switch (RI.getTyped().DXILStorageTy) {
     case dxil::ElementType::I1:
       return "i1";
     case dxil::ElementType::I16:

--- a/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
@@ -49,7 +49,7 @@ static StringRef getRCPrefix(dxil::ResourceClass RC) {
 
 static StringRef getFormatName(const dxil::ResourceTypeInfo &RI) {
   if (RI.isTyped()) {
-    switch (RI.getTyped().ElementTy) {
+    switch (RI.getTyped().DXILTargetTy) {
     case dxil::ElementType::I1:
       return "i1";
     case dxil::ElementType::I16:

--- a/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
+++ b/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
@@ -9,9 +9,9 @@
 @Four.str = private unnamed_addr constant [5 x i8] c"Four\00", align 1
 @Array.str = private unnamed_addr constant [6 x i8] c"Array\00", align 1
 @Five.str = private unnamed_addr constant [5 x i8] c"Five\00", align 1
+@Six.str = private unnamed_addr constant [4 x i8] c"Six\00", align 1
 @CB.str = private unnamed_addr constant [3 x i8] c"CB\00", align 1
 @Constants.str = private unnamed_addr constant [10 x i8] c"Constants\00", align 1
-@Six.str = private unnamed_addr constant [4 x i8] c"Six\00", align 1
 
 
 define void @test_typedbuffer() {

--- a/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
+++ b/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
@@ -11,6 +11,8 @@
 @Five.str = private unnamed_addr constant [5 x i8] c"Five\00", align 1
 @CB.str = private unnamed_addr constant [3 x i8] c"CB\00", align 1
 @Constants.str = private unnamed_addr constant [10 x i8] c"Constants\00", align 1
+@Six.str = private unnamed_addr constant [4 x i8] c"Six\00", align 1
+
 
 define void @test_typedbuffer() {
   ; ByteAddressBuffer Buf : register(t8, space1)
@@ -137,6 +139,23 @@ define void @test_typedbuffer() {
   ; CHECK:   Element Type: f32
   ; CHECK:   Element Count: 4
 
+  %uav4 = call target("dx.TypedBuffer", double, 1, 0, 0) 
+    @llvm.dx.resource.handlefrombinding(i32 5, i32 0, i32 1, i32 0, ptr @Six.str)
+  ; CHECK: Resource [[UAV4:[0-9]+]]:
+  ; CHECK:   Name: Six
+  ; CHECK:   Binding:
+  ; CHECK:     Record ID: 4
+  ; CHECK:     Space: 5
+  ; CHECK:     Lower Bound: 0
+  ; CHECK:     Size: 1
+  ; CHECK:   Globally Coherent: 0
+  ; CHECK:   Counter Direction: Unknown
+  ; CHECK:   Class: UAV
+  ; CHECK:   Kind: Buffer
+  ; CHECK:   IsROV: 0
+  ; CHECK:   Element Type: f64 (stored as u32)
+  ; CHECK:   Element Count: 1
+
   %cb0 = call target("dx.CBuffer", {float})
      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr @CB.str)
   ; CHECK: Resource [[CB0:[0-9]+]]:
@@ -175,6 +194,7 @@ define void @test_typedbuffer() {
 ; CHECK-DAG: Call bound to [[UAV1]]: %uav1 =
 ; CHECK-DAG: Call bound to [[UAV2]]: %uav2_1 =
 ; CHECK-DAG: Call bound to [[UAV2]]: %uav2_2 =
+; CHECK-DAG: Call bound to [[UAV4]]: %uav4 =
 ; CHECK-DAG: Call bound to [[CB0]]: %cb0 =
 ; CHECK-DAG: Call bound to [[CB1]]: %cb1 =
 

--- a/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
+++ b/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
@@ -13,7 +13,6 @@
 @CB.str = private unnamed_addr constant [3 x i8] c"CB\00", align 1
 @Constants.str = private unnamed_addr constant [10 x i8] c"Constants\00", align 1
 
-
 define void @test_typedbuffer() {
   ; ByteAddressBuffer Buf : register(t8, space1)
   %srv0 = call target("dx.RawBuffer", void, 0, 0)

--- a/llvm/test/CodeGen/DirectX/Metadata/srv_metadata.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/srv_metadata.ll
@@ -22,14 +22,14 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 ; PRINT-NEXT:; ------------------------------ ---------- ------- ----------- ------- -------------- ---------
 ; PRINT-NEXT:; Zero                              texture     f16         buf      T0             t0         1
 ; PRINT-NEXT:; One                               texture     f32         buf      T1             t1         1
-; PRINT-NEXT:; Two                               texture     f64         buf      T2             t2         1
+; PRINT-NEXT:; Two                               texture     u32         buf      T2             t2         1
 ; PRINT-NEXT:; Three                             texture     i32         buf      T3             t3         1
 ; PRINT-NEXT:; Four                              texture    byte         r/o      T4             t5         1
 ; PRINT-NEXT:; Five                              texture  struct         r/o      T5             t6         1
-; PRINT-NEXT:; Six                               texture     u64         buf      T6     t10,space2         1
+; PRINT-NEXT:; Six                               texture     u32         buf      T6     t10,space2         1
 ; PRINT-NEXT:; Array                             texture     f32         buf      T7      t4,space3       100
-; PRINT-NEXT:; Array2                            texture     f64         buf      T8      t2,space4 unbounded
-; PRINT-NEXT:; Seven                             texture     u64         buf      T9     t20,space5         1
+; PRINT-NEXT:; Array2                            texture     u32         buf      T8      t2,space4 unbounded
+; PRINT-NEXT:; Seven                             texture     u32         buf      T9     t20,space5         1
 ;
 
 define void @test() #0 {
@@ -120,15 +120,14 @@ attributes #0 = { noinline nounwind "hlsl.shader"="compute" }
 ; CHECK: ![[Half]] = !{i32 0, i32 8}
 ; CHECK: ![[One]] = !{i32 1, ptr @One, !"One", i32 0, i32 1, i32 1, i32 10, i32 0, ![[Float:[0-9]+]]}
 ; CHECK: ![[Float]] = !{i32 0, i32 9}
-; CHECK: ![[Two]] = !{i32 2, ptr @Two, !"Two", i32 0, i32 2, i32 1, i32 10, i32 0, ![[Double:[0-9]+]]}
-; CHECK: ![[Double]] = !{i32 0, i32 10}
+; CHECK: ![[Two]] = !{i32 2, ptr @Two, !"Two", i32 0, i32 2, i32 1, i32 10, i32 0, ![[U32:[0-9]+]]}
+; CHECK: ![[U32]] = !{i32 0, i32 5}
 ; CHECK: ![[Three]] = !{i32 3, ptr @Three, !"Three", i32 0, i32 3, i32 1, i32 10, i32 0, ![[I32:[0-9]+]]}
 ; CHECK: ![[I32]] = !{i32 0, i32 4}
 ; CHECK: ![[Four]] = !{i32 4, ptr @Four, !"Four", i32 0, i32 5, i32 1, i32 11, i32 0, null}
 ; CHECK: ![[Five]] = !{i32 5, ptr @Five, !"Five", i32 0, i32 6, i32 1, i32 12, i32 0, ![[FiveStride:[0-9]+]]}
 ; CHECK: ![[FiveStride]] = !{i32 1, i32 2}
-; CHECK: ![[Six]] = !{i32 6, ptr @Six, !"Six", i32 2, i32 10, i32 1, i32 10, i32 0, ![[U64:[0-9]+]]}
-; CHECK: ![[U64]] = !{i32 0, i32 7}
+; CHECK: ![[Six]] = !{i32 6, ptr @Six, !"Six", i32 2, i32 10, i32 1, i32 10, i32 0, ![[U32:[0-9]+]]}
 ; CHECK: ![[Array]] = !{i32 7, ptr @Array, !"Array", i32 3, i32 4, i32 100, i32 10, i32 0, ![[Float]]}
-; CHECK: ![[Array2]] = !{i32 8, ptr @Array2, !"Array2", i32 4, i32 2, i32 -1, i32 10, i32 0, ![[Double]]}
-; CHECK: ![[Seven]] = !{i32 9, ptr @Seven, !"Seven", i32 5, i32 20, i32 1, i32 10, i32 0, ![[U64]]}
+; CHECK: ![[Array2]] = !{i32 8, ptr @Array2, !"Array2", i32 4, i32 2, i32 -1, i32 10, i32 0, ![[U32]]}
+; CHECK: ![[Seven]] = !{i32 9, ptr @Seven, !"Seven", i32 5, i32 20, i32 1, i32 10, i32 0, ![[U32]]}

--- a/llvm/test/CodeGen/DirectX/Metadata/uav_metadata.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/uav_metadata.ll
@@ -25,17 +25,17 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 ; PRINT-NEXT:; ------------------------------ ---------- ------- ----------- ------- -------------- ---------
 ; PRINT-NEXT:; Zero                                  UAV     f16         buf      U0             u0         1
 ; PRINT-NEXT:; One                                   UAV     f32         buf      U1             u1         1
-; PRINT-NEXT:; Two                                   UAV     f64         buf      U2             u2         1
+; PRINT-NEXT:; Two                                   UAV     u32         buf      U2             u2         1
 ; PRINT-NEXT:; Three                                 UAV     i32         buf      U3             u3         1
 ; PRINT-NEXT:; Four                                  UAV    byte         r/w      U4             u5         1
 ; PRINT-NEXT:; Five                                  UAV  struct         r/w      U5             u6         1
 ; PRINT-NEXT:; Six                                   UAV     i32         buf      U6             u7         1
 ; PRINT-NEXT:; Seven                                 UAV  struct         r/w      U7             u8         1
 ; PRINT-NEXT:; Eight                                 UAV    byte         r/w      U8             u9         1
-; PRINT-NEXT:; Nine                                  UAV     u64         buf      U9     u10,space2         1
+; PRINT-NEXT:; Nine                                  UAV     u32         buf      U9     u10,space2         1
 ; PRINT-NEXT:; Array                                 UAV     f32         buf     U10      u4,space3       100
-; PRINT-NEXT:; Array2                                UAV     f64         buf     U11      u2,space4 unbounded
-; PRINT-NEXT:; Ten                                   UAV     u64         buf     U12     u22,space5         1
+; PRINT-NEXT:; Array2                                UAV     u32         buf     U11      u2,space4 unbounded
+; PRINT-NEXT:; Ten                                   UAV     u32         buf     U12     u22,space5         1
 
 define void @test() #0 {
   ; RWBuffer<half4> Zero : register(u0)
@@ -144,8 +144,8 @@ attributes #0 = { noinline nounwind "hlsl.shader"="compute" }
 ; CHECK: ![[Half]] = !{i32 0, i32 8}
 ; CHECK: ![[One]] = !{i32 1, ptr @One, !"One", i32 0, i32 1, i32 1, i32 10, i1 false, i1 false, i1 false, ![[Float:[0-9]+]]}
 ; CHECK: ![[Float]] = !{i32 0, i32 9}
-; CHECK: ![[Two]] = !{i32 2, ptr @Two, !"Two", i32 0, i32 2, i32 1, i32 10, i1 false, i1 false, i1 false, ![[Double:[0-9]+]]}
-; CHECK: ![[Double]] = !{i32 0, i32 10}
+; CHECK: ![[Two]] = !{i32 2, ptr @Two, !"Two", i32 0, i32 2, i32 1, i32 10, i1 false, i1 false, i1 false, ![[U32:[0-9]+]]}
+; CHECK: ![[U32]] = !{i32 0, i32 5}
 ; CHECK: ![[Three]] = !{i32 3, ptr @Three, !"Three", i32 0, i32 3, i32 1, i32 10, i1 false, i1 false, i1 false, ![[I32:[0-9]+]]}
 ; CHECK: ![[I32]] = !{i32 0, i32 4}
 ; CHECK: ![[Four]] = !{i32 4, ptr @Four, !"Four", i32 0, i32 5, i32 1, i32 11, i1 false, i1 false, i1 false, null}
@@ -155,8 +155,7 @@ attributes #0 = { noinline nounwind "hlsl.shader"="compute" }
 ; CHECK: ![[Seven]] = !{i32 7, ptr @Seven, !"Seven", i32 0, i32 8, i32 1, i32 12, i1 false, i1 false, i1 true, ![[SevenStride:[0-9]+]]}
 ; CHECK: ![[SevenStride]] = !{i32 1, i32 16}
 ; CHECK: ![[Eight]] = !{i32 8, ptr @Eight, !"Eight", i32 0, i32 9, i32 1, i32 11, i1 false, i1 false, i1 true, null}
-; CHECK: ![[Nine]] = !{i32 9, ptr @Nine, !"Nine", i32 2, i32 10, i32 1, i32 10, i1 false, i1 false, i1 false, ![[U64:[0-9]+]]}
-; CHECK: ![[U64]] = !{i32 0, i32 7}
+; CHECK: ![[Nine]] = !{i32 9, ptr @Nine, !"Nine", i32 2, i32 10, i32 1, i32 10, i1 false, i1 false, i1 false, ![[U32]]}
 ; CHECK: ![[Array]] = !{i32 10, ptr @Array, !"Array", i32 3, i32 4, i32 100, i32 10, i1 false, i1 false, i1 false, ![[Float]]}
-; CHECK: ![[Array2]] = !{i32 11, ptr @Array2, !"Array2", i32 4, i32 2, i32 -1, i32 10, i1 false, i1 false, i1 false, ![[Double]]}
+; CHECK: ![[Array2]] = !{i32 11, ptr @Array2, !"Array2", i32 4, i32 2, i32 -1, i32 10, i1 false, i1 false, i1 false, ![[U32]]}
 ; CHECK: ![[Ten]] = !{i32 12, ptr @Ten, !"Ten", i32 5, i32 22, i32 1, i32 10, i1 false, i1 false, i1 false, ![[U64:[0-9]+]]}


### PR DESCRIPTION
In DXIL, some 64bit types are actually represented with their 32bit counterpart. This was already being address in the codegen, however the metadata generation was lacking this information. This PR is fixing this issue.

Closes: [#146735](https://github.com/llvm/llvm-project/issues/146735)