### PR TITLE
[flang] Let !@acc and !@cuf conditional lines be continuations

### DIFF
--- a/flang/test/Preprocessing/bug164727.cuf
+++ b/flang/test/Preprocessing/bug164727.cuf
@@ -1,0 +1,6 @@
+!RUN: %flang_fc1 -fdebug-unparse -x cuda %s 2>&1 | FileCheck %s
+!CHECK: REAL, MANAGED, ALLOCATABLE :: x
+real, &
+  !@cuf managed, &
+  allocatable :: x
+end


### PR DESCRIPTION
OpenMP conditional compilation lines (!$) work as continuation lines, but OpenACC and CUDA conditional lines do not.

Fixes https://github.com/llvm/llvm-project/issues/164727 and https://github.com/llvm/llvm-project/issues/164708.