### PR TITLE
[asan] Avoid -Wpointer-bool-conversion warning by comparing to nullptr

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -58,7 +58,7 @@ namespace __asan {
 
 static inline uptr MaybeRealStrnlen(const char *s, uptr maxlen) {
 #if SANITIZER_INTERCEPT_STRNLEN
-  if (REAL(strnlen))
+  if (static_cast<bool>(REAL(strnlen)))
     return REAL(strnlen)(s, maxlen);
 #  endif
   return internal_strnlen(s, maxlen);
@@ -66,7 +66,7 @@ static inline uptr MaybeRealStrnlen(const char *s, uptr maxlen) {
 
 static inline uptr MaybeRealWcsnlen(const wchar_t* s, uptr maxlen) {
 #  if SANITIZER_INTERCEPT_WCSNLEN
-  if (REAL(wcsnlen))
+  if (static_cast<bool>(REAL(wcsnlen)))
     return REAL(wcsnlen)(s, maxlen);
 #  endif
   return internal_wcsnlen(s, maxlen);

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -58,7 +58,7 @@ namespace __asan {
 
 static inline uptr MaybeRealStrnlen(const char *s, uptr maxlen) {
 #if SANITIZER_INTERCEPT_STRNLEN
-  if (static_cast<bool>(REAL(strnlen)))
+  if (REAL(strnlen) != nullptr)
     return REAL(strnlen)(s, maxlen);
 #  endif
   return internal_strnlen(s, maxlen);
@@ -66,7 +66,7 @@ static inline uptr MaybeRealStrnlen(const char *s, uptr maxlen) {
 
 static inline uptr MaybeRealWcsnlen(const wchar_t* s, uptr maxlen) {
 #  if SANITIZER_INTERCEPT_WCSNLEN
-  if (static_cast<bool>(REAL(wcsnlen)))
+  if (REAL(wcsnlen) != nullptr)
     return REAL(wcsnlen)(s, maxlen);
 #  endif
   return internal_wcsnlen(s, maxlen);


### PR DESCRIPTION
The current code may trigger a compiler warning:
```
address of function 'wcsnlen' will always evaluate to 'true' [-Wpointer-bool-conversion]
```

Fix this by comparing to nullptr. The same fix is applied to strnlen for future-proofing.