### PR TITLE
[AArch64][llvm] Add instructions for FEAT_MOPS_GO

### DIFF
--- a/clang/test/Driver/aarch64-vfat.c
+++ b/clang/test/Driver/aarch64-vfat.c
@@ -1,0 +1,7 @@
+// ===== Features supported on aarch64 =====
+
+// FAT features (Future Architecture Technologies)
+
+// RUN: %clang -target aarch64 -march=armv9.7a+mops-go -### -c %s 2>&1 | FileCheck -check-prefix=VFAT-MOPS-GO %s
+// RUN: %clang -target aarch64 -march=armv9.7-a+mops-go -### -c %s 2>&1 | FileCheck -check-prefix=VFAT-MOPS-GO %s
+// VFAT-MOPS-GO: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "generic" "-target-feature" "+v9.7a"{{.*}} "-target-feature" "+mops-go"

--- a/clang/test/Driver/print-supported-extensions-aarch64.c
+++ b/clang/test/Driver/print-supported-extensions-aarch64.c
@@ -49,6 +49,7 @@
 // CHECK-NEXT:     lsui                FEAT_LSUI                                              Enable Armv9.6-A unprivileged load/store instructions
 // CHECK-NEXT:     lut                 FEAT_LUT                                               Enable Lookup Table instructions
 // CHECK-NEXT:     mops                FEAT_MOPS                                              Enable Armv8.8-A memcpy and memset acceleration instructions
+// CHECK-NEXT:     mops-go             FEAT_MOPS_GO                                           Enable memset acceleration granule only
 // CHECK-NEXT:     mpamv2              FEAT_MPAMv2                                            Enable Armv9.7-A MPAMv2 Lookaside Buffer Invalidate instructions
 // CHECK-NEXT:     memtag              FEAT_MTE, FEAT_MTE2                                    Enable Memory Tagging Extension
 // CHECK-NEXT:     mtetc               FEAT_MTETC                                             Enable Virtual Memory Tagging Extension

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -104,6 +104,9 @@ Changes to the AArch64 Backend
 * Assembler/disassembler support has been added for Armv9.7-A (2025)
   architecture extensions.
 
+* Assembler/disassembler support has been added for 'Virtual Tagging
+  Extension (vMTE)' Future Architecture Technologies extension.
+
 Changes to the AMDGPU Backend
 -----------------------------
 

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -626,6 +626,13 @@ def FeatureF16F32MM : ExtensionWithMArch<"f16f32mm", "F16F32MM", "FEAT_F16F32MM"
   "Enable Armv9.7-A Advanced SIMD half-precision matrix multiply-accumulate to single-precision", [FeatureNEON, FeatureFullFP16]>;
 
 //===----------------------------------------------------------------------===//
+//  Future Architecture Technologies
+//===----------------------------------------------------------------------===//
+
+def FeatureMOPS_GO: ExtensionWithMArch<"mops-go", "MOPS_GO", "FEAT_MOPS_GO",
+  "Enable memset acceleration granule only">;
+
+//===----------------------------------------------------------------------===//
 //  Other Features
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -12621,6 +12621,13 @@ class MOPSMemorySet<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
 class MOPSMemorySetTagging<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
   : MOPSMemorySetBase<1, opcode, op1, op2, op3, asm>;
 
+class MOPSGoMemorySetTagging<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
+  : MOPSMemorySetBase<1, opcode, op1, op2, op3, asm> {
+  // No `Rm` operand is required, as all bits are set to 1
+  let AsmString = !strconcat(asm, "\t[$Rd]!, $Rn!");
+  let Inst{20-16} = 0b11111;
+}
+
 multiclass MOPSMemoryCopyInsns<bits<2> opcode, string asm> {
   def ""   : MOPSMemoryCopy<opcode, 0b00, 0b00, asm>;
   def WN   : MOPSMemoryCopy<opcode, 0b00, 0b01, asm # "wn">;
@@ -12677,10 +12684,10 @@ multiclass MOPSMemorySetTaggingInsns<bits<2> opcode, string asm> {
 // MOPS Granule Only - FEAT_MOPS_GO
 //----------------------------------------------------------------------------
 multiclass MOPSGoMemorySetTaggingInsns<bits<2> opcode, string asm> {
-  def "" : MOPSMemorySetTagging<opcode, 0, 0, 0, asm>;
-  def T  : MOPSMemorySetTagging<opcode, 1, 0, 0, asm # "t">;
-  def N  : MOPSMemorySetTagging<opcode, 0, 1, 0, asm # "n">;
-  def TN : MOPSMemorySetTagging<opcode, 1, 1, 0, asm # "tn">;
+  def "" : MOPSGoMemorySetTagging<opcode, 0, 0, 0, asm>;
+  def T  : MOPSGoMemorySetTagging<opcode, 1, 0, 0, asm # "t">;
+  def N  : MOPSGoMemorySetTagging<opcode, 0, 1, 0, asm # "n">;
+  def TN : MOPSGoMemorySetTagging<opcode, 1, 1, 0, asm # "tn">;
 }
 
 //----------------------------------------------------------------------------

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -12589,7 +12589,7 @@ class MOPSMemoryMove<bits<2> opcode, bits<2> op1, bits<2> op2, string asm>
   : MOPSMemoryCopyMoveBase<1, opcode, op1, op2, asm>;
 
 class MOPSMemorySetBase<bit isTagging, bits<2> opcode, bit op1, bit op2,
-                        string asm>
+                        bit op3, string asm>
   : I<(outs GPR64common:$Rd_wb, GPR64:$Rn_wb),
       (ins GPR64common:$Rd, GPR64:$Rn, GPR64:$Rm),
       asm, "\t[$Rd]!, $Rn!, $Rm",
@@ -12605,7 +12605,8 @@ class MOPSMemorySetBase<bit isTagging, bits<2> opcode, bit op1, bit op2,
   let Inst{15-14} = opcode;
   let Inst{13} = op2;
   let Inst{12} = op1;
-  let Inst{11-10} = 0b01;
+  let Inst{11} = 0b0;
+  let Inst{10} = op3;
   let Inst{9-5} = Rn;
   let Inst{4-0} = Rd;
 
@@ -12614,11 +12615,11 @@ class MOPSMemorySetBase<bit isTagging, bits<2> opcode, bit op1, bit op2,
   let mayStore = 1;
 }
 
-class MOPSMemorySet<bits<2> opcode, bit op1, bit op2, string asm>
-  : MOPSMemorySetBase<0, opcode, op1, op2, asm>;
+class MOPSMemorySet<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
+  : MOPSMemorySetBase<0, opcode, op1, op2, op3, asm>;
 
-class MOPSMemorySetTagging<bits<2> opcode, bit op1, bit op2, string asm>
-  : MOPSMemorySetBase<1, opcode, op1, op2, asm>;
+class MOPSMemorySetTagging<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
+  : MOPSMemorySetBase<1, opcode, op1, op2, op3, asm>;
 
 multiclass MOPSMemoryCopyInsns<bits<2> opcode, string asm> {
   def ""   : MOPSMemoryCopy<opcode, 0b00, 0b00, asm>;
@@ -12659,17 +12660,27 @@ multiclass MOPSMemoryMoveInsns<bits<2> opcode, string asm> {
 }
 
 multiclass MOPSMemorySetInsns<bits<2> opcode, string asm> {
-  def "" : MOPSMemorySet<opcode, 0, 0, asm>;
-  def T  : MOPSMemorySet<opcode, 1, 0, asm # "t">;
-  def N  : MOPSMemorySet<opcode, 0, 1, asm # "n">;
-  def TN : MOPSMemorySet<opcode, 1, 1, asm # "tn">;
+  def "" : MOPSMemorySet<opcode, 0, 0, 1, asm>;
+  def T  : MOPSMemorySet<opcode, 1, 0, 1, asm # "t">;
+  def N  : MOPSMemorySet<opcode, 0, 1, 1, asm # "n">;
+  def TN : MOPSMemorySet<opcode, 1, 1, 1, asm # "tn">;
 }
 
 multiclass MOPSMemorySetTaggingInsns<bits<2> opcode, string asm> {
-  def "" : MOPSMemorySetTagging<opcode, 0, 0, asm>;
-  def T  : MOPSMemorySetTagging<opcode, 1, 0, asm # "t">;
-  def N  : MOPSMemorySetTagging<opcode, 0, 1, asm # "n">;
-  def TN : MOPSMemorySetTagging<opcode, 1, 1, asm # "tn">;
+  def "" : MOPSMemorySetTagging<opcode, 0, 0, 1, asm>;
+  def T  : MOPSMemorySetTagging<opcode, 1, 0, 1, asm # "t">;
+  def N  : MOPSMemorySetTagging<opcode, 0, 1, 1, asm # "n">;
+  def TN : MOPSMemorySetTagging<opcode, 1, 1, 1, asm # "tn">;
+}
+
+//----------------------------------------------------------------------------
+// MOPS Granule Only - FEAT_MOPS_GO
+//----------------------------------------------------------------------------
+multiclass MOPSGoMemorySetTaggingInsns<bits<2> opcode, string asm> {
+  def "" : MOPSMemorySetTagging<opcode, 0, 0, 0, asm>;
+  def T  : MOPSMemorySetTagging<opcode, 1, 0, 0, asm # "t">;
+  def N  : MOPSMemorySetTagging<opcode, 0, 1, 0, asm # "n">;
+  def TN : MOPSMemorySetTagging<opcode, 1, 1, 0, asm # "tn">;
 }
 
 //----------------------------------------------------------------------------

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -12588,12 +12588,10 @@ class MOPSMemoryCopy<bits<2> opcode, bits<2> op1, bits<2> op2, string asm>
 class MOPSMemoryMove<bits<2> opcode, bits<2> op1, bits<2> op2, string asm>
   : MOPSMemoryCopyMoveBase<1, opcode, op1, op2, asm>;
 
-class MOPSMemorySetBase<bit isTagging, bits<2> opcode, bit op1, bit op2,
-                        bit op3, string asm>
-  : I<(outs GPR64common:$Rd_wb, GPR64:$Rn_wb),
-      (ins GPR64common:$Rd, GPR64:$Rn, GPR64:$Rm),
-      asm, "\t[$Rd]!, $Rn!, $Rm",
-      "$Rd = $Rd_wb,$Rn = $Rn_wb", []>,
+class MOPSMemorySetBase<dag ins, string operands, bit isTagging, bits<2> opcode,
+                        bit op1, bit op2, bit op3, string asm>
+  : I<(outs GPR64common:$Rd_wb, GPR64:$Rn_wb), ins,
+      asm, operands, "$Rd = $Rd_wb,$Rn = $Rn_wb", []>,
     Sched<[]> {
   bits<5> Rd;
   bits<5> Rn;
@@ -12610,22 +12608,28 @@ class MOPSMemorySetBase<bit isTagging, bits<2> opcode, bit op1, bit op2,
   let Inst{9-5} = Rn;
   let Inst{4-0} = Rd;
 
-  let DecoderMethod = "DecodeSETMemOpInstruction";
   let mayLoad = 0;
   let mayStore = 1;
 }
 
 class MOPSMemorySet<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
-  : MOPSMemorySetBase<0, opcode, op1, op2, op3, asm>;
+  : MOPSMemorySetBase<(ins GPR64common:$Rd, GPR64:$Rn, GPR64:$Rm),
+                       "\t[$Rd]!, $Rn!, $Rm", 0, opcode, op1, op2, op3, asm> {
+  let DecoderMethod = "DecodeSETMemOpInstruction";
+}
 
 class MOPSMemorySetTagging<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
-  : MOPSMemorySetBase<1, opcode, op1, op2, op3, asm>;
+  : MOPSMemorySetBase<(ins GPR64common:$Rd, GPR64:$Rn, GPR64:$Rm),
+                       "\t[$Rd]!, $Rn!, $Rm", 1, opcode, op1, op2, op3, asm> {
+  let DecoderMethod = "DecodeSETMemOpInstruction";
+}
 
 class MOPSGoMemorySetTagging<bits<2> opcode, bit op1, bit op2, bit op3, string asm>
-  : MOPSMemorySetBase<1, opcode, op1, op2, op3, asm> {
-  // No `Rm` operand is required, as all bits are set to 1
-  let AsmString = !strconcat(asm, "\t[$Rd]!, $Rn!");
+  : MOPSMemorySetBase<(ins GPR64common:$Rd, GPR64:$Rn),
+                       "\t[$Rd]!, $Rn!", 1, opcode, op1, op2, op3, asm> {
+  // No `Rm` operand, as all bits must be set to 1
   let Inst{20-16} = 0b11111;
+  let DecoderMethod = "DecodeSETMemGoOpInstruction";
 }
 
 multiclass MOPSMemoryCopyInsns<bits<2> opcode, string asm> {

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -405,6 +405,8 @@ def HasMTETC         : Predicate<"Subtarget->hasMTETC()">,
                                  AssemblerPredicateWithAll<(all_of FeatureMTETC), "mtetc">;
 def HasGCIE          : Predicate<"Subtarget->hasGCIE()">,
                                  AssemblerPredicateWithAll<(all_of FeatureGCIE), "gcie">;
+def HasMOPS_GO       : Predicate<"Subtarget->hasMOPS_GO()">,
+                                 AssemblerPredicateWithAll<(all_of FeatureMOPS_GO), "mops-go">;
 def IsLE             : Predicate<"Subtarget->isLittleEndian()">;
 def IsBE             : Predicate<"!Subtarget->isLittleEndian()">;
 def IsWindows        : Predicate<"Subtarget->isTargetWindows()">;
@@ -10865,6 +10867,15 @@ let Predicates = [HasMOPS, HasMTE], Defs = [NZCV], Size = 12, mayLoad = 0, maySt
   def MOPSMemorySetTaggingPseudo : Pseudo<(outs GPR64common:$Rd_wb, GPR64:$Rn_wb),
                                           (ins GPR64common:$Rd, GPR64:$Rn, GPR64:$Rm),
                                           [], "$Rd = $Rd_wb,$Rn = $Rn_wb">, Sched<[]>;
+}
+
+//-----------------------------------------------------------------------------
+// MOPS Granule Only Protection (FEAT_MOPS_GO)
+
+let Predicates = [HasMOPS_GO, HasMTE] in {
+    defm SETGOP : MOPSGoMemorySetTaggingInsns<0b00, "setgop">;
+    defm SETGOM : MOPSGoMemorySetTaggingInsns<0b01, "setgom">;
+    defm SETGOE : MOPSGoMemorySetTaggingInsns<0b10, "setgoe">;
 }
 
 //-----------------------------------------------------------------------------

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3893,6 +3893,7 @@ static const struct Extension {
     {"f16mm", {AArch64::FeatureF16MM}},
     {"f16f32dot", {AArch64::FeatureF16F32DOT}},
     {"f16f32mm", {AArch64::FeatureF16F32MM}},
+    {"mops-go", {AArch64::FeatureMOPS_GO}},
 };
 
 static void setRequiredFeatureString(FeatureBitset FBS, std::string &Str) {
@@ -5971,7 +5972,19 @@ bool AArch64AsmParser::validateInstruction(MCInst &Inst, SMLoc &IDLoc,
   case AArch64::MOPSSETGE:
   case AArch64::MOPSSETGET:
   case AArch64::MOPSSETGEN:
-  case AArch64::MOPSSETGETN: {
+  case AArch64::MOPSSETGETN:
+  case AArch64::SETGOP:
+  case AArch64::SETGOPT:
+  case AArch64::SETGOPN:
+  case AArch64::SETGOPTN:
+  case AArch64::SETGOM:
+  case AArch64::SETGOMT:
+  case AArch64::SETGOMN:
+  case AArch64::SETGOMTN:
+  case AArch64::SETGOE:
+  case AArch64::SETGOET:
+  case AArch64::SETGOEN:
+  case AArch64::SETGOETN: {
     MCRegister Xd_wb = Inst.getOperand(0).getReg();
     MCRegister Xn_wb = Inst.getOperand(1).getReg();
     MCRegister Xd = Inst.getOperand(2).getReg();

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -5972,19 +5972,7 @@ bool AArch64AsmParser::validateInstruction(MCInst &Inst, SMLoc &IDLoc,
   case AArch64::MOPSSETGE:
   case AArch64::MOPSSETGET:
   case AArch64::MOPSSETGEN:
-  case AArch64::MOPSSETGETN:
-  case AArch64::SETGOP:
-  case AArch64::SETGOPT:
-  case AArch64::SETGOPN:
-  case AArch64::SETGOPTN:
-  case AArch64::SETGOM:
-  case AArch64::SETGOMT:
-  case AArch64::SETGOMN:
-  case AArch64::SETGOMTN:
-  case AArch64::SETGOE:
-  case AArch64::SETGOET:
-  case AArch64::SETGOEN:
-  case AArch64::SETGOETN: {
+  case AArch64::MOPSSETGETN: {
     MCRegister Xd_wb = Inst.getOperand(0).getReg();
     MCRegister Xn_wb = Inst.getOperand(1).getReg();
     MCRegister Xd = Inst.getOperand(2).getReg();
@@ -6004,6 +5992,33 @@ bool AArch64AsmParser::validateInstruction(MCInst &Inst, SMLoc &IDLoc,
                            " registers are the same");
     if (Xn == Xm)
       return Error(Loc[0], "invalid SET instruction, source and size"
+                           " registers are the same");
+    break;
+  }
+  case AArch64::SETGOP:
+  case AArch64::SETGOPT:
+  case AArch64::SETGOPN:
+  case AArch64::SETGOPTN:
+  case AArch64::SETGOM:
+  case AArch64::SETGOMT:
+  case AArch64::SETGOMN:
+  case AArch64::SETGOMTN:
+  case AArch64::SETGOE:
+  case AArch64::SETGOET:
+  case AArch64::SETGOEN:
+  case AArch64::SETGOETN: {
+    MCRegister Xd_wb = Inst.getOperand(0).getReg();
+    MCRegister Xn_wb = Inst.getOperand(1).getReg();
+    MCRegister Xd = Inst.getOperand(2).getReg();
+    MCRegister Xn = Inst.getOperand(3).getReg();
+    if (Xd_wb != Xd)
+      return Error(Loc[0],
+                   "invalid SET instruction, Xd_wb and Xd do not match");
+    if (Xn_wb != Xn)
+      return Error(Loc[0],
+                   "invalid SET instruction, Xn_wb and Xn do not match");
+    if (Xd == Xn)
+      return Error(Loc[0], "invalid SET instruction, destination and size"
                            " registers are the same");
     break;
   }

--- a/llvm/test/MC/AArch64/arm-mops-go-diagnostics.s
+++ b/llvm/test/MC/AArch64/arm-mops-go-diagnostics.s
@@ -1,0 +1,56 @@
+// RUN: not llvm-mc -triple aarch64-none-linux-gnu -show-encoding -mattr=+mops-go,+mte < %s 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+
+// All operand must be different from each other
+
+// CHECK-ERROR: error: invalid SET instruction, destination and size registers are the same
+// CHECK-ERROR: error: invalid SET instruction, destination and source registers are the same
+// CHECK-ERROR: error: invalid SET instruction, source and size registers are the same
+setgop [x0]!, x0!, x1
+setgop [x0]!, x1!, x0
+setgop [x1]!, x0!, x0
+
+// CHECK-ERROR: error: invalid SET instruction, destination and size registers are the same
+// CHECK-ERROR: error: invalid SET instruction, destination and source registers are the same
+// CHECK-ERROR: error: invalid SET instruction, source and size registers are the same
+setgom [x0]!, x0!, x1
+setgom [x0]!, x1!, x0
+setgom [x1]!, x0!, x0
+
+// CHECK-ERROR: error: invalid SET instruction, destination and size registers are the same
+// CHECK-ERROR: error: invalid SET instruction, destination and source registers are the same
+// CHECK-ERROR: error: invalid SET instruction, source and size registers are the same
+setgoe [x0]!, x0!, x1
+setgoe [x0]!, x1!, x0
+setgoe [x1]!, x0!, x0
+
+// SP cannot be used as argument at any position
+
+// CHECK-ERROR: error: invalid operand for instruction
+// CHECK-ERROR: error: invalid operand for instruction
+// CHECK-ERROR: error: invalid operand for instruction
+setgop [sp]!, x1!, x2
+setgop [x0]!, sp!, x2
+setgop [x0]!, x1!, sp
+
+// CHECK-ERROR: error: invalid operand for instruction
+// CHECK-ERROR: error: invalid operand for instruction
+// CHECK-ERROR: error: invalid operand for instruction
+setgom [sp]!, x1!, x2
+setgom [x0]!, sp!, x2
+setgom [x0]!, x1!, sp
+
+// CHECK-ERROR: error: invalid operand for instruction
+// CHECK-ERROR: error: invalid operand for instruction
+// CHECK-ERROR: error: invalid operand for instruction
+setgoe [sp]!, x1!, x2
+setgoe [x0]!, sp!, x2
+setgoe [x0]!, x1!, sp
+
+// CHECK-ERROR: error: invalid operand for instruction
+setgop [xzr]!, x1!, x2
+
+// CHECK-ERROR: error: invalid operand for instruction
+setgom [xzr]!, x1!, x2
+
+// CHECK-ERROR: error: invalid operand for instruction
+setgoe [xzr]!, x1!, x2

--- a/llvm/test/MC/AArch64/arm-mops-go-diagnostics.s
+++ b/llvm/test/MC/AArch64/arm-mops-go-diagnostics.s
@@ -1,56 +1,36 @@
 // RUN: not llvm-mc -triple aarch64-none-linux-gnu -show-encoding -mattr=+mops-go,+mte < %s 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
-// All operand must be different from each other
+// Operands must be different from each other
 
 // CHECK-ERROR: error: invalid SET instruction, destination and size registers are the same
-// CHECK-ERROR: error: invalid SET instruction, destination and source registers are the same
-// CHECK-ERROR: error: invalid SET instruction, source and size registers are the same
-setgop [x0]!, x0!, x1
-setgop [x0]!, x1!, x0
-setgop [x1]!, x0!, x0
-
 // CHECK-ERROR: error: invalid SET instruction, destination and size registers are the same
-// CHECK-ERROR: error: invalid SET instruction, destination and source registers are the same
-// CHECK-ERROR: error: invalid SET instruction, source and size registers are the same
-setgom [x0]!, x0!, x1
-setgom [x0]!, x1!, x0
-setgom [x1]!, x0!, x0
-
 // CHECK-ERROR: error: invalid SET instruction, destination and size registers are the same
-// CHECK-ERROR: error: invalid SET instruction, destination and source registers are the same
-// CHECK-ERROR: error: invalid SET instruction, source and size registers are the same
-setgoe [x0]!, x0!, x1
-setgoe [x0]!, x1!, x0
-setgoe [x1]!, x0!, x0
+setgop [x0]!, x0!
+setgom [x0]!, x0!
+setgoe [x0]!, x0!
 
 // SP cannot be used as argument at any position
 
 // CHECK-ERROR: error: invalid operand for instruction
 // CHECK-ERROR: error: invalid operand for instruction
-// CHECK-ERROR: error: invalid operand for instruction
-setgop [sp]!, x1!, x2
-setgop [x0]!, sp!, x2
-setgop [x0]!, x1!, sp
+setgop [sp]!, x1!
+setgop [x0]!, sp!
 
 // CHECK-ERROR: error: invalid operand for instruction
 // CHECK-ERROR: error: invalid operand for instruction
-// CHECK-ERROR: error: invalid operand for instruction
-setgom [sp]!, x1!, x2
-setgom [x0]!, sp!, x2
-setgom [x0]!, x1!, sp
+setgom [sp]!, x1!
+setgom [x0]!, sp!
 
 // CHECK-ERROR: error: invalid operand for instruction
 // CHECK-ERROR: error: invalid operand for instruction
-// CHECK-ERROR: error: invalid operand for instruction
-setgoe [sp]!, x1!, x2
-setgoe [x0]!, sp!, x2
-setgoe [x0]!, x1!, sp
+setgoe [sp]!, x1!
+setgoe [x0]!, sp!
 
 // CHECK-ERROR: error: invalid operand for instruction
-setgop [xzr]!, x1!, x2
+setgop [xzr]!, x1!
 
 // CHECK-ERROR: error: invalid operand for instruction
-setgom [xzr]!, x1!, x2
+setgom [xzr]!, x1!
 
 // CHECK-ERROR: error: invalid operand for instruction
-setgoe [xzr]!, x1!, x2
+setgoe [xzr]!, x1!

--- a/llvm/test/MC/AArch64/arm-mops-go.s
+++ b/llvm/test/MC/AArch64/arm-mops-go.s
@@ -16,74 +16,74 @@
 // FEAT_MOPS_GO Extension instructions
 //------------------------------------------------------------------------------
 
-setgop [x3]!, x2!, x1
-// CHECK-INST:    setgop [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x00,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc10043
+setgop [x3]!, x2!
+// CHECK-INST:    setgop [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x00,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf0043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgom [x3]!, x2!, x1
-// CHECK-INST:    setgom [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x40,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc14043
+setgom [x3]!, x2!
+// CHECK-INST:    setgom [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x40,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf4043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgoe [x3]!, x2!, x1
-// CHECK-INST:    setgoe [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x80,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc18043
+setgoe [x3]!, x2!
+// CHECK-INST:    setgoe [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x80,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf8043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgopn [x3]!, x2!, x1
-// CHECK-INST:    setgopn [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x20,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc12043
+setgopn [x3]!, x2!
+// CHECK-INST:    setgopn [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x20,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf2043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgomn [x3]!, x2!, x1
-// CHECK-INST:    setgomn [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x60,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc16043
+setgomn [x3]!, x2!
+// CHECK-INST:    setgomn [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x60,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf6043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgoen [x3]!, x2!, x1
-// CHECK-INST:    setgoen [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0xa0,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc1a043
+setgoen [x3]!, x2!
+// CHECK-INST:    setgoen [x3]!, x2!
+// CHECK-ENCODING: [0x43,0xa0,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddfa043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgopt [x3]!, x2!, x1
-// CHECK-INST:    setgopt [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x10,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc11043
+setgopt [x3]!, x2!
+// CHECK-INST:    setgopt [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x10,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf1043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgomt [x3]!, x2!, x1
-// CHECK-INST:    setgomt [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x50,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc15043
+setgomt [x3]!, x2!
+// CHECK-INST:    setgomt [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x50,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf5043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgoet [x3]!, x2!, x1
-// CHECK-INST:    setgoet [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x90,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc19043
+setgoet [x3]!, x2!
+// CHECK-INST:    setgoet [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x90,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf9043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgoptn [x3]!, x2!, x1
-// CHECK-INST:    setgoptn [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x30,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc13043
+setgoptn [x3]!, x2!
+// CHECK-INST:    setgoptn [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x30,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf3043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgomtn [x3]!, x2!, x1
-// CHECK-INST:    setgomtn [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0x70,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc17043
+setgomtn [x3]!, x2!
+// CHECK-INST:    setgomtn [x3]!, x2!
+// CHECK-ENCODING: [0x43,0x70,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddf7043
 // CHECK-ERROR: instruction requires: mops-go mte
 
-setgoetn [x3]!, x2!, x1
-// CHECK-INST:    setgoetn [x3]!, x2!, x1
-// CHECK-ENCODING: [0x43,0xb0,0xc1,0x1d]
-// CHECK-UNKNOWN: 1dc1b043
+setgoetn [x3]!, x2!
+// CHECK-INST:    setgoetn [x3]!, x2!
+// CHECK-ENCODING: [0x43,0xb0,0xdf,0x1d]
+// CHECK-UNKNOWN: 1ddfb043
 // CHECK-ERROR: instruction requires: mops-go mte

--- a/llvm/test/MC/AArch64/arm-mops-go.s
+++ b/llvm/test/MC/AArch64/arm-mops-go.s
@@ -1,0 +1,89 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mops-go,+mte < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+all < %s \
+// RUN:        | llvm-objdump -d --mattr=+mops-go,+mte --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+all < %s \
+// RUN:        | llvm-objdump -d --mattr=-mops-go,-mte --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mops-go,+mte < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+mops-go,+mte -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+//------------------------------------------------------------------------------
+// FEAT_MOPS_GO Extension instructions
+//------------------------------------------------------------------------------
+
+setgop [x3]!, x2!, x1
+// CHECK-INST:    setgop [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x00,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc10043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgom [x3]!, x2!, x1
+// CHECK-INST:    setgom [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x40,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc14043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgoe [x3]!, x2!, x1
+// CHECK-INST:    setgoe [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x80,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc18043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgopn [x3]!, x2!, x1
+// CHECK-INST:    setgopn [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x20,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc12043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgomn [x3]!, x2!, x1
+// CHECK-INST:    setgomn [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x60,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc16043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgoen [x3]!, x2!, x1
+// CHECK-INST:    setgoen [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0xa0,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc1a043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgopt [x3]!, x2!, x1
+// CHECK-INST:    setgopt [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x10,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc11043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgomt [x3]!, x2!, x1
+// CHECK-INST:    setgomt [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x50,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc15043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgoet [x3]!, x2!, x1
+// CHECK-INST:    setgoet [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x90,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc19043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgoptn [x3]!, x2!, x1
+// CHECK-INST:    setgoptn [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x30,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc13043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgomtn [x3]!, x2!, x1
+// CHECK-INST:    setgomtn [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0x70,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc17043
+// CHECK-ERROR: instruction requires: mops-go mte
+
+setgoetn [x3]!, x2!, x1
+// CHECK-INST:    setgoetn [x3]!, x2!, x1
+// CHECK-ENCODING: [0x43,0xb0,0xc1,0x1d]
+// CHECK-UNKNOWN: 1dc1b043
+// CHECK-ERROR: instruction requires: mops-go mte

--- a/llvm/test/MC/AArch64/arm-mops-go.s
+++ b/llvm/test/MC/AArch64/arm-mops-go.s
@@ -2,9 +2,9 @@
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+all < %s \
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+mops-go,+mte < %s \
 // RUN:        | llvm-objdump -d --mattr=+mops-go,+mte --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+all < %s \
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+mops-go,+mte < %s \
 // RUN:        | llvm-objdump -d --mattr=-mops-go,-mte --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mops-go,+mte < %s \

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1452,7 +1452,7 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
       AArch64::AEK_GCIE,         AArch64::AEK_SME2P3,
       AArch64::AEK_SVE2P3,       AArch64::AEK_SVE_B16MM,
       AArch64::AEK_F16MM,        AArch64::AEK_F16F32DOT,
-      AArch64::AEK_F16F32MM,
+      AArch64::AEK_F16F32MM,     AArch64::AEK_MOPS_GO,
   };
 
   std::vector<StringRef> Features;
@@ -1576,6 +1576,7 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
   EXPECT_TRUE(llvm::is_contained(Features, "+f16mm"));
   EXPECT_TRUE(llvm::is_contained(Features, "+f16f32dot"));
   EXPECT_TRUE(llvm::is_contained(Features, "+f16f32mm"));
+  EXPECT_TRUE(llvm::is_contained(Features, "+mops-go"));
 
   // Assuming we listed every extension above, this should produce the same
   // result.
@@ -1754,6 +1755,7 @@ TEST(TargetParserTest, AArch64ArchExtFeature) {
       {"f16mm", "nof16mm", "+f16mm", "-f16mm"},
       {"f16f32dot", "nof16f32dot", "+f16f32dot", "-f16f32dot"},
       {"f16f32mm", "nof16f32mm", "+f16f32mm", "-f16f32mm"},
+      {"mops-go", "nomops-go", "+mops-go", "-mops-go"},
   };
 
   for (unsigned i = 0; i < std::size(ArchExt); i++) {


### PR DESCRIPTION
Add the following `FEAT_MOPS_GO` instructions:
  * `SETGOP`, `SETGOM`, `SETGOE`
  * `SETGOPN`, `SETGOMN`, `SETGOEN`
  * `SETGOPT`, `SETGOMT`, `SETGOET`
  * `SETGOPTN`, `SETGOMTN`, `SETGOETN`

as blogged about here:
 * https://developer.arm.com/community/arm-community-blogs/b/architectures-and-processors-blog/posts/future-architecture-technologies-poe2-and-vmte

and as documented here:
 * https://developer.arm.com/documentation/109697/2025_09/Future-Architecture-Technologies