### PR TITLE
[asan] Avoid -Wtautological-pointer-compare

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -58,7 +58,7 @@ namespace __asan {
 
 static inline uptr MaybeRealStrnlen(const char *s, uptr maxlen) {
 #if SANITIZER_INTERCEPT_STRNLEN
-  if (REAL(strnlen) != nullptr)
+  if (static_cast<bool>(REAL(strnlen)))
     return REAL(strnlen)(s, maxlen);
 #  endif
   return internal_strnlen(s, maxlen);
@@ -66,7 +66,7 @@ static inline uptr MaybeRealStrnlen(const char *s, uptr maxlen) {
 
 static inline uptr MaybeRealWcsnlen(const wchar_t* s, uptr maxlen) {
 #  if SANITIZER_INTERCEPT_WCSNLEN
-  if (REAL(wcsnlen) != nullptr)
+  if (static_cast<bool>(REAL(wcsnlen)))
     return REAL(wcsnlen)(s, maxlen);
 #  endif
   return internal_wcsnlen(s, maxlen);


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/164906 converted a -Wpointer-bool-conversion warning into a -Wtautological-pointer-compare warning. Avoid both by using the bool cast.