### PR TITLE
[libc] fix architecture guarding for 32bit sigsetjmp

### DIFF
--- a/libc/src/setjmp/x86_64/sigsetjmp.cpp
+++ b/libc/src/setjmp/x86_64/sigsetjmp.cpp
@@ -41,7 +41,7 @@ LLVM_LIBC_FUNCTION(int, sigsetjmp, (sigjmp_buf buf)) {
       [epilogue] "X"(sigsetjmp_epilogue)
       : "eax", "ebx", "ecx");
 }
-#endif
+#else
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, sigsetjmp, (sigjmp_buf, int)) {
   asm(R"(
@@ -64,5 +64,6 @@ LLVM_LIBC_FUNCTION(int, sigsetjmp, (sigjmp_buf, int)) {
       [epilogue] "X"(sigsetjmp_epilogue)
       : "rax", "rbx");
 }
+#endif
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/164653