### PR TITLE
[ADT] Rename variable names in IndexedMap (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/IndexedMap.h
+++ b/llvm/include/llvm/ADT/IndexedMap.h
@@ -43,40 +43,40 @@ class IndexedMap {
   // is trivially copyable.
   using StorageT = SmallVector<T, 0>;
 
-  StorageT storage_;
-  T nullVal_ = T();
-  ToIndexT toIndex_;
+  StorageT Storage;
+  T NullVal = T();
+  ToIndexT ToIndex;
 
 public:
   IndexedMap() = default;
 
-  explicit IndexedMap(const T &val) : nullVal_(val) {}
+  explicit IndexedMap(const T &Val) : NullVal(Val) {}
 
-  typename StorageT::reference operator[](IndexT n) {
-    assert(toIndex_(n) < storage_.size() && "index out of bounds!");
-    return storage_[toIndex_(n)];
+  typename StorageT::reference operator[](IndexT N) {
+    assert(ToIndex(N) < Storage.size() && "index out of bounds!");
+    return Storage[ToIndex(N)];
   }
 
-  typename StorageT::const_reference operator[](IndexT n) const {
-    assert(toIndex_(n) < storage_.size() && "index out of bounds!");
-    return storage_[toIndex_(n)];
+  typename StorageT::const_reference operator[](IndexT N) const {
+    assert(ToIndex(N) < Storage.size() && "index out of bounds!");
+    return Storage[ToIndex(N)];
   }
 
-  void reserve(typename StorageT::size_type s) { storage_.reserve(s); }
+  void reserve(typename StorageT::size_type S) { Storage.reserve(S); }
 
-  void resize(typename StorageT::size_type s) { storage_.resize(s, nullVal_); }
+  void resize(typename StorageT::size_type S) { Storage.resize(S, NullVal); }
 
-  void clear() { storage_.clear(); }
+  void clear() { Storage.clear(); }
 
-  void grow(IndexT n) {
-    unsigned NewSize = toIndex_(n) + 1;
-    if (NewSize > storage_.size())
+  void grow(IndexT N) {
+    unsigned NewSize = ToIndex(N) + 1;
+    if (NewSize > Storage.size())
       resize(NewSize);
   }
 
-  bool inBounds(IndexT n) const { return toIndex_(n) < storage_.size(); }
+  bool inBounds(IndexT N) const { return ToIndex(N) < Storage.size(); }
 
-  typename StorageT::size_type size() const { return storage_.size(); }
+  typename StorageT::size_type size() const { return Storage.size(); }
 };
 
 } // namespace llvm


### PR DESCRIPTION
This patch renames variable names to conform to the LLVM Coding
Standards.  The public interface remains the same.
