### PR TITLE
[libclc] Implement integer __clc_abs using __builtin_elementwise_abs

### DIFF
--- a/libclc/clc/include/clc/integer/gentype.inc
+++ b/libclc/clc/include/clc/integer/gentype.inc
@@ -23,6 +23,7 @@
 // to keep this file manageable.
 #define __CLC_GENSIZE 8
 #define __CLC_SCALAR_GENTYPE char
+#define __CLC_GEN_S
 
 #define __CLC_GENTYPE char
 #define __CLC_U_GENTYPE uchar
@@ -93,6 +94,8 @@
 
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE uchar
+#undef __CLC_GEN_S
+#define __CLC_GEN_U
 
 #define __CLC_GENTYPE uchar
 #define __CLC_U_GENTYPE uchar
@@ -165,6 +168,8 @@
 #define __CLC_GENSIZE 16
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE short
+#undef __CLC_GEN_U
+#define __CLC_GEN_S
 
 #define __CLC_GENTYPE short
 #define __CLC_U_GENTYPE ushort
@@ -235,6 +240,8 @@
 
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE ushort
+#undef __CLC_GEN_S
+#define __CLC_GEN_U
 
 #define __CLC_GENTYPE ushort
 #define __CLC_U_GENTYPE ushort
@@ -307,6 +314,8 @@
 #define __CLC_GENSIZE 32
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE int
+#undef __CLC_GEN_U
+#define __CLC_GEN_S
 
 #define __CLC_GENTYPE int
 #define __CLC_U_GENTYPE uint
@@ -377,6 +386,8 @@
 
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE uint
+#undef __CLC_GEN_S
+#define __CLC_GEN_U
 
 #define __CLC_GENTYPE uint
 #define __CLC_U_GENTYPE uint
@@ -449,6 +460,8 @@
 #define __CLC_GENSIZE 64
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE long
+#undef __CLC_GEN_U
+#define __CLC_GEN_S
 
 #define __CLC_GENTYPE long
 #define __CLC_U_GENTYPE ulong
@@ -519,6 +532,8 @@
 
 #undef __CLC_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE ulong
+#undef __CLC_GEN_S
+#define __CLC_GEN_U
 
 #define __CLC_GENTYPE ulong
 #define __CLC_U_GENTYPE ulong
@@ -587,6 +602,8 @@
 #undef __CLC_U_GENTYPE
 #undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
+
+#undef __CLC_GEN_U
 
 #undef __CLC_GENSIZE
 #undef __CLC_SCALAR_GENTYPE

--- a/libclc/clc/lib/generic/integer/clc_abs.inc
+++ b/libclc/clc/lib/generic/integer/clc_abs.inc
@@ -6,7 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifdef __CLC_GEN_S
+
 _CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE __clc_abs(__CLC_GENTYPE x) {
-  return __builtin_astype((__CLC_GENTYPE)(x > (__CLC_GENTYPE)(0) ? x : -x),
-                          __CLC_U_GENTYPE);
+  return __builtin_astype(__builtin_elementwise_abs(x), __CLC_U_GENTYPE);
 }
+
+#else
+
+_CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE __clc_abs(__CLC_GENTYPE x) {
+  return x;
+}
+
+#endif

--- a/libclc/clc/lib/generic/integer/clc_abs.inc
+++ b/libclc/clc/lib/generic/integer/clc_abs.inc
@@ -14,8 +14,6 @@ _CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE __clc_abs(__CLC_GENTYPE x) {
 
 #else
 
-_CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE __clc_abs(__CLC_GENTYPE x) {
-  return x;
-}
+_CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE __clc_abs(__CLC_GENTYPE x) { return x; }
 
 #endif


### PR DESCRIPTION
Previous implementation was cmp, select and @llvm.smax sequence in LLVM IR.

__CLC_GEN_U/__CLC_GEN_S is upstreamed from intel/llvm repo.