### PR TITLE
[IR] Add argument to Function::deleteBody to preserve metadata

### DIFF
--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -144,7 +144,7 @@ private:
 
   void clearArguments();
 
-  void deleteBodyImpl(bool ShouldDrop);
+  void deleteBodyImpl(bool ShouldDrop, bool PreserveMetadata);
 
   /// Function ctor - If the (optional) Module argument is specified, the
   /// function is automatically inserted into the end of the function list for
@@ -727,8 +727,8 @@ public:
   /// deleteBody - This method deletes the body of the function, and converts
   /// the linkage to external.
   ///
-  void deleteBody() {
-    deleteBodyImpl(/*ShouldDrop=*/false);
+  void deleteBody(bool PreserveMetadata = false) {
+    deleteBodyImpl(/*ShouldDrop=*/false, PreserveMetadata);
     setLinkage(ExternalLinkage);
   }
 
@@ -982,7 +982,7 @@ public:
   /// including any contained basic blocks.
   ///
   void dropAllReferences() {
-    deleteBodyImpl(/*ShouldDrop=*/true);
+    deleteBodyImpl(/*ShouldDrop=*/true, /*PreserveMetadata=*/false);
   }
 
   /// hasAddressTaken - returns true if there are any uses of this function

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -600,7 +600,7 @@ void Function::stealArgumentListFrom(Function &Src) {
   Src.setValueSubclassData(Src.getSubclassDataFromValue() | (1 << 0));
 }
 
-void Function::deleteBodyImpl(bool ShouldDrop) {
+void Function::deleteBodyImpl(bool ShouldDrop, bool PreserveMetadata) {
   setIsMaterializable(false);
 
   for (BasicBlock &BB : *this)
@@ -627,7 +627,8 @@ void Function::deleteBodyImpl(bool ShouldDrop) {
   }
 
   // Metadata is stored in a side-table.
-  clearMetadata();
+  if (!PreserveMetadata)
+    clearMetadata();
 }
 
 void Function::addAttributeAtIndex(unsigned i, Attribute Attr) {


### PR DESCRIPTION
`Function::deleteBody` deletes all function metadata, which is undesirable in some cases.

This patch adds a boolean argument `PreserveMetadata` to control that. The new argument defaults to `false`, preserving the old behavior.