### PR TITLE
Fix build failures related to PR #164551

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   JITLink
   Object
+  ObjectYAML
   OrcDebugging
   OrcJIT
   OrcShared

--- a/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
@@ -690,14 +690,21 @@ TEST_F(LibraryResolverIT, PathResolverFollowsSymlinks) {
   // Create a symlink temp -> BaseDir (only if filesystem allows it)
   std::string linkName = BaseDir + withext("/link_to_C");
   std::string target = lib("C");
-  ::symlink(target.c_str(), linkName.c_str());
+
+  if (::symlink(target.c_str(), linkName.c_str()) != 0) {
+    perror("symlink failed");
+    FAIL() << "Failed to create symlink: " << strerror(errno);
+  }
 
   auto resolved = PResolver->resolve(linkName, EC);
   ASSERT_TRUE(resolved.has_value());
   EXPECT_FALSE(EC);
   EXPECT_EQ(*resolved, target);
 
-  ::unlink(linkName.c_str()); // cleanup
+  if (::unlink(linkName.c_str()) != 0) {
+    perror("unlink failed");
+    FAIL() << "Failed to remove symlink: " << strerror(errno);
+  }
 }
 
 TEST_F(LibraryResolverIT, PathResolverCachesResults) {

--- a/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
@@ -691,20 +691,15 @@ TEST_F(LibraryResolverIT, PathResolverFollowsSymlinks) {
   std::string linkName = BaseDir + withext("/link_to_C");
   std::string target = lib("C");
 
-  if (::symlink(target.c_str(), linkName.c_str()) != 0) {
-    perror("symlink failed");
-    FAIL() << "Failed to create symlink: " << strerror(errno);
-  }
+  if (::symlink(target.c_str(), linkName.c_str()) != 0)
+    GTEST_SKIP() << "Failed to create symlink: " << strerror(errno);
 
   auto resolved = PResolver->resolve(linkName, EC);
   ASSERT_TRUE(resolved.has_value());
   EXPECT_FALSE(EC);
   EXPECT_EQ(*resolved, target);
 
-  if (::unlink(linkName.c_str()) != 0) {
-    perror("unlink failed");
-    FAIL() << "Failed to remove symlink: " << strerror(errno);
-  }
+  (void)::unlink(linkName.c_str());
 }
 
 TEST_F(LibraryResolverIT, PathResolverCachesResults) {


### PR DESCRIPTION
Fix build failures in LibraryResolverTest and silence symlink warning

This commit resolves two issues observed in the build bots:

1. Silences the -Wunused-result warning by handling the return value
   of ::symlink in LibraryResolverTest.cpp. Previously, ignoring
   the return value triggered compiler warnings.

2. Fixes a linker error in OrcJITTests caused by an undefined
   symbol: `llvm::yaml::convertYAML`. The test setup in
   LibraryResolverTest.cpp now correctly links against the required
   LLVM YAML library symbols.

This resolves the build failures for PR #164551 on the affected bots.
