### PR TITLE
Revert "[bazel][lldb] Port #162730: tablegen for lldb-server platform ops"

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -979,20 +979,11 @@ cc_binary(
 )
 
 gentbl_cc_library(
-    name = "lldb_server_llgs_opts_gen",
+    name = "lldb_server_opts_gen",
     strip_include_prefix = ".",
     tbl_outs = {"LLGSOptions.inc": ["-gen-opt-parser-defs"]},
     tblgen = "//llvm:llvm-tblgen",
     td_file = "tools/lldb-server/LLGSOptions.td",
-    deps = ["//llvm:OptParserTdFiles"],
-)
-
-gentbl_cc_library(
-    name = "lldb_server_platform_opts_gen",
-    strip_include_prefix = ".",
-    tbl_outs = {"PlatformOptions.inc": ["-gen-opt-parser-defs"]},
-    tblgen = "//llvm:llvm-tblgen",
-    td_file = "tools/lldb-server/PlatformOptions.td",
     deps = ["//llvm:OptParserTdFiles"],
 )
 
@@ -1014,8 +1005,7 @@ cc_binary(
         ":Interpreter",
         ":Utility",
         ":Version",
-        ":lldb_server_llgs_opts_gen",
-        ":lldb_server_platform_opts_gen",
+        ":lldb_server_opts_gen",
         "//lldb:Target",
         "//lldb:TargetHeaders",
         "//lldb/source/Plugins:PluginCPlusPlusLanguage",


### PR DESCRIPTION
Reverts llvm/llvm-project#164832.  The corresponding [#162730](https://github.com/llvm/llvm-project/pull/162730) was reverted in https://github.com/llvm/llvm-project/commit/aac036a7f6730118f0d832150243d66b603c3af3.