### PR TITLE
[clang][bytecode] Fail on reads from constexpr-unknown pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -832,6 +832,8 @@ bool CheckLoad(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     return false;
   if (!CheckVolatile(S, OpPC, Ptr, AK))
     return false;
+  if (!Ptr.isConst() && !S.inConstantContext() && isConstexprUnknown(Ptr))
+    return false;
   return true;
 }
 

--- a/clang/test/AST/ByteCode/codegen-cxx20.cpp
+++ b/clang/test/AST/ByteCode/codegen-cxx20.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -o - %s -fcxx-exceptions                                         | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -o - %s -fcxx-exceptions -fexperimental-new-constant-interpreter | FileCheck %s
+
+
+/// The read from a used to succeed, causing the entire if statement to vanish.
+extern void e();
+int somefunc() {
+  auto foo = [a = false]() mutable {
+    if (a)
+      e();
+  };
+  foo();
+}
+
+// CHECK: call void @_Z1ev()


### PR DESCRIPTION
If they aren't const.

Fixes https://github.com/llvm/llvm-project/issues/164985