### PR TITLE
[clang][bytecode] Handle discarded AddrLabelExprs properly

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -3942,6 +3942,8 @@ bool Compiler<Emitter>::VisitRecoveryExpr(const RecoveryExpr *E) {
 template <class Emitter>
 bool Compiler<Emitter>::VisitAddrLabelExpr(const AddrLabelExpr *E) {
   assert(E->getType()->isVoidPointerType());
+  if (DiscardResult)
+    return true;
 
   return this->emitDummyPtr(E, E);
 }

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -370,3 +370,12 @@ namespace GH150709 {
   static_assert((e2[0].*mp)() == 1, ""); // ref-error {{constant expression}}
   static_assert((g.*mp)() == 1, ""); // ref-error {{constant expression}}
 }
+
+namespace DiscardedAddrLabel {
+  void foo(void) {
+  L:
+    *&&L; // both-error {{indirection not permitted}} \
+          // both-warning {{expression result unused}}
+  }
+}
+


### PR DESCRIPTION
emitDummyPtr() doesn't like to be called with DiscardResult set, so check this first.

Fixes https://github.com/llvm/llvm-project/issues/164979