### PR TITLE
[AsmWriter] Fix MIR printing of single constant LLVM IR metadata

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2807,6 +2807,12 @@ static void writeAsOperandInternal(raw_ostream &Out, const Metadata *MD,
         writeDILocation(Out, Loc, WriterCtx);
         return;
       }
+      if (N->getNumOperands() == 1) {
+        if (const auto *CAM = dyn_cast<ConstantAsMetadata>(N->getOperand(0))) {
+          writeConstantInternal(Out, CAM->getValue(), WriterCtx);
+          return;
+        }
+      }
       // Give the pointer value instead of "badref", since this comes up all
       // the time when debugging.
       Out << "<" << N << ">";

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2807,12 +2807,6 @@ static void writeAsOperandInternal(raw_ostream &Out, const Metadata *MD,
         writeDILocation(Out, Loc, WriterCtx);
         return;
       }
-      if (N->getNumOperands() == 1) {
-        if (const auto *CAM = dyn_cast<ConstantAsMetadata>(N->getOperand(0))) {
-          writeConstantInternal(Out, CAM->getValue(), WriterCtx);
-          return;
-        }
-      }
       // Give the pointer value instead of "badref", since this comes up all
       // the time when debugging.
       Out << "<" << N << ">";

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-metadata.ll
@@ -6,8 +6,7 @@ define i32 @reloc_constant() {
   ; CHECK-LABEL: name: reloc_constant
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), !0
-  ; We cannot have any specific metadata check here as ConstantAsMetadata is printed as <raw_ptr_val>
-  ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), <0x{{[0-9a-f]+}}>
+  ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), 4
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[INT]], [[INT1]]
   ; CHECK-NEXT:   $vgpr0 = COPY [[ADD]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-metadata.ll
@@ -6,7 +6,7 @@ define i32 @reloc_constant() {
   ; CHECK-LABEL: name: reloc_constant
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), !0
-  ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), 4
+  ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), i32 4
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[INT]], [[INT1]]
   ; CHECK-NEXT:   $vgpr0 = COPY [[ADD]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0


### PR DESCRIPTION
When LLVM IR is read in and its metadata are canonicalized into Value objects, single constant metadata are not turned into MDNode objects like every other metadata. Instead, they are left as ConstantAsMetadata objects. When the ModuleSlotTracker creates slots for MDNode objects, it thus does not make one for the constant. However, during translation into MIR that constant metadata will be turned into an MDNode because that is the only Metadata object that MachineInstruction objects can house. So when MIRPrintingPass makes use of that ModuleSlotTracker, it will pass it an MDNode corresponding to that constant that never got a slot. This causes the pass to dump a pointer instead.

This change fixes this issue by updating the writeAsOperandInternal function to catch the case where it cannot find the slot for the solo constant metadata node and print the constant itself directly instead of dumping the pointer.