### PR TITLE
[compiler-rt] fix gcc 12 support by removing enum-type-specifier

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/x86.c
+++ b/compiler-rt/lib/builtins/cpu_model/x86.c
@@ -36,14 +36,14 @@ enum VendorSignatures {
   SIG_AMD = 0x68747541,   // Auth
 };
 
-enum ProcessorVendors : unsigned int {
+enum ProcessorVendors {
   VENDOR_INTEL = 1,
   VENDOR_AMD,
   VENDOR_OTHER,
   VENDOR_MAX
 };
 
-enum ProcessorTypes : unsigned int {
+enum ProcessorTypes {
   INTEL_BONNELL = 1,
   INTEL_CORE2,
   INTEL_COREI7,


### PR DESCRIPTION
This `unsigned int` here is a new addition introduced in https://github.com/llvm/llvm-project/pull/164713 and doesn't compile under older (<13) gcc (see [godbolt](https://godbolt.org/z/e6TzP6h6s)), which LLVM officially supports from 7.4+. This change should be fine as none of the enum values are negative. 