### PR TITLE
[PowerPC] Add xor-not patterns to eqv

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -1994,3 +1994,7 @@ def : Pat<(i64 (int_ppc_mfspr timm:$SPR)),
           (MFSPR8 $SPR)>;
 def : Pat<(int_ppc_mtspr timm:$SPR, g8rc:$RT),
           (MTSPR8 $SPR, $RT)>;
+
+// XOR-NOT to EQV optimization patterns (64-bit) (moved to end of file)
+def : Pat<(xor (not i64:$A), i64:$B), (EQV8 i64:$A, i64:$B)>;
+def : Pat<(xor i64:$A, (not i64:$B)), (EQV8 i64:$A, i64:$B)>;

--- a/llvm/lib/Target/PowerPC/PPCInstrAltivec.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrAltivec.td
@@ -1673,3 +1673,7 @@ def VABSDUW : VXForm_1<1155, (outs vrrc:$VD), (ins vrrc:$VA, vrrc:$VB),
                        [(set v4i32:$VD, (int_ppc_altivec_vabsduw v4i32:$VA, v4i32:$VB))]>;
 
 } // end HasP9Altivec
+
+// XOR-NOT to VEQV optimization patterns (AltiVec) (moved to end of file)
+def : Pat<(xor (vnot v4i32:$A), v4i32:$B), (VEQV v4i32:$A, v4i32:$B)>;
+def : Pat<(xor v4i32:$A, (vnot v4i32:$B)), (VEQV v4i32:$A, v4i32:$B)>;

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2362,6 +2362,7 @@ defm XOR  : XForm_6r<31, 316, (outs gprc:$RA), (ins gprc:$RST, gprc:$RB),
                      "xor", "$RA, $RST, $RB", IIC_IntSimple,
                      [(set i32:$RA, (xor i32:$RST, i32:$RB))]>;
 } // isCommutable
+
 defm SLW  : XForm_6r<31,  24, (outs gprc:$RA), (ins gprc:$RST, gprc:$RB),
                      "slw", "$RA, $RST, $RB", IIC_IntGeneral,
                      [(set i32:$RA, (PPCshl i32:$RST, i32:$RB))]>, ZExt32To64;
@@ -5313,3 +5314,6 @@ def : Pat<(int_ppc_dcbtt ForceXForm:$dst),
 
 def : Pat<(int_ppc_stfiw ForceXForm:$dst, f64:$XT),
           (STFIWX f64:$XT, ForceXForm:$dst)>;
+
+def : Pat<(xor (not i32:$A), i32:$B), (EQV i32:$A, i32:$B)>;
+def : Pat<(xor i32:$A, (not i32:$B)), (EQV i32:$A, i32:$B)>;

--- a/llvm/lib/Target/PowerPC/PPCInstrVSX.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrVSX.td
@@ -5144,3 +5144,7 @@ def : InstAlias<"mtvrwz $XT, $rA",
                 (MTVRWZ vrrc:$XT, gprc:$rA), 0>;
 def : InstAlias<"mtfprwz $dst, $rA",
                 (MTVSRWZ f8rc:$dst, gprc:$rA)>;
+
+// XOR-NOT to XXLEQV optimization patterns (VSX) (moved to end of file)
+def : Pat<(xor (vnot v4i32:$A), v4i32:$B), (XXLEQV v4i32:$A, v4i32:$B)>;
+def : Pat<(xor v4i32:$A, (vnot v4i32:$B)), (XXLEQV v4i32:$A, v4i32:$B)>;


### PR DESCRIPTION
(~x ^ y) is equal to ~(x ^ y)