### PR TITLE
Move LIBC_CONF_STRING_UNSAFE_WIDE_READ to top-level libc-configuration

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -81,6 +81,10 @@ function(_get_compile_options_from_config output_var)
     list(APPEND config_options "-DLIBC_QSORT_IMPL=${LIBC_CONF_QSORT_IMPL}")
   endif()
 
+  if(LIBC_CONF_STRING_UNSAFE_WIDE_READ)
+    list(APPEND config_options "-DLIBC_COPT_STRING_UNSAFE_WIDE_READ")
+  endif()
+
   if(LIBC_TYPES_TIME_T_IS_32_BIT AND LLVM_LIBC_FULL_BUILD)
     list(APPEND config_options "-DLIBC_TYPES_TIME_T_IS_32_BIT")
   endif()

--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -86,7 +86,7 @@ function(_get_compile_options_from_config output_var)
   endif()
 
   if(LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING)
-    list(APPEND string_config_options "-DLIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING")
+    list(APPEND config_options "-DLIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING")
   endif()
 
   if(LIBC_TYPES_TIME_T_IS_32_BIT AND LLVM_LIBC_FULL_BUILD)

--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -85,6 +85,10 @@ function(_get_compile_options_from_config output_var)
     list(APPEND config_options "-DLIBC_COPT_STRING_UNSAFE_WIDE_READ")
   endif()
 
+  if(LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING)
+    list(APPEND string_config_options "-DLIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING")
+  endif()
+
   if(LIBC_TYPES_TIME_T_IS_32_BIT AND LLVM_LIBC_FULL_BUILD)
     list(APPEND config_options "-DLIBC_TYPES_TIME_T_IS_32_BIT")
   endif()

--- a/libc/src/string/CMakeLists.txt
+++ b/libc/src/string/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_subdirectory(memory_utils)
 
-if(LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING)
-  list(APPEND string_config_options "-DLIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING")
-endif()
 if(string_config_options)
   list(PREPEND string_config_options "COMPILE_OPTIONS")
 endif()

--- a/libc/src/string/CMakeLists.txt
+++ b/libc/src/string/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_subdirectory(memory_utils)
 
-if(LIBC_CONF_STRING_UNSAFE_WIDE_READ)
-  list(APPEND string_config_options "-DLIBC_COPT_STRING_UNSAFE_WIDE_READ")
-endif()
 if(LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING)
   list(APPEND string_config_options "-DLIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING")
 endif()

--- a/libc/src/string/CMakeLists.txt
+++ b/libc/src/string/CMakeLists.txt
@@ -1,9 +1,5 @@
 add_subdirectory(memory_utils)
 
-if(string_config_options)
-  list(PREPEND string_config_options "COMPILE_OPTIONS")
-endif()
-
 add_header_library(
   string_utils
   HDRS
@@ -18,7 +14,6 @@ add_header_library(
     libc.src.__support.common
     libc.src.__support.macros.attributes
     libc.src.string.memory_utils.inline_memcpy
-  ${string_config_options}
 )
 
 add_header_library(


### PR DESCRIPTION
This options sets a compile option when building sources inside the string directory, and this option affects string_utils.h. But string_utils.h is #included from more places than just the string directory (such as from __support/CPP/string.h), leading to both narrow-reads in those cases, but more seriously, ODR violations when the two different string_length implementations are included int he same program.

Having this option at the top level avoids this problem.