### PR TITLE
[ADT][NFC] Add missing #include <vector>

### DIFF
--- a/llvm/include/llvm/ADT/RadixTree.h
+++ b/llvm/include/llvm/ADT/RadixTree.h
@@ -22,6 +22,7 @@
 #include <limits>
 #include <list>
 #include <utility>
+#include <vector>
 
 namespace llvm {
 


### PR DESCRIPTION
Added in #164524. Fails when using libc++ in a mode that prunes transitive headers.