### PR TITLE
[Github][Bazel] Add Workflow to Run Bazel Build

### DIFF
--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -52,5 +52,5 @@ jobs:
         working-directory: utils/bazel
         run: |
           bazel test --config=ci @llvm-project//llvm/... \
-            @llvm-project/clang/... \
-            @llvm-project/mlir/...
+            @llvm-project//clang/... \
+            @llvm-project//mlir/...

--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmpfr-dev pfm
+          sudo apt-get install -y libmpfr-dev libpfm4-dev
           sudo curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-amd64.deb > /tmp/bazelisk.deb
           sudo apt-get install -y /tmp/bazelisk.deb
           rm /tmp/bazelisk.deb

--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -43,6 +43,7 @@ jobs:
         # ARC in GKE.
       - name: Setup System Dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libmpfr-dev pfm
           sudo curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-amd64.deb > /tmp/bazelisk.deb
           sudo apt-get install -y /tmp/bazelisk.deb

--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -30,3 +30,26 @@ jobs:
       - name: Run Buildifier
         run: |
           buildifier --mode=check $(find ./utils/bazel -name *BUILD*)
+  
+  bazel-build:
+    name: "Bazel Build/Test"
+    runs-on: llvm-premerge-linux-runners
+    if: github.repository == 'llvm/llvm-project'
+    steps:
+      - name: Fetch LLVM sources
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        # TODO(boomanaiden154): We should use a purpose built container for this. Move
+        # over when we have fixed the issues with using custom containers with Github
+        # ARC in GKE.
+      - name: Setup System Dependencies
+        run: |
+          sudo apt-get install -y libmpfr-dev pfm
+          sudo curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-amd64.deb > /tmp/bazelisk.deb
+          sudo apt-get install -y /tmp/bazelisk.deb
+          rm /tmp/bazelisk.deb
+      - name: Build/Test
+        working-directory: utils/bazel
+        run: |
+          bazel test --config=ci @llvm-project//llvm/... \
+            @llvm-project/clang/... \
+            @llvm-project/mlir/...

--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Build/Test
         working-directory: utils/bazel
         run: |
-          bazel test --config=ci @llvm-project//llvm/... \
+          bazel test --config=ci --sandbox_base="" \
+            @llvm-project//llvm/... \
             @llvm-project//clang/... \
             @llvm-project//mlir/...

--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -51,7 +51,5 @@ jobs:
       - name: Build/Test
         working-directory: utils/bazel
         run: |
-          bazel test --config=ci --sandbox_base="" \
-            @llvm-project//llvm/... \
-            @llvm-project//clang/... \
-            @llvm-project//mlir/...
+          bazelisk test --config=ci --sandbox_base="" \
+            @llvm-project//llvm/unittests:adt_tests


### PR DESCRIPTION
This patch adds a job to the bazel checks workflow to run the bazel build/test. This patch only tests a couple projects just to get things going. The plan is to expand to more projects eventually and setup a GCS bucket for caching so jobs complete quickly by using cached artifacts.

This should add minimal load to the CI given the low frequency of bazel PRs, and especially when we enable GCS based caching due to bazel's effective use of caching. Google is also sponsoring the Linux Premerge CI and is interested in having premerge bazel builds which is why it makes sense to do premerge testing of this alternative build system using those resources.