### PR TITLE
[Clang][CodeGen][CIR][NFC] Refactor CGCXXABI classes for code sharing

### DIFF
--- a/clang/include/clang/CodeGenShared/CXXABIShared.h
+++ b/clang/include/clang/CodeGenShared/CXXABIShared.h
@@ -1,0 +1,99 @@
+//===----- CXXABIShared.h - Shared C++ ABI Base Class -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides a base class for C++ ABI functionality that can be shared
+// between LLVM IR codegen and CIR codegen.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CODEGENSHARED_CXXABISHARED_H
+#define LLVM_CLANG_CODEGENSHARED_CXXABISHARED_H
+
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/GlobalDecl.h"
+#include "clang/AST/Mangle.h"
+#include "clang/Basic/ABI.h"
+
+namespace clang {
+class ASTContext;
+
+/// Implements C++ ABI functionality that can be shared between LLVM IR codegen
+/// and CIR codegen.
+class CXXABIShared {
+protected:
+  ASTContext &Context;
+  std::unique_ptr<MangleContext> MangleCtx;
+
+  CXXABIShared(ASTContext &Context)
+      : Context(Context), MangleCtx(Context.createMangleContext()) {}
+
+public:
+  virtual ~CXXABIShared() = default;
+
+  /// Similar to AddedStructorArgs, but only notes the number of additional
+  /// arguments.
+  struct AddedStructorArgCounts {
+    unsigned Prefix = 0;
+    unsigned Suffix = 0;
+    AddedStructorArgCounts() = default;
+    AddedStructorArgCounts(unsigned P, unsigned S) : Prefix(P), Suffix(S) {}
+    static AddedStructorArgCounts prefix(unsigned N) { return {N, 0}; }
+    static AddedStructorArgCounts suffix(unsigned N) { return {0, N}; }
+  };
+
+  /// Get the AST context.
+  ASTContext &getContext() const { return Context; }
+
+  /// Gets the mangle context.
+  MangleContext &getMangleContext() { return *MangleCtx; }
+
+  /// Determine whether there's something special about the rules of
+  /// the ABI tell us that 'this' is a complete object within the
+  /// given function.  Obvious common logic like being defined on a
+  /// final class will have been taken care of by the caller.
+  virtual bool isThisCompleteObject(GlobalDecl GD) const = 0;
+
+  /// Returns true if the most-derived return value should be returned.
+  virtual bool hasMostDerivedReturn(GlobalDecl GD) const { return false; }
+
+  /// Return whether the given global decl needs a VTT parameter.
+  virtual bool NeedsVTTParameter(GlobalDecl GD) const { return false; }
+
+  /// Returns true if the given constructor or destructor is one of the
+  /// kinds that the ABI says returns 'this' (only applies when called
+  /// non-virtually for destructors).
+  ///
+  /// There currently is no way to indicate if a destructor returns 'this'
+  /// when called virtually, and code generation does not support the case.
+  /// Returns true if the given constructor or destructor is one of the
+  /// kinds that the ABI says returns 'this' (only applies when called
+  /// non-virtually for destructors).
+  ///
+  /// There currently is no way to indicate if a destructor returns 'this'
+  /// when called virtually, and code generation does not support the case.
+  virtual bool HasThisReturn(GlobalDecl GD) const {
+    if (isa<CXXConstructorDecl>(GD.getDecl()) ||
+        (isa<CXXDestructorDecl>(GD.getDecl()) &&
+         GD.getDtorType() != Dtor_Deleting))
+      return constructorsAndDestructorsReturnThis();
+    return false;
+  }
+
+  /// Returns true if the given destructor type should be emitted as a linkonce
+  /// delegating thunk, regardless of whether the dtor is defined in this TU or
+  /// not.
+  virtual bool useThunkForDtorVariant(const CXXDestructorDecl *Dtor,
+                                      CXXDtorType DT) const = 0;
+
+protected:
+  virtual bool constructorsAndDestructorsReturnThis() const = 0;
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_CODEGENSHARED_CXXABISHARED_H

--- a/clang/include/clang/CodeGenShared/ItaniumCXXABIShared.h
+++ b/clang/include/clang/CodeGenShared/ItaniumCXXABIShared.h
@@ -1,0 +1,118 @@
+//===--- ItaniumCXXABIShared.h - Itanium C++ ABI Shared Base ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides a base class for Itanium C++ ABI implementations that can
+// be shared between LLVM IR codegen and CIR codegen.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CODEGENSHARED_ITANIUMCXXABISHARED_H
+#define LLVM_CLANG_CODEGENSHARED_ITANIUMCXXABISHARED_H
+
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/GlobalDecl.h"
+#include "clang/Basic/ABI.h"
+#include <utility>
+
+namespace clang {
+
+template <typename BaseT> class ItaniumCXXABIShared : public BaseT {
+protected:
+  /// Constructor forwarding to the base ABI class.
+  template <typename... Args>
+  ItaniumCXXABIShared(Args &&...args) : BaseT(std::forward<Args>(args)...) {}
+
+public:
+  /// Determine whether there's something special about the rules of
+  /// the ABI tell us that 'this' is a complete object within the
+  /// given function.  Obvious common logic like being defined on a
+  /// final class will have been taken care of by the caller.
+  bool isThisCompleteObject(GlobalDecl GD) const override {
+    // The Itanium ABI has separate complete-object vs. base-object
+    // variants of both constructors and destructors.
+    if (isa<CXXDestructorDecl>(GD.getDecl())) {
+      switch (GD.getDtorType()) {
+      case Dtor_Complete:
+      case Dtor_Deleting:
+        return true;
+
+      case Dtor_Base:
+        return false;
+
+      case Dtor_Comdat:
+        llvm_unreachable("emitting dtor comdat as function?");
+      case Dtor_Unified:
+        llvm_unreachable("emitting unified dtor as function?");
+      }
+      llvm_unreachable("bad dtor kind");
+    }
+    if (isa<CXXConstructorDecl>(GD.getDecl())) {
+      switch (GD.getCtorType()) {
+      case Ctor_Complete:
+        return true;
+
+      case Ctor_Base:
+        return false;
+
+      case Ctor_CopyingClosure:
+      case Ctor_DefaultClosure:
+        llvm_unreachable("closure ctors in Itanium ABI?");
+
+      case Ctor_Comdat:
+        llvm_unreachable("emitting ctor comdat as function?");
+
+      case Ctor_Unified:
+        llvm_unreachable("emitting unified ctor as function?");
+      }
+      llvm_unreachable("bad ctor kind");
+    }
+
+    // No other kinds.
+    return false;
+  }
+
+  bool NeedsVTTParameter(GlobalDecl GD) const override {
+    const CXXMethodDecl *MD = cast<CXXMethodDecl>(GD.getDecl());
+
+    // We don't have any virtual bases, just return early.
+    if (!MD->getParent()->getNumVBases())
+      return false;
+
+    // Check if we have a base constructor.
+    if (isa<CXXConstructorDecl>(MD) && GD.getCtorType() == Ctor_Base)
+      return true;
+
+    // Check if we have a base destructor.
+    if (isa<CXXDestructorDecl>(MD) && GD.getDtorType() == Dtor_Base)
+      return true;
+
+    return false;
+  }
+
+  /// Returns true if the given destructor type should be emitted as a linkonce
+  /// delegating thunk, regardless of whether the dtor is defined in this TU or
+  /// not.
+  ///
+  /// Itanium does not emit any destructor variant as an inline thunk.
+  /// Delegating may occur as an optimization, but all variants are either
+  /// emitted with external linkage or as linkonce if they are inline and used.
+  bool useThunkForDtorVariant(const CXXDestructorDecl *Dtor,
+                              CXXDtorType DT) const override {
+    return false;
+  }
+
+  /// Returns true if this ABI initializes vptrs in constructors/destructors.
+  /// For Itanium, this is always true.
+  bool doStructorsInitializeVPtrs(const CXXRecordDecl *VTableClass) override {
+    return true;
+  }
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_CODEGENSHARED_ITANIUMCXXABISHARED_H

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -116,7 +116,7 @@ static void emitDeclDestroy(CIRGenFunction &cgf, const VarDecl *vd,
   // mismatch.
   const CXXRecordDecl *record = type->getAsCXXRecordDecl();
   bool canRegisterDestructor =
-      record && (!cgm.getCXXABI().hasThisReturn(
+      record && (!cgm.getCXXABI().HasThisReturn(
                      GlobalDecl(record->getDestructor(), Dtor_Complete)) ||
                  cgm.getCXXABI().canCallMismatchedFunctionType());
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -206,12 +206,12 @@ CIRGenTypes::arrangeCXXStructorDeclaration(GlobalDecl gd) {
       (passParams && md->isVariadic() ? RequiredArgs(argTypes.size())
                                       : RequiredArgs::All);
 
-  CanQualType resultType = theCXXABI.hasThisReturn(gd) ? argTypes.front()
+  CanQualType resultType = theCXXABI.HasThisReturn(gd) ? argTypes.front()
                            : theCXXABI.hasMostDerivedReturn(gd)
                                ? astContext.VoidPtrTy
                                : astContext.VoidTy;
 
-  assert(!theCXXABI.hasThisReturn(gd) &&
+  assert(!theCXXABI.HasThisReturn(gd) &&
          "Please send PR with a test and remove this");
 
   assert(!cir::MissingFeatures::opCallCIRGenFuncInfoExtParamInfo());
@@ -350,7 +350,7 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCXXConstructorCall(
                               : RequiredArgs::All;
 
   GlobalDecl gd(d, ctorKind);
-  if (theCXXABI.hasThisReturn(gd))
+  if (theCXXABI.HasThisReturn(gd))
     cgm.errorNYI(d->getSourceRange(),
                  "arrangeCXXConstructorCall: hasThisReturn");
   if (theCXXABI.hasMostDerivedReturn(gd))

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -759,7 +759,7 @@ void CIRGenFunction::emitDelegateCXXConstructorCall(
 
   // FIXME: The location of the VTT parameter in the parameter list is specific
   // to the Itanium ABI and shouldn't be hardcoded here.
-  if (cgm.getCXXABI().needsVTTParameter(curGD)) {
+  if (cgm.getCXXABI().NeedsVTTParameter(curGD)) {
     cgm.errorNYI(loc, "emitDelegateCXXConstructorCall: VTT parameter");
     return;
   }
@@ -1068,7 +1068,7 @@ void CIRGenFunction::emitCXXDestructorCall(const CXXDestructorDecl *dd,
 
 mlir::Value CIRGenFunction::getVTTParameter(GlobalDecl gd, bool forVirtualBase,
                                             bool delegating) {
-  if (!cgm.getCXXABI().needsVTTParameter(gd))
+  if (!cgm.getCXXABI().NeedsVTTParameter(gd))
     return nullptr;
 
   const CXXRecordDecl *rd = cast<CXXMethodDecl>(curCodeDecl)->getParent();
@@ -1082,7 +1082,7 @@ mlir::Value CIRGenFunction::getVTTParameter(GlobalDecl gd, bool forVirtualBase,
   } else if (rd == base) {
     // If the record matches the base, this is the complete ctor/dtor
     // variant calling the base variant in a class with virtual bases.
-    assert(!cgm.getCXXABI().needsVTTParameter(curGD) &&
+    assert(!cgm.getCXXABI().NeedsVTTParameter(curGD) &&
            "doing no-op VTT offset in base dtor/ctor?");
     assert(!forVirtualBase && "Can't have same class as virtual base!");
     subVTTIndex = 0;
@@ -1097,7 +1097,7 @@ mlir::Value CIRGenFunction::getVTTParameter(GlobalDecl gd, bool forVirtualBase,
   }
 
   mlir::Location loc = cgm.getLoc(rd->getBeginLoc());
-  if (cgm.getCXXABI().needsVTTParameter(curGD)) {
+  if (cgm.getCXXABI().NeedsVTTParameter(curGD)) {
     // A VTT parameter was passed to the constructor, use it.
     mlir::Value vtt = loadCXXVTT();
     return builder.createVTTAddrPoint(loc, vtt.getType(), vtt, subVTTIndex);
@@ -1266,7 +1266,7 @@ void CIRGenFunction::emitCXXConstructorCall(
   // Emit the call.
   auto calleePtr = cgm.getAddrOfCXXStructor(GlobalDecl(d, type));
   const CIRGenFunctionInfo &info = cgm.getTypes().arrangeCXXConstructorCall(
-      args, d, type, extraArgs.prefix, extraArgs.suffix, passPrototypeArgs);
+      args, d, type, extraArgs.Prefix, extraArgs.Suffix, passPrototypeArgs);
   CIRGenCallee callee = CIRGenCallee::forDirect(calleePtr, GlobalDecl(d, type));
   cir::CIRCallOpInterface c;
   emitCall(info, callee, ReturnValueSlot(), args, &c, getLoc(loc));

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -833,7 +833,7 @@ clang::QualType CIRGenFunction::buildFunctionArgList(clang::GlobalDecl gd,
 
   const auto *md = dyn_cast<CXXMethodDecl>(fd);
   if (md && md->isInstance()) {
-    if (cgm.getCXXABI().hasThisReturn(gd))
+    if (cgm.getCXXABI().HasThisReturn(gd))
       cgm.errorNYI(fd->getSourceRange(), "this return");
     else if (cgm.getCXXABI().hasMostDerivedReturn(gd))
       cgm.errorNYI(fd->getSourceRange(), "most derived return");

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -81,7 +81,6 @@ public:
   void emitRethrow(CIRGenFunction &cgf, bool isNoReturn) override;
   void emitThrow(CIRGenFunction &cgf, const CXXThrowExpr *e) override;
 
-
   bool isVirtualOffsetNeededForVTableField(CIRGenFunction &cgf,
                                            CIRGenFunction::VPtr vptr) override;
 

--- a/clang/lib/CodeGen/CGCXXABI.cpp
+++ b/clang/lib/CodeGen/CGCXXABI.cpp
@@ -319,10 +319,6 @@ llvm::GlobalValue::LinkageTypes CGCXXABI::getCXXDestructorLinkage(
   return CGM.getLLVMLinkageForDeclarator(Dtor, Linkage);
 }
 
-bool CGCXXABI::NeedsVTTParameter(GlobalDecl GD) {
-  return false;
-}
-
 llvm::CallInst *
 CGCXXABI::emitTerminateForUnexpectedException(CodeGenFunction &CGF,
                                               llvm::Value *Exn) {

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -219,7 +219,6 @@ public:
   buildStructorSignature(GlobalDecl GD,
                          SmallVectorImpl<CanQualType> &ArgTys) override;
 
-
   void EmitCXXDestructors(const CXXDestructorDecl *D) override;
 
   void addImplicitStructorParams(CodeGenFunction &CGF, QualType &ResTy,
@@ -249,7 +248,6 @@ public:
 
   bool isVirtualOffsetNeededForVTableField(CodeGenFunction &CGF,
                                            CodeGenFunction::VPtr Vptr) override;
-
 
   llvm::Constant *
   getVTableAddressPoint(BaseSubobject Base,


### PR DESCRIPTION
This refactors the CGCXXABI and ItaniumCXXABI classes in LLVM IR codegen and their CIR codegen counterparts so that common code can be shared between the two.

This is a small first step towards better code sharing between LLVM IR codegen and CIR codegen. We should be able to expand this significantly as CIR codegen matures.

Note that some other code can very nearly, but not quite be shared at this point. For example `AddedStructorArgs` and its uses are nearly identical between LLVM IR and CIR codegen, but the struct contains an `llvm::Value*` member in LLVM IR codegen where it conatins an `mlir::Value` member in CIR codegen. We will need additional refactoring to handle cases like that.