### PR TITLE
[Clang] Fix a wrong diagnostic about a local variable inside a lambda in unevaluated   context need capture

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -432,6 +432,8 @@ Bug Fixes in This Version
 - Fixed a failed assertion with empty filename arguments in ``__has_embed``. (#GH159898)
 - Fixed a failed assertion with empty filename in ``#embed`` directive. (#GH162951)
 - Fixed a crash triggered by unterminated ``__has_embed``. (#GH162953)
+- Fixed a wrong diagnostic about a local variable inside a lambda in unevaluated
+  contexts need capture. (#GH163837)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -433,7 +433,7 @@ Bug Fixes in This Version
 - Fixed a failed assertion with empty filename in ``#embed`` directive. (#GH162951)
 - Fixed a crash triggered by unterminated ``__has_embed``. (#GH162953)
 - Fixed a wrong diagnostic about a local variable inside a lambda in unevaluated
-  contexts need capture. (#GH163837)
+  context needs capture. (#GH163837)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -7062,11 +7062,12 @@ NamedDecl *Sema::FindInstantiatedDecl(SourceLocation Loc, NamedDecl *D,
   }
 
   if (!ParentDependsOnArgs) {
-    if (auto Found =
-            CurrentInstantiationScope
-                ? CurrentInstantiationScope->getInstantiationOfIfExists(D)
-                : nullptr) {
-      return cast<NamedDecl>(Found->dyn_cast<Decl *>());
+    if (CurrentInstantiationScope) {
+      if (llvm::PointerUnion<Decl *, LocalInstantiationScope::DeclArgumentPack *> *Found =
+          CurrentInstantiationScope->getInstantiationOfIfExists(D)) {
+        if (Decl* FD = Found->dyn_cast<Decl *>())
+          return cast<NamedDecl>(FD);
+      }
     }
     return D;
   }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -7061,8 +7061,15 @@ NamedDecl *Sema::FindInstantiatedDecl(SourceLocation Loc, NamedDecl *D,
     // anonymous unions in class templates).
   }
 
-  if (!ParentDependsOnArgs)
+  if (!ParentDependsOnArgs) {
+    if (auto Found =
+            CurrentInstantiationScope
+                ? CurrentInstantiationScope->getInstantiationOfIfExists(D)
+                : nullptr) {
+      return cast<NamedDecl>(Found->dyn_cast<Decl *>());
+    }
     return D;
+  }
 
   ParentDC = FindInstantiatedContext(Loc, ParentDC, TemplateArgs);
   if (!ParentDC)

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -7063,9 +7063,10 @@ NamedDecl *Sema::FindInstantiatedDecl(SourceLocation Loc, NamedDecl *D,
 
   if (!ParentDependsOnArgs) {
     if (CurrentInstantiationScope) {
-      if (llvm::PointerUnion<Decl *, LocalInstantiationScope::DeclArgumentPack *> *Found =
-          CurrentInstantiationScope->getInstantiationOfIfExists(D)) {
-        if (Decl* FD = Found->dyn_cast<Decl *>())
+      if (llvm::PointerUnion<
+              Decl *, LocalInstantiationScope::DeclArgumentPack *> *Found =
+              CurrentInstantiationScope->getInstantiationOfIfExists(D)) {
+        if (Decl *FD = Found->dyn_cast<Decl *>())
           return cast<NamedDecl>(FD);
       }
     }

--- a/clang/test/SemaCXX/lambda-unevaluated.cpp
+++ b/clang/test/SemaCXX/lambda-unevaluated.cpp
@@ -282,3 +282,22 @@ static_assert(__is_same_as(int, helper<int>));
 
 
 } // namespace GH138018
+
+namespace GH163837 {
+
+template<int N>
+void f();
+
+template<class>
+struct X {
+    using type = decltype([](auto) {
+        f<[]{
+            int result = 0;
+            return result;
+        }()>();
+    }(0));
+};
+
+X<void> l;
+
+} // namespace GH163837


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/163837

We should return true here https://github.com/llvm/llvm-project/blob/035f81138888f30aab67ee12ce09982cd03370cb/clang/lib/Sema/SemaExpr.cpp#L19398-L19400 , but we won't currently due to mismatch of `VarDC` and `DC` while `DC` is instantiated version of `VarDC`.

The reason of mismatch is that `FindInstantiatedDecl` to `result` returns uninstantiated version incorrectly here

https://github.com/llvm/llvm-project/blob/059d90d08f610d5919c42646f267bbab77f7bee4/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp#L7064-L7065

We should return instantiated version if we can find one.