### PR TITLE
[CIR] Add structured CatchParamOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5197,7 +5197,7 @@ def CIR_CatchParamOp : CIR_Op<"catch_param", [HasParent<"cir::TryOp">]> {
     Example:
 
     ```mlir
-    %exception = cir.catch_param -> !cir.ptr<!void>
+    %exception = cir.catch_param : !cir.ptr<!void>
     ```
   }];
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5184,6 +5184,33 @@ def CIR_TryOp : CIR_Op<"try",[
 }
 
 //===----------------------------------------------------------------------===//
+// CatchParamOp
+//===----------------------------------------------------------------------===//
+
+def CIR_CatchParamOp : CIR_Op<"catch_param", [HasParent<"cir::TryOp">]> {
+  let summary = "Represents catch clause formal parameter";
+  let description = [{
+    The `cir.catch_param` operate in the catch regions of `cir.try`.
+
+    This operation is used only before the CFG flatterning pass.
+
+    Example:
+
+    ```mlir
+    %exception = cir.catch_param -> !cir.ptr<!void>
+    ```
+  }];
+
+  let results = (outs Optional<CIR_AnyType>:$param);
+  let assemblyFormat = [{
+    (`:` qualified(type($param))^)?
+    attr-dict
+  }];
+
+  let hasLLVMLowering = false;
+}
+
+//===----------------------------------------------------------------------===//
 // Exception related: EhInflightOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5190,7 +5190,7 @@ def CIR_TryOp : CIR_Op<"try",[
 def CIR_CatchParamOp : CIR_Op<"catch_param", [HasParent<"cir::TryOp">]> {
   let summary = "Represents the catch clause formal parameter";
   let description = [{
-    The `cir.catch_param` used to retrieves the exception object inside
+    The `cir.catch_param` is used to retrieves the exception object inside
     the handler regions of `cir.try`.
 
     This operation is used only before the CFG flatterning pass.

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5188,9 +5188,10 @@ def CIR_TryOp : CIR_Op<"try",[
 //===----------------------------------------------------------------------===//
 
 def CIR_CatchParamOp : CIR_Op<"catch_param", [HasParent<"cir::TryOp">]> {
-  let summary = "Represents catch clause formal parameter";
+  let summary = "Represents the catch clause formal parameter";
   let description = [{
-    The `cir.catch_param` operate in the catch regions of `cir.try`.
+    The `cir.catch_param` used to retrieves the exception object inside
+    the handler regions of `cir.try`.
 
     This operation is used only before the CFG flatterning pass.
 

--- a/clang/test/CIR/IR/catch-param.cir
+++ b/clang/test/CIR/IR/catch-param.cir
@@ -10,7 +10,7 @@ cir.func @catch_param_inside_catch() {
     cir.try {
       cir.yield
     } catch all {
-      cir.catch_param : !cir.ptr<!void>
+      %exception = cir.catch_param : !cir.ptr<!void>
       cir.yield
     }
   }
@@ -22,7 +22,7 @@ cir.func @catch_param_inside_catch() {
 // CHECK:     cir.try {
 // CHECK:       cir.yield
 // CHECK:     } catch all {
-// CHECK:       cir.catch_param : !cir.ptr<!void> 
+// CHECK:       %[[EXCEPTION:.*]] = cir.catch_param : !cir.ptr<!void> 
 // CHECK:       cir.yield
 // CHECK:     }
 // CHECK:   }

--- a/clang/test/CIR/IR/catch-param.cir
+++ b/clang/test/CIR/IR/catch-param.cir
@@ -1,0 +1,32 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s  
+
+!s32i = !cir.int<s, 32>
+!void = !cir.void
+
+module {
+
+cir.func @catch_param_inside_catch() {
+  cir.scope {
+    cir.try {
+      cir.yield
+    } catch all {
+      cir.catch_param : !cir.ptr<!void>
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK: cir.func @catch_param_inside_catch() {
+// CHECK:   cir.scope {
+// CHECK:     cir.try {
+// CHECK:       cir.yield
+// CHECK:     } catch all {
+// CHECK:       cir.catch_param : !cir.ptr<!void> 
+// CHECK:       cir.yield
+// CHECK:     }
+// CHECK:   }
+// CHECK:   cir.return
+// CHECK: }
+
+}


### PR DESCRIPTION
Upstream, the structured CatchParamOp as a prerequisite for implementing exception handlers

Issue https://github.com/llvm/llvm-project/issues/154992