### PR TITLE
[ADT] Fix a comment in ScopedHashTable

### DIFF
--- a/llvm/include/llvm/ADT/ScopedHashTable.h
+++ b/llvm/include/llvm/ADT/ScopedHashTable.h
@@ -151,8 +151,8 @@ class ScopedHashTable : detail::AllocatorHolder<AllocatorTy> {
   using AllocTy = detail::AllocatorHolder<AllocatorTy>;
 
 public:
-  /// ScopeTy - This is a helpful typedef that allows clients to get easy access
-  /// to the name of the scope for this hash table.
+  /// ScopeTy - A type alias for easy access to the name of the scope for this
+  /// hash table.
   using ScopeTy = ScopedHashTableScope<K, V, KInfo, AllocatorTy>;
   using size_type = unsigned;
 


### PR DESCRIPTION
This patch replaces "typedef" with "type alias" in the comment while
making it more concise.
