### PR TITLE
[llvm] Use iterator_range<T>(Container &&) (NFC)

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
@@ -102,9 +102,7 @@ public:
   using attr_iterator_range =
       iterator_range<AttributeSpecVector::const_iterator>;
 
-  attr_iterator_range attributes() const {
-    return attr_iterator_range(AttributeSpecs.begin(), AttributeSpecs.end());
-  }
+  attr_iterator_range attributes() const { return AttributeSpecs; }
 
   dwarf::Form getFormByIndex(uint32_t idx) const {
     assert(idx < AttributeSpecs.size());

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
@@ -226,9 +226,7 @@ public:
   /// DWARF Frame entries accessors
   iterator begin() const { return Entries.begin(); }
   iterator end() const { return Entries.end(); }
-  iterator_range<iterator> entries() const {
-    return iterator_range<iterator>(Entries.begin(), Entries.end());
-  }
+  iterator_range<iterator> entries() const { return Entries; }
 
   uint64_t getEHFrameAddress() const { return EHFrameAddress; }
 };

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -563,7 +563,7 @@ public:
 
   die_iterator_range dies() {
     extractDIEsIfNeeded(false);
-    return die_iterator_range(DieArray.begin(), DieArray.end());
+    return DieArray;
   }
 
   virtual void dump(raw_ostream &OS, DIDumpOptions DumpOpts) = 0;

--- a/llvm/include/llvm/IR/DebugInfo.h
+++ b/llvm/include/llvm/IR/DebugInfo.h
@@ -140,25 +140,17 @@ public:
   using type_iterator = SmallVectorImpl<DIType *>::const_iterator;
   using scope_iterator = SmallVectorImpl<DIScope *>::const_iterator;
 
-  iterator_range<compile_unit_iterator> compile_units() const {
-    return make_range(CUs.begin(), CUs.end());
-  }
+  iterator_range<compile_unit_iterator> compile_units() const { return CUs; }
 
-  iterator_range<subprogram_iterator> subprograms() const {
-    return make_range(SPs.begin(), SPs.end());
-  }
+  iterator_range<subprogram_iterator> subprograms() const { return SPs; }
 
   iterator_range<global_variable_expression_iterator> global_variables() const {
-    return make_range(GVs.begin(), GVs.end());
+    return GVs;
   }
 
-  iterator_range<type_iterator> types() const {
-    return make_range(TYs.begin(), TYs.end());
-  }
+  iterator_range<type_iterator> types() const { return TYs; }
 
-  iterator_range<scope_iterator> scopes() const {
-    return make_range(Scopes.begin(), Scopes.end());
-  }
+  iterator_range<scope_iterator> scopes() const { return Scopes; }
 
   unsigned compile_unit_count() const { return CUs.size(); }
   unsigned global_variable_count() const { return GVs.size(); }

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -245,10 +245,10 @@ public:
   uint32_t getStaticSamplersOffset() const { return StaticSamplersOffset; }
   uint32_t getNumRootParameters() const { return ParametersHeaders.size(); }
   llvm::iterator_range<param_header_iterator> param_headers() const {
-    return llvm::make_range(ParametersHeaders.begin(), ParametersHeaders.end());
+    return ParametersHeaders;
   }
   llvm::iterator_range<samplers_iterator> samplers() const {
-    return llvm::make_range(StaticSamplers.begin(), StaticSamplers.end());
+    return StaticSamplers;
   }
   uint32_t getFlags() const { return Flags; }
 

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -121,9 +121,7 @@ private:
   NodeList Stack;
   bool Done = false;
 
-  iterator_range<node_iterator> nodes() const {
-    return make_range(Stack.begin(), Stack.end());
-  }
+  iterator_range<node_iterator> nodes() const { return Stack; }
 };
 using export_iterator = content_iterator<ExportEntry>;
 

--- a/llvm/include/llvm/Remarks/RemarkLinker.h
+++ b/llvm/include/llvm/Remarks/RemarkLinker.h
@@ -101,9 +101,7 @@ public:
   /// for (const Remark &R : RL.remarks() { [...] }
   using iterator = pointee_iterator<decltype(Remarks)::const_iterator>;
 
-  iterator_range<iterator> remarks() const {
-    return {Remarks.begin(), Remarks.end()};
-  }
+  iterator_range<iterator> remarks() const { return Remarks; }
 };
 
 /// Returns a buffer with the contents of the remarks section depending on the

--- a/llvm/include/llvm/TextAPI/SymbolSet.h
+++ b/llvm/include/llvm/TextAPI/SymbolSet.h
@@ -139,18 +139,14 @@ public:
       iterator_range<const_filtered_symbol_iterator>;
 
   // Range that contains all symbols.
-  const_symbol_range symbols() const {
-    return {Symbols.begin(), Symbols.end()};
-  }
+  const_symbol_range symbols() const { return Symbols; }
 
   // Range that contains all defined and exported symbols.
   const_filtered_symbol_range exports() const {
     std::function<bool(const Symbol *)> fn = [](const Symbol *Symbol) {
       return !Symbol->isUndefined() && !Symbol->isReexported();
     };
-    return make_filter_range(
-        make_range<const_symbol_iterator>({Symbols.begin()}, {Symbols.end()}),
-        fn);
+    return make_filter_range(symbols(), fn);
   }
 
   // Range that contains all reexported symbols.
@@ -158,9 +154,7 @@ public:
     std::function<bool(const Symbol *)> fn = [](const Symbol *Symbol) {
       return Symbol->isReexported();
     };
-    return make_filter_range(
-        make_range<const_symbol_iterator>({Symbols.begin()}, {Symbols.end()}),
-        fn);
+    return make_filter_range(symbols(), fn);
   }
 
   // Range that contains all undefined and exported symbols.
@@ -168,9 +162,7 @@ public:
     std::function<bool(const Symbol *)> fn = [](const Symbol *Symbol) {
       return Symbol->isUndefined();
     };
-    return make_filter_range(
-        make_range<const_symbol_iterator>({Symbols.begin()}, {Symbols.end()}),
-        fn);
+    return make_filter_range(symbols(), fn);
   }
 
   LLVM_ABI bool operator==(const SymbolSet &O) const;

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -665,11 +665,11 @@ void DbgMarker::eraseFromParent() {
 }
 
 iterator_range<DbgRecord::self_iterator> DbgMarker::getDbgRecordRange() {
-  return make_range(StoredDbgRecords.begin(), StoredDbgRecords.end());
+  return StoredDbgRecords;
 }
 iterator_range<DbgRecord::const_self_iterator>
 DbgMarker::getDbgRecordRange() const {
-  return make_range(StoredDbgRecords.begin(), StoredDbgRecords.end());
+  return StoredDbgRecords;
 }
 
 void DbgRecord::removeFromParent() {

--- a/llvm/lib/Target/ARM/ARMConstantPoolValue.h
+++ b/llvm/lib/Target/ARM/ARMConstantPoolValue.h
@@ -176,9 +176,7 @@ public:
 
   using promoted_iterator = SmallPtrSet<const GlobalVariable *, 1>::iterator;
 
-  iterator_range<promoted_iterator> promotedGlobals() {
-    return iterator_range<promoted_iterator>(GVars.begin(), GVars.end());
-  }
+  iterator_range<promoted_iterator> promotedGlobals() { return GVars; }
 
   const Constant *getPromotedGlobalInit() const {
     return CVal;

--- a/llvm/lib/Target/X86/X86DomainReassignment.cpp
+++ b/llvm/lib/Target/X86/X86DomainReassignment.cpp
@@ -324,9 +324,7 @@ public:
   bool insertEdge(Register Reg) { return Edges.insert(Reg).second; }
 
   using const_edge_iterator = DenseSet<Register>::const_iterator;
-  iterator_range<const_edge_iterator> edges() const {
-    return iterator_range<const_edge_iterator>(Edges.begin(), Edges.end());
-  }
+  iterator_range<const_edge_iterator> edges() const { return Edges; }
 
   void addInstruction(MachineInstr *I) {
     Instrs.push_back(I);

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -365,7 +365,7 @@ public:
   /// has been already called. If any of the matchers are moved out, the group
   /// becomes safe to destroy, but not safe to re-use for anything else.
   iterator_range<std::vector<Matcher *>::iterator> matchers() {
-    return make_range(Matchers.begin(), Matchers.end());
+    return Matchers;
   }
   size_t size() const { return Matchers.size(); }
   bool empty() const { return Matchers.empty(); }
@@ -704,9 +704,7 @@ public:
     return make_range(PhysRegOperands.begin(), PhysRegOperands.end());
   }
 
-  iterator_range<MatchersTy::iterator> insnmatchers() {
-    return make_range(Matchers.begin(), Matchers.end());
-  }
+  iterator_range<MatchersTy::iterator> insnmatchers() { return Matchers; }
   bool insnmatchers_empty() const { return Matchers.empty(); }
   void insnmatchers_pop_front();
 };

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -102,7 +102,7 @@ public:
 
   iterator_range<typename RegisterClassesTy::const_iterator>
   register_classes() const {
-    return llvm::make_range(RCs.begin(), RCs.end());
+    return RCs;
   }
 };
 


### PR DESCRIPTION
This patch simplifies construction of iterator_range<T> by using:

  iterator_range<T>(Container &&)

instead of:

  iterator_range<T>(T begin_iterator, T end_iterator)
