### PR TITLE
[clang-tidy] Fix `modernize-use-scoped-lock` crash on malformed code

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
@@ -217,7 +217,8 @@ void UseScopedLockCheck::diagOnSingleLock(
 
   // Create Fix-its only if we can find the constructor call to properly handle
   // 'std::lock_guard l(m, std::adopt_lock)' case.
-  const auto *CtorCall = dyn_cast<CXXConstructExpr>(LockGuard->getInit());
+  const auto *CtorCall =
+      dyn_cast_if_present<CXXConstructExpr>(LockGuard->getInit());
   if (!CtorCall)
     return;
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -364,6 +364,11 @@ Changes in existing checks
   on Windows when the check was enabled with a 32-bit :program:`clang-tidy`
   binary.
 
+- Improved :doc:`modernize-use-scoped-lock
+  <clang-tidy/checks/modernize/use-scoped-lock>` check by fixing a crash
+  on malformed code (common when using :program:`clang-tidy` through
+  :program:`clangd`).
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check to correctly match
   when the format string is converted to a different type by an implicit

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-scoped-lock-no-crash.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-scoped-lock-no-crash.cpp
@@ -1,0 +1,9 @@
+// RUN: %check_clang_tidy -std=c++17-or-later -expect-clang-tidy-error %s modernize-use-scoped-lock %t -- -- -isystem %clang_tidy_headers
+
+#include <mutex>
+
+void f() {
+  std::lock_guard<std::mutex> dont_crash {some_nonexistant_variable};
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'std::scoped_lock' instead of 'std::lock_guard' [modernize-use-scoped-lock]
+  // CHECK-MESSAGES: :[[@LINE-2]]:43: error: use of undeclared identifier 'some_nonexistant_variable' [clang-diagnostic-error]
+}


### PR DESCRIPTION
This code:

```cpp
void f() {
  std::lock_guard<std::mutex> dont_crash {some_nonexistant_variable};
}
```

Generates an AST like this:

```txt
TranslationUnitDecl
`-FunctionDecl <line:3:1, line:5:1> line:3:6 f 'void ()'
  `-CompoundStmt <col:10, line:5:1>
    `-DeclStmt <line:4:3, col:69>
      `-VarDecl <col:3, col:31> col:31 dont_crash 'std::lock_guard<std::mutex>' destroyed
```

Where the `VarDecl` has no initializer. The check doesn't expect this and crashes.