### PR TITLE
[MC] Fix accidentally eating the newline when handling a comment char at the end of the line.

### DIFF
--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -836,9 +836,9 @@ AsmToken AsmLexer::LexToken() {
 
   if (isAtStartOfComment(TokStart)) {
     StringRef CommentString = MAI.getCommentString();
-    // For multi-char comment strings, advance CurPtr only if we matched the full
-    // string. This stops us from accidentally eating the newline if the current
-    // line ends in a single comment char.
+    // For multi-char comment strings, advance CurPtr only if we matched the
+    // full string. This stops us from accidentally eating the newline if the
+    // current line ends in a single comment char.
     if (CommentString.size() > 1 &&
         StringRef(TokStart, CommentString.size()) == CommentString) {
       CurPtr += CommentString.size() - 1;

--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -835,7 +835,14 @@ AsmToken AsmLexer::LexToken() {
   }
 
   if (isAtStartOfComment(TokStart)) {
-    CurPtr += MAI.getCommentString().size() - 1;
+    StringRef CommentString = MAI.getCommentString();
+    // For multi-char comment strings, advance CurPtr only if we matched the full
+    // string. This stops us from accidentally eating the newline if the current
+    // line ends in a single comment char.
+    if (CommentString.size() > 1 &&
+        StringRef(TokStart, CommentString.size()) == CommentString) {
+      CurPtr += CommentString.size() - 1;
+    }
     return LexLineComment();
   }
 

--- a/llvm/test/MC/AsmParser/comments-x86-darwin-eol-dropped.s
+++ b/llvm/test/MC/AsmParser/comments-x86-darwin-eol-dropped.s
@@ -1,0 +1,10 @@
+// RUN: llvm-mc -triple i386-apple-darwin %s 2>&1 | FileCheck %s
+.p2align 3
+// CHECK: .p2align 3
+test:
+// CHECK-LABEL: test:
+// CHECK: pushl %ebp
+// CHECK: movl %esp, %ebp
+# Check that the following line's comment # doesn't drop the movl after
+   pushl %ebp #
+   movl %esp, %ebp


### PR DESCRIPTION
If we have a target where both # and ## are valid comment strings,
a line ending in # would trigger the lexer to eat 2 characters
and therefore lex the _next_ line as a comment. Oops. This was introduced
in 4946db15a74b761c5ac4ead18873639236b4ab5d

rdar://162635338