### PR TITLE
[Clang] Drop Shell Requirements

### DIFF
--- a/clang/test/ClangScanDeps/resource_directory.c
+++ b/clang/test/ClangScanDeps/resource_directory.c
@@ -1,5 +1,3 @@
-// REQUIRES: shell
-
 // RUN: rm -rf %t && mkdir %t
 // RUN: cp %S/Inputs/resource_directory/* %t
 

--- a/clang/test/ClangScanDeps/resource_directory.c
+++ b/clang/test/ClangScanDeps/resource_directory.c
@@ -1,3 +1,6 @@
+// Path seperator differences
+// UNSUPPORTED: system-windows
+
 // RUN: rm -rf %t && mkdir %t
 // RUN: cp %S/Inputs/resource_directory/* %t
 

--- a/clang/test/Driver/baremetal-multilib-custom-error.yaml
+++ b/clang/test/Driver/baremetal-multilib-custom-error.yaml
@@ -1,4 +1,3 @@
-# REQUIRES: shell
 # UNSUPPORTED: system-windows
 
 # RUN: %clang --multi-lib-config=%s -no-canonical-prefixes -print-multi-directory 2>&1 \

--- a/clang/test/Frontend/absolute-paths-symlinks.c
+++ b/clang/test/Frontend/absolute-paths-symlinks.c
@@ -12,6 +12,5 @@
 // CHECK-SAME: error: unknown type name
 This do not compile
 
-// REQUIRES: shell
 // Don't make symlinks on Windows.
 // UNSUPPORTED: system-windows

--- a/clang/test/Tooling/clang-check-pwd.cpp
+++ b/clang/test/Tooling/clang-check-pwd.cpp
@@ -12,5 +12,3 @@
 // CHECK: a type specifier is required
 // CHECK: .foobar/test.cpp
 invalid;
-
-// REQUIRES: shell


### PR DESCRIPTION
These are basically synonymous with marking windows as an unsupported platform at this point and should be removed in favor of such annotations. Removing the remianing annotations which should further unblock removing the feature altogether now that everything minus compiler-rt is using the internal shell by default. These were missed when making the tests compatible with the internal shell.