### PR TITLE
[lldb] print errors when the debug server is not found

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3672,6 +3672,12 @@ Status ProcessGDBRemote::LaunchAndConnectToDebugserver(
     }
   }
 #endif
+
+  if (!FileSystem::Instance().Exists(debugserver_path))
+    return Status::FromErrorString("could not find '" DEBUGSERVER_BASENAME
+                                   "'. Please ensure it is properly installed "
+                                   "and available in your PATH");
+
   debugserver_launch_info.SetExecutableFile(debugserver_path,
                                             /*add_exe_file_as_first_arg=*/true);
 


### PR DESCRIPTION
Previously, when the debug server binary could not be located, LLDB emitted a vague error:
`error: executable doesn't exist: '(empty)'`

This patch adds a check just right after the debug server path resolution and produces a clearer message if it's is not found: `error: could not find 'lldb-server'. Please ensure it is properly installed and available in your PATH`.