### PR TITLE
[CodeGen] Use DenseMap::try_emplace (NFC)

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AddressPool.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AddressPool.cpp
@@ -18,8 +18,7 @@ using namespace llvm;
 
 unsigned AddressPool::getIndex(const MCSymbol *Sym, bool TLS) {
   resetUsedFlag(true);
-  auto IterBool =
-      Pool.insert(std::make_pair(Sym, AddressPoolEntry(Pool.size(), TLS)));
+  auto IterBool = Pool.try_emplace(Sym, Pool.size(), TLS);
   return IterBool.first->second.Number;
 }
 

--- a/llvm/lib/CodeGen/TailDuplicator.cpp
+++ b/llvm/lib/CodeGen/TailDuplicator.cpp
@@ -363,7 +363,7 @@ void TailDuplicator::processPHI(
   Register SrcReg = MI->getOperand(SrcOpIdx).getReg();
   unsigned SrcSubReg = MI->getOperand(SrcOpIdx).getSubReg();
   const TargetRegisterClass *RC = MRI->getRegClass(DefReg);
-  LocalVRMap.insert(std::make_pair(DefReg, RegSubRegPair(SrcReg, SrcSubReg)));
+  LocalVRMap.try_emplace(DefReg, SrcReg, SrcSubReg);
 
   // Insert a copy from source to the end of the block. The def register is the
   // available value liveout of the block.
@@ -411,7 +411,7 @@ void TailDuplicator::duplicateInstruction(
       const TargetRegisterClass *RC = MRI->getRegClass(Reg);
       Register NewReg = MRI->createVirtualRegister(RC);
       MO.setReg(NewReg);
-      LocalVRMap.insert(std::make_pair(Reg, RegSubRegPair(NewReg, 0)));
+      LocalVRMap.try_emplace(Reg, NewReg, 0);
       if (isDefLiveOut(Reg, TailBB, MRI) || UsedByPhi.count(Reg))
         addSSAUpdateEntry(Reg, NewReg, PredBB);
       continue;
@@ -463,7 +463,7 @@ void TailDuplicator::duplicateInstruction(
               NewReg)
           .addReg(VI->second.Reg, 0, VI->second.SubReg);
       LocalVRMap.erase(VI);
-      LocalVRMap.insert(std::make_pair(Reg, RegSubRegPair(NewReg, 0)));
+      LocalVRMap.try_emplace(Reg, NewReg, 0);
       MO.setReg(NewReg);
       // The composed VI.Reg:VI.SubReg is replaced with NewReg, which
       // is equivalent to the whole register Reg. Hence, Reg:subreg


### PR DESCRIPTION
With try_emplace, we can pass the key and the arguments for the
value's constructor, which is a lot shorter than:

  Map.insert(std::make_pair(Key, ValueType(Arg1, Arg2)))
