### PR TITLE
[llvm] Remove argument_type in std::hash specializations (NFC)

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
@@ -600,10 +600,7 @@ struct Variant {
 namespace std {
 
 template <> struct hash<llvm::pdb::PDB_SymType> {
-  using argument_type = llvm::pdb::PDB_SymType;
-  using result_type = std::size_t;
-
-  result_type operator()(const argument_type &Arg) const {
+  std::size_t operator()(const llvm::pdb::PDB_SymType &Arg) const {
     return std::hash<int>()(static_cast<int>(Arg));
   }
 };

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -86,10 +86,7 @@ template <> struct llvm::DenseMapInfo<VariableID> {
 using VarLocInsertPt = PointerUnion<const Instruction *, const DbgRecord *>;
 
 template <> struct std::hash<VarLocInsertPt> {
-  using argument_type = VarLocInsertPt;
-  using result_type = std::size_t;
-
-  result_type operator()(const argument_type &Arg) const {
+  std::size_t operator()(const VarLocInsertPt &Arg) const {
     return std::hash<void *>()(Arg.getOpaqueValue());
   }
 };


### PR DESCRIPTION
The argument_type and result_type type aliases in std::hash are
deprecated in C++17 and removed in C++20.  This patch aligns two
specializations of ours with the C++ standard.
