### PR TITLE
[llvm] Add "override" where appropriate (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/DDG.h
+++ b/llvm/include/llvm/Analysis/DDG.h
@@ -96,7 +96,7 @@ public:
   RootDDGNode() : DDGNode(NodeKind::Root) {}
   RootDDGNode(const RootDDGNode &N) = delete;
   RootDDGNode(RootDDGNode &&N) : DDGNode(std::move(N)) {}
-  ~RootDDGNode() = default;
+  ~RootDDGNode() override = default;
 
   /// Define classof to be able to use isa<>, cast<>, dyn_cast<>, etc.
   static bool classof(const DDGNode *N) {
@@ -114,7 +114,7 @@ public:
   SimpleDDGNode(Instruction &I);
   SimpleDDGNode(const SimpleDDGNode &N);
   SimpleDDGNode(SimpleDDGNode &&N);
-  ~SimpleDDGNode();
+  ~SimpleDDGNode() override;
 
   SimpleDDGNode &operator=(const SimpleDDGNode &N) = default;
 
@@ -176,7 +176,7 @@ public:
   PiBlockDDGNode(const PiNodeList &List);
   PiBlockDDGNode(const PiBlockDDGNode &N);
   PiBlockDDGNode(PiBlockDDGNode &&N);
-  ~PiBlockDDGNode();
+  ~PiBlockDDGNode() override;
 
   PiBlockDDGNode &operator=(const PiBlockDDGNode &N) = default;
 
@@ -318,7 +318,7 @@ public:
       : DDGBase(std::move(G)), DDGInfo(std::move(G)) {}
   DataDependenceGraph(Function &F, DependenceInfo &DI);
   DataDependenceGraph(Loop &L, LoopInfo &LI, DependenceInfo &DI);
-  ~DataDependenceGraph();
+  ~DataDependenceGraph() override;
 
   /// If node \p N belongs to a pi-block return a pointer to the pi-block,
   /// otherwise return null.

--- a/llvm/include/llvm/Analysis/InteractiveModelRunner.h
+++ b/llvm/include/llvm/Analysis/InteractiveModelRunner.h
@@ -51,7 +51,7 @@ public:
     Log->flush();
   }
 
-  virtual ~InteractiveModelRunner();
+  ~InteractiveModelRunner() override;
 
 private:
   void *evaluateUntyped() override;

--- a/llvm/include/llvm/Analysis/MLInlineAdvisor.h
+++ b/llvm/include/llvm/Analysis/MLInlineAdvisor.h
@@ -33,7 +33,7 @@ public:
                       GetModelRunner,
                   std::function<bool(CallBase &)> GetDefaultAdvice);
 
-  virtual ~MLInlineAdvisor() = default;
+  ~MLInlineAdvisor() override = default;
 
   void onPassEntry(LazyCallGraph::SCC *SCC) override;
   void onPassExit(LazyCallGraph::SCC *SCC) override;
@@ -105,7 +105,7 @@ class MLInlineAdvice : public InlineAdvice {
 public:
   MLInlineAdvice(MLInlineAdvisor *Advisor, CallBase &CB,
                  OptimizationRemarkEmitter &ORE, bool Recommendation);
-  virtual ~MLInlineAdvice() = default;
+  ~MLInlineAdvice() override = default;
 
   void recordInliningImpl() override;
   void recordInliningWithCalleeDeletedImpl() override;

--- a/llvm/include/llvm/Analysis/ReleaseModeModelRunner.h
+++ b/llvm/include/llvm/Analysis/ReleaseModeModelRunner.h
@@ -106,7 +106,7 @@ public:
     assert(ResultIndex >= 0 && "Cannot find DecisionName in inlining model");
   }
 
-  virtual ~ReleaseModeModelRunner() = default;
+  ~ReleaseModeModelRunner() override = default;
 
   static bool classof(const MLModelRunner *R) {
     return R->getKind() == MLModelRunner::Kind::Release;

--- a/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
+++ b/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
@@ -156,7 +156,7 @@ public:
   static char ID;
 
   StackSafetyGlobalInfoWrapperPass();
-  ~StackSafetyGlobalInfoWrapperPass();
+  ~StackSafetyGlobalInfoWrapperPass() override;
 
   const StackSafetyGlobalInfo &getResult() const { return SSGI; }
 

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameAnalyzer.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameAnalyzer.h
@@ -32,7 +32,7 @@ class LLVM_ABI CFIFunctionFrameAnalyzer : public CFIFunctionFrameReceiver {
 public:
   CFIFunctionFrameAnalyzer(MCContext &Context, const MCInstrInfo &MCII)
       : CFIFunctionFrameReceiver(Context), MCII(MCII) {}
-  ~CFIFunctionFrameAnalyzer();
+  ~CFIFunctionFrameAnalyzer() override;
 
   void startFunctionFrame(bool IsEH,
                           ArrayRef<MCCFIInstruction> Prologue) override;

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFStreamer.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFStreamer.h
@@ -48,7 +48,7 @@ public:
                 raw_pwrite_stream &OutFile,
                 DWARFLinkerBase::MessageHandlerTy Warning)
       : OutFile(OutFile), OutFileType(OutFileType), WarningHandler(Warning) {}
-  virtual ~DwarfStreamer() = default;
+  ~DwarfStreamer() override = default;
 
   static Expected<std::unique_ptr<DwarfStreamer>> createStreamer(
       const Triple &TheTriple, DWARFLinkerBase::OutputFileType FileType,

--- a/llvm/include/llvm/DWARFLinker/Parallel/DWARFLinker.h
+++ b/llvm/include/llvm/DWARFLinker/Parallel/DWARFLinker.h
@@ -120,7 +120,7 @@ using SectionHandlerTy =
 
 class DWARFLinker : public DWARFLinkerBase {
 public:
-  virtual ~DWARFLinker() = default;
+  ~DWARFLinker() override = default;
 
   /// Creates dwarf linker instance.
   LLVM_ABI static std::unique_ptr<DWARFLinker>

--- a/llvm/include/llvm/Debuginfod/BuildIDFetcher.h
+++ b/llvm/include/llvm/Debuginfod/BuildIDFetcher.h
@@ -24,7 +24,7 @@ class DebuginfodFetcher : public object::BuildIDFetcher {
 public:
   DebuginfodFetcher(std::vector<std::string> DebugFileDirectories)
       : BuildIDFetcher(std::move(DebugFileDirectories)) {}
-  virtual ~DebuginfodFetcher() = default;
+  ~DebuginfodFetcher() override = default;
 
   /// Fetches the given Build ID using debuginfod and returns a local path to
   /// the resulting file.

--- a/llvm/include/llvm/IR/DroppedVariableStatsIR.h
+++ b/llvm/include/llvm/IR/DroppedVariableStatsIR.h
@@ -71,13 +71,12 @@ private:
                                         StringRef PassLevel);
 
   /// Override base class method to run on an llvm::Function specifically.
-  virtual void
-  visitEveryInstruction(unsigned &DroppedCount,
-                        DenseMap<VarID, DILocation *> &InlinedAtsMap,
-                        VarID Var) override;
+  void visitEveryInstruction(unsigned &DroppedCount,
+                             DenseMap<VarID, DILocation *> &InlinedAtsMap,
+                             VarID Var) override;
 
   /// Override base class method to run on #dbg_values specifically.
-  virtual void visitEveryDebugRecord(
+  void visitEveryDebugRecord(
       DenseSet<VarID> &VarIDSet,
       DenseMap<StringRef, DenseMap<VarID, DILocation *>> &InlinedAtsMap,
       StringRef FuncName, bool Before) override;

--- a/llvm/include/llvm/IR/OptBisect.h
+++ b/llvm/include/llvm/IR/OptBisect.h
@@ -51,7 +51,7 @@ public:
   /// through LLVMContext.
   OptBisect() = default;
 
-  virtual ~OptBisect() = default;
+  ~OptBisect() override = default;
 
   /// Checks the bisect limit to determine if the specified pass should run.
   ///

--- a/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
@@ -57,7 +57,7 @@ public:
   LSUnitBase(const MCSchedModel &SM, unsigned LoadQueueSize,
              unsigned StoreQueueSize, bool AssumeNoAlias);
 
-  virtual ~LSUnitBase();
+  ~LSUnitBase() override;
 
   /// Returns the total number of entries in the load queue.
   unsigned getLoadQueueSize() const { return LQSize; }
@@ -465,19 +465,19 @@ public:
   /// 6. A store has to wait until an older store barrier is fully executed.
   unsigned dispatch(const InstRef &IR) override;
 
-  virtual void onInstructionIssued(const InstRef &IR) override {
+  void onInstructionIssued(const InstRef &IR) override {
     unsigned GroupID = IR.getInstruction()->getLSUTokenID();
     Groups[GroupID]->onInstructionIssued(IR);
   }
 
-  virtual void onInstructionRetired(const InstRef &IR) override;
+  void onInstructionRetired(const InstRef &IR) override;
 
-  virtual void onInstructionExecuted(const InstRef &IR) override;
+  void onInstructionExecuted(const InstRef &IR) override;
 
-  virtual void cycleEvent() override;
+  void cycleEvent() override;
 
 #ifndef NDEBUG
-  virtual void dump() const override;
+  void dump() const override;
 #endif
 
 private:

--- a/llvm/include/llvm/MCA/HardwareUnits/ResourceManager.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/ResourceManager.h
@@ -121,7 +121,7 @@ public:
   DefaultResourceStrategy(uint64_t UnitMask)
       : ResourceUnitMask(UnitMask), NextInSequenceMask(UnitMask),
         RemovedFromNextInSequence(0) {}
-  virtual ~DefaultResourceStrategy() = default;
+  ~DefaultResourceStrategy() override = default;
 
   uint64_t select(uint64_t ReadyMask) override;
   void used(uint64_t Mask) override;

--- a/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h
@@ -47,7 +47,7 @@ class LLVM_ABI DefaultSchedulerStrategy : public SchedulerStrategy {
 
 public:
   DefaultSchedulerStrategy() = default;
-  virtual ~DefaultSchedulerStrategy();
+  ~DefaultSchedulerStrategy() override;
 
   bool compare(const InstRef &Lhs, const InstRef &Rhs) const override {
     int LhsRank = computeRank(Lhs);

--- a/llvm/include/llvm/MCA/View.h
+++ b/llvm/include/llvm/MCA/View.h
@@ -26,7 +26,7 @@ namespace mca {
 
 class LLVM_ABI View : public HWEventListener {
 public:
-  virtual ~View() = default;
+  ~View() override = default;
 
   virtual void printView(llvm::raw_ostream &OS) const = 0;
   virtual StringRef getNameAsString() const = 0;

--- a/llvm/include/llvm/ObjCopy/ConfigManager.h
+++ b/llvm/include/llvm/ObjCopy/ConfigManager.h
@@ -23,7 +23,7 @@ namespace llvm {
 namespace objcopy {
 
 struct LLVM_ABI ConfigManager : public MultiFormatConfig {
-  virtual ~ConfigManager() {}
+  ~ConfigManager() override {}
 
   const CommonConfig &getCommonConfig() const override { return Common; }
 

--- a/llvm/include/llvm/Object/GOFFObjectFile.h
+++ b/llvm/include/llvm/Object/GOFFObjectFile.h
@@ -91,10 +91,10 @@ private:
 
   // SectionRef.
   void moveSectionNext(DataRefImpl &Sec) const override;
-  virtual Expected<StringRef> getSectionName(DataRefImpl Sec) const override;
+  Expected<StringRef> getSectionName(DataRefImpl Sec) const override;
   uint64_t getSectionAddress(DataRefImpl Sec) const override;
   uint64_t getSectionSize(DataRefImpl Sec) const override;
-  virtual Expected<ArrayRef<uint8_t>>
+  Expected<ArrayRef<uint8_t>>
   getSectionContents(DataRefImpl Sec) const override;
   uint64_t getSectionIndex(DataRefImpl Sec) const override { return Sec.d.a; }
   uint64_t getSectionAlignment(DataRefImpl Sec) const override;

--- a/llvm/include/llvm/ProfileData/MemProfReader.h
+++ b/llvm/include/llvm/ProfileData/MemProfReader.h
@@ -110,7 +110,7 @@ class LLVM_ABI RawMemProfReader final : public MemProfReader {
 public:
   RawMemProfReader(const RawMemProfReader &) = delete;
   RawMemProfReader &operator=(const RawMemProfReader &) = delete;
-  virtual ~RawMemProfReader() override;
+  ~RawMemProfReader() override;
 
   // Prints the contents of the profile in YAML format.
   void printYAML(raw_ostream &OS);

--- a/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
@@ -92,7 +92,7 @@ public:
   PGOCtxProfileWriter(raw_ostream &Out,
                       std::optional<unsigned> VersionOverride = std::nullopt,
                       bool IncludeEmpty = false);
-  ~PGOCtxProfileWriter() { Writer.ExitBlock(); }
+  ~PGOCtxProfileWriter() override { Writer.ExitBlock(); }
 
   void startContextSection() override;
   void writeContextual(const ctx_profile::ContextNode &RootNode,

--- a/llvm/include/llvm/SandboxIR/BasicBlock.h
+++ b/llvm/include/llvm/SandboxIR/BasicBlock.h
@@ -78,7 +78,7 @@ class BasicBlock : public Value {
   }
 
 public:
-  ~BasicBlock() = default;
+  ~BasicBlock() override = default;
   /// For isa/dyn_cast.
   static bool classof(const Value *From) {
     return From->getSubclassID() == Value::ClassID::Block;

--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -49,7 +49,7 @@ protected:
   }
   PassManager(const PassManager &) = delete;
   PassManager(PassManager &&) = default;
-  virtual ~PassManager() = default;
+  ~PassManager() override = default;
   PassManager &operator=(const PassManager &) = delete;
 
 public:

--- a/llvm/include/llvm/Target/TargetLoweringObjectFile.h
+++ b/llvm/include/llvm/Target/TargetLoweringObjectFile.h
@@ -74,7 +74,7 @@ public:
   TargetLoweringObjectFile(const TargetLoweringObjectFile &) = delete;
   TargetLoweringObjectFile &
   operator=(const TargetLoweringObjectFile &) = delete;
-  virtual ~TargetLoweringObjectFile();
+  ~TargetLoweringObjectFile() override;
 
   Mangler &getMangler() const { return *Mang; }
 

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -3325,7 +3325,7 @@ struct LLVM_ABI AbstractAttribute : public IRPosition, public AADepGraphNode {
   AbstractAttribute(const IRPosition &IRP) : IRPosition(IRP) {}
 
   /// Virtual destructor.
-  virtual ~AbstractAttribute() = default;
+  ~AbstractAttribute() override = default;
 
   /// Compile time access to the IR attribute kind.
   static constexpr Attribute::AttrKind IRAttributeKind = Attribute::None;
@@ -5588,7 +5588,7 @@ struct AACallEdges : public StateWrapper<BooleanState, AbstractAttribute>,
 // Synthetic root node for the Attributor's internal call graph.
 struct AttributorCallGraph : public AACallGraphNode {
   AttributorCallGraph(Attributor &A) : AACallGraphNode(A) {}
-  virtual ~AttributorCallGraph() = default;
+  ~AttributorCallGraph() override = default;
 
   AACallEdgeIterator optimisticEdgesBegin() const override {
     return AACallEdgeIterator(A, A.Functions.begin());

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -305,7 +305,7 @@ public:
     return make_range(MemSuccs.begin(), MemSuccs.end());
   }
 #ifndef NDEBUG
-  virtual void print(raw_ostream &OS, bool PrintDeps = true) const override;
+  void print(raw_ostream &OS, bool PrintDeps = true) const override;
 #endif // NDEBUG
 };
 

--- a/llvm/include/llvm/XRay/FDRRecords.h
+++ b/llvm/include/llvm/XRay/FDRRecords.h
@@ -101,7 +101,7 @@ public:
 
   MetadataType metadataType() const { return MT; }
 
-  virtual ~MetadataRecord() = default;
+  ~MetadataRecord() override = default;
 };
 
 // What follows are specific Metadata record types which encapsulate the

--- a/llvm/include/llvm/XRay/FDRTraceWriter.h
+++ b/llvm/include/llvm/XRay/FDRTraceWriter.h
@@ -30,7 +30,7 @@ class LLVM_ABI FDRTraceWriter : public RecordVisitor {
 public:
   // Construct an FDRTraceWriter associated with an output stream.
   explicit FDRTraceWriter(raw_ostream &O, const XRayFileHeader &H);
-  ~FDRTraceWriter();
+  ~FDRTraceWriter() override;
 
   Error visit(BufferExtents &) override;
   Error visit(WallclockRecord &) override;

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -1242,7 +1242,7 @@ public:
     return std::nullopt;
   }
 
-  virtual ~InlineCostCallAnalyzer() = default;
+  ~InlineCostCallAnalyzer() override = default;
   int getThreshold() const { return Threshold; }
   int getCost() const { return Cost; }
   int getStaticBonusApplied() const { return StaticBonusApplied; }

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -843,7 +843,7 @@ public:
   SlotTracker(const SlotTracker &) = delete;
   SlotTracker &operator=(const SlotTracker &) = delete;
 
-  ~SlotTracker() = default;
+  ~SlotTracker() override = default;
 
   void setProcessHook(
       std::function<void(AbstractSlotTrackerStorage *, const Module *, bool)>);
@@ -5323,7 +5323,7 @@ struct MDTreeAsmWriterContext : public AsmWriterContext {
     --Level;
   }
 
-  ~MDTreeAsmWriterContext() {
+  ~MDTreeAsmWriterContext() override {
     for (const auto &Entry : Buffer) {
       MainOS << "\n";
       unsigned NumIndent = Entry.first * 2U;

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1711,7 +1711,7 @@ public:
                              /*ShouldEmitImportsFiles=*/false),
         IRFiles(std::move(IRFiles)), CombinedCGDataHash(CombinedCGDataHash) {}
 
-  virtual Error runThinLTOBackendThread(
+  Error runThinLTOBackendThread(
       AddStreamFn AddStream, FileCache Cache, unsigned Task, BitcodeModule BM,
       ModuleSummaryIndex &CombinedIndex,
       const FunctionImporter::ImportMapTy &ImportList,
@@ -2271,8 +2271,8 @@ public:
         RemoteCompilerPrependArgs(RemoteCompilerPrependArgs),
         RemoteCompilerArgs(RemoteCompilerArgs), SaveTemps(SaveTemps) {}
 
-  virtual void setup(unsigned ThinLTONumTasks, unsigned ThinLTOTaskOffset,
-                     llvm::Triple Triple) override {
+  void setup(unsigned ThinLTONumTasks, unsigned ThinLTOTaskOffset,
+             llvm::Triple Triple) override {
     UID = itostr(sys::Process::getProcessId());
     Jobs.resize((size_t)ThinLTONumTasks);
     this->ThinLTOTaskOffset = ThinLTOTaskOffset;

--- a/llvm/lib/ObjCopy/ELF/ELFObject.h
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.h
@@ -109,7 +109,7 @@ protected:
   WritableMemoryBuffer &Out;
 
 public:
-  virtual ~SectionWriter() = default;
+  ~SectionWriter() override = default;
 
   Error visit(const Section &Sec) override;
   Error visit(const OwnedDataSection &Sec) override;
@@ -134,7 +134,7 @@ private:
   using Elf_Sym = typename ELFT::Sym;
 
 public:
-  virtual ~ELFSectionWriter() {}
+  ~ELFSectionWriter() override {}
   Error visit(const SymbolTableSection &Sec) override;
   Error visit(const RelocationSection &Sec) override;
   Error visit(const GnuDebugLinkSection &Sec) override;
@@ -180,7 +180,7 @@ public:
 
 class BinarySectionWriter : public SectionWriter {
 public:
-  virtual ~BinarySectionWriter() {}
+  ~BinarySectionWriter() override {}
 
   Error visit(const SymbolTableSection &Sec) override;
   Error visit(const RelocationSection &Sec) override;
@@ -346,7 +346,7 @@ private:
   size_t totalSize() const;
 
 public:
-  virtual ~ELFWriter() {}
+  ~ELFWriter() override {}
   bool WriteSectionHeaders;
 
   // For --only-keep-debug, select an alternative section/segment layout
@@ -367,7 +367,7 @@ private:
   uint64_t TotalSize = 0;
 
 public:
-  ~BinaryWriter() {}
+  ~BinaryWriter() override {}
   Error finalize() override;
   Error write() override;
   BinaryWriter(Object &Obj, raw_ostream &Out, const CommonConfig &Config)
@@ -784,7 +784,7 @@ private:
   SymbolTableSection *Symbols = nullptr;
 
 public:
-  virtual ~SectionIndexSection() {}
+  ~SectionIndexSection() override {}
   void addIndex(uint32_t Index) {
     assert(Size > 0);
     Indexes.push_back(Index);

--- a/llvm/lib/ObjectYAML/GOFFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/GOFFEmitter.cpp
@@ -71,7 +71,7 @@ public:
     SetBufferSize(GOFF::PayloadLength);
   }
 
-  ~GOFFOstream() { finalize(); }
+  ~GOFFOstream() override { finalize(); }
 
   void makeNewRecord(GOFF::RecordType Type, size_t Size) {
     fillRecord();

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -1044,15 +1044,13 @@ struct AAPointerInfoImpl
     return AAPointerInfo::manifest(A);
   }
 
-  virtual const_bin_iterator begin() const override { return State::begin(); }
-  virtual const_bin_iterator end() const override { return State::end(); }
-  virtual int64_t numOffsetBins() const override {
-    return State::numOffsetBins();
-  }
-  virtual bool reachesReturn() const override {
+  const_bin_iterator begin() const override { return State::begin(); }
+  const_bin_iterator end() const override { return State::end(); }
+  int64_t numOffsetBins() const override { return State::numOffsetBins(); }
+  bool reachesReturn() const override {
     return !ReturnedOffsets.isUnassigned();
   }
-  virtual void addReturnedOffsetsTo(OffsetInfo &OI) const override {
+  void addReturnedOffsetsTo(OffsetInfo &OI) const override {
     if (ReturnedOffsets.isUnknown()) {
       OI.setUnknown();
       return;
@@ -6653,7 +6651,7 @@ struct AAHeapToStackFunction final : public AAHeapToStack {
   AAHeapToStackFunction(const IRPosition &IRP, Attributor &A)
       : AAHeapToStack(IRP, A) {}
 
-  ~AAHeapToStackFunction() {
+  ~AAHeapToStackFunction() override {
     // Ensure we call the destructor so we release any memory allocated in the
     // sets.
     for (auto &It : AllocationInfos)
@@ -8374,7 +8372,7 @@ struct AAMemoryLocationImpl : public AAMemoryLocation {
     AccessKind2Accesses.fill(nullptr);
   }
 
-  ~AAMemoryLocationImpl() {
+  ~AAMemoryLocationImpl() override {
     // The AccessSets are allocated via a BumpPtrAllocator, we call
     // the destructor manually.
     for (AccessSet *AS : AccessKind2Accesses)

--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -2693,7 +2693,7 @@ struct AAExecutionDomainFunction : public AAExecutionDomain {
   AAExecutionDomainFunction(const IRPosition &IRP, Attributor &A)
       : AAExecutionDomain(IRP, A) {}
 
-  ~AAExecutionDomainFunction() { delete RPOT; }
+  ~AAExecutionDomainFunction() override { delete RPOT; }
 
   void initialize(Attributor &A) override {
     Function *F = getAnchorScope();

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -72,7 +72,7 @@ public:
       : InstCombiner(Worklist, Builder, F, AA, AC, TLI, TTI, DT, ORE, BFI, BPI,
                      PSI, DL, RPOT) {}
 
-  virtual ~InstCombinerImpl() = default;
+  ~InstCombinerImpl() override = default;
 
   /// Perform early cleanup and prepare the InstCombine worklist.
   bool prepareWorklist(Function &F);

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -398,7 +398,7 @@ public:
                DebugLoc DL = DebugLoc::getUnknown())
       : VPDef(SC), VPUser(Operands), DL(DL) {}
 
-  virtual ~VPRecipeBase() = default;
+  ~VPRecipeBase() override = default;
 
   /// Clone the current recipe.
   virtual VPRecipeBase *clone() = 0;
@@ -576,7 +576,7 @@ public:
     return R && classof(R);
   }
 
-  virtual VPSingleDefRecipe *clone() override = 0;
+  VPSingleDefRecipe *clone() override = 0;
 
   /// Returns the underlying instruction.
   Instruction *getUnderlyingInstr() {
@@ -907,7 +907,7 @@ struct VPRecipeWithIRFlags : public VPSingleDefRecipe, public VPIRFlags {
     return R && classof(R);
   }
 
-  virtual VPRecipeWithIRFlags *clone() override = 0;
+  VPRecipeWithIRFlags *clone() override = 0;
 
   static inline bool classof(const VPSingleDefRecipe *U) {
     auto *R = dyn_cast<VPRecipeBase>(U);
@@ -2068,7 +2068,7 @@ public:
     return classof(static_cast<const VPRecipeBase *>(R));
   }
 
-  virtual void execute(VPTransformState &State) override = 0;
+  void execute(VPTransformState &State) override = 0;
 
   /// Returns the step value of the induction.
   VPValue *getStepValue() { return getOperand(1); }
@@ -2557,7 +2557,7 @@ public:
                               VPCostContext &Ctx) const override;
 
   /// Returns true if the recipe only uses the first lane of operand \p Op.
-  virtual bool onlyFirstLaneUsed(const VPValue *Op) const override = 0;
+  bool onlyFirstLaneUsed(const VPValue *Op) const override = 0;
 
   /// Returns the number of stored operands of this interleave group. Returns 0
   /// for load interleave groups.

--- a/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
@@ -666,7 +666,7 @@ public:
 #endif
   }
 
-  ~X86SavedState() {
+  ~X86SavedState() override {
     // Restoring the X87 state does not flush pending exceptions, make sure
     // these exceptions are flushed now.
 #if defined(_MSC_VER) && defined(_M_X64) && !defined(_M_ARM64EC)

--- a/llvm/tools/llvm-jitlink/llvm-jitlink-statistics.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-statistics.cpp
@@ -52,7 +52,7 @@ public:
       S.ObjLayer.addPlugin(std::move(Instance));
   }
 
-  ~StatsPlugin() { publish(dbgs()); }
+  ~StatsPlugin() override { publish(dbgs()); }
 
   void publish(raw_ostream &OS);
 

--- a/llvm/tools/llvm-mca/Views/InstructionView.h
+++ b/llvm/tools/llvm-mca/Views/InstructionView.h
@@ -38,7 +38,7 @@ public:
                   llvm::MCInstPrinter &Printer, llvm::ArrayRef<llvm::MCInst> S)
       : STI(STI), MCIP(Printer), Source(S), InstrStream(InstructionString) {}
 
-  virtual ~InstructionView();
+  ~InstructionView() override;
 
   StringRef getNameAsString() const override { return "Instructions"; }
 

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -795,7 +795,7 @@ public:
   void printFileSummary(StringRef FileStr, ObjectFile &Obj,
                         ArrayRef<std::string> InputFilenames,
                         const Archive *A) override;
-  virtual void printZeroSymbolOtherField(const Elf_Sym &Symbol) const override;
+  void printZeroSymbolOtherField(const Elf_Sym &Symbol) const override;
 
   void printDefaultRelRelaReloc(const Relocation<ELFT> &R,
                                 StringRef SymbolName,

--- a/llvm/unittests/ADT/TrieRawHashMapTest.cpp
+++ b/llvm/unittests/ADT/TrieRawHashMapTest.cpp
@@ -64,7 +64,7 @@ public:
   }
 
   void destroyTrie() { Trie.reset(); }
-  ~SimpleTrieHashMapTest() { destroyTrie(); }
+  ~SimpleTrieHashMapTest() override { destroyTrie(); }
 
   // Use the number itself as hash to test the pathological case.
   static HashType hash(uint64_t Num) {

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -42,8 +42,8 @@ protected:
     auto TD = GetParam()(++(*NextCASIndex));
     return std::move(TD.Cache);
   }
-  void SetUp() { NextCASIndex = 0; }
-  void TearDown() { NextCASIndex = std::nullopt; }
+  void SetUp() override { NextCASIndex = 0; }
+  void TearDown() override { NextCASIndex = std::nullopt; }
 };
 
 #endif

--- a/llvm/unittests/SandboxIR/PassTest.cpp
+++ b/llvm/unittests/SandboxIR/PassTest.cpp
@@ -84,7 +84,9 @@ define void @foo() {
   class TestNamePass final : public FunctionPass {
   public:
     TestNamePass(llvm::StringRef Name) : FunctionPass(Name) {}
-    bool runOnFunction(Function &F, const Analyses &A) { return false; }
+    bool runOnFunction(Function &F, const Analyses &A) override {
+      return false;
+    }
   };
   EXPECT_DEATH(TestNamePass("white space"), ".*whitespace.*");
   EXPECT_DEATH(TestNamePass("-dash"), ".*start with.*");
@@ -146,7 +148,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   class TestNamePass final : public RegionPass {
   public:
     TestNamePass(llvm::StringRef Name) : RegionPass(Name) {}
-    bool runOnRegion(Region &F, const Analyses &A) { return false; }
+    bool runOnRegion(Region &F, const Analyses &A) override { return false; }
   };
   EXPECT_DEATH(TestNamePass("white space"), ".*whitespace.*");
   EXPECT_DEATH(TestNamePass("-dash"), ".*start with.*");

--- a/llvm/unittests/Support/ScopedPrinterTest.cpp
+++ b/llvm/unittests/Support/ScopedPrinterTest.cpp
@@ -109,7 +109,7 @@ protected:
     verifyJSONScopedPrinter(JSONExpectedOut, Func);
   }
 
-  void TearDown() {
+  void TearDown() override {
     // JSONScopedPrinter fails an assert if nothing's been printed.
     if (!HasPrintedToJSON)
       JSONWriter.printString("");

--- a/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
@@ -401,7 +401,8 @@ TEST(ValueMapperTest, mapValueLocalAsMetadataToConstant) {
 class TestTypeRemapper : public ValueMapTypeRemapper {
 public:
   TestTypeRemapper(Type *Ty) : DstTy(Ty) { }
-  Type *remapType(Type *srcTy) { return DstTy; }
+  Type *remapType(Type *srcTy) override { return DstTy; }
+
 private:
   Type *DstTy;
 };

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -899,7 +899,7 @@ public:
   OperandPredicateMatcher(PredicateKind Kind, unsigned InsnVarID,
                           unsigned OpIdx)
       : PredicateMatcher(Kind, InsnVarID, OpIdx) {}
-  virtual ~OperandPredicateMatcher();
+  ~OperandPredicateMatcher() override;
 
   /// Compare the priority of this object and B.
   ///
@@ -1375,7 +1375,7 @@ class InstructionPredicateMatcher : public PredicateMatcher {
 public:
   InstructionPredicateMatcher(PredicateKind Kind, unsigned InsnVarID)
       : PredicateMatcher(Kind, InsnVarID) {}
-  virtual ~InstructionPredicateMatcher() {}
+  ~InstructionPredicateMatcher() override {}
 
   /// Compare the priority of this object and B.
   ///

--- a/llvm/utils/TableGen/Common/GlobalISel/Patterns.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/Patterns.h
@@ -318,7 +318,7 @@ private:
 /// instruction.
 class InstructionPattern : public Pattern {
 public:
-  virtual ~InstructionPattern() = default;
+  ~InstructionPattern() override = default;
 
   static bool classof(const Pattern *P) {
     return P->getKind() == K_CodeGenInstruction || P->getKind() == K_PatFrag ||

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -2441,7 +2441,7 @@ public:
   explicit GICombinerEmitter(const RecordKeeper &RK,
                              const CodeGenTarget &Target, StringRef Name,
                              const Record *Combiner);
-  ~GICombinerEmitter() {}
+  ~GICombinerEmitter() override {}
 
   void run(raw_ostream &OS);
 };


### PR DESCRIPTION
Note that "override" makes "virtual" redundant.

Identified with modernize-use-override.
