### PR TITLE
[Docs][clang-tools-extra] Convert maintainers list to .rst format

### DIFF
--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -4,7 +4,7 @@ Clang Tools Extra Maintainers
 
 This file is a list of the 
 `maintainers <https://llvm.org/docs/DeveloperPolicy.html#maintainers>`_
-for clang-tools-extra.
+for `clang-tools-extra <https://clang.llvm.org/extra/index.html>`_ project.
 
 .. contents::
    :depth: 2

--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -2,9 +2,13 @@
 Clang Tools Extra Maintainers
 =============================
 
-This file is a list of the maintainers
-(https://llvm.org/docs/DeveloperPolicy.html#maintainers) for clang-tools-extra.
+This file is a list of the 
+`maintainers <https://llvm.org/docs/DeveloperPolicy.html#maintainers>`_
+for clang-tools-extra.
 
+.. contents::
+   :depth: 2
+   :local:
 
 Active Maintainers
 ==================

--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -4,7 +4,7 @@ Clang Tools Extra Maintainers
 
 This file is a list of the 
 `maintainers <https://llvm.org/docs/DeveloperPolicy.html#maintainers>`_
-for `clang-tools-extra <https://clang.llvm.org/extra/index.html>`_ project.
+for `Extra Clang Tools <https://clang.llvm.org/extra/index.html>`_ project.
 
 .. contents::
    :depth: 2

--- a/clang-tools-extra/docs/Maintainers.rst
+++ b/clang-tools-extra/docs/Maintainers.rst
@@ -1,0 +1,1 @@
+.. include:: ../Maintainers.rst

--- a/clang-tools-extra/docs/index.rst
+++ b/clang-tools-extra/docs/index.rst
@@ -22,6 +22,7 @@ Contents
    pp-trace
    clangd <https://clangd.llvm.org/>
    clang-doc
+   Maintainers
 
 
 Doxygen Documentation


### PR DESCRIPTION
[Clang maintainers list](https://github.com/llvm/llvm-project/blob/main/clang/Maintainers.rst) is already in `.rst` format, which gives nice visuals.
I think we should convert clang-tools-extra maintainers too to `.rst`.