### PR TITLE
[clang-tidy][NFC] Fix various clang-tidy warning on headers 1/N

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyModule.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyModule.h
@@ -85,7 +85,7 @@ private:
 /// them a prefixed name.
 class ClangTidyModule {
 public:
-  virtual ~ClangTidyModule() {}
+  virtual ~ClangTidyModule() = default;
 
   /// Implement this function in order to register all \c CheckFactories
   /// belonging to this module.

--- a/clang-tools-extra/clang-tidy/ClangTidyOptions.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyOptions.h
@@ -171,7 +171,7 @@ public:
   static const char OptionsSourceTypeCheckCommandLineOption[];
   static const char OptionsSourceTypeConfigCommandLineOption[];
 
-  virtual ~ClangTidyOptionsProvider() {}
+  virtual ~ClangTidyOptionsProvider() = default;
 
   /// Returns global options, which are independent of the file.
   virtual const ClangTidyGlobalOptions &getGlobalOptions() = 0;

--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.h
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.h
@@ -44,7 +44,7 @@ public:
   ExpandModularHeadersPPCallbacks(
       CompilerInstance *CI,
       IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS);
-  ~ExpandModularHeadersPPCallbacks();
+  ~ExpandModularHeadersPPCallbacks() override;
 
   /// Returns the preprocessor that provides callbacks for the whole
   /// translation unit, including the main file, textual headers, and modular

--- a/clang-tools-extra/clang-tidy/abseil/DurationAdditionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/DurationAdditionCheck.cpp
@@ -21,7 +21,7 @@ void DurationAdditionCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       binaryOperator(hasOperatorName("+"),
                      hasEitherOperand(expr(ignoringParenImpCasts(
-                         callExpr(callee(functionDecl(TimeConversionFunction())
+                         callExpr(callee(functionDecl(timeConversionFunction())
                                              .bind("function_decl")))
                              .bind("call")))))
           .bind("binop"),

--- a/clang-tools-extra/clang-tidy/abseil/DurationComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/DurationComparisonCheck.cpp
@@ -17,7 +17,7 @@ namespace clang::tidy::abseil {
 
 void DurationComparisonCheck::registerMatchers(MatchFinder *Finder) {
   auto Matcher = expr(comparisonOperatorWithCallee(functionDecl(
-                          functionDecl(DurationConversionFunction())
+                          functionDecl(durationConversionFunction())
                               .bind("function_decl"))))
                      .bind("binop");
 

--- a/clang-tools-extra/clang-tidy/abseil/DurationConversionCastCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/DurationConversionCastCheck.cpp
@@ -19,7 +19,7 @@ namespace clang::tidy::abseil {
 
 void DurationConversionCastCheck::registerMatchers(MatchFinder *Finder) {
   auto CallMatcher = ignoringImpCasts(callExpr(
-      callee(functionDecl(DurationConversionFunction()).bind("func_decl")),
+      callee(functionDecl(durationConversionFunction()).bind("func_decl")),
       hasArgument(0, expr().bind("arg"))));
 
   Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/abseil/DurationFactoryFloatCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/DurationFactoryFloatCheck.cpp
@@ -28,7 +28,7 @@ static bool insideMacroDefinition(const MatchFinder::MatchResult &Result,
 
 void DurationFactoryFloatCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      callExpr(callee(functionDecl(DurationFactoryFunction())),
+      callExpr(callee(functionDecl(durationFactoryFunction())),
                hasArgument(0, anyOf(cxxStaticCastExpr(hasDestinationType(
                                         realFloatingPointType())),
                                     cStyleCastExpr(hasDestinationType(

--- a/clang-tools-extra/clang-tidy/abseil/DurationFactoryScaleCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/DurationFactoryScaleCheck.cpp
@@ -112,7 +112,7 @@ static std::optional<DurationScale> getNewScale(DurationScale OldScale,
 void DurationFactoryScaleCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       callExpr(
-          callee(functionDecl(DurationFactoryFunction()).bind("call_decl")),
+          callee(functionDecl(durationFactoryFunction()).bind("call_decl")),
           hasArgument(
               0,
               ignoringImpCasts(anyOf(

--- a/clang-tools-extra/clang-tidy/abseil/DurationRewriter.h
+++ b/clang-tools-extra/clang-tidy/abseil/DurationRewriter.h
@@ -96,7 +96,7 @@ bool isInMacro(const ast_matchers::MatchFinder::MatchResult &Result,
                const Expr *E);
 
 AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
-                     DurationConversionFunction) {
+                     durationConversionFunction) {
   using namespace clang::ast_matchers;
   return functionDecl(
       hasAnyName("::absl::ToDoubleHours", "::absl::ToDoubleMinutes",
@@ -108,7 +108,7 @@ AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
 }
 
 AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
-                     DurationFactoryFunction) {
+                     durationFactoryFunction) {
   using namespace clang::ast_matchers;
   return functionDecl(hasAnyName("::absl::Nanoseconds", "::absl::Microseconds",
                                  "::absl::Milliseconds", "::absl::Seconds",
@@ -116,7 +116,7 @@ AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
 }
 
 AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
-                     TimeConversionFunction) {
+                     timeConversionFunction) {
   using namespace clang::ast_matchers;
   return functionDecl(hasAnyName(
       "::absl::ToUnixHours", "::absl::ToUnixMinutes", "::absl::ToUnixSeconds",
@@ -125,12 +125,12 @@ AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
 
 AST_MATCHER_FUNCTION_P(ast_matchers::internal::Matcher<Stmt>,
                        comparisonOperatorWithCallee,
-                       ast_matchers::internal::Matcher<Decl>, funcDecl) {
+                       ast_matchers::internal::Matcher<Decl>, FuncDecl) {
   using namespace clang::ast_matchers;
   return binaryOperator(
       anyOf(hasOperatorName(">"), hasOperatorName(">="), hasOperatorName("=="),
             hasOperatorName("<="), hasOperatorName("<")),
-      hasEitherOperand(ignoringImpCasts(callExpr(callee(funcDecl)))));
+      hasEitherOperand(ignoringImpCasts(callExpr(callee(FuncDecl)))));
 }
 
 } // namespace clang::tidy::abseil

--- a/clang-tools-extra/clang-tidy/abseil/DurationSubtractionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/DurationSubtractionCheck.cpp
@@ -21,7 +21,7 @@ void DurationSubtractionCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       binaryOperator(
           hasOperatorName("-"),
-          hasLHS(callExpr(callee(functionDecl(DurationConversionFunction())
+          hasLHS(callExpr(callee(functionDecl(durationConversionFunction())
                                      .bind("function_decl")),
                           hasArgument(0, expr().bind("lhs_arg")))))
           .bind("binop"),

--- a/clang-tools-extra/clang-tidy/abseil/TimeComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/TimeComparisonCheck.cpp
@@ -18,7 +18,7 @@ namespace clang::tidy::abseil {
 void TimeComparisonCheck::registerMatchers(MatchFinder *Finder) {
   auto Matcher =
       expr(comparisonOperatorWithCallee(functionDecl(
-               functionDecl(TimeConversionFunction()).bind("function_decl"))))
+               functionDecl(timeConversionFunction()).bind("function_decl"))))
           .bind("binop");
 
   Finder->addMatcher(Matcher, this);

--- a/clang-tools-extra/clang-tidy/abseil/UpgradeDurationConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/UpgradeDurationConversionsCheck.cpp
@@ -104,7 +104,7 @@ void UpgradeDurationConversionsCheck::registerMatchers(MatchFinder *Finder) {
                                       hasCastKind(CK_UserDefinedConversion)))),
                             hasParent(callExpr(
                                 callee(functionDecl(
-                                    DurationFactoryFunction(),
+                                    durationFactoryFunction(),
                                     unless(hasParent(functionTemplateDecl())))),
                                 hasArgument(0, expr().bind("arg")))))
                             .bind("OuterExpr")),

--- a/clang-tools-extra/clang-tidy/android/CloexecCheck.h
+++ b/clang-tools-extra/clang-tidy/android/CloexecCheck.h
@@ -82,7 +82,7 @@ protected:
   /// \param Mode The required mode char.
   /// \param ArgPos The 0-based position of the flag argument.
   void insertStringFlag(const ast_matchers::MatchFinder::MatchResult &Result,
-                        const char Mode, const int ArgPos);
+                        char Mode, int ArgPos);
 
   /// Helper function to get the spelling of a particular argument.
   StringRef getSpellingArg(const ast_matchers::MatchFinder::MatchResult &Result,

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.h
@@ -41,7 +41,7 @@ private:
   void diagNarrowIntegerConstantToSignedInt(SourceLocation SourceLoc,
                                             const Expr &Lhs, const Expr &Rhs,
                                             const llvm::APSInt &Value,
-                                            const uint64_t HexBits);
+                                            uint64_t HexBits);
 
   void diagNarrowConstant(SourceLocation SourceLoc, const Expr &Lhs,
                           const Expr &Rhs);

--- a/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
@@ -823,7 +823,7 @@ void NotNullTerminatedResultCheck::check(
   if (Name.starts_with("mem") || Name.starts_with("wmem"))
     memoryHandlerFunctionFix(Name, Result);
   else if (Name == "strerror_s")
-    strerror_sFix(Result);
+    strerrorSFix(Result);
   else if (Name.ends_with("ncmp"))
     ncmpFix(Name, Result);
   else if (Name.ends_with("xfrm"))
@@ -852,7 +852,7 @@ void NotNullTerminatedResultCheck::memoryHandlerFunctionFix(
   if (Name.ends_with("cpy")) {
     memcpyFix(Name, Result, Diag);
   } else if (Name.ends_with("cpy_s")) {
-    memcpy_sFix(Name, Result, Diag);
+    memcpySFix(Name, Result, Diag);
   } else if (Name.ends_with("move")) {
     memmoveFix(Name, Result, Diag);
   } else if (Name.ends_with("move_s")) {
@@ -889,7 +889,7 @@ void NotNullTerminatedResultCheck::memcpyFix(
     insertNullTerminatorExpr(Name, Result, Diag);
 }
 
-void NotNullTerminatedResultCheck::memcpy_sFix(
+void NotNullTerminatedResultCheck::memcpySFix(
     StringRef Name, const MatchFinder::MatchResult &Result,
     DiagnosticBuilder &Diag) {
   bool IsOverflows = isDestCapacityFix(Result, Diag);
@@ -950,7 +950,7 @@ void NotNullTerminatedResultCheck::memmoveFix(
   lengthArgHandle(LengthHandleKind::Increase, Result, Diag);
 }
 
-void NotNullTerminatedResultCheck::strerror_sFix(
+void NotNullTerminatedResultCheck::strerrorSFix(
     const MatchFinder::MatchResult &Result) {
   auto Diag =
       diag(Result.Nodes.getNodeAs<CallExpr>(FunctionExprName)->getBeginLoc(),

--- a/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.h
@@ -43,15 +43,15 @@ private:
   void memcpyFix(StringRef Name,
                  const ast_matchers::MatchFinder::MatchResult &Result,
                  DiagnosticBuilder &Diag);
-  void memcpy_sFix(StringRef Name,
-                   const ast_matchers::MatchFinder::MatchResult &Result,
-                   DiagnosticBuilder &Diag);
+  void memcpySFix(StringRef Name,
+                  const ast_matchers::MatchFinder::MatchResult &Result,
+                  DiagnosticBuilder &Diag);
   void memchrFix(StringRef Name,
                  const ast_matchers::MatchFinder::MatchResult &Result);
   void memmoveFix(StringRef Name,
                   const ast_matchers::MatchFinder::MatchResult &Result,
                   DiagnosticBuilder &Diag) const;
-  void strerror_sFix(const ast_matchers::MatchFinder::MatchResult &Result);
+  void strerrorSFix(const ast_matchers::MatchFinder::MatchResult &Result);
   void ncmpFix(StringRef Name,
                const ast_matchers::MatchFinder::MatchResult &Result);
   void xfrmFix(StringRef Name,

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/SpecialMemberFunctionsCheck.h
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/SpecialMemberFunctionsCheck.h
@@ -84,11 +84,11 @@ struct DenseMapInfo<
   using ClassDefId =
       clang::tidy::cppcoreguidelines::SpecialMemberFunctionsCheck::ClassDefId;
 
-  static inline ClassDefId getEmptyKey() {
+  static ClassDefId getEmptyKey() {
     return {DenseMapInfo<clang::SourceLocation>::getEmptyKey(), "EMPTY"};
   }
 
-  static inline ClassDefId getTombstoneKey() {
+  static ClassDefId getTombstoneKey() {
     return {DenseMapInfo<clang::SourceLocation>::getTombstoneKey(),
             "TOMBSTONE"};
   }

--- a/clang-tools-extra/clang-tidy/google/TodoCommentCheck.h
+++ b/clang-tools-extra/clang-tidy/google/TodoCommentCheck.h
@@ -22,7 +22,7 @@ namespace clang::tidy::google::readability {
 class TodoCommentCheck : public ClangTidyCheck {
 public:
   TodoCommentCheck(StringRef Name, ClangTidyContext *Context);
-  ~TodoCommentCheck();
+  ~TodoCommentCheck() override;
 
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;

--- a/clang-tools-extra/clang-tidy/misc/ConfusableIdentifierCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/ConfusableIdentifierCheck.h
@@ -21,7 +21,7 @@ namespace clang::tidy::misc {
 class ConfusableIdentifierCheck : public ClangTidyCheck {
 public:
   ConfusableIdentifierCheck(StringRef Name, ClangTidyContext *Context);
-  ~ConfusableIdentifierCheck();
+  ~ConfusableIdentifierCheck() override;
 
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;

--- a/clang-tools-extra/clang-tidy/misc/MisleadingBidirectional.h
+++ b/clang-tools-extra/clang-tidy/misc/MisleadingBidirectional.h
@@ -16,7 +16,7 @@ namespace clang::tidy::misc {
 class MisleadingBidirectionalCheck : public ClangTidyCheck {
 public:
   MisleadingBidirectionalCheck(StringRef Name, ClangTidyContext *Context);
-  ~MisleadingBidirectionalCheck();
+  ~MisleadingBidirectionalCheck() override;
 
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;

--- a/clang-tools-extra/clang-tidy/misc/MisleadingIdentifier.h
+++ b/clang-tools-extra/clang-tidy/misc/MisleadingIdentifier.h
@@ -16,7 +16,7 @@ namespace clang::tidy::misc {
 class MisleadingIdentifierCheck : public ClangTidyCheck {
 public:
   MisleadingIdentifierCheck(StringRef Name, ClangTidyContext *Context);
-  ~MisleadingIdentifierCheck();
+  ~MisleadingIdentifierCheck() override;
 
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;

--- a/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.h
@@ -18,7 +18,7 @@ namespace clang::tidy::misc {
 class UnusedParametersCheck : public ClangTidyCheck {
 public:
   UnusedParametersCheck(StringRef Name, ClangTidyContext *Context);
-  ~UnusedParametersCheck();
+  ~UnusedParametersCheck() override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.cpp
@@ -785,7 +785,7 @@ bool ForLoopIndexUseVisitor::TraverseLambdaCapture(LambdaExpr *LE,
                      C->getLocation()));
     }
     if (VDecl->isInitCapture())
-      TraverseStmtImpl(cast<VarDecl>(VDecl)->getInit());
+      traverseStmtImpl(cast<VarDecl>(VDecl)->getInit());
   }
   return VisitorBase::TraverseLambdaCapture(LE, C, Init);
 }
@@ -815,7 +815,7 @@ bool ForLoopIndexUseVisitor::VisitDeclStmt(DeclStmt *S) {
   return true;
 }
 
-bool ForLoopIndexUseVisitor::TraverseStmtImpl(Stmt *S) {
+bool ForLoopIndexUseVisitor::traverseStmtImpl(Stmt *S) {
   // All this pointer swapping is a mechanism for tracking immediate parentage
   // of Stmts.
   const Stmt *OldNextParent = NextStmtParent;
@@ -838,7 +838,7 @@ bool ForLoopIndexUseVisitor::TraverseStmt(Stmt *S) {
       return true;
     }
   }
-  return TraverseStmtImpl(S);
+  return traverseStmtImpl(S);
 }
 
 std::string VariableNamer::createIndexName() {

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.h
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.h
@@ -354,7 +354,7 @@ private:
   bool VisitDeclStmt(DeclStmt *S);
   bool TraverseStmt(Stmt *S);
 
-  bool TraverseStmtImpl(Stmt *S);
+  bool traverseStmtImpl(Stmt *S);
 
   /// Add an expression to the list of expressions on which the container
   /// expression depends.

--- a/clang-tools-extra/clang-tidy/performance/NoexceptDestructorCheck.h
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptDestructorCheck.h
@@ -27,10 +27,9 @@ public:
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
 
 private:
-  DiagnosticBuilder
-  reportMissingNoexcept(const FunctionDecl *FuncDecl) final override;
+  DiagnosticBuilder reportMissingNoexcept(const FunctionDecl *FuncDecl) final;
   void reportNoexceptEvaluatedToFalse(const FunctionDecl *FuncDecl,
-                                      const Expr *NoexceptExpr) final override;
+                                      const Expr *NoexceptExpr) final;
 };
 
 } // namespace clang::tidy::performance

--- a/clang-tools-extra/clang-tidy/performance/NoexceptFunctionBaseCheck.h
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptFunctionBaseCheck.h
@@ -27,8 +27,7 @@ public:
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus11 && LangOpts.CXXExceptions;
   }
-  void
-  check(const ast_matchers::MatchFinder::MatchResult &Result) final override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) final;
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }

--- a/clang-tools-extra/clang-tidy/performance/NoexceptMoveConstructorCheck.h
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptMoveConstructorCheck.h
@@ -31,10 +31,9 @@ public:
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
 
 private:
-  DiagnosticBuilder
-  reportMissingNoexcept(const FunctionDecl *FuncDecl) final override;
+  DiagnosticBuilder reportMissingNoexcept(const FunctionDecl *FuncDecl) final;
   void reportNoexceptEvaluatedToFalse(const FunctionDecl *FuncDecl,
-                                      const Expr *NoexceptExpr) final override;
+                                      const Expr *NoexceptExpr) final;
 };
 
 } // namespace clang::tidy::performance

--- a/clang-tools-extra/clang-tidy/performance/NoexceptSwapCheck.h
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptSwapCheck.h
@@ -27,10 +27,9 @@ public:
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
 
 private:
-  DiagnosticBuilder
-  reportMissingNoexcept(const FunctionDecl *FuncDecl) final override;
+  DiagnosticBuilder reportMissingNoexcept(const FunctionDecl *FuncDecl) final;
   void reportNoexceptEvaluatedToFalse(const FunctionDecl *FuncDecl,
-                                      const Expr *NoexceptExpr) final override;
+                                      const Expr *NoexceptExpr) final;
 };
 
 } // namespace clang::tidy::performance

--- a/clang-tools-extra/clang-tidy/readability/AvoidReturnWithVoidValueCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/AvoidReturnWithVoidValueCheck.h
@@ -34,7 +34,6 @@ private:
   }
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 
-private:
   bool IgnoreMacros;
   bool StrictMode;
 };

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.h
@@ -33,7 +33,7 @@ enum StyleKind : int;
 class IdentifierNamingCheck final : public RenamerClangTidyCheck {
 public:
   IdentifierNamingCheck(StringRef Name, ClangTidyContext *Context);
-  ~IdentifierNamingCheck();
+  ~IdentifierNamingCheck() override;
 
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 

--- a/clang-tools-extra/clang-tidy/utils/BracesAroundStatement.h
+++ b/clang-tools-extra/clang-tidy/utils/BracesAroundStatement.h
@@ -68,7 +68,7 @@ private:
 /// The algorithm computing them respects comment before and after the statement
 /// and adds line breaks before the braces accordingly.
 BraceInsertionHints
-getBraceInsertionsHints(const Stmt *const S, const LangOptions &LangOpts,
+getBraceInsertionsHints(const Stmt *S, const LangOptions &LangOpts,
                         const SourceManager &SM, SourceLocation StartLoc,
                         SourceLocation EndLocHint = SourceLocation());
 

--- a/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
@@ -118,9 +118,8 @@ static int compareHeaders(StringRef LHS, StringRef RHS,
   return LHS.compare(RHS);
 }
 
-IncludeSorter::IncludeSorter(const SourceManager *SourceMgr,
-                             const FileID FileID, StringRef FileName,
-                             IncludeStyle Style)
+IncludeSorter::IncludeSorter(const SourceManager *SourceMgr, FileID FileID,
+                             StringRef FileName, IncludeStyle Style)
     : SourceMgr(SourceMgr), Style(Style), CurrentFileID(FileID),
       CanonicalFile(makeCanonicalName(FileName, Style)) {}
 

--- a/clang-tools-extra/clang-tidy/utils/IncludeSorter.h
+++ b/clang-tools-extra/clang-tidy/utils/IncludeSorter.h
@@ -23,7 +23,7 @@ namespace utils {
 class IncludeSorter {
 public:
   /// Supported include styles.
-  enum IncludeStyle { IS_LLVM = 0, IS_Google = 1, IS_Google_ObjC };
+  enum IncludeStyle { IS_LLVM = 0, IS_Google = 1, IS_Google_ObjC = 2 };
 
   /// The classifications of inclusions, in the order they should be sorted.
   enum IncludeKinds {
@@ -37,7 +37,7 @@ public:
 
   /// ``IncludeSorter`` constructor; takes the FileID and name of the file to be
   /// processed by the sorter.
-  IncludeSorter(const SourceManager *SourceMgr, const FileID FileID,
+  IncludeSorter(const SourceManager *SourceMgr, FileID FileID,
                 StringRef FileName, IncludeStyle Style);
 
   /// Adds the given include directive to the sorter.

--- a/clang-tools-extra/clang-tidy/utils/Matchers.h
+++ b/clang-tools-extra/clang-tidy/utils/Matchers.h
@@ -51,7 +51,7 @@ AST_MATCHER_FUNCTION(ast_matchers::TypeMatcher, isPointerToConst) {
 
 // Returns QualType matcher for target char type only.
 AST_MATCHER(QualType, isSimpleChar) {
-  const auto ActualType = Node.getTypePtr();
+  const auto *ActualType = Node.getTypePtr();
   return ActualType &&
          (ActualType->isSpecificBuiltinType(BuiltinType::Char_S) ||
           ActualType->isSpecificBuiltinType(BuiltinType::Char_U));

--- a/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.h
+++ b/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.h
@@ -28,7 +28,7 @@ namespace tidy {
 class RenamerClangTidyCheck : public ClangTidyCheck {
 public:
   RenamerClangTidyCheck(StringRef CheckName, ClangTidyContext *Context);
-  ~RenamerClangTidyCheck();
+  ~RenamerClangTidyCheck() override;
 
   /// Derived classes should not implement any matching logic themselves; this
   /// class will do the matching and call the derived class'

--- a/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Types.h
+++ b/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Types.h
@@ -219,10 +219,10 @@ template <> struct DenseMapInfo<clang::include_cleaner::Symbol> {
   using Outer = clang::include_cleaner::Symbol;
   using Base = DenseMapInfo<decltype(Outer::Storage)>;
 
-  static inline Outer getEmptyKey() {
+  static Outer getEmptyKey() {
     return {Outer::SentinelTag{}, Base::getEmptyKey()};
   }
-  static inline Outer getTombstoneKey() {
+  static Outer getTombstoneKey() {
     return {Outer::SentinelTag{}, Base::getTombstoneKey()};
   }
   static unsigned getHashValue(const Outer &Val) {
@@ -236,10 +236,8 @@ template <> struct DenseMapInfo<clang::include_cleaner::Macro> {
   using Outer = clang::include_cleaner::Macro;
   using Base = DenseMapInfo<decltype(Outer::Definition)>;
 
-  static inline Outer getEmptyKey() { return {nullptr, Base::getEmptyKey()}; }
-  static inline Outer getTombstoneKey() {
-    return {nullptr, Base::getTombstoneKey()};
-  }
+  static Outer getEmptyKey() { return {nullptr, Base::getEmptyKey()}; }
+  static Outer getTombstoneKey() { return {nullptr, Base::getTombstoneKey()}; }
   static unsigned getHashValue(const Outer &Val) {
     return Base::getHashValue(Val.Definition);
   }
@@ -251,10 +249,10 @@ template <> struct DenseMapInfo<clang::include_cleaner::Header> {
   using Outer = clang::include_cleaner::Header;
   using Base = DenseMapInfo<decltype(Outer::Storage)>;
 
-  static inline Outer getEmptyKey() {
+  static Outer getEmptyKey() {
     return {Outer::SentinelTag{}, Base::getEmptyKey()};
   }
-  static inline Outer getTombstoneKey() {
+  static Outer getTombstoneKey() {
     return {Outer::SentinelTag{}, Base::getTombstoneKey()};
   }
   static unsigned getHashValue(const Outer &Val) {


### PR DESCRIPTION
Started running `clang-tidy` on our clang-tidy headers. This part covers what `clang-tidy` could fix automatically (with `--fix` option).

The main goal is to enable `HeaderFilterRegex: 'clang-tools-extra/clang-tidy/.*'` eventually in config.