### PR TITLE
AArch64: Fix undefined behavior in sme calling convention test

### DIFF
--- a/llvm/test/CodeGen/AArch64/sme-support-routines-calling-convention.ll
+++ b/llvm/test/CodeGen/AArch64/sme-support-routines-calling-convention.ll
@@ -64,6 +64,6 @@ define i64 @test_sme_calling_convention_x2() nounwind {
   ret i64 %pstate.sm
 }
 
-declare void @__arm_tpidr2_save()
-declare i64 @__arm_get_current_vg()
-declare {i64, i64} @__arm_sme_state()
+declare aarch64_sme_preservemost_from_x0 void @__arm_tpidr2_save()
+declare aarch64_sme_preservemost_from_x1 i64 @__arm_get_current_vg()
+declare aarch64_sme_preservemost_from_x2 {i64, i64} @__arm_sme_state()


### PR DESCRIPTION
Mismatch of callsite and callee calling conventions