### PR TITLE
[ADT] Achieve the "Rule of Zero" in DGNode

### DIFF
--- a/llvm/include/llvm/ADT/DirectedGraph.h
+++ b/llvm/include/llvm/ADT/DirectedGraph.h
@@ -80,18 +80,6 @@ public:
   explicit DGNode(EdgeType &E) : Edges() { Edges.insert(&E); }
   DGNode() = default;
 
-  explicit DGNode(const DGNode<NodeType, EdgeType> &N) : Edges(N.Edges) {}
-  DGNode(DGNode<NodeType, EdgeType> &&N) : Edges(std::move(N.Edges)) {}
-
-  DGNode<NodeType, EdgeType> &operator=(const DGNode<NodeType, EdgeType> &N) {
-    Edges = N.Edges;
-    return *this;
-  }
-  DGNode<NodeType, EdgeType> &operator=(const DGNode<NodeType, EdgeType> &&N) {
-    Edges = std::move(N.Edges);
-    return *this;
-  }
-
   /// Static polymorphism: delegate implementation (via isEqualTo) to the
   /// derived class.
   friend bool operator==(const NodeType &M, const NodeType &N) {


### PR DESCRIPTION
This patch achieves the "Rule of Zero" in DGNode by removing the
copy/move constructors and copy/move assignment operators.

Note that the code being deleted does a couple of unusual things that
are most likely oversight:

- The copy constructor with "explicit" is highly unusual.  This means
  that we allow "DGNode<N, E> A(B);" but disallow
  "DGNode<N, E> A = B;".

- The move assignment operator with const r-value reference is also
  unusual, especially given that the move constructor is correctly
  implemented.
