### PR TITLE
[DebugInfo] Fold a namespace into a std::hash specialization (NFC)

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
@@ -597,14 +597,10 @@ struct Variant {
 } // end namespace pdb
 } // end namespace llvm
 
-namespace std {
-
-template <> struct hash<llvm::pdb::PDB_SymType> {
+template <> struct std::hash<llvm::pdb::PDB_SymType> {
   std::size_t operator()(const llvm::pdb::PDB_SymType &Arg) const {
     return std::hash<int>()(static_cast<int>(Arg));
   }
 };
-
-} // end namespace std
 
 #endif // LLVM_DEBUGINFO_PDB_PDBTYPES_H


### PR DESCRIPTION
This patch folds "std" into the std::hash specialization so that the
template mentions std::hash.  std::hash is much easier to recognize
than std and hash separated by a couple of lines.
