### PR TITLE
[OpenCL] Support for inline asm

### DIFF
--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -354,7 +354,7 @@ KEYWORD(__ptrauth                   , KEYALL)
 UNARY_EXPR_OR_TYPE_TRAIT(_Countof, CountOf, KEYNOCXX)
 
 // C++ 2.11p1: Keywords.
-KEYWORD(asm                         , KEYCXX|KEYGNU)
+KEYWORD(asm                         , KEYCXX|KEYGNU|KEYOPENCLC|KEYOPENCLCXX)
 KEYWORD(bool                        , BOOLSUPPORT|KEYC23)
 KEYWORD(catch                       , KEYCXX)
 KEYWORD(class                       , KEYCXX)

--- a/clang/test/SemaOpenCL/inline-asm.cl
+++ b/clang/test/SemaOpenCL/inline-asm.cl
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL1.2
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=clc++
+
+// expected-no-diagnostics
+
+void test(void)
+{
+  asm("");
+loop:
+  asm goto(""::::loop);
+}


### PR DESCRIPTION
Resolves #165155.
Currently, we don't support inline asm and asm goto in OpenCL. But it's a widely used feature in many scenarios. This patch enables the asm keyword to support it.