### PR TITLE
[clang][bytecode] Check overflow ops for block pointers

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -749,7 +749,7 @@ static bool interp__builtin_overflowop(InterpState &S, CodePtr OpPC,
                                        const CallExpr *Call,
                                        unsigned BuiltinOp) {
   const Pointer &ResultPtr = S.Stk.pop<Pointer>();
-  if (ResultPtr.isDummy())
+  if (ResultPtr.isDummy() || !ResultPtr.isBlockPointer())
     return false;
 
   PrimType RHST = *S.getContext().classify(Call->getArg(1)->getType());

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1853,3 +1853,8 @@ namespace InitParam {
 }
 
 #endif
+
+namespace SAddOverflowInt {
+  int a;
+  void foo(void) { a *= __builtin_sadd_overflow(1, 2, 0); }
+}


### PR DESCRIPTION
We can't save the result in a non-block pointer.

Fixes https://github.com/llvm/llvm-project/issues/165076