### PR TITLE
[BOLT][PAC] Warn about synchronous unwind tables

### DIFF
--- a/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
+++ b/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
@@ -133,10 +133,17 @@ Error PointerAuthCFIAnalyzer::runOnFunctions(BinaryContext &BC) {
   ParallelUtilities::runOnEachFunction(
       BC, ParallelUtilities::SchedulingPolicy::SP_INST_LINEAR, WorkFun,
       SkipPredicate, "PointerAuthCFIAnalyzer");
+
+  float IgnoredPercent = (100.0 * FunctionsIgnored) / Total;
   BC.outs() << "BOLT-INFO: PointerAuthCFIAnalyzer ran on " << Total
             << " functions. Ignored " << FunctionsIgnored << " functions "
-            << format("(%.2lf%%)", (100.0 * FunctionsIgnored) / Total)
+            << format("(%.2lf%%)", IgnoredPercent)
             << " because of CFI inconsistencies\n";
+
+  if (IgnoredPercent >= 10.0)
+    BC.outs() << "BOLT-WARNING: PointerAuthCFIAnalyzer only supports "
+                 "asynchronous unwind tables. For C compilers, see "
+                 "-fasynchronous-unwind-tables.\n";
 
   return Error::success();
 }

--- a/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
+++ b/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
@@ -137,6 +137,9 @@ Error PointerAuthCFIAnalyzer::runOnFunctions(BinaryContext &BC) {
     return P.second.containedNegateRAState() && !P.second.isIgnored();
   });
 
+  if (Total == 0)
+    return Error::success();
+
   ParallelUtilities::runOnEachFunction(
       BC, ParallelUtilities::SchedulingPolicy::SP_INST_LINEAR, WorkFun,
       SkipPredicate, "PointerAuthCFIAnalyzer");

--- a/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
+++ b/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
@@ -152,14 +152,15 @@ Error PointerAuthCFIAnalyzer::runOnFunctions(BinaryContext &BC) {
 
   // Errors in the input are expected from two sources:
   // - compilers emitting incorrect CFIs. This happens more frequently with
-  // older compiler versions, but it should not account for a large percentage.
+  //   older compiler versions, but it should not account for a large
+  //   percentage.
   // - input binary is using synchronous unwind tables. This means that after
-  // call sites, the unwind CFIs are dropped: the pass sees missing
-  // .cfi_negate_ra_state from autiasp instructions. If this is the case, a
-  // larger percentage of functions will be ignored.
+  //   call sites, the unwind CFIs are dropped: the pass sees missing
+  //   .cfi_negate_ra_state from autiasp instructions. If this is the case, a
+  //   larger percentage of functions will be ignored.
   //
   // This is why the 10% threshold was chosen: we should not warn about
-  // synchronous unwind tables if only a few % is ignored.
+  // synchronous unwind tables if only a few % are ignored.
   if (IgnoredPercent >= 10.0)
     BC.outs() << "BOLT-WARNING: PointerAuthCFIAnalyzer only supports "
                  "asynchronous unwind tables. For C compilers, see "

--- a/bolt/test/AArch64/pacret-cfi-incorrect.s
+++ b/bolt/test/AArch64/pacret-cfi-incorrect.s
@@ -8,7 +8,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags  %t.o -o %t.exe -Wl,-q
-# RUN: llvm-bolt %t.exe -o %t.exe.bolt --no-threads | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-bolt %t.exe -o %t.exe.bolt -v=1 --no-threads | FileCheck %s --check-prefix=CHECK-BOLT
 
 # CHECK-BOLT: BOLT-INFO: inconsistent RAStates in function foo: ptr authenticating inst encountered in Unsigned RA state
 # CHECK-BOLT: BOLT-INFO: inconsistent RAStates in function bar: ptr signing inst encountered in Signed RA state

--- a/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
+++ b/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
@@ -1,0 +1,33 @@
+// Test to demonstrate that functions compiled with synchronous unwind tables
+// are ignored by the PointerAuthCFIAnalyzer.
+// Exception handling is needed to have _any_ unwind tables, otherwise the
+// PointerAuthCFIAnalyzer does not run on these functions, so it does not ignore
+// any function.
+//
+// REQUIRES: system-linux,bolt-runtime
+//
+// RUN: %clangxx --target=aarch64-unknown-linux-gnu \
+// RUN: -mbranch-protection=pac-ret \
+// RUN: -fno-asynchronous-unwind-tables \
+// RUN: %s -o %t.exe -Wl,-q
+// RUN: llvm-bolt %t.exe -o %t.bolt | FileCheck %s --check-prefix=CHECK
+//
+// CHECK: PointerAuthCFIAnalyzer ran on 3 functions. Ignored
+// CHECK-NOT: 0 functions (0.00%) because of CFI inconsistencies
+// CHECK-SAME: 1 functions (33.33%) because of CFI inconsistencies
+// CHECK-NEXT: BOLT-WARNING: PointerAuthCFIAnalyzer only supports asynchronous
+// CHECK-SAME: unwind tables. For C compilers, see -fasynchronous-unwind-tables.
+
+#include <cstdio>
+#include <stdexcept>
+
+void foo() { throw std::runtime_error("Exception from foo()."); }
+
+int main() {
+  try {
+    foo();
+  } catch (const std::exception &e) {
+    printf("Exception caught: %s\n", e.what());
+  }
+  return 0;
+}


### PR DESCRIPTION
BOLT currently ignores functions with synchronous PAuth DWARF info.
If more than 10% of functions get ignored for inconsistencies, we
should emit a warning to only use asynchronous unwind tables.

See related issue: #165215