### PR TITLE
[openmp][cmake] Don't glob for build dependencies

### DIFF
--- a/openmp/tools/CMakeLists.txt
+++ b/openmp/tools/CMakeLists.txt
@@ -1,9 +1,4 @@
-# Discover the tools that use CMake in the subdirectories.
-# Note that explicit cmake invocation is required every time a new tool
-# is added or removed.
-file(GLOB entries *)
-foreach(entry ${entries})
-  if(IS_DIRECTORY ${entry} AND EXISTS ${entry}/CMakeLists.txt)
-    add_subdirectory(${entry})
-  endif()
-endforeach(entry)
+add_subdirectory(archer)
+add_subdirectory(Modules)
+add_subdirectory(multiplex)
+add_subdirectory(omptest)

--- a/openmp/tools/omptest/test/CMakeLists.txt
+++ b/openmp/tools/omptest/test/CMakeLists.txt
@@ -5,7 +5,13 @@
 ##===----------------------------------------------------------------------===##
 
 # Target: ompTest library unit tests
-file(GLOB UNITTEST_SOURCES "unittests/*.cpp")
+set(UNITTEST_SOURCES
+  unittests/asserter-seq-test.cpp
+  unittests/internal-event-eq-test.cpp
+  unittests/internal-event-tostring-test.cpp
+  unittests/internal-util-test
+  unittests/main-test.cpp
+)
 add_executable(omptest-unittests ${UNITTEST_SOURCES})
 
 # Add local and LLVM-provided GoogleTest include directories.


### PR DESCRIPTION
LLVM's cmake standard explicitly lists all source in the CMakeLists.txt. Remove globbing for source files in OpenMP's CMakeLists.txt.

Also see #4899, #71404, https://reviews.llvm.org/D79906, https://reviews.llvm.org/D31363, https://reviews.llvm.org/D61275, https://discourse.llvm.org/t/cmake-builds-clang/11536, and CMake's note at https://cmake.org/cmake/help/latest/command/file.html#glob. Two reasons to not glob for source files is that it breaks bisecting and incremental builds. Renaming a file, reverting or checking out an older reversion where a newly added source file disappears again will not trigger a CMake configure step and make the build fail because of a non-existing source file.