### PR TITLE
[PredicateInfo] Reformat PT_Switch's annotation as valid comments

### DIFF
--- a/llvm/lib/Transforms/Utils/PredicateInfo.cpp
+++ b/llvm/lib/Transforms/Utils/PredicateInfo.cpp
@@ -14,7 +14,6 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
 #include "llvm/IR/Dominators.h"
@@ -26,7 +25,6 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugCounter.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/raw_ostream.h"
 #define DEBUG_TYPE "predicateinfo"
 using namespace llvm;
 using namespace PatternMatch;
@@ -818,19 +816,7 @@ public:
         PS->From->printAsOperand(OS);
         OS << ",";
         PS->To->printAsOperand(OS);
-        OS << "] Switch:\n";
-        // A switch might cross > 1 lines, we should add the comment prefix ';'
-        // for each line
-        std::string SwitchStr;
-        {
-          llvm::raw_string_ostream SwitchOS(SwitchStr);
-          PS->Switch->print(SwitchOS);
-        }
-        SmallVector<StringRef, 8> Lines;
-        StringRef(SwitchStr).split(Lines, '\n');
-        for (const auto &Line : Lines)
-          OS << ";   " << Line << "\n";
-        OS << "; ";
+        OS << "]";
       } else if (const auto *PA = dyn_cast<PredicateAssume>(PI)) {
         OS << "; assume predicate info {"
            << " Comparison:" << *PA->Condition;

--- a/llvm/test/Transforms/Util/PredicateInfo/condprop.ll
+++ b/llvm/test/Transforms/Util/PredicateInfo/condprop.ll
@@ -133,19 +133,13 @@ define void @test4(i1 %b, i32 %x) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:    br i1 [[B:%.*]], label [[SW:%.*]], label [[CASE3:%.*]]
 ; CHECK:       sw:
-; CHECK:         i32 0, label [[CASE0:%.*]]
-; CHECK-NEXT:    i32 1, label [[CASE1:%.*]]
-; CHECK-NEXT:    i32 2, label [[CASE0]]
-; CHECK-NEXT:    i32 3, label [[CASE3]]
-; CHECK-NEXT:    i32 4, label [[DEFAULT:%.*]]
-; CHECK-NEXT:    ] Edge: [label [[SW]],label %case1], RenamedOp: [[X:%.*]] }
-; CHECK-NEXT:    [[X_0:%.*]] = bitcast i32 [[X]] to i32
-; CHECK-NEXT:    switch i32 [[X]], label [[DEFAULT]] [
-; CHECK-NEXT:    i32 0, label [[CASE0]]
-; CHECK-NEXT:    i32 1, label [[CASE1]]
-; CHECK-NEXT:    i32 2, label [[CASE0]]
-; CHECK-NEXT:    i32 3, label [[CASE3]]
-; CHECK-NEXT:    i32 4, label [[DEFAULT]]
+; CHECK:         [[X_0:%.*]] = bitcast i32 [[X:%.*]] to i32
+; CHECK-NEXT:    switch i32 [[X]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i32 0, label [[CASE0:%.*]]
+; CHECK-NEXT:      i32 1, label [[CASE1:%.*]]
+; CHECK-NEXT:      i32 2, label [[CASE0]]
+; CHECK-NEXT:      i32 3, label [[CASE3]]
+; CHECK-NEXT:      i32 4, label [[DEFAULT]]
 ; CHECK-NEXT:    ]
 ; CHECK:       default:
 ; CHECK-NEXT:    call void @bar(i32 [[X]])


### PR DESCRIPTION
Previously, PredicateInfo brutally annotated `PT_Switch` as follows:
```python
f'"; switch predicate info ... CaseValue: ... Switch: {*PS->Switch} Edge: ... RenamedOp: ..."'
```

However, the `switch` instruction in LLVM might cross >1 lines, leading to the annotation of `PT_Switch` being **illegal comments**, e.g., 
```LLVM
; switch predicate info { CaseValue: i32 1 Switch:  switch i32 %x, label %default [
    i32 0, label %case0
    i32 1, label %case1
    i32 2, label %case0
    i32 3, label %case3
    i32 4, label %default
  ] Edge: [label %sw,label %case1], RenamedOp: %x }
  x.0 = bitcast i32 %x to i32
```

This patch removes the `switch` printing, reformating the `PT_Switch`'s annotation as follows:
```python
f'"; switch predicate info ... CaseValue: ... Edge: ...  RenamedOp: ..."'
```
, e.g., 

```LLVM
; switch predicate info { CaseValue: i32 1 Edge: [label %sw,label %case1], RenamedOp: %x }
  x.0 = bitcast i32 %x to i32
```

It should be Okay because `CaseValue: ...` + `Edge: ...` are meaningful enough for diagnostics, covering the necessary info provided by full switch printing (E.g., `PT_Branch` also did not print the relevant branch instruction).