### PR TITLE
[flang][cmake] Set the usual linker flags for non-gtest unit tests

### DIFF
--- a/flang/unittests/CMakeLists.txt
+++ b/flang/unittests/CMakeLists.txt
@@ -48,6 +48,7 @@ function(add_flang_nongtest_unittest test_name)
     llvm_map_components_to_libnames(llvm_libs Support)
   endif()
   target_link_libraries(${test_name}${suffix} ${llvm_libs} ${ARG_UNPARSED_ARGUMENTS})
+  set_unittest_link_flags(${test_name}${suffix})
 
   if(NOT ARG_SLOW_TEST)
     add_dependencies(FlangUnitTests ${test_name}${suffix})


### PR DESCRIPTION
Flang also uses non-gtest based unittests, which don't go through the usual add_unittest() helper. These currently do not use the usual linker flags for unit tests. This means that in LTO builds, they do not disable LTO when building unit tests, which increases the build time.