### PR TITLE
[mlir][tosa] Move variable op definitions to `TosaOps.td` (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -19,6 +19,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Dialect/Tosa/IR/TosaInterfaces.td"
 
 include "mlir/Dialect/Tosa/IR/TosaTypesBase.td"
@@ -2748,6 +2749,106 @@ def Tosa_WhileOp : Tosa_Op<"while_loop", [
   );
 
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Operator: variable
+//===----------------------------------------------------------------------===//
+def Tosa_VariableOp : Tosa_Op<"variable", [Symbol]> {
+  let summary = "Defines a variable";
+
+  let description = [{
+    Defines a new TOSA variable. This is a persistent mutable value across multiple
+    TOSA graph invocations. Modifications are expressed using read/write semantics.
+  }];
+
+  let arguments = (ins
+    // Note: "sym_name" is used as opposed to "name" in the specification,
+    // since a Symbol must be named "sym_name" for it to be recognised by
+    // the containing SymbolTable.
+    SymbolNameAttr:$sym_name,
+    IndexElementsAttr:$var_shape,
+    TypeAttr:$type,
+    OptionalAttr<AnyAttr>:$initial_value
+  );
+
+  list<Availability> availability = [
+    Profile<[Tosa_PRO_INT, Tosa_PRO_FP]>,
+    Extension<[Tosa_EXT_VARIABLE]>,
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+
+  let assemblyFormat = [{
+    $sym_name
+    attr-dict
+    custom<VariableOpTypeOrInitialValue>($var_shape, $type, $initial_value)
+  }];
+
+  let builders = [Tosa_VariableOpBuilder];
+
+  let extraClassDeclaration = [{
+    ::llvm::StringRef getName() {
+      return getSymName();
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Operator: variable_write
+//===----------------------------------------------------------------------===//
+def Tosa_VariableWriteOp : Tosa_Op<"variable_write", []> {
+  let summary = "write_buffer operator";
+
+  let description = [{
+    Assigns a value to the pseudo-buffer resource holding a persistent mutable tensor.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$name,
+    Tosa_Tensor:$input1
+  );
+
+  list<Availability> availability = [
+    Profile<[Tosa_PRO_INT, Tosa_PRO_FP]>,
+    Extension<[Tosa_EXT_VARIABLE]>,
+  ];
+
+  let assemblyFormat = [{
+    $name attr-dict `,` $input1 `:` type($input1)
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Operator: variable_read
+//===----------------------------------------------------------------------===//
+def Tosa_VariableReadOp : Tosa_Op<"variable_read", []> {
+  let summary = "read_buffer operator";
+
+  let description = [{
+    Reads the value from a pseudo-buffer resource holding a persistent mutable tensor.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$name
+  );
+
+  let results = (outs
+    Tosa_Tensor:$output1
+  );
+
+  list<Availability> availability = [
+    Profile<[Tosa_PRO_INT, Tosa_PRO_FP]>,
+    Extension<[Tosa_EXT_VARIABLE]>,
+  ];
+
+  let assemblyFormat = [{
+    $name attr-dict `:` type($output1)
+  }];
+
   let hasVerifier = 1;
 }
 

--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaUtilOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaUtilOps.td
@@ -18,7 +18,6 @@
 include "mlir/IR/OpBase.td"
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/VectorInterfaces.td"
 include "mlir/Dialect/Tosa/IR/TosaInterfaces.td"
@@ -78,106 +77,6 @@ def Tosa_YieldOp : Tosa_Op<"yield", [
   );
 
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";
-}
-
-//===----------------------------------------------------------------------===//
-// Operator: variable
-//===----------------------------------------------------------------------===//
-def Tosa_VariableOp : Tosa_Op<"variable", [Symbol]> {
-  let summary = "Defines a variable";
-
-  let description = [{
-    Defines a new TOSA variable. This is a persistent mutable value across multiple
-    TOSA graph invocations. Modifications are expressed using read/write semantics.
-  }];
-
-  let arguments = (ins
-    // Note: "sym_name" is used as opposed to "name" in the specification,
-    // since a Symbol must be named "sym_name" for it to be recognised by
-    // the containing SymbolTable.
-    SymbolNameAttr:$sym_name,
-    IndexElementsAttr:$var_shape,
-    TypeAttr:$type,
-    OptionalAttr<AnyAttr>:$initial_value
-  );
-
-  list<Availability> availability = [
-    Profile<[Tosa_PRO_INT, Tosa_PRO_FP]>,
-    Extension<[Tosa_EXT_VARIABLE]>,
-  ];
-
-  let hasCustomAssemblyFormat = 1;
-
-  let assemblyFormat = [{
-    $sym_name
-    attr-dict
-    custom<VariableOpTypeOrInitialValue>($var_shape, $type, $initial_value)
-  }];
-
-  let builders = [Tosa_VariableOpBuilder];
-
-  let extraClassDeclaration = [{
-    ::llvm::StringRef getName() {
-      return getSymName();
-    }
-  }];
-}
-
-//===----------------------------------------------------------------------===//
-// Operator: variable_write
-//===----------------------------------------------------------------------===//
-def Tosa_VariableWriteOp : Tosa_Op<"variable_write", []> {
-  let summary = "write_buffer operator";
-
-  let description = [{
-    Assigns a value to the pseudo-buffer resource holding a persistent mutable tensor.
-  }];
-
-  let arguments = (ins
-    SymbolNameAttr:$name,
-    Tosa_Tensor:$input1
-  );
-
-  list<Availability> availability = [
-    Profile<[Tosa_PRO_INT, Tosa_PRO_FP]>,
-    Extension<[Tosa_EXT_VARIABLE]>,
-  ];
-
-  let assemblyFormat = [{
-    $name attr-dict `,` $input1 `:` type($input1)
-  }];
-
-  let hasVerifier = 1;
-}
-
-//===----------------------------------------------------------------------===//
-// Operator: variable_read
-//===----------------------------------------------------------------------===//
-def Tosa_VariableReadOp : Tosa_Op<"variable_read", []> {
-  let summary = "read_buffer operator";
-
-  let description = [{
-    Reads the value from a pseudo-buffer resource holding a persistent mutable tensor.
-  }];
-
-  let arguments = (ins
-    SymbolNameAttr:$name
-  );
-
-  let results = (outs
-    Tosa_Tensor:$output1
-  );
-
-  list<Availability> availability = [
-    Profile<[Tosa_PRO_INT, Tosa_PRO_FP]>,
-    Extension<[Tosa_EXT_VARIABLE]>,
-  ];
-
-  let assemblyFormat = [{
-    $name attr-dict `:` type($output1)
-  }];
-
-  let hasVerifier = 1;
 }
 
 #endif // TOSA_UTIL_OPS


### PR DESCRIPTION
Variable ops (VARIABLE/VARIABLE_READ/VARIABLE_WRITE) are part of the TOSA specification and should therefore be defined in `TosaOps.td`.