### PR TITLE
[libcxx] Update picolibc version used in CI to 1.8.10

### DIFF
--- a/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
@@ -11,9 +11,6 @@
 // Apple platforms don't provide <uchar.h> yet, so these tests fail.
 // XFAIL: target={{.+}}-apple-{{.+}}
 
-// mbrtoc16 not defined.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // <uchar.h>
 
 #include <uchar.h>

--- a/libcxx/test/std/depr/depr.c.headers/uchar_h_char8_t.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/uchar_h_char8_t.compile.pass.cpp
@@ -15,11 +15,12 @@
 // XFAIL: freebsd
 // XFAIL: windows
 // XFAIL: glibc-no-char8_t-support
-// XFAIL: LIBCXX-PICOLIBC-FIXME
 
 // <uchar.h>
 
 #include <uchar.h>
+
+#include "test_macros.h"
 
 ASSERT_SAME_TYPE(size_t, decltype(mbrtoc8((char8_t*)0, (const char*)0, (size_t)0, (mbstate_t*)0)));
 ASSERT_SAME_TYPE(size_t, decltype(c8rtomb((char*)0, (char8_t)0, (mbstate_t*)0)));

--- a/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
+++ b/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
@@ -11,9 +11,6 @@
 // Apple platforms don't provide <uchar.h> yet, so these tests fail.
 // XFAIL: target={{.+}}-apple-{{.+}}
 
-// mbrtoc16 not defined.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // <cuchar>
 
 #include <cuchar>

--- a/libcxx/test/std/strings/c.strings/cuchar_char8_t.compile.pass.cpp
+++ b/libcxx/test/std/strings/c.strings/cuchar_char8_t.compile.pass.cpp
@@ -15,11 +15,12 @@
 // XFAIL: freebsd
 // XFAIL: windows
 // XFAIL: glibc-no-char8_t-support
-// XFAIL: LIBCXX-PICOLIBC-FIXME
 
 // <cuchar>
 
 #include <cuchar>
+
+#include "test_macros.h"
 
 ASSERT_SAME_TYPE(std::size_t, decltype(std::mbrtoc8((char8_t*)0, (const char*)0, (size_t)0, (mbstate_t*)0)));
 ASSERT_SAME_TYPE(std::size_t, decltype(std::c8rtomb((char*)0, (char8_t)0, (mbstate_t*)0)));

--- a/libcxx/utils/ci/build-picolibc.sh
+++ b/libcxx/utils/ci/build-picolibc.sh
@@ -69,8 +69,8 @@ picolibc_source_dir="${build_dir}/picolibc-source"
 picolibc_build_dir="${build_dir}/picolibc-build"
 mkdir -p "${picolibc_source_dir}"
 mkdir -p "${picolibc_build_dir}"
-# Download a known good version of picolibc.
-picolibc_commit="48fbc2009c6473293d03d5ec6f190565c6223a5c"
+# Download a known good version of picolibc: v1.8.10
+picolibc_commit="51a8b32857e75345c37652a80b5cda98b28d69e5"
 curl -L "https://github.com/picolibc/picolibc/archive/${picolibc_commit}.zip" --output "${picolibc_source_dir}/picolibc.zip"
 unzip -q "${picolibc_source_dir}/picolibc.zip" -d "${picolibc_source_dir}"
 mv "${picolibc_source_dir}/picolibc-${picolibc_commit}"/* "${picolibc_source_dir}"


### PR DESCRIPTION
With this change, two xfails have been removed.

It also introduces a header inclusion for test macros that was wrongly missed.