### PR TITLE
[lld][macho] Use reloc length correctly in hash computation

### DIFF
--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -61,12 +61,13 @@ struct BPOrdererMachO : lld::BPOrderer<BPOrdererMachO> {
 
     // Calculate relocation hashes
     for (const auto &r : sec.relocs) {
-      if (r.length == 0 || r.referent.isNull() || r.offset >= data.size())
+      uint32_t relocLength = 1 << r.length;
+      if (r.referent.isNull() || r.offset + relocLength > data.size())
         continue;
 
       uint64_t relocHash = getRelocHash(r, sectionToIdx);
       uint32_t start = (r.offset < windowSize) ? 0 : r.offset - windowSize + 1;
-      for (uint32_t i = start; i < r.offset + r.length; i++) {
+      for (uint32_t i = start; i < r.offset + relocLength; i++) {
         auto window = data.drop_front(i).take_front(windowSize);
         hashes.push_back(xxh3_64bits(window) ^ relocHash);
       }


### PR DESCRIPTION
`Reloc::length` actually encodes the log2 of the length. Thanks @int3 for pointing this out in https://github.com/llvm/llvm-project/issues/160894#issuecomment-3416250179.

This code computes hashes of relocations. With the correct length, the hashes should more accurately represent the relocation. In my testing of some large binaries, the compressed size change is negligable.