### PR TITLE
[dsymutil] Add option to copy swiftmodules built from interface

### DIFF
--- a/llvm/docs/CommandGuide/dsymutil.rst
+++ b/llvm/docs/CommandGuide/dsymutil.rst
@@ -70,6 +70,14 @@ OPTIONS
 
  Print this help output.
 
+.. option:: --include-swiftmodules-from-interface
+
+ Whether or not to copy binary swiftmodules built from textual .swiftinterface
+ files into the dSYM bundle. These typically come only from the SDK (since
+ textual interfaces require library evolution) and thus are a waste of space to
+ copy into the bundle. Turn this on if the swiftmodules are different from
+ those in the SDK.
+
 .. option:: --keep-function-for-static
 
  Make a static variable keep the enclosing function even if it would have been

--- a/llvm/test/tools/dsymutil/ARM/swiftmodule-include-from-interface.test
+++ b/llvm/test/tools/dsymutil/ARM/swiftmodule-include-from-interface.test
@@ -1,0 +1,33 @@
+# RUN: dsymutil -include-swiftmodules-from-interface -verbose -oso-prepend-path=%p -y -o %t.dSYM  %s | FileCheck %s
+#
+# RUN: dsymutil -include-swiftmodules-from-interface --linker parallel -verbose -oso-prepend-path=%p -y %s -o %t-parallel.dSYM | FileCheck %s
+#
+# To regenerate:
+# echo ''>I.swift
+# echo ''>B.swift
+# echo 'import I'>main.swift
+# xcrun swiftc -emit-module-interface-path I.swiftinterface -enable-library-evolution I.swift
+# xcrun swiftc -emit-module-path B.swiftmodule B.swift -Xfrontend -no-serialize-debugging-options
+# xcrun swiftc -explicit-module-build main.swift -I. -module-cache-path cache -g -Xfrontend  -no-serialize-debugging-options
+# output is "B.swiftmodule" and "cache/I*.swiftmodule"
+#
+# CHECK-NOT: Skipping compiled textual Swift interface: {{.*}}/Inputs/Binary.swiftmodule
+# CHECK-NOT: Skipping compiled textual Swift interface: {{.*}}/Inputs/FromInterface.swiftmodule
+
+#
+---
+triple:          'arm64-apple-darwin'
+objects:
+  - filename:        '../Inputs/Binary.swiftmodule'
+    timestamp:       0
+    type:            50
+    symbols:         []
+  - filename:        '../Inputs/FromInterface.swiftmodule'
+    timestamp:       0
+    type:            50
+    symbols:         []
+  - filename:        '../Inputs/FromInterface.swiftmodule'
+    timestamp:       0
+    type:            50
+    symbols:         []
+...

--- a/llvm/test/tools/dsymutil/cmdline.test
+++ b/llvm/test/tools/dsymutil/cmdline.test
@@ -14,6 +14,7 @@ CHECK: -fat64
 CHECK: -flat
 CHECK: -gen-reproducer
 CHECK: -help
+CHECK: -include-swiftmodules-from-interface
 CHECK: -keep-function-for-static
 CHECK: -no-object-timestamp
 CHECK: -no-odr

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -794,9 +794,9 @@ bool DwarfLinkerForBinary::linkImpl(
         reportWarning("Could not parse binary Swift module: " +
                           toString(FromInterfaceOrErr.takeError()),
                       Obj->getObjectFilename());
-        // Only skip swiftmodules that could be parsed and are
-        // positively identified as textual.
-      } else if (*FromInterfaceOrErr) {
+        // Only skip swiftmodules that could be parsed and are positively
+        // identified as textual. Do so only when the option allows.
+      } else if (*FromInterfaceOrErr && !Options.IncludeSwiftModulesFromInterface) {
         if (Options.Verbose)
           outs() << "Skipping compiled textual Swift interface: "
                  << Obj->getObjectFilename() << "\n";

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -796,7 +796,8 @@ bool DwarfLinkerForBinary::linkImpl(
                       Obj->getObjectFilename());
         // Only skip swiftmodules that could be parsed and are positively
         // identified as textual. Do so only when the option allows.
-      } else if (*FromInterfaceOrErr && !Options.IncludeSwiftModulesFromInterface) {
+      } else if (*FromInterfaceOrErr &&
+                 !Options.IncludeSwiftModulesFromInterface) {
         if (Options.Verbose)
           outs() << "Skipping compiled textual Swift interface: "
                  << Obj->getObjectFilename() << "\n";

--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -114,6 +114,13 @@ struct LinkOptions {
   /// Whether all remarks should be kept or only remarks with valid debug
   /// locations.
   bool RemarksKeepAll = true;
+
+  /// Whether or not to copy binary swiftmodules built from textual
+  /// .swiftinterface files into the dSYM bundle. These typically come only
+  /// from the SDK (since textual interfaces require library evolution) and
+  /// thus are a waste of space to copy into the bundle. Turn this on if the
+  /// swiftmodules are different from those in the SDK.
+  bool IncludeSwiftModulesFromInterface = false;
   /// @}
 
   LinkOptions() = default;

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -202,6 +202,14 @@ def remarks_drop_without_debug: Flag<["--", "-"], "remarks-drop-without-debug">,
            "all remarks are kept.">,
   Group<grp_general>;
 
+def include_swiftmodules_from_interface: Flag<["--", "-"], "include-swiftmodules-from-interface">,
+  HelpText<"Whether or not to copy binary swiftmodules built from textual "
+  ".swiftinterface files into the dSYM bundle. These typically come only "
+  "from the SDK (since textual interfaces require library evolution) and "
+  "thus are a waste of space to copy into the bundle. Turn this on if the "
+  "swiftmodules are different from those in the SDK.">,
+  Group<grp_general>;
+
 def linker: Separate<["--", "-"], "linker">,
   MetaVarName<"<DWARF linker type>">,
   HelpText<"Specify the desired type of DWARF linker. Defaults to 'classic'">,

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -391,6 +391,9 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   Options.LinkOpts.RemarksKeepAll =
       !Args.hasArg(OPT_remarks_drop_without_debug);
 
+  Options.LinkOpts.IncludeSwiftModulesFromInterface =
+      Args.hasArg(OPT_include_swiftmodules_from_interface);
+
   if (opt::Arg *BuildVariantSuffix = Args.getLastArg(OPT_build_variant_suffix))
     Options.LinkOpts.BuildVariantSuffix = BuildVariantSuffix->getValue();
 


### PR DESCRIPTION
# Change

The default behavior is to _not_ copy such swiftmodules into the dSYM, as perviously implemented in 96f95c9d89d8a1784d3865fa941fb1c510f4e2d7. This patch adds the option to override the behavior, so that such swiftmodules can be copied into the dSYM.

This is useful when the dSYM will be used on a machine which has a different Xcode/SDK than where the swiftmodules were built. Without this, when LLDB is asked to "p/po" a Swift variable, the underlying Swift compiler code would rebuild the dependent `.swiftmodule` files of the Swift stdlibs, which takes ~1 minute in some cases.


# Test

**Shell tests:**
```
royshi-mac-office ~/public_llvm/build % bin/llvm-lit              \
    ../llvm-project/llvm/test/tools/dsymutil/cmdline.test         \
    ../llvm-project/llvm/test/tools/dsymutil/ARM/swiftmodule.test \
    ../llvm-project/llvm/test/tools/dsymutil/ARM/swiftmodule-include-from-interface.test

-- Testing: 3 tests, 3 workers --
PASS: LLVM :: tools/dsymutil/cmdline.test (1 of 3)
PASS: LLVM :: tools/dsymutil/ARM/swiftmodule-include-from-interface.test (2 of 3)
PASS: LLVM :: tools/dsymutil/ARM/swiftmodule.test (3 of 3)

Testing Time: 6.07s

Total Discovered Tests: 3
  Passed: 3 (100.00%)
```

--

**Manually tested** by running dsymutil to build a dSYM with and without the option and then checking the size of the `__swift_ast` section.

Without change:
```
royshi-mac-office ~/fbsource % ~/public_llvm/build/bin/dsymutil buck-out/v2/gen/fbsource/6aca8cf7b38a80d6/fbobjc/Apps/Internal/FocusPlayground/__FocusPlayground__/FocusPlayground.app/Frameworks/Features.framework/Features
royshi-mac-office ~/fbsource % otool -lv buck-out/v2/gen/fbsource/6aca8cf7b38a80d6/fbobjc/Apps/Internal/FocusPlayground/__FocusPlayground__/FocusPlayground.app/Frameworks/Features.framework/Features.dSYM/Contents/Resources/DWARF/Features | grep -B 1 -A 3 __swift_ast
Section
  sectname __swift_ast
   segname __DWARF
      addr 0x000000000001c000
      size 0x0000000000033dc4   <-- This is small.
```

With change:
```
royshi-mac-office ~/fbsource % ~/public_llvm/build/bin/dsymutil buck-out/v2/gen/fbsource/6aca8cf7b38a80d6/fbobjc/Apps/Internal/FocusPlayground/__FocusPlayground__/FocusPlayground.app/Frameworks/Features.framework/Features --include-swiftmodules-from-interface
royshi-mac-office ~/fbsource % otool -lv buck-out/v2/gen/fbsource/6aca8cf7b38a80d6/fbobjc/Apps/Internal/FocusPlayground/__FocusPlayground__/FocusPlayground.app/Frameworks/Features.framework/Features.dSYM/Contents/Resources/DWARF/Features | grep -B 1 -A 3 __swift_ast
Section
  sectname __swift_ast
   segname __DWARF
      addr 0x000000000001c000
      size 0x000000000205feec   <-- Notice the large increase in section size.
```
