### PR TITLE
[lit] Fix to make "RUN: env PATH=..." work as intended

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -945,7 +945,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
             path = (
                 cmd_shenv.env["PATH"] if "PATH" in cmd_shenv.env else shenv.env["PATH"]
             )
-            executable = lit.util.which(args[0], shenv.env["PATH"])
+            executable = lit.util.which(args[0], path)
         if not executable:
             raise InternalShellError(j, "%r: command not found" % args[0])
 

--- a/llvm/utils/lit/tests/Inputs/shtest-env-path/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-path/lit.cfg
@@ -1,0 +1,8 @@
+import lit.formats
+
+config.name = "shtest-env-path"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/shtest-env-path/path.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-path/path.txt
@@ -1,0 +1,8 @@
+## Tests env command for setting the PATH variable.
+
+## Check that test.sh can be found using the configured PATH.
+#
+# RUN: env PATH=%S test.sh | FileCheck --check-prefix=CHECK %s
+#
+
+# CHECK: TEST-ENV-PATH-123

--- a/llvm/utils/lit/tests/Inputs/shtest-env-path/test.sh
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-path/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "TEST-ENV-PATH-123"
+

--- a/llvm/utils/lit/tests/shtest-env-path.py
+++ b/llvm/utils/lit/tests/shtest-env-path.py
@@ -1,7 +1,7 @@
 ## Tests env command for setting the PATH variable.
 
 # The test is using /bin/sh. Limit to system known to have /bin/sh.
-# REQUIRED: system-linux
+# REQUIRES: system-linux
 
 # RUN: %{lit} -a -v %{inputs}/shtest-env-path/path.txt \
 # RUN:   | FileCheck -match-full-lines %s

--- a/llvm/utils/lit/tests/shtest-env-path.py
+++ b/llvm/utils/lit/tests/shtest-env-path.py
@@ -1,0 +1,13 @@
+## Tests env command for setting the PATH variable.
+
+# The test is using /bin/sh. Limit to system known to have /bin/sh.
+# REQUIRED: system-linux
+
+# RUN: %{lit} -a -v %{inputs}/shtest-env-path/path.txt \
+# RUN:   | FileCheck -match-full-lines %s
+#
+# END.
+
+# CHECK: -- Testing: 1 tests{{.*}}
+# CHECK: PASS: shtest-env-path :: path.txt (1 of 1)
+# CHECK: --


### PR DESCRIPTION
There was a bug in llvm-lit related to setting PATH using env in the internal shell.

The new PATH wasn't used when looking up the command to be executed. So when doing things like this in a test case
  RUN: mkdir %t
  RUN: env PATH=%t program ...
the internal shell would search for "program" using the orignal PATH and not the PATH set by env when preceeding the command.

It seems like this was a simple mistake in commit 57782eff31e9d454, since the logic to pick a PATH from the cmd_shenv instead of shenv actually was added in that patch, but the resulting path wasn't used.