### PR TITLE
[DirectX] Allow llvm.assume intrinsic to pass on to DXIL

### DIFF
--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -904,6 +904,8 @@ public:
       case Intrinsic::dx_resource_casthandle:
       // NOTE: llvm.dbg.value is supported as is in DXIL.
       case Intrinsic::dbg_value:
+      // NOTE: llvm.assume is supported as is in DXIL.
+      case Intrinsic::assume:
       case Intrinsic::not_intrinsic:
         if (F.use_empty())
           F.eraseFromParent();

--- a/llvm/test/tools/dxil-dis/llvm_assume.ll
+++ b/llvm/test/tools/dxil-dis/llvm_assume.ll
@@ -1,0 +1,11 @@
+; RUN: llc --filetype=obj %s -o - | dxil-dis -o - | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.7-library"
+
+define void @test_llvm_assume(i1 %0)  {
+; CHECK-LABEL: test_llvm_assume
+; CHECK-NEXT: tail call void @llvm.assume(i1 %0)
+tail call void @llvm.assume(i1 %0)
+ret void
+}
+


### PR DESCRIPTION
fixes #165051

Change is just to let the assume intrinsic pass on unmodified. Test is to confirm the DXIL disassembler doesn't blow up whe we generate DXIL with this intrinsic.