### PR TITLE
[DataLayout] Add isNullPointerAllZeroes

### DIFF
--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -400,9 +400,7 @@ public:
 
   /// Returns if the null pointer for this address space has an all-zero bit
   /// representation.
-  bool isNullPointerAllZeroes(unsigned AddrSpace) const {
-    return AddrSpace == 0;
-  }
+  bool isNullPointerAllZeroes(unsigned AddrSpace) const { return true; }
 
   /// Returns whether this address space has an "unstable" pointer
   /// representation. The bitwise pattern of such pointers is allowed to change

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -398,6 +398,12 @@ public:
            PS.HasExternalState;
   }
 
+  /// Returns if the null pointer for this address space has an all-zero bit
+  /// representation.
+  bool isNullPointerAllZeroes(unsigned AddrSpace) const {
+    return AddrSpace == 0;
+  }
+
   /// Returns whether this address space has an "unstable" pointer
   /// representation. The bitwise pattern of such pointers is allowed to change
   /// in a target-specific way. For example, this could be used for copying

--- a/llvm/unittests/IR/DataLayoutTest.cpp
+++ b/llvm/unittests/IR/DataLayoutTest.cpp
@@ -700,6 +700,15 @@ TEST(DataLayout, NonIntegralHelpers) {
   }
 }
 
+TEST(DataLayoutTest, IsNullPointerAllZeroes) {
+  EXPECT_TRUE(DataLayout("").isNullPointerAllZeroes(0));
+  EXPECT_FALSE(DataLayout("").isNullPointerAllZeroes(1));
+  EXPECT_TRUE(DataLayout("p:32:32").isNullPointerAllZeroes(0));
+  EXPECT_FALSE(DataLayout("p:32:32").isNullPointerAllZeroes(1));
+  EXPECT_TRUE(DataLayout("p:64:64").isNullPointerAllZeroes(0));
+  EXPECT_FALSE(DataLayout("p:64:64").isNullPointerAllZeroes(1));
+}
+
 TEST(DataLayoutTest, CopyAssignmentInvalidatesStructLayout) {
   DataLayout DL1 = cantFail(DataLayout::parse("p:32:32"));
   DataLayout DL2 = cantFail(DataLayout::parse("p:64:64"));

--- a/llvm/unittests/IR/DataLayoutTest.cpp
+++ b/llvm/unittests/IR/DataLayoutTest.cpp
@@ -702,11 +702,11 @@ TEST(DataLayout, NonIntegralHelpers) {
 
 TEST(DataLayoutTest, IsNullPointerAllZeroes) {
   EXPECT_TRUE(DataLayout("").isNullPointerAllZeroes(0));
-  EXPECT_FALSE(DataLayout("").isNullPointerAllZeroes(1));
+  EXPECT_TRUE(DataLayout("").isNullPointerAllZeroes(1));
   EXPECT_TRUE(DataLayout("p:32:32").isNullPointerAllZeroes(0));
-  EXPECT_FALSE(DataLayout("p:32:32").isNullPointerAllZeroes(1));
+  EXPECT_TRUE(DataLayout("p:32:32").isNullPointerAllZeroes(1));
   EXPECT_TRUE(DataLayout("p:64:64").isNullPointerAllZeroes(0));
-  EXPECT_FALSE(DataLayout("p:64:64").isNullPointerAllZeroes(1));
+  EXPECT_TRUE(DataLayout("p:64:64").isNullPointerAllZeroes(1));
 }
 
 TEST(DataLayoutTest, CopyAssignmentInvalidatesStructLayout) {


### PR DESCRIPTION
Add a function to check for a given address space if its null pointer has an all-zero bit representation.

---------

See https://github.com/llvm/llvm-project/pull/140802#discussion_r2466373958
Maybe something like `getNullPointerValue` would be more useful, but would depend on https://github.com/llvm/llvm-project/pull/131557 and the open questions around it.