### PR TITLE
(WIP) lower waveid on GFX9

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -2839,6 +2839,9 @@ def int_amdgcn_global_load_lds : AMDGPUGlobalLoadLDS;
 def int_amdgcn_pops_exiting_wave_id :
   DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrNoMem, IntrHasSideEffects]>;
 
+// i32 @llvm.amdgcn.gfx9_wave_id(i32)
+def int_amdgcn_gfx9_wave_id : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem, IntrConvergent]>;
+
 //===----------------------------------------------------------------------===//
 // GFX10 Intrinsics
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
#### There are still some problems in this draft so it's tagged with WIP ####
There is no safeway to get `waveid`, which is computed in [getLaneAndWarpId](https://github.com/triton-lang/triton/blob/main/lib/Conversion/TritonGPUToLLVM/Utility.cpp#L352)
on GFX9 by reading a scalar register.
In this PR, we add a new intrinsic `gfx9_wave_id` with attribute `convergent`.
In the lowering phase, we will re-compute workitem.id and apply 
 `waveid = (workitem.id.x & (num_warps * threads_per_warp)) / wavefront_size`