### PR TITLE
[llvm][UnifyLoopExits] Avoid optimization if no exit block is found

### DIFF
--- a/llvm/lib/Transforms/Utils/ControlFlowUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ControlFlowUtils.cpp
@@ -299,6 +299,8 @@ std::pair<BasicBlock *, bool> ControlFlowHub::finalize(
       Outgoing.insert(Succ1);
   }
 
+  assert(Outgoing.size() && "No outgoing edges");
+
   if (Outgoing.size() < 2)
     return {Outgoing.front(), false};
 

--- a/llvm/lib/Transforms/Utils/UnifyLoopExits.cpp
+++ b/llvm/lib/Transforms/Utils/UnifyLoopExits.cpp
@@ -154,8 +154,13 @@ static bool unifyLoopExits(DominatorTree &DT, LoopInfo &LI, Loop *L) {
   SmallVector<BasicBlock *, 8> ExitingBlocks;
   L->getExitingBlocks(ExitingBlocks);
 
+  // No exit blocks, so nothing to do. Just return.
+  if (ExitingBlocks.empty())
+    return false;
+
   DomTreeUpdater DTU(DT, DomTreeUpdater::UpdateStrategy::Eager);
   SmallVector<BasicBlock *, 8> CallBrTargetBlocksToFix;
+
   // Redirect exiting edges through a control flow hub.
   ControlFlowHub CHub;
   bool Changed = false;

--- a/llvm/test/Transforms/UnifyLoopExits/no-exit-blocks.ll
+++ b/llvm/test/Transforms/UnifyLoopExits/no-exit-blocks.ll
@@ -1,0 +1,15 @@
+; RUN: opt -passes=unify-loop-exits -S %s
+; Based from this issue: https://github.com/llvm/llvm-project/issues/165252
+
+define void @test() {
+entry:
+  br i1 true, label %end, label %Loop
+
+Loop:
+  %V = phi i32 [0, %entry], [%V1, %Loop]
+  %V1 = add i32 %V, 1
+  br label %Loop
+
+end:
+  ret void
+}


### PR DESCRIPTION
If there is not an exit block, we should not try unify the loops. Instead we should just return.

Fixes #165252