### PR TITLE
[BOLT] Fix thread-safety of PointerAuthCFIAnalyzer

### DIFF
--- a/bolt/include/bolt/Passes/PointerAuthCFIAnalyzer.h
+++ b/bolt/include/bolt/Passes/PointerAuthCFIAnalyzer.h
@@ -13,11 +13,16 @@
 #define BOLT_PASSES_POINTER_AUTH_CFI_ANALYZER
 
 #include "bolt/Passes/BinaryPasses.h"
+#include <mutex>
 
 namespace llvm {
 namespace bolt {
 
 class PointerAuthCFIAnalyzer : public BinaryFunctionPass {
+  // setIgnored() is not thread-safe, but the pass is running on functions in
+  // parallel.
+  std::mutex IgnoreMutex;
+
 public:
   explicit PointerAuthCFIAnalyzer() : BinaryFunctionPass(false) {}
 

--- a/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
+++ b/bolt/lib/Passes/PointerAuthCFIAnalyzer.cpp
@@ -47,6 +47,7 @@ bool PointerAuthCFIAnalyzer::runOnFunction(BinaryFunction &BF) {
         // Not all functions have .cfi_negate_ra_state in them. But if one does,
         // we expect psign/pauth instructions to have the hasNegateRAState
         // annotation.
+        std::lock_guard<std::mutex> Lock(IgnoreMutex);
         BF.setIgnored();
         if (opts::Verbosity >= 1)
           BC.outs() << "BOLT-INFO: inconsistent RAStates in function "
@@ -73,6 +74,7 @@ bool PointerAuthCFIAnalyzer::runOnFunction(BinaryFunction &BF) {
             BC.outs() << "BOLT-INFO: inconsistent RAStates in function "
                       << BF.getPrintName()
                       << ": ptr signing inst encountered in Signed RA state\n";
+          std::lock_guard<std::mutex> Lock(IgnoreMutex);
           BF.setIgnored();
           return false;
         }
@@ -84,6 +86,7 @@ bool PointerAuthCFIAnalyzer::runOnFunction(BinaryFunction &BF) {
                       << BF.getPrintName()
                       << ": ptr authenticating inst encountered in Unsigned RA "
                          "state\n";
+          std::lock_guard<std::mutex> Lock(IgnoreMutex);
           BF.setIgnored();
           return false;
         }


### PR DESCRIPTION
The pass calls setIgnored() on functions in parallel, but setIgnored is
not thread safe. The patch adds a mutex to guard setIgnored calls.

Fixes: #165362