### PR TITLE
[LLVM][IR] Emit diagnostic for invalid pointee type for constant GEP.

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4538,11 +4538,11 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
       if (!Indices.empty() && !Ty->isSized(&Visited))
         return error(ID.Loc, "base element of getelementptr must be sized");
 
-      if (!GetElementPtrInst::getIndexedType(Ty, Indices))
-        return error(ID.Loc, "invalid getelementptr indices");
-
       if (!ConstantExpr::isSupportedGetElementPtr(Ty))
         return error(ID.Loc, "invalid base element for constant getelementptr");
+
+      if (!GetElementPtrInst::getIndexedType(Ty, Indices))
+        return error(ID.Loc, "invalid getelementptr indices");
 
       ID.ConstantVal =
           ConstantExpr::getGetElementPtr(Ty, Elts[0], Indices, NW, InRange);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4541,6 +4541,9 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
       if (!GetElementPtrInst::getIndexedType(Ty, Indices))
         return error(ID.Loc, "invalid getelementptr indices");
 
+      if (!ConstantExpr::isSupportedGetElementPtr(Ty))
+        return error(ID.Loc, "invalid base element for constant getelementptr");
+
       ID.ConstantVal =
           ConstantExpr::getGetElementPtr(Ty, Elts[0], Indices, NW, InRange);
     } else if (Opc == Instruction::ShuffleVector) {

--- a/llvm/test/Assembler/constant-getelementptr-scalable_pointee.ll
+++ b/llvm/test/Assembler/constant-getelementptr-scalable_pointee.ll
@@ -1,0 +1,8 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+; Test the case of an invalid pointee type on a constant GEP
+
+; CHECK: invalid base element for constant getelementptr
+
+define ptr @test_scalable_vector_gep(ptr %a) {
+  ret ptr getelementptr (<vscale x 1 x i8>, ptr @a, i64 1)
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/165137