### PR TITLE
[BOLT] Add validation for direct call/branch targets

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -934,10 +934,11 @@ public:
   /// that should be used by the branch. For example, main or secondary entry
   /// point.
   ///
-  /// If \p Address is an invalid destination, such as a constant island, return
-  /// nullptr and mark \p BF as ignored, since we cannot properly handle a
-  /// branch to a constant island.
-  MCSymbol *handleExternalBranchTarget(uint64_t Address, BinaryFunction &BF);
+  /// This function also performs validations: If \p Address points to an
+  /// invalid instruction or lies within a constant island, return nullptr and
+  /// mark both \p Source and \p Target as ignored.
+  MCSymbol *handleExternalBranchTarget(uint64_t Address, BinaryFunction &Source,
+                                       BinaryFunction &Target);
 
   /// Analyze memory contents at the given \p Address and return the type of
   /// memory contents (such as a possible jump table).

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -2264,13 +2264,6 @@ public:
   /// it is probably another function.
   bool isSymbolValidInScope(const SymbolRef &Symbol, uint64_t SymbolSize) const;
 
-  /// Validates if the target of a direct branch/call is a valid
-  /// executable instruction.
-  /// Return true if the target is valid, false otherwise.
-  bool validateBranchTarget(uint64_t TargetAddress,
-                            uint64_t AbsoluteInstrAddr,
-                            const ArrayRef<uint8_t> &CurrentFunctionData);
-
   /// Disassemble function from raw data.
   /// If successful, this function will populate the list of instructions
   /// for this function together with offsets from the function start
@@ -2326,6 +2319,16 @@ public:
   /// Verify that starting at \p Offset function contents are filled with
   /// zero-value bytes.
   bool isZeroPaddingAt(uint64_t Offset) const;
+
+  /// Validates if the target of an external direct branch/call is a valid
+  /// executable instruction.
+  /// Return true if the target is valid, false otherwise.
+  bool validateExternalBranch(uint64_t TargetAddress);
+
+  /// Validates if the target of an internal direct branch/call is a valid
+  /// executable instruction.
+  /// Return true if the target is valid, false otherwise.
+  bool validateInternalBranch();
 
   /// Check that entry points have an associated instruction at their
   /// offsets after disassembly.

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -2264,6 +2264,13 @@ public:
   /// it is probably another function.
   bool isSymbolValidInScope(const SymbolRef &Symbol, uint64_t SymbolSize) const;
 
+  /// Validates if the target of a direct branch/call is a valid
+  /// executable instruction.
+  /// Return true if the target is valid, false otherwise.
+  bool validateBranchTarget(uint64_t TargetAddress,
+                            uint64_t AbsoluteInstrAddr,
+                            const ArrayRef<uint8_t> &CurrentFunctionData);
+
   /// Disassemble function from raw data.
   /// If successful, this function will populate the list of instructions
   /// for this function together with offsets from the function start

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -385,6 +385,10 @@ private:
   /// True if the function should not have an associated symbol table entry.
   bool IsAnonymous{false};
 
+  /// Indicates whether branch validation has already been performed,
+  /// to avoid redundant processing.
+  bool NeedBranchValidation{true};
+
   /// Name for the section this function code should reside in.
   std::string CodeSectionName;
 

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -2320,15 +2320,15 @@ public:
   /// zero-value bytes.
   bool isZeroPaddingAt(uint64_t Offset) const;
 
-  /// Validates if the target of an external direct branch/call is a valid
+  /// Validate if the target of an external direct branch/call is a valid
   /// executable instruction.
   /// Return true if the target is valid, false otherwise.
   bool validateExternalBranch(uint64_t TargetAddress);
 
-  /// Validates if the target of an internal direct branch/call is a valid
+  /// Validate if the target of any internal direct branch/call is a valid
   /// executable instruction.
-  /// Return true if the target is valid, false otherwise.
-  bool validateInternalBranch();
+  /// Return true if all the targets are valid, false otherwise.
+  bool validateInternalBranches();
 
   /// Check that entry points have an associated instruction at their
   /// offsets after disassembly.

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -2320,11 +2320,6 @@ public:
   /// zero-value bytes.
   bool isZeroPaddingAt(uint64_t Offset) const;
 
-  /// Validate if the target of an external direct branch/call is a valid
-  /// executable instruction.
-  /// Return true if the target is valid, false otherwise.
-  bool validateExternalBranch(uint64_t TargetAddress);
-
   /// Validate if the target of any internal direct branch/call is a valid
   /// executable instruction.
   /// Return true if all the targets are valid, false otherwise.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1421,9 +1421,6 @@ void BinaryContext::processInterproceduralReferences() {
     if (&Function == TargetFunction)
       continue;
 
-    if (!Function.validateExternalBranch(Address))
-      continue;
-
     if (TargetFunction) {
       if (TargetFunction->isFragment() &&
           !areRelatedFragments(TargetFunction, &Function)) {
@@ -1440,6 +1437,9 @@ void BinaryContext::processInterproceduralReferences() {
 
       continue;
     }
+
+    if (!Function.validateExternalBranch(Address))
+      continue;
 
     // Check if address falls in function padding space - this could be
     // unmarked data in code. In this case adjust the padding space size.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1421,6 +1421,9 @@ void BinaryContext::processInterproceduralReferences() {
     if (&Function == TargetFunction)
       continue;
 
+    if (!Function.validateExternalBranch(Address))
+      continue;
+
     if (TargetFunction) {
       if (TargetFunction->isFragment() &&
           !areRelatedFragments(TargetFunction, &Function)) {

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -544,7 +544,7 @@ MCSymbol *BinaryContext::handleExternalBranchTarget(uint64_t Address,
       this->outs()
           << "BOLT-WARNING: corrupted control flow detected in function "
           << Source
-          << ", an external branch/call targets an invalid instruction "
+          << ": an external branch/call targets an invalid instruction "
           << "at address 0x" << Twine::utohexstr(Address) << '\n';
       IsValid = false;
     }

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -546,7 +546,7 @@ MCSymbol *BinaryContext::handleExternalBranchTarget(uint64_t Address,
           << Source
           << ": an external branch/call targets an invalid instruction "
           << "in function " << Target << " at address 0x"
-          << Twine::utohexstr(Address) << ", ignoring both functions\n";
+          << Twine::utohexstr(Address) << "; ignoring both functions\n";
       IsValid = false;
     }
     if (Target.isInConstantIsland(Address)) {

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -541,7 +541,7 @@ MCSymbol *BinaryContext::handleExternalBranchTarget(uint64_t Address,
   if (Source.NeedBranchValidation) {
     if (Target.CurrentState == BinaryFunction::State::Disassembled &&
         !Target.getInstructionAtOffset(Offset)) {
-      this->outs()
+      this->errs()
           << "BOLT-WARNING: corrupted control flow detected in function "
           << Source
           << ": an external branch/call targets an invalid instruction "
@@ -549,7 +549,7 @@ MCSymbol *BinaryContext::handleExternalBranchTarget(uint64_t Address,
       IsValid = false;
     }
     if (Target.isInConstantIsland(Address)) {
-      this->outs() << "BOLT-WARNING: ignoring entry point at address 0x"
+      this->errs() << "BOLT-WARNING: ignoring entry point at address 0x"
                    << Twine::utohexstr(Address)
                    << " in constant island of function " << Target << '\n';
       IsValid = false;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -545,7 +545,8 @@ MCSymbol *BinaryContext::handleExternalBranchTarget(uint64_t Address,
           << "BOLT-WARNING: corrupted control flow detected in function "
           << Source
           << ": an external branch/call targets an invalid instruction "
-          << "at address 0x" << Twine::utohexstr(Address) << '\n';
+          << "in function " << Target << " at address 0x"
+          << Twine::utohexstr(Address) << ", ignoring both functions\n";
       IsValid = false;
     }
     if (Target.isInConstantIsland(Address)) {

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1283,6 +1283,41 @@ BinaryFunction::disassembleInstructionAtOffset(uint64_t Offset) const {
   return std::nullopt;
 }
 
+bool BinaryFunction::validateBranchTarget(
+    uint64_t TargetAddress, uint64_t AbsoluteInstrAddr,
+    const ArrayRef<uint8_t> &CurrentFunctionData) {
+  if (auto *TargetFunc =
+          BC.getBinaryFunctionContainingAddress(TargetAddress)) {
+    const uint64_t TargetOffset = TargetAddress - TargetFunc->getAddress();
+    ArrayRef<uint8_t> TargetFunctionData;
+    // Check if the target address is within the current function.
+    if (TargetFunc == this) {
+      TargetFunctionData = CurrentFunctionData;
+    } else {
+      // external call/branch, fetch the binary data for target
+      ErrorOr<ArrayRef<uint8_t>> TargetDataOrErr = TargetFunc->getData();
+      assert(TargetDataOrErr && "function data is not available");
+      TargetFunctionData = *TargetDataOrErr;
+    }
+
+    MCInst TargetInst;
+    uint64_t TargetInstSize;
+    if (!BC.SymbolicDisAsm->getInstruction(
+            TargetInst, TargetInstSize, TargetFunctionData.slice(TargetOffset),
+            TargetAddress, nulls())) {
+      // If the target address cannot be disassembled well,
+      // it implies a corrupted control flow.
+      BC.errs() << "BOLT-WARNING: direct branch/call at 0x"
+                << Twine::utohexstr(AbsoluteInstrAddr) << " in function "
+                << *this << " targets an invalid instruction at 0x"
+                << Twine::utohexstr(TargetAddress) << "\n";
+      return false;
+    }
+  }
+
+  return true;
+}
+
 Error BinaryFunction::disassemble() {
   NamedRegionTimer T("disassemble", "Disassemble function", "buildfuncs",
                      "Build Binary Functions", opts::TimeBuild);
@@ -1396,6 +1431,11 @@ Error BinaryFunction::disassemble() {
       uint64_t TargetAddress = 0;
       if (MIB->evaluateBranch(Instruction, AbsoluteInstrAddr, Size,
                               TargetAddress)) {
+        if (!validateBranchTarget(TargetAddress, AbsoluteInstrAddr,
+                                  FunctionData)) {
+          setIgnored();
+          break;
+        }
         // Check if the target is within the same function. Otherwise it's
         // a call, possibly a tail call.
         //

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1919,6 +1919,11 @@ bool BinaryFunction::validateExternalBranch(uint64_t TargetAddress) {
 
   if (TargetFunction) {
     const uint64_t TargetOffset = TargetAddress - TargetFunction->getAddress();
+    // Skip empty functions and out-of-bounds offsets,
+    // as they may not be disassembled.
+    if (!TargetOffset || (TargetOffset > TargetFunction->getSize()))
+      return true;
+
     if (TargetFunction->CurrentState == State::Disassembled &&
         !TargetFunction->getInstructionAtOffset(TargetOffset))
       IsValid = false;
@@ -1949,8 +1954,12 @@ bool BinaryFunction::validateInternalBranch() {
       continue;
 
     const uint32_t Offset = KV.first;
+    // Skip empty functions and out-of-bounds offsets,
+    // as they may not be disassembled.
+    if (!Offset || (Offset > getSize()))
+      continue;
 
-    if (getInstructionAtOffset(Offset) || !Offset)
+    if (getInstructionAtOffset(Offset))
       continue;
 
     BC.errs() << "BOLT-WARNING: corrupted control flow detected in function "

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1927,7 +1927,7 @@ bool BinaryFunction::validateInternalBranches() {
 
     if (!getInstructionAtOffset(Offset) ||
         isInConstantIsland(getAddress() + Offset)) {
-      BC.outs() << "BOLT-WARNING: corrupted control flow detected in function "
+      BC.errs() << "BOLT-WARNING: corrupted control flow detected in function "
                 << *this << ": an internal branch/call targets an invalid "
                 << "instruction at address 0x"
                 << Twine::utohexstr(getAddress() + Offset) << "\n";

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1930,7 +1930,8 @@ bool BinaryFunction::validateInternalBranches() {
       BC.errs() << "BOLT-WARNING: corrupted control flow detected in function "
                 << *this << ": an internal branch/call targets an invalid "
                 << "instruction at address 0x"
-                << Twine::utohexstr(getAddress() + Offset) << "\n";
+                << Twine::utohexstr(getAddress() + Offset)
+                << ", ignoring this function\n";
       setIgnored();
       return false;
     }

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1931,7 +1931,7 @@ bool BinaryFunction::validateInternalBranches() {
                 << *this << ": an internal branch/call targets an invalid "
                 << "instruction at address 0x"
                 << Twine::utohexstr(getAddress() + Offset)
-                << ", ignoring this function\n";
+                << "; ignoring this function\n";
       setIgnored();
       return false;
     }

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1928,7 +1928,7 @@ bool BinaryFunction::validateInternalBranches() {
     if (!getInstructionAtOffset(Offset) ||
         isInConstantIsland(getAddress() + Offset)) {
       BC.outs() << "BOLT-WARNING: corrupted control flow detected in function "
-                << *this << ", an internal branch/call targets an invalid "
+                << *this << ": an internal branch/call targets an invalid "
                 << "instruction at address 0x"
                 << Twine::utohexstr(getAddress() + Offset) << "\n";
       setIgnored();

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1702,7 +1702,7 @@ bool BinaryFunction::scanExternalRefs() {
       // Get a reference symbol for the function when address is a valid code
       // reference.
       BranchTargetSymbol =
-          BC.handleExternalBranchTarget(TargetAddress, *TargetFunction);
+          BC.handleExternalBranchTarget(TargetAddress, *this, *TargetFunction);
       if (!BranchTargetSymbol)
         continue;
     }
@@ -1925,8 +1925,9 @@ bool BinaryFunction::validateInternalBranches() {
     if (!Offset || (Offset > getSize()))
       continue;
 
-    if (!getInstructionAtOffset(Offset) || getSizeOfDataInCodeAt(Offset)) {
-      BC.errs() << "BOLT-WARNING: corrupted control flow detected in function "
+    if (!getInstructionAtOffset(Offset) ||
+        isInConstantIsland(getAddress() + Offset)) {
+      BC.outs() << "BOLT-WARNING: corrupted control flow detected in function "
                 << *this << ", an internal branch/call targets an invalid "
                 << "instruction at address 0x"
                 << Twine::utohexstr(getAddress() + Offset) << "\n";

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1947,7 +1947,7 @@ bool BinaryFunction::validateExternalBranch(uint64_t TargetAddress) {
   return true;
 }
 
-bool BinaryFunction::validateInternalBranch() {
+bool BinaryFunction::validateInternalBranches() {
   if (!isSimple())
     return true;
 

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3498,6 +3498,7 @@ void RewriteInstance::disassembleFunctions() {
     if (!shouldDisassemble(Function))
       continue;
 
+    Function.validateInternalBranch();
     Function.postProcessEntryPoints();
     Function.postProcessJumpTables();
   }

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3498,7 +3498,7 @@ void RewriteInstance::disassembleFunctions() {
     if (!shouldDisassemble(Function))
       continue;
 
-    Function.validateInternalBranch();
+    Function.validateInternalBranches();
     Function.postProcessEntryPoints();
     Function.postProcessJumpTables();
   }

--- a/bolt/test/AArch64/constant-island-alignment.s
+++ b/bolt/test/AArch64/constant-island-alignment.s
@@ -53,6 +53,7 @@ _start:
   blr x0
   mov x0, #1
   ret
+.size _start,.-_start
   nop
 # CHECK: {{0|8}} <$d>:
 .Lci:

--- a/bolt/test/AArch64/validate-branch-target.s
+++ b/bolt/test/AArch64/validate-branch-target.s
@@ -7,8 +7,8 @@
 # RUN: %clang %cflags %t/main.o -o main.exe -Wl,-q
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt, an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt, an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
 
 
 .globl  internal_corrupt

--- a/bolt/test/AArch64/validate-branch-target.s
+++ b/bolt/test/AArch64/validate-branch-target.s
@@ -7,8 +7,8 @@
 # RUN: %clang %cflags %t/main.o -o main.exe -Wl,-q
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction in function external_func at address 0x{{[0-9a-f]+}}, ignoring both functions
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}, ignoring this function
 
 
 .globl  internal_corrupt

--- a/bolt/test/AArch64/validate-branch-target.s
+++ b/bolt/test/AArch64/validate-branch-target.s
@@ -7,8 +7,8 @@
 # RUN: %clang %cflags %t/main.o -o main.exe -Wl,-q
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction in function external_func at address 0x{{[0-9a-f]+}}, ignoring both functions
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}, ignoring this function
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction in function external_func at address 0x{{[0-9a-f]+}}; ignoring both functions
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}; ignoring this function
 
 
 .globl  internal_corrupt

--- a/bolt/test/AArch64/validate-branch-target.s
+++ b/bolt/test/AArch64/validate-branch-target.s
@@ -1,0 +1,33 @@
+## Test that BOLT errs when detecting the target 
+## of a direct call/branch is a invalid instruction
+
+# REQUIRES: system-linux
+# RUN: rm -rf %t && mkdir -p %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-linux %s -o main.o
+# RUN: %clang %cflags %t/main.o -o main.exe -Wl,-q
+# RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
+
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt, an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt, an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+
+
+.globl  internal_corrupt
+.type   internal_corrupt,@function
+internal_corrupt:
+    ret
+    nop
+.Lfake_branch_1:
+    .inst 0x14000001  // Opcode 0x14=b, check for internal branch: b + 0x4
+.Lgarbage_1:
+    .word 0xffffffff
+.size   internal_corrupt,.-internal_corrupt
+
+
+.globl  external_corrupt
+.type   external_corrupt,@function
+external_corrupt:
+    ret
+    nop
+.Lfake_branch_2:
+    .inst   0x14000004  // Opcode 0x14=b, check for external branch: b + 0xf
+.size   external_corrupt,.-external_corrupt

--- a/bolt/test/AArch64/validate-branch-target.s
+++ b/bolt/test/AArch64/validate-branch-target.s
@@ -14,11 +14,8 @@
 .globl  internal_corrupt
 .type   internal_corrupt,@function
 internal_corrupt:
-    ret
-    nop
-.Lfake_branch_1:
-    .inst 0x14000001  // Opcode 0x14=b, check for internal branch: b + 0x4
-.Lgarbage_1:
+    b constant_island_0  // targeting the data in code
+constant_island_0:
     .word 0xffffffff
 .size   internal_corrupt,.-internal_corrupt
 
@@ -26,8 +23,14 @@ internal_corrupt:
 .globl  external_corrupt
 .type   external_corrupt,@function
 external_corrupt:
-    ret
-    nop
-.Lfake_branch_2:
-    .inst   0x14000004  // Opcode 0x14=b, check for external branch: b + 0xf
+    b   constant_island_1  // targeting the data in code externally
 .size   external_corrupt,.-external_corrupt
+
+.globl  external_func
+.type   external_func,@function
+external_func:
+    add x0, x0, x1
+constant_island_1:
+    .word 0xffffffff // data in code
+    ret
+.size   external_func,.-external_func

--- a/bolt/test/X86/validate-branch-target.s
+++ b/bolt/test/X86/validate-branch-target.s
@@ -1,0 +1,47 @@
+## Test that BOLT errs when detecting the target 
+## of a direct call/branch is a invalid instruction
+
+# REQUIRES: system-linux
+# RUN: rm -rf %t && mkdir -p %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o main.o
+# RUN: %clang %cflags -pie -Wl,-q %t/main.o -o main.exe
+# RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
+
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrcupt, an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrcupt, an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+
+
+.globl	internal_corrcupt
+.type	internal_corrcupt,@function
+.align	16
+internal_corrcupt:
+	leaq	.Lopts_1(%rip),%rax
+	addq	$25,%rax
+	.byte	0xf3,0xc3
+.L8xchar_1:
+	addq	$12,%rax
+.Ldone_1:
+	.byte	0xf3,0xc3
+.align	64
+.Lopts_1:
+.byte	114,1,52,40,56,120,44,105,110,116,41,0  # data '114' will be disassembled as 'jb', check for internal branch: jb + 0x1
+.align	64
+.size	internal_corrcupt,.-internal_corrcupt
+
+
+.globl	external_corrcupt
+.type	external_corrcupt,@function
+.align	16
+external_corrcupt:
+	leaq	.Lopts_2(%rip),%rax
+	addq	$25,%rax
+	.byte	0xf3,0xc3
+.L8xchar_2:
+	addq	$12,%rax
+.Ldone_2:
+	.byte	0xf3,0xc3
+.align	64
+.Lopts_2:
+.byte	114,99,52,40,56,120,44,99,104,97,114,41,0  # data '114' will be disassembled as 'jb', check for external branch: jb + 0x63
+.align	64
+.size	external_corrcupt,.-external_corrcupt

--- a/bolt/test/X86/validate-branch-target.s
+++ b/bolt/test/X86/validate-branch-target.s
@@ -7,8 +7,8 @@
 # RUN: %clang %cflags -pie -Wl,-q %t/main.o -o main.exe
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt, an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt, an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
 
 
 .globl	internal_corrupt

--- a/bolt/test/X86/validate-branch-target.s
+++ b/bolt/test/X86/validate-branch-target.s
@@ -7,8 +7,8 @@
 # RUN: %clang %cflags -pie -Wl,-q %t/main.o -o main.exe
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction in function external_func at address 0x{{[0-9a-f]+}}, ignoring both functions
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}, ignoring this function
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction in function external_func at address 0x{{[0-9a-f]+}}; ignoring both functions
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}; ignoring this function
 
 
 .globl	internal_corrupt

--- a/bolt/test/X86/validate-branch-target.s
+++ b/bolt/test/X86/validate-branch-target.s
@@ -7,8 +7,8 @@
 # RUN: %clang %cflags -pie -Wl,-q %t/main.o -o main.exe
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt: an external branch/call targets an invalid instruction in function external_func at address 0x{{[0-9a-f]+}}, ignoring both functions
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt: an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}, ignoring this function
 
 
 .globl	internal_corrupt

--- a/bolt/test/X86/validate-branch-target.s
+++ b/bolt/test/X86/validate-branch-target.s
@@ -7,14 +7,14 @@
 # RUN: %clang %cflags -pie -Wl,-q %t/main.o -o main.exe
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -lite=0 2>&1 | FileCheck %s --check-prefix=CHECK-TARGETS
 
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrcupt, an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
-# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrcupt, an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function external_corrupt, an external branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
+# CHECK-TARGETS: BOLT-WARNING: corrupted control flow detected in function internal_corrupt, an internal branch/call targets an invalid instruction at address 0x{{[0-9a-f]+}}
 
 
-.globl	internal_corrcupt
-.type	internal_corrcupt,@function
+.globl	internal_corrupt
+.type	internal_corrupt,@function
 .align	16
-internal_corrcupt:
+internal_corrupt:
 	leaq	.Lopts_1(%rip),%rax
 	addq	$25,%rax
 	.byte	0xf3,0xc3
@@ -26,13 +26,13 @@ internal_corrcupt:
 .Lopts_1:
 .byte	114,1,52,40,56,120,44,105,110,116,41,0  # data '114' will be disassembled as 'jb', check for internal branch: jb + 0x1
 .align	64
-.size	internal_corrcupt,.-internal_corrcupt
+.size	internal_corrupt,.-internal_corrupt
 
 
-.globl	external_corrcupt
-.type	external_corrcupt,@function
+.globl	external_corrupt
+.type	external_corrupt,@function
 .align	16
-external_corrcupt:
+external_corrupt:
 	leaq	.Lopts_2(%rip),%rax
 	addq	$25,%rax
 	.byte	0xf3,0xc3
@@ -44,4 +44,4 @@ external_corrcupt:
 .Lopts_2:
 .byte	114,99,52,40,56,120,44,99,104,97,114,41,0  # data '114' will be disassembled as 'jb', check for external branch: jb + 0x63
 .align	64
-.size	external_corrcupt,.-external_corrcupt
+.size	external_corrupt,.-external_corrupt

--- a/bolt/test/X86/validate-branch-target.s
+++ b/bolt/test/X86/validate-branch-target.s
@@ -13,35 +13,21 @@
 
 .globl	internal_corrupt
 .type	internal_corrupt,@function
-.align	16
 internal_corrupt:
-	leaq	.Lopts_1(%rip),%rax
-	addq	$25,%rax
-	.byte	0xf3,0xc3
-.L8xchar_1:
-	addq	$12,%rax
-.Ldone_1:
-	.byte	0xf3,0xc3
-.align	64
-.Lopts_1:
-.byte	114,1,52,40,56,120,44,105,110,116,41,0  # data '114' will be disassembled as 'jb', check for internal branch: jb + 0x1
-.align	64
+	jb  data_in_code + 1  # targeting the data in code, and jump into the middle of 'xorb' instruction
+data_in_code:
+	.byte 0x34, 0x01 # data in code, will be disassembled as 'xorb 0x1, %al'
 .size	internal_corrupt,.-internal_corrupt
 
 
 .globl	external_corrupt
 .type	external_corrupt,@function
-.align	16
 external_corrupt:
-	leaq	.Lopts_2(%rip),%rax
-	addq	$25,%rax
-	.byte	0xf3,0xc3
-.L8xchar_2:
-	addq	$12,%rax
-.Ldone_2:
-	.byte	0xf3,0xc3
-.align	64
-.Lopts_2:
-.byte	114,99,52,40,56,120,44,99,104,97,114,41,0  # data '114' will be disassembled as 'jb', check for external branch: jb + 0x63
-.align	64
+	jb  external_func + 1  # targeting the middle of normal instruction externally
 .size	external_corrupt,.-external_corrupt
+
+.globl	external_func
+.type	external_func,@function
+external_func:
+	addq  $1, %rax  # normal instruction
+.size	external_func,.-external_func


### PR DESCRIPTION
In some edge cases, a binary may contain direct `branch` or `call` instructions whose target do not point to a valid executable instruction. This can occur due to compiler bugs, hand-written assembly, obfuscation technique, **or when control flow targets a data by mistake.**

We also encountered the problems as described in this [issue](https://github.com/llvm/llvm-project/issues/149382), where "data in code" within OpenSSL's hand-written assembly was misidentified as instructions(island identification seems fail due to the absence of a corresponding data symbol). The problem occurred because a data sequence was incorrectly disassembled as a "jb" instruction. 

The point here is that the data should not be pointed to by any edge, so this patch tries to address this by validating the destination address for **direct branches and calls**. If the target instruction is invalid(implies a corrupted control flow), this function will be set ignored. 

Although this approach appears helpful for addressing the 'data in code' problem, its validation might be compromised if the data can be disassembled as normal instruction. 
