### PR TITLE
[OFFLOAD] Add support for more fine grained debug messages control

### DIFF
--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -42,6 +42,7 @@
 #include <mutex>
 #include <string>
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/circular_raw_ostream.h"
 
 /// 32-Bit field data attributes controlling information presented to the user.
@@ -330,11 +331,11 @@ struct DebugSettings {
 
     Settings.DefaultLevel = 1;
 
-    SmallVector<StringRef> DbgTypes;
-    EnvRef.split(DbgTypes, ',', -1, false);
-
-    for (auto &DT : DbgTypes)
-      Settings.Filters.push_back(parseDebugFilter(DT));
+    for (auto &FilterSpec : llvm::split(EnvRef, ',')) {
+      if (FilterSpec.empty())
+        continue;
+      Settings.Filters.push_back(parseDebugFilter(FilterSpec));
+    }
   });
 
   return Settings;

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -282,10 +282,10 @@ inline DebugSettings &getDebugSettings() {
   static std::once_flag Flag{};
   std::call_once(Flag, []() {
     printf("Configuring debug settings\n");
-    // Eventually, we probably should allow for the upper layers to set
-    // the debug settings directly according to their own env var
-    // (or other methods) settings.
-    // For now mantain compatibility with existing libomptarget env var
+    // Eventually, we probably should allow the upper layers to set
+    // debug settings directly according to their own env var or
+    // other methods.
+    // For now, mantain compatibility with existing libomptarget env var
     // and add a liboffload independent one.
     char *Env = getenv("LIBOMPTARGET_DEBUG");
     if (!Env) {
@@ -317,11 +317,10 @@ inline DebugSettings &getDebugSettings() {
   return Settings;
 }
 
-inline bool isDebugEnabled() {
-  return getDebugSettings().Enabled;
-}
+inline bool isDebugEnabled() { return getDebugSettings().Enabled; }
 
-inline bool shouldPrintDebug(const char *Component, const char *Type, uint32_t Level) {
+inline bool shouldPrintDebug(const char *Component, const char *Type,
+                             uint32_t Level) {
   const auto &Settings = getDebugSettings();
   if (!Settings.Enabled)
     return false;

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -227,12 +227,23 @@ inline uint32_t getDebugLevel() {
 // [integer]|all|<type1>[:<level1>][,<type2>[:<level2>],...]
 //
 // 0 : Disable all debug messages
-// all : Enable all debug messages
+// all : Enable all level 1 debug messages
 // integer : Set the default level for all messages
 // <type> : Enable only messages of the specified type and level (more than one
 //          can be specified). Components are also supported as
 //          types.
 // <level> : Set the verbosity level for the specified type (default is 1)
+//
+// Some examples:
+// LIBOFFLOAD_DEBUG=1  (Print all messages of level 1 or lower)
+// LIBOFFLOAD_DEBUG=5  (Print all messages of level 5 or lower)
+// LIBOFFLOAD_DEBUG=init (Print messages of type "init" of level 1 or lower)
+// LIBOFFLOAD_DEBUG=init:3,mapping:2 (Print messages of type "init" of level 3
+//                                   or lower and messages of type "mapping" of
+//                                   level 2 or lower)
+// LIBOFFLOAD_DEBUG=omptarget:4, init (Print messages from component "omptarget" of
+//                                   level 4 or lower and messages of type
+//                                   "init" of level 1 or lower)
 //
 // For very specific cases where more control is needed, use OFFLOAD_DEBUG_RAW
 // or OFFLOAD_DEBUG_BASE. See below for details.

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -241,7 +241,7 @@ inline uint32_t getDebugLevel() {
 // LIBOFFLOAD_DEBUG=init:3,mapping:2 (Print messages of type "init" of level 3
 //                                   or lower and messages of type "mapping" of
 //                                   level 2 or lower)
-// LIBOFFLOAD_DEBUG=omptarget:4, init (Print messages from component "omptarget" 
+// LIBOFFLOAD_DEBUG=omptarget:4, init (Print messages from component "omptarget"
 //                                   of level 4 or lower and messages of type
 //                                   "init" of level 1 or lower)
 //

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -292,7 +292,6 @@ inline DebugSettings &getDebugSettings() {
   static DebugSettings Settings;
   static std::once_flag Flag{};
   std::call_once(Flag, []() {
-    printf("Configuring debug settings\n");
     // Eventually, we probably should allow the upper layers to set
     // debug settings directly according to their own env var or
     // other methods.

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -241,8 +241,8 @@ inline uint32_t getDebugLevel() {
 // LIBOFFLOAD_DEBUG=init:3,mapping:2 (Print messages of type "init" of level 3
 //                                   or lower and messages of type "mapping" of
 //                                   level 2 or lower)
-// LIBOFFLOAD_DEBUG=omptarget:4, init (Print messages from component "omptarget" of
-//                                   level 4 or lower and messages of type
+// LIBOFFLOAD_DEBUG=omptarget:4, init (Print messages from component "omptarget" 
+//                                   of level 4 or lower and messages of type
 //                                   "init" of level 1 or lower)
 //
 // For very specific cases where more control is needed, use OFFLOAD_DEBUG_RAW

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -35,7 +35,7 @@ void initRuntime() {
 
   RefCount++;
   if (RefCount == 1) {
-    OPENMP_DEBUG("Init offload library!\n");
+    ODBG() << "Init offload library!";
 #ifdef OMPT_SUPPORT
     // Initialize OMPT first
     llvm::omp::target::ompt::connectLibrary();

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -35,7 +35,7 @@ void initRuntime() {
 
   RefCount++;
   if (RefCount == 1) {
-    DP("Init offload library!\n");
+    OPENMP_DEBUG("Init offload library!\n");
 #ifdef OMPT_SUPPORT
     // Initialize OMPT first
     llvm::omp::target::ompt::connectLibrary();

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -36,7 +36,7 @@ void PluginManager::init() {
     return;
   }
 
-  OPENMP_DEBUG("Init", "Loading RTLs\n");
+  ODBG("Init") << "Loading RTLs";
 
   // Attempt to create an instance of each supported plugin.
 #define PLUGIN_TARGET(Name)                                                    \

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -36,7 +36,7 @@ void PluginManager::init() {
     return;
   }
 
-  DP("Loading RTLs...\n");
+  OPENMP_DEBUG("Init", "Loading RTLs\n");
 
   // Attempt to create an instance of each supported plugin.
 #define PLUGIN_TARGET(Name)                                                    \

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -451,9 +451,8 @@ struct GenELF64PluginTy final : public GenericPluginTy {
     if (auto Err = Plugin::check(ffi_init(), "failed to initialize libffi"))
       return std::move(Err);
 #endif
-    ODBG("Init") << "GenELF64 plugin detected "
-      << ODBG_IF_LEVEL(2) << NUM_DEVICES << " "
-      << ODBG_RESET_LEVEL() << "devices";
+    ODBG("Init") << "GenELF64 plugin detected " << ODBG_IF_LEVEL(2)
+                 << NUM_DEVICES << " " << ODBG_RESET_LEVEL() << "devices";
 
     return NUM_DEVICES;
   }

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -451,8 +451,9 @@ struct GenELF64PluginTy final : public GenericPluginTy {
     if (auto Err = Plugin::check(ffi_init(), "failed to initialize libffi"))
       return std::move(Err);
 #endif
-    OFFLOAD_DEBUG("Init", 2,
-                  "GenELF64 plugin detected" << NUM_DEVICES << " devices\n");
+    ODBG("Init") << "GenELF64 plugin detected "
+      << ODBG_IF_LEVEL(2) << NUM_DEVICES << " "
+      << ODBG_RESET_LEVEL() << "devices";
 
     return NUM_DEVICES;
   }

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -451,6 +451,8 @@ struct GenELF64PluginTy final : public GenericPluginTy {
     if (auto Err = Plugin::check(ffi_init(), "failed to initialize libffi"))
       return std::move(Err);
 #endif
+    OFFLOAD_DEBUG("Init", 2,
+                  "GenELF64 plugin detected" << NUM_DEVICES << " devices\n");
 
     return NUM_DEVICES;
   }


### PR DESCRIPTION
This PR introduces new debug macros that allow a more fined control of which debug message to output and introduce C++ stream syntax for debug messages. 

Changing existing messages (except a few that I changed for testing) will come in subsequent PRs. 

I also think that we should make debug enabling OpenMP agnostic but, for now, I prioritized maintaing the current libomptarget behavior for now, and we might need more changes further down the line as we we decouple libomptarget.
