### PR TITLE
[lldb] The test added for PR#164905 doesn't run on Windows host.

### DIFF
--- a/lldb/test/API/driver/stdio_closed/TestDriverWithClosedSTDIO.py
+++ b/lldb/test/API/driver/stdio_closed/TestDriverWithClosedSTDIO.py
@@ -24,7 +24,7 @@ class TestDriverWithClosedSTDIO(TestBase):
 
     # Windows doesn't have the fcntl module, so we can't run this
     # test there.
-    @skipIf(oslist=["windows"])
+    @skipIf(hostoslist=["windows"])
     def test_run_lldb_and_wait(self):
         """This test forks, closes the stdio channels and exec's lldb.
         Then it waits for it to exit and asserts it did that successfully"""


### PR DESCRIPTION
Skip the test for Windows hosts.
This patch fixes the buildbot `lldb-remote-linux-win`. 
https://lab.llvm.org/buildbot/#/builders/197/builds/10304