### PR TITLE
[X86] combineTruncate - drop load alignment after (trunc (srl (load p), amt)) -> (load p + amt/8) fold

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54679,7 +54679,8 @@ static SDValue combineTruncate(SDNode *N, SelectionDAG &DAG,
         SDValue NewPtr = DAG.getMemBasePlusOffset(
             Ld->getBasePtr(), PtrByteOfs, DL, SDNodeFlags::NoUnsignedWrap);
         SDValue NewLoad =
-            DAG.getLoad(VT, DL, Ld->getChain(), NewPtr, Ld->getMemOperand());
+            DAG.getLoad(VT, DL, Ld->getChain(), NewPtr, Ld->getPointerInfo(),
+                        Align(), Ld->getMemOperand()->getFlags());
         DAG.ReplaceAllUsesOfValueWith(Src.getOperand(0).getValue(1),
                                       NewLoad.getValue(1));
         return NewLoad;


### PR DESCRIPTION
The pointer adjustment no longer guarantees any alignment

Missed in #165266 and only noticed in some follow up work