### PR TITLE
[libc][hdrgen] Fix `includes` sorting in JSON emission

### DIFF
--- a/libc/utils/hdrgen/hdrgen/header.py
+++ b/libc/utils/hdrgen/hdrgen/header.py
@@ -241,7 +241,7 @@ class HeaderFile:
         return {
             "name": self.name,
             "standards": self.standards,
-            "includes": [
-                str(file) for file in sorted({COMMON_HEADER} | self.includes())
-            ],
+            "includes": sorted(
+                str(file) for file in {COMMON_HEADER} | self.includes()
+            ),
         }

--- a/libc/utils/hdrgen/hdrgen/header.py
+++ b/libc/utils/hdrgen/hdrgen/header.py
@@ -241,7 +241,5 @@ class HeaderFile:
         return {
             "name": self.name,
             "standards": self.standards,
-            "includes": sorted(
-                str(file) for file in {COMMON_HEADER} | self.includes()
-            ),
+            "includes": sorted(str(file) for file in {COMMON_HEADER} | self.includes()),
         }


### PR DESCRIPTION
The JSON output support in hdrgen had a bug that tripped when
used with headers that use special-case headers like <stdint.h>
to supply some times, as well as llvm-libc-types/*.h headers.
