### PR TITLE
[libc++] proper guarding for locale usage in filesystem on Windows

### DIFF
--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -324,6 +324,7 @@ struct _PathCVT<char> {
   }
 };
 
+#    if _LIBCPP_HAS_LOCALIZATION
 template <class _ECharT>
 struct _PathExport {
   typedef __narrow_to_utf8<sizeof(wchar_t) * __CHAR_BIT__> _Narrower;
@@ -364,7 +365,7 @@ struct _PathExport<char16_t> {
   }
 };
 
-#    if _LIBCPP_HAS_CHAR8_T
+#      if _LIBCPP_HAS_CHAR8_T
 template <>
 struct _PathExport<char8_t> {
   typedef __narrow_to_utf8<sizeof(wchar_t) * __CHAR_BIT__> _Narrower;
@@ -374,8 +375,9 @@ struct _PathExport<char8_t> {
     _Narrower()(back_inserter(__dest), __src.data(), __src.data() + __src.size());
   }
 };
-#    endif // _LIBCPP_HAS_CHAR8_T
-#  endif   /* _LIBCPP_WIN32API */
+#      endif // _LIBCPP_HAS_CHAR8_T
+#    endif   // _LIBCPP_HAS_LOCALIZATION
+#  endif     // _LIBCPP_WIN32API
 
 class _LIBCPP_EXPORTED_FROM_ABI path {
   template <class _SourceOrIter, class _Tp = path&>

--- a/libcxx/include/__filesystem/u8path.h
+++ b/libcxx/include/__filesystem/u8path.h
@@ -24,28 +24,30 @@
 
 _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
+#  if !defined(_LIBCPP_WIN32API) || _LIBCPP_HAS_LOCALIZATION
 template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _InputIt __l) {
   static_assert(
-#  if _LIBCPP_HAS_CHAR8_T
+#    if _LIBCPP_HAS_CHAR8_T
       is_same<typename __is_pathable<_InputIt>::__char_type, char8_t>::value ||
-#  endif
+#    endif
           is_same<typename __is_pathable<_InputIt>::__char_type, char>::value,
       "u8path(Iter, Iter) requires Iter have a value_type of type 'char'"
       " or 'char8_t'");
-#  if defined(_LIBCPP_WIN32API)
+#    if defined(_LIBCPP_WIN32API)
   string __tmp(__f, __l);
   using _CVT = __widen_from_utf8<sizeof(wchar_t) * __CHAR_BIT__>;
   std::wstring __w;
   __w.reserve(__tmp.size());
   _CVT()(back_inserter(__w), __tmp.data(), __tmp.data() + __tmp.size());
   return path(__w);
-#  else
+#    else
   return path(__f, __l);
-#  endif /* !_LIBCPP_WIN32API */
+#    endif // defined(_LIBCPP_WIN32API)
 }
+#  endif // !defined(_LIBCPP_WIN32API) || _LIBCPP_HAS_LOCALIZATION
 
-#  if defined(_LIBCPP_WIN32API)
+#  if defined(_LIBCPP_WIN32API) && _LIBCPP_HAS_LOCALIZATION
 template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _NullSentinel) {
   static_assert(
@@ -65,7 +67,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, 
   _CVT()(back_inserter(__w), __tmp.data(), __tmp.data() + __tmp.size());
   return path(__w);
 }
-#  endif /* _LIBCPP_WIN32API */
+#  endif // defined(_LIBCPP_WIN32API) && _LIBCPP_HAS_LOCALIZATION
 
 template <class _Source, __enable_if_t<__is_pathable<_Source>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(const _Source& __s) {


### PR DESCRIPTION
- Resolves build issues when localization support is disabled on Windows.
- Resolves dependencies on localization in filesystem header implementations.

Related PR #164602
Fixes #164074