### PR TITLE
[MLIR][gpu-to-llvm] Support multiple async dependencies when calling `gpu.launch_func`

### DIFF
--- a/mlir/include/mlir/Conversion/GPUCommon/GPUCommonPass.h
+++ b/mlir/include/mlir/Conversion/GPUCommon/GPUCommonPass.h
@@ -74,7 +74,9 @@ using MemorySpaceMapping = std::function<unsigned(gpu::AddressSpace)>;
 void populateGpuMemorySpaceAttributeConversions(
     TypeConverter &typeConverter, const MemorySpaceMapping &mapping);
 
-/// TODO name this better
+/// Insert gpu.wait calls before gpu operations with multiple async dependencies
+/// when the gpu operation does not support multiple async dependencies, i.e.
+/// gpu.launch_func.
 void populateGpuMultipleAsyncDepsConversionPatterns(
     RewritePatternSet &patterns);
 } // namespace mlir

--- a/mlir/include/mlir/Conversion/GPUCommon/GPUCommonPass.h
+++ b/mlir/include/mlir/Conversion/GPUCommon/GPUCommonPass.h
@@ -73,6 +73,10 @@ using MemorySpaceMapping = std::function<unsigned(gpu::AddressSpace)>;
 /// gpu.address_space to integer values.
 void populateGpuMemorySpaceAttributeConversions(
     TypeConverter &typeConverter, const MemorySpaceMapping &mapping);
+
+/// TODO name this better
+void populateGpuMultipleAsyncDepsConversionPatterns(
+    RewritePatternSet &patterns);
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_GPUCOMMON_GPUCOMMONPASS_H_

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -552,6 +552,7 @@ def GpuToLLVMConversionPass : Pass<"gpu-to-llvm", "ModuleOp"> {
            "runtime with the kernel bare pointer calling convention, to enable "
            "dynamic binding of buffers as arguments without static type info."
           >
+    // TODO should an option be made to turn this feature on?
   ];
 
   let dependentDialects = [

--- a/mlir/test/Conversion/GPUCommon/lower-multiple-async-deps.mlir
+++ b/mlir/test/Conversion/GPUCommon/lower-multiple-async-deps.mlir
@@ -2,6 +2,74 @@
 
 module attributes {gpu.container_module} {
 
+  gpu.module @foo {
+    gpu.func @bar() kernel {
+      gpu.return
+    }
+  }
+
+  // CHECK-LABEL: func @main
+  func.func @main() {
+    %c1 = arith.constant 1 : index
+
+    // Check that pass does not modify launch_func ops with only 1 dependency:
+
+    // CHECK: llvm.call @mgpuStreamCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventRecord(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    %t0 = gpu.wait async
+    // CHECK: llvm.call @mgpuEventCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventRecord(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuStreamWaitEvent(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuEventDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    %t1 = gpu.wait async [%t0]
+    // CHECK: llvm.call @mgpuEventCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventRecord(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuStreamWaitEvent(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamWaitEvent(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuEventDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuEventDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    %0 = gpu.wait async [%t0, %t1]
+    // CHECK: gpu.launch_func <%{{.*}} : !llvm.ptr> @foo::@bar blocks in (%{{.*}}, %{{.*}}, %{{.*}}) threads in (%{{.*}}, %{{.*}}, %{{.*}}) : i64
+    %good_call = gpu.launch_func async [%0] @foo::@bar
+        blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1)
+    // CHECK: llvm.call @mgpuStreamSynchronize(%{{.*}}) : (!llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    gpu.wait [%good_call]
+
+    // Check that launch_func ops with multiple dependencies are properly
+    // handled and do not result in a failure:
+
+    // CHECK: llvm.call @mgpuStreamCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventRecord(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    %t2 = gpu.wait async
+    // CHECK: llvm.call @mgpuEventCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventRecord(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuStreamWaitEvent(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuEventDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    %t3 = gpu.wait async [%t2]
+    // Inserted gpu.wait:
+    // CHECK: llvm.call @mgpuEventCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuEventRecord(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamCreate() : () -> !llvm.ptr
+    // CHECK: llvm.call @mgpuStreamWaitEvent(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamWaitEvent(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuEventDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuEventDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    // gpu.launch_func only has 1 async dependency:
+    // CHECK: gpu.launch_func <%{{.*}} : !llvm.ptr> @foo::@bar blocks in (%{{.*}}, %{{.*}}, %{{.*}}) threads in (%{{.*}}, %{{.*}}, %{{.*}}) : i64
+    %bad_call = gpu.launch_func async [%t2, %t3] @foo::@bar
+        blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1)
+    // CHECK: llvm.call @mgpuStreamSynchronize(%{{.*}}) : (!llvm.ptr) -> ()
+    // CHECK: llvm.call @mgpuStreamDestroy(%{{.*}}) : (!llvm.ptr) -> ()
+    gpu.wait [%bad_call]
+    return
+  }
+
   // func.func @foo(%size : index) -> memref<?xf32> {
   //   %t0 = gpu.wait async
   //   %t1 = gpu.wait async [%t0]
@@ -9,22 +77,5 @@ module attributes {gpu.container_module} {
   //   // gpu.wait [%1]
   //   return %0 : memref<?xf32>
   // }
-
-  gpu.module @foo {
-    gpu.func @bar() kernel {
-      gpu.return
-    }
-  }
-
-  func.func @main() {
-    %c1 = arith.constant 1 : index
-
-    %t0 = gpu.wait async
-    %t1 = gpu.wait async [%t0]
-    %token = gpu.launch_func async [%t0, %t1] @foo::@bar
-        blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1)
-    gpu.wait [%token]
-    return
-  }
 
 }

--- a/mlir/test/Conversion/GPUCommon/lower-multiple-async-deps.mlir
+++ b/mlir/test/Conversion/GPUCommon/lower-multiple-async-deps.mlir
@@ -1,0 +1,30 @@
+// RUN: mlir-opt %s --gpu-to-llvm | FileCheck %s
+
+module attributes {gpu.container_module} {
+
+  // func.func @foo(%size : index) -> memref<?xf32> {
+  //   %t0 = gpu.wait async
+  //   %t1 = gpu.wait async [%t0]
+  //   %0 = gpu.alloc [%t0, %t1] (%size) : memref<?xf32>
+  //   // gpu.wait [%1]
+  //   return %0 : memref<?xf32>
+  // }
+
+  gpu.module @foo {
+    gpu.func @bar() kernel {
+      gpu.return
+    }
+  }
+
+  func.func @main() {
+    %c1 = arith.constant 1 : index
+
+    %t0 = gpu.wait async
+    %t1 = gpu.wait async [%t0]
+    %token = gpu.launch_func async [%t0, %t1] @foo::@bar
+        blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1)
+    gpu.wait [%token]
+    return
+  }
+
+}


### PR DESCRIPTION
Adds a new pattern to `gpu-to-llvm` pass that generates additional `gpu.wait`s before `gpu.launch_func` in the case that `gpu.launch_func` has multiple async dependencies. Without this PR, `gpu.launch_func` ops would fail to convert/legalize to GPU runtime calls when multiple async dependencies are provided.

Notes/Request for comment:
- This PR was written in a way such that support for other operations that also require a single async dependency, i.e. `gpu.alloc` can also benefit from the pattern and implicitly support multiple async dependencies. The question is, would people like this in MLIR?
- Additionally, should this be an option instead of enabled by default?