### PR TITLE
[MemRef] Fix-forward use-after-scope in #164955

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -107,7 +107,7 @@ struct CollapseShapeOpInterface
     assert(value == collapseOp.getResult() && "invalid value");
 
     // Multiply the expressions for the dimensions in the reassociation group.
-    const ReassociationIndices &reassocIndices =
+    const ReassociationIndices reassocIndices =
         collapseOp.getReassociationIndices()[dim];
     AffineExpr productExpr =
         cstr.getExpr(collapseOp.getSrc(), reassocIndices[0]);


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/164955 has a use-after-scope (https://lab.llvm.org/buildbot/#/builders/169/builds/16454):

```
==mlir-opt==3940651==ERROR: AddressSanitizer: stack-use-after-scope on address 0x6e1f6ba5c878 at pc 0x6336b214912a bp 0x7ffe607f1670 sp 0x7ffe607f1668
READ of size 4 at 0x6e1f6ba5c878 thread T0
    #0 0x6336b2149129 in size /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/include/llvm/ADT/SmallVector.h:80:32
    #1 0x6336b2149129 in operator[] /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/include/llvm/ADT/SmallVector.h:299:5
    #2 0x6336b2149129 in populateBoundsForShapedValueDim /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/mlir/lib/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.cpp:113:43
...
```

This patch attempts to fix-forward by stack-allocating reassocIndices, instead of taking a reference to a return value.