### PR TITLE
[mlir][tosa] Fix select folder when operands are broadcast

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1484,7 +1484,24 @@ OpFoldResult SliceOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+static bool
+mayRequireBroadcast(ValueTypeRange<mlir::OperandRange> operandTypes) {
+  const auto isDynamic = [](Type ty) {
+    const auto shapedTy = llvm::dyn_cast<ShapedType>(ty);
+    return !shapedTy || !shapedTy.hasStaticShape();
+  };
+
+  return llvm::any_of(operandTypes, isDynamic) ||
+         failed(verifyCompatibleShapes(operandTypes));
+}
+
 OpFoldResult tosa::SelectOp::fold(FoldAdaptor adaptor) {
+  // Select allows operand shapes to be broadcast to the output shape. For
+  // now, don't support folding when we cannot prove no broadcasting is
+  // involved.
+  if (mayRequireBroadcast(getOperandTypes()))
+    return {};
+
   if (getOnTrue() == getOnFalse())
     return getOnTrue();
 


### PR DESCRIPTION
This commit addresses a crash in the dialects folder. The currently folder assumes no broadcasting of the input operand happens and therefore the folder can complain that the returned value was not the same
shape as the result.

For now, this commit ensures no folding happens when broadcasting is involved. In the future, folding with a broadcast could likely be supported by inserting a `tosa.tile` operation before returning the operand. This type of transformation is likely better suited for a canonicalization pass. This commit only aims to avoid the crash.