### PR TITLE
[llvm-libgcc] Fix symlink path for libcc when LLVM_ENABLE_PER_TARGET_…

### DIFF
--- a/llvm-libgcc/CMakeLists.txt
+++ b/llvm-libgcc/CMakeLists.txt
@@ -124,11 +124,27 @@ target_link_libraries(unwind_shared PUBLIC
 #===============================================================================
 
 get_compiler_rt_install_dir(${COMPILER_RT_DEFAULT_TARGET_ARCH} install_dir_builtins)
-string(REGEX REPLACE "^lib/" "" install_dir_builtins "${install_dir_builtins}")
-string(FIND "${install_dir_builtins}" "clang" install_path_contains_triple)
-if(install_path_contains_triple EQUAL -1)
-  set(builtins_suffix "-${COMPILER_RT_DEFAULT_TARGET_ARCH}")
+
+# Extract the relative path starting from 'clang' or after 'lib/'
+if(IS_ABSOLUTE "${install_dir_builtins}")
+  # For absolute paths, extract starting from 'clang/' if it exists
+  string(REGEX MATCH "clang/.*$" install_dir_builtins_temp "${install_dir_builtins}")
+  if(install_dir_builtins_temp)
+    set(install_dir_builtins "${install_dir_builtins_temp}")
+  else()
+    # Fallback: strip up to first lib/
+    string(REGEX REPLACE "^.*/lib/" "" install_dir_builtins "${install_dir_builtins}")
+  endif()
 else()
+  string(REGEX REPLACE "^lib/" "" install_dir_builtins "${install_dir_builtins}")
+endif()
+
+# Always add the architecture suffix
+set(builtins_suffix "-${COMPILER_RT_DEFAULT_TARGET_ARCH}")
+
+# Only prepend ../ when using per-target runtime directories
+string(FIND "${install_dir_builtins}" "clang" install_path_contains_triple)
+if(install_path_contains_triple GREATER -1 AND LLVM_ENABLE_PER_TARGET_RUNTIME_DIR)
   string(PREPEND install_dir_builtins "../")
 endif()
 set(LLVM_LIBGCC_COMPILER_RT ${install_dir_builtins}/libclang_rt.builtins${builtins_suffix}.a)

--- a/llvm-libgcc/CMakeLists.txt
+++ b/llvm-libgcc/CMakeLists.txt
@@ -137,7 +137,7 @@ add_custom_target(llvm-libgcc ALL
   DEPENDS unwind_shared unwind_static clang_rt.builtins-${COMPILER_RT_DEFAULT_TARGET_ARCH}
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${LLVM_LIBGCC_COMPILER_RT} libgcc.a
   COMMAND ${CMAKE_COMMAND} -E create_symlink libunwind.a libgcc_eh.a
-  COMMAND ${CMAKE_COMMAND} -E create_symlink libunwind.so libgcc_s.so.1.0
+  COMMAND ${CMAKE_COMMAND} -E create_symlink libunwind.so.1 libgcc_s.so.1.0
   COMMAND ${CMAKE_COMMAND} -E create_symlink libgcc_s.so.1.0 libgcc_s.so.1
   COMMAND ${CMAKE_COMMAND} -E create_symlink libgcc_s.so.1 libgcc_s.so
 )


### PR DESCRIPTION
…RUNTIME_DIR is unset

current logic fails when LLVM_ENABLE_PER_TARGET_RUNTIME_DIR = OFF and it ends up with symlinks e.g.

libgcc.a -> ..//usr/lib/clang/21.1.4/lib/linux/libclang_rt.builtins.a

the real library is at
../lib/clang/21.1.4/lib/linux/libclang_rt.builtins-aarch64.a

The relative path is incorrect and its missing to add -arch suffix as well.

So we make checks a bit more explicit to cover this case.

The symlink for libgcc_so.1.0 is made to point to libunwind.so which is functionally correct but it fails some linux distro packaging complain because libunwind.so is made part of -dev package but libgcc_so.1.0 ends up in the real package, and creates an unneeded package -> dev dependency

create the symlink to point to libunwind.so.1 instead then the boundaries of packaging are not crossed and all is well.