### PR TITLE
[tblgen] Use `emitError` for inferResultTypes failures

### DIFF
--- a/mlir/include/mlir/Interfaces/InferTypeOpInterface.h
+++ b/mlir/include/mlir/Interfaces/InferTypeOpInterface.h
@@ -245,9 +245,8 @@ inferReturnTensorTypes(ArrayRef<ShapedTypeComponents> retComponents,
 /// the op. Precondition: op implements InferTypeOpInterface.
 LogicalResult verifyInferredResultTypes(Operation *op);
 
-/// Report a fatal error indicating that the result types could not be
-/// inferred.
-void reportFatalInferReturnTypesError(OperationState &state);
+/// Report an error indicating that the result types could not be inferred.
+void emitInferReturnTypesError(OperationState &state);
 } // namespace detail
 
 namespace OpTrait {

--- a/mlir/lib/Interfaces/InferTypeOpInterface.cpp
+++ b/mlir/lib/Interfaces/InferTypeOpInterface.cpp
@@ -240,15 +240,12 @@ LogicalResult mlir::detail::verifyInferredResultTypes(Operation *op) {
   return result;
 }
 
-void mlir::detail::reportFatalInferReturnTypesError(OperationState &state) {
-  std::string buffer;
-  llvm::raw_string_ostream os(buffer);
-  os << "Failed to infer result type(s):\n"
-     << "\"" << state.name << "\"(...) "
-     << state.attributes.getDictionary(state.location.getContext()) << " : ("
-     << llvm::interleaved(llvm::map_range(
-            state.operands, [](Value val) { return val.getType(); }))
-     << ") -> ( ??? )";
-  emitRemark(state.location, "location of op");
-  llvm::report_fatal_error(llvm::StringRef(buffer));
+void mlir::detail::emitInferReturnTypesError(OperationState &state) {
+  mlir::emitError(state.location)
+      << "failed to infer result type(s):\n"
+      << "\"" << state.name << "\"(...) "
+      << state.attributes.getDictionary(state.location.getContext()) << " : ("
+      << llvm::interleaved(llvm::map_range(
+             state.operands, [](Value val) { return val.getType(); }))
+      << ") -> ( ??? )";
 }

--- a/mlir/test/mlir-tblgen/op-decl-and-defs.td
+++ b/mlir/test/mlir-tblgen/op-decl-and-defs.td
@@ -232,7 +232,7 @@ def NS_FOp : NS_Op<"op_with_all_types_constraint",
 // DEFS: void FOp::build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a) {
 // DEFS:   if (::mlir::succeeded(FOp::inferReturnTypes(odsBuilder.getContext(),
 // DEFS:   else
-// DEFS:     ::mlir::detail::reportFatalInferReturnTypesError(odsState);
+// DEFS:     ::mlir::detail::emitInferReturnTypesError(odsState);
 
 // DEFS: FOp FOp::create(::mlir::OpBuilder &builder, ::mlir::Location location, ::mlir::Value a) {
 // DEFS:   ::mlir::OperationState __state__(location, getOperationName());

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -2681,7 +2681,7 @@ void OpEmitter::genSeparateArgParamBuilder() {
                       {1}.regions, inferredReturnTypes)))
           {1}.addTypes(inferredReturnTypes);
         else
-          ::mlir::detail::reportFatalInferReturnTypesError({1});
+          ::mlir::detail::emitInferReturnTypesError({1});
         )",
                       opClass.getClassName(), builderOpState);
       return;
@@ -2967,10 +2967,11 @@ void OpEmitter::genInferredTypeCollectiveParamBuilder(
          << "u && \"mismatched number of return types\");";
   body << "\n    " << builderOpState << ".addTypes(inferredReturnTypes);";
 
-  body << R"(
+  body << formatv(R"(
   } else {
-    ::llvm::report_fatal_error("Failed to infer result type(s).");
-  })";
+    ::mlir::detail::emitInferReturnTypesError({0});
+  })",
+                  builderOpState);
 }
 
 void OpEmitter::genUseOperandAsResultTypeSeparateParamBuilder() {


### PR DESCRIPTION
Tablegen builders generated for InferTypeOpTrait currently generate a call to `llvm::report_fatal_error`. This prevents error recovery even though the underlying machinery, including the generic builder, support failing result type inference.

This PR updates `reportFatalInferReturnTypesError` -> `emitInferReturnTypesError`, using `mlir::emitError()` instead of `llvm::report_fatal_error`, and then updates `OpDefinitionsGen` to use this function.