### PR TITLE
[Clang] [NFC] Fix trailing whitespace in Parser.h

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -7677,7 +7677,7 @@ private:
   /// [GNU] asm-clobbers:
   ///         asm-string-literal
   ///         asm-clobbers ',' asm-string-literal
-  /// \endverbatim 
+  /// \endverbatim
   ///
   StmtResult ParseAsmStatement(bool &msAsm);
 


### PR DESCRIPTION
Many editors and IDEs automatically delete trailing whitespace on save, and this particular one has shown up as an unrelated change in several of my patches that I then had to remove later (and I’ve seen it in other people’s patches too); this has wasted too much of my time, so I’m removing it separately.