### PR TITLE
[DAG] Add generic m_TernaryOp() / m_c_TernaryOp() matchers

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -583,6 +583,18 @@ m_InsertSubvector(const LHS &Base, const RHS &Sub, const IDX &Idx) {
   return TernaryOpc_match<LHS, RHS, IDX>(ISD::INSERT_SUBVECTOR, Base, Sub, Idx);
 }
 
+template <typename T0_P, typename T1_P, typename T2_P>
+inline TernaryOpc_match<T0_P, T1_P, T2_P>
+m_TernaryOp(unsigned Opc, const T0_P &Op0, const T1_P &Op1, const T2_P &Op2) {
+  return TernaryOpc_match<T0_P, T1_P, T2_P>(Opc, Op0, Op1, Op2);
+}
+
+template <typename T0_P, typename T1_P, typename T2_P>
+inline TernaryOpc_match<T0_P, T1_P, T2_P, true>
+m_c_TernaryOp(unsigned Opc, const T0_P &Op0, const T1_P &Op1, const T2_P &Op2) {
+  return TernaryOpc_match<T0_P, T1_P, T2_P, true>(Opc, Op0, Op1, Op2);
+}
+
 template <typename LTy, typename RTy, typename TTy, typename FTy, typename CCTy>
 inline auto m_SelectCC(const LTy &L, const RTy &R, const TTy &T, const FTy &F,
                        const CCTy &CC) {

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18369,13 +18369,11 @@ template <class MatchContextClass> SDValue DAGCombiner::visitFMA(SDNode *N) {
     }
   }
 
-  SDValue X, Y;
-
-  // (fma 1.0, X, Y) or (fma X, 1.0, Y) -> (fadd X, Y)
-  SDValue C1 = DAG.getConstantFP(1.0, DL, VT);
-  if (sd_match(N,
-               m_c_TernaryOp(ISD::FMA, m_Specific(C1), m_Value(X), m_Value(Y))))
-    return matcher.getNode(ISD::FADD, DL, VT, X, Y);
+  // FIXME: Support splat of constant.
+  if (N0CFP && N0CFP->isExactlyValue(1.0))
+    return matcher.getNode(ISD::FADD, DL, VT, N1, N2);
+  if (N1CFP && N1CFP->isExactlyValue(1.0))
+    return matcher.getNode(ISD::FADD, DL, VT, N0, N2);
 
   // Canonicalize (fma c, x, y) -> (fma x, c, y)
   if (DAG.isConstantFPBuildVectorOrConstantFP(N0) &&

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18369,8 +18369,7 @@ template <class MatchContextClass> SDValue DAGCombiner::visitFMA(SDNode *N) {
     }
   }
 
-  using namespace SDPatternMatch;
-  SDValue X, Y, Cst;
+  SDValue X, Y;
 
   // (fma 1.0, X, Y) or (fma X, 1.0, Y) -> (fadd X, Y)
   SDValue C1 = DAG.getConstantFP(1.0, DL, VT);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18369,11 +18369,14 @@ template <class MatchContextClass> SDValue DAGCombiner::visitFMA(SDNode *N) {
     }
   }
 
-  // FIXME: Support splat of constant.
-  if (N0CFP && N0CFP->isExactlyValue(1.0))
-    return matcher.getNode(ISD::FADD, DL, VT, N1, N2);
-  if (N1CFP && N1CFP->isExactlyValue(1.0))
-    return matcher.getNode(ISD::FADD, DL, VT, N0, N2);
+  using namespace SDPatternMatch;
+  SDValue X, Y, Cst;
+
+  // (fma 1.0, X, Y) or (fma X, 1.0, Y) -> (fadd X, Y)
+  SDValue C1 = DAG.getConstantFP(1.0, DL, VT);
+  if (sd_match(N,
+               m_c_TernaryOp(ISD::FMA, m_Specific(C1), m_Value(X), m_Value(Y))))
+    return matcher.getNode(ISD::FADD, DL, VT, X, Y);
 
   // Canonicalize (fma c, x, y) -> (fma x, c, y)
   if (DAG.isConstantFPBuildVectorOrConstantFP(N0) &&


### PR DESCRIPTION
Similar to the m_BinOp/m_c_BinOp matchers, this patch introduces
generic matchers for SelectionDAG nodes with three operands.

This includes:
- Adding m_TernaryOp() and m_c_TernaryOp() templates in SDPatternMatch.h.
- Adding comprehensive test coverage in SelectionDAGPatternMatchTest.cpp.

Fixes #165378