### PR TITLE
[LoongArch] Convert ld to fld when result is only used by sitofp

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchFloat32InstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchFloat32InstrInfo.td
@@ -26,6 +26,7 @@ def SDT_LoongArchMOVFR2GR_S_LA64
 def SDT_LoongArchFTINT : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisFP<1>]>;
 def SDT_LoongArchFRECIPE : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisFP<1>]>;
 def SDT_LoongArchFRSQRTE : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisFP<1>]>;
+def SDT_LoongArchITOF : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisSameAs<0, 1>]>;
 
 // ISD::BRCOND is custom-lowered to LoongArchISD::BRCOND for floating-point
 // comparisons to prevent recursive lowering.
@@ -44,6 +45,7 @@ def loongarch_ftint : SDNode<"LoongArchISD::FTINT", SDT_LoongArchFTINT>;
 // Floating point approximate reciprocal operation
 def loongarch_frecipe : SDNode<"LoongArchISD::FRECIPE", SDT_LoongArchFRECIPE>;
 def loongarch_frsqrte : SDNode<"LoongArchISD::FRSQRTE", SDT_LoongArchFRSQRTE>;
+def loongarch_sitof : SDNode<"LoongArchISD::SITOF", SDT_LoongArchITOF>;
 
 //===----------------------------------------------------------------------===//
 // Instructions
@@ -351,6 +353,9 @@ def : Pat<(fneg (fma FPR32:$fj, FPR32:$fk, (fneg FPR32:$fa))),
 // fnmsub.s: -fj * fk + fa (the nsz flag on the FMA)
 def : Pat<(fma_nsz (fneg FPR32:$fj), FPR32:$fk, FPR32:$fa),
           (FNMSUB_S FPR32:$fj, FPR32:$fk, FPR32:$fa)>;
+
+// ffint.s.w
+def : Pat<(loongarch_sitof FPR32:$fj), (FFINT_S_W FPR32:$fj)>;
 } // Predicates = [HasBasicF]
 
 let Predicates = [HasBasicF, IsLA64] in {

--- a/llvm/lib/Target/LoongArch/LoongArchFloat64InstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchFloat64InstrInfo.td
@@ -308,6 +308,9 @@ def : Pat<(fneg (fma FPR64:$fj, FPR64:$fk, (fneg FPR64:$fa))),
 // fnmsub.d: -fj * fk + fa (the nsz flag on the FMA)
 def : Pat<(fma_nsz (fneg FPR64:$fj), FPR64:$fk, FPR64:$fa),
           (FNMSUB_D FPR64:$fj, FPR64:$fk, FPR64:$fa)>;
+
+// ffint.d.l
+def : Pat<(loongarch_sitof FPR64:$fj), (FFINT_D_L FPR64:$fj)>;
 } // Predicates = [HasBasicD]
 
 /// Floating point constants

--- a/llvm/test/CodeGen/LoongArch/load-itofp-combine.ll
+++ b/llvm/test/CodeGen/LoongArch/load-itofp-combine.ll
@@ -7,33 +7,25 @@
 define float @load_sitofp_f32(ptr %src) nounwind {
 ; LA32F-LABEL: load_sitofp_f32:
 ; LA32F:       # %bb.0:
-; LA32F-NEXT:    ld.w $a0, $a0, 0
-; LA32F-NEXT:    movgr2fr.w $fa0, $a0
+; LA32F-NEXT:    fld.s $fa0, $a0, 0
 ; LA32F-NEXT:    ffint.s.w $fa0, $fa0
 ; LA32F-NEXT:    ret
 ;
 ; LA32D-LABEL: load_sitofp_f32:
 ; LA32D:       # %bb.0:
-; LA32D-NEXT:    ld.w $a0, $a0, 0
-; LA32D-NEXT:    movgr2fr.w $fa0, $a0
+; LA32D-NEXT:    fld.s $fa0, $a0, 0
 ; LA32D-NEXT:    ffint.s.w $fa0, $fa0
 ; LA32D-NEXT:    ret
 ;
 ; LA64F-LABEL: load_sitofp_f32:
 ; LA64F:       # %bb.0:
-; LA64F-NEXT:    addi.d $sp, $sp, -16
-; LA64F-NEXT:    st.d $ra, $sp, 8 # 8-byte Folded Spill
-; LA64F-NEXT:    ld.w $a0, $a0, 0
-; LA64F-NEXT:    pcaddu18i $ra, %call36(__floatdisf)
-; LA64F-NEXT:    jirl $ra, $ra, 0
-; LA64F-NEXT:    ld.d $ra, $sp, 8 # 8-byte Folded Reload
-; LA64F-NEXT:    addi.d $sp, $sp, 16
+; LA64F-NEXT:    fld.s $fa0, $a0, 0
+; LA64F-NEXT:    ffint.s.w $fa0, $fa0
 ; LA64F-NEXT:    ret
 ;
 ; LA64D-LABEL: load_sitofp_f32:
 ; LA64D:       # %bb.0:
-; LA64D-NEXT:    ld.w $a0, $a0, 0
-; LA64D-NEXT:    movgr2fr.w $fa0, $a0
+; LA64D-NEXT:    fld.s $fa0, $a0, 0
 ; LA64D-NEXT:    ffint.s.w $fa0, $fa0
 ; LA64D-NEXT:    ret
   %1 = load i32, ptr %src
@@ -56,14 +48,8 @@ define double @load_sitofp_f64(ptr %src) nounwind {
 ;
 ; LA32D-LABEL: load_sitofp_f64:
 ; LA32D:       # %bb.0:
-; LA32D-NEXT:    addi.w $sp, $sp, -16
-; LA32D-NEXT:    st.w $ra, $sp, 12 # 4-byte Folded Spill
-; LA32D-NEXT:    ld.w $a2, $a0, 0
-; LA32D-NEXT:    ld.w $a1, $a0, 4
-; LA32D-NEXT:    move $a0, $a2
-; LA32D-NEXT:    bl __floatdidf
-; LA32D-NEXT:    ld.w $ra, $sp, 12 # 4-byte Folded Reload
-; LA32D-NEXT:    addi.w $sp, $sp, 16
+; LA32D-NEXT:    fld.d $fa0, $a0, 0
+; LA32D-NEXT:    ffint.d.l $fa0, $fa0
 ; LA32D-NEXT:    ret
 ;
 ; LA64F-LABEL: load_sitofp_f64:
@@ -79,8 +65,7 @@ define double @load_sitofp_f64(ptr %src) nounwind {
 ;
 ; LA64D-LABEL: load_sitofp_f64:
 ; LA64D:       # %bb.0:
-; LA64D-NEXT:    ld.d $a0, $a0, 0
-; LA64D-NEXT:    movgr2fr.d $fa0, $a0
+; LA64D-NEXT:    fld.d $fa0, $a0, 0
 ; LA64D-NEXT:    ffint.d.l $fa0, $fa0
 ; LA64D-NEXT:    ret
   %1 = load i64, ptr %src


### PR DESCRIPTION
If the result of an integer load is only used by an integer-to-float conversion, use a fp load instead. This eliminates an integer-to-float-move (movgr2fr) instruction.