### PR TITLE
[TSan][Test-Only][Darwin] Fix typo in external.cpp test

### DIFF
--- a/compiler-rt/test/tsan/Darwin/external.cpp
+++ b/compiler-rt/test/tsan/Darwin/external.cpp
@@ -68,9 +68,9 @@ int main(int argc, char *argv[]) {
   // TEST2-NOT: WARNING: ThreadSanitizer
   
   // TEST3: WARNING: ThreadSanitizer: race on MyLibrary::MyObject
-  // TEST3: {{Modifying|read-only}} access of MyLibrary::MyObject at
+  // TEST3: {{Modifying|Read-only}} access of MyLibrary::MyObject at
   // TEST3: {{ObjectWrite|ObjectRead}}
-  // TEST3: Previous {{modifying|read-only}} access of MyLibrary::MyObject at
+  // TEST3: Previous {{modifying|Read-only}} access of MyLibrary::MyObject at
   // TEST3: {{ObjectWrite|ObjectRead}}
   // TEST3: Location is MyLibrary::MyObject of size 16 at
   // TEST3: {{ObjectCreate}}


### PR DESCRIPTION
Occasionally this test fails in CI. There are two possible races that can occur, one of which is rare. Both are supposed to be handled, but because the test matches "read-only" and the runtime outputs "Read-only" (note the capital letter), the FileCheck fails.

This patch fixes the miscapitalisation of the FileCheck string in the test.

rdar://163398219