### PR TITLE
[clang-tidy] Update google todo checker with style guide changes.

### DIFF
--- a/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
@@ -11,42 +11,102 @@
 #include "clang/Lex/Preprocessor.h"
 #include <optional>
 
-namespace clang::tidy::google::readability {
+namespace clang::tidy {
 
+namespace google::readability {
+
+enum class StyleKind { Parentheses, Hyphen };
+
+} // namespace google::readability
+
+template <> struct OptionEnumMapping<google::readability::StyleKind> {
+  static ArrayRef<std::pair<google::readability::StyleKind, StringRef>>
+  getEnumMapping() {
+    static constexpr std::pair<google::readability::StyleKind, StringRef>
+        Mapping[] = {
+            {google::readability::StyleKind::Hyphen, "Hyphen"},
+            {google::readability::StyleKind::Parentheses, "Parentheses"},
+        };
+    return {Mapping};
+  }
+};
+
+} // namespace clang::tidy
+
+namespace clang::tidy::google::readability {
 class TodoCommentCheck::TodoCommentHandler : public CommentHandler {
 public:
   TodoCommentHandler(TodoCommentCheck &Check, std::optional<std::string> User)
       : Check(Check), User(User ? *User : "unknown"),
-        TodoMatch("^// *TODO *(\\(.*\\))?:?( )?(.*)$") {}
+        TodoMatch(R"(^// *TODO *((\((.*)\))?:?( )?|: *(.*) *- *)?(.*)$)") {
+    const llvm::StringRef TodoStyleString =
+        Check.Options.get("Style", "Hyphen");
+    for (const auto &[Value, Name] :
+         OptionEnumMapping<StyleKind>::getEnumMapping()) {
+      if (Name == TodoStyleString) {
+        TodoStyle = Value;
+        return;
+      }
+    }
+    Check.configurationDiag(
+        "invalid value '%0' for "
+        "google-readability-todo.Style; valid values are "
+        "'Parentheses' and 'Hyphen'. Defaulting to 'Hyphen'")
+        << TodoStyleString;
+  }
 
   bool HandleComment(Preprocessor &PP, SourceRange Range) override {
     const StringRef Text =
         Lexer::getSourceText(CharSourceRange::getCharRange(Range),
                              PP.getSourceManager(), PP.getLangOpts());
 
-    SmallVector<StringRef, 4> Matches;
+    SmallVector<StringRef, 7> Matches;
     if (!TodoMatch.match(Text, &Matches))
       return false;
 
-    const StringRef Username = Matches[1];
-    const StringRef Comment = Matches[3];
+    const StyleKind ParsedStyle =
+        !Matches[3].empty() ? StyleKind::Parentheses : StyleKind::Hyphen;
+    const StringRef Username =
+        ParsedStyle == StyleKind::Parentheses ? Matches[3] : Matches[5];
+    const StringRef Comment = Matches[6];
 
-    if (!Username.empty())
+    if (!Username.empty() &&
+        (ParsedStyle == StyleKind::Parentheses || !Comment.empty())) {
       return false;
+    }
 
-    const std::string NewText =
-        ("// TODO(" + Twine(User) + "): " + Comment).str();
+    if (Username.empty()) {
+      Check.diag(Range.getBegin(), "missing username/bug in TODO")
+          << FixItHint::CreateReplacement(
+                 CharSourceRange::getCharRange(Range),
+                 createReplacementString(Username, Comment));
+    }
 
-    Check.diag(Range.getBegin(), "missing username/bug in TODO")
-        << FixItHint::CreateReplacement(CharSourceRange::getCharRange(Range),
-                                        NewText);
+    if (Comment.empty())
+      Check.diag(Range.getBegin(), "missing details in TODO");
+
     return false;
   }
+
+  std::string createReplacementString(const StringRef Username,
+                                      const StringRef Comment) const {
+    if (TodoStyle == StyleKind::Parentheses) {
+      return ("// TODO(" + Twine(User) +
+              "): " + (Comment.empty() ? "some details" : Comment))
+          .str();
+    }
+    return ("// TODO: " + Twine(User) + " - " +
+            (Comment.empty() ? "some details" : Comment))
+        .str();
+  }
+
+  StyleKind getTodoStyle() const { return TodoStyle; }
 
 private:
   TodoCommentCheck &Check;
   std::string User;
   llvm::Regex TodoMatch;
+  StyleKind TodoStyle = StyleKind::Hyphen;
 };
 
 TodoCommentCheck::TodoCommentCheck(StringRef Name, ClangTidyContext *Context)
@@ -60,6 +120,10 @@ void TodoCommentCheck::registerPPCallbacks(const SourceManager &SM,
                                            Preprocessor *PP,
                                            Preprocessor *ModuleExpanderPP) {
   PP->addCommentHandler(Handler.get());
+}
+
+void TodoCommentCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "Style", Handler->getTodoStyle());
 }
 
 } // namespace clang::tidy::google::readability

--- a/clang-tools-extra/clang-tidy/google/TodoCommentCheck.h
+++ b/clang-tools-extra/clang-tidy/google/TodoCommentCheck.h
@@ -27,6 +27,8 @@ public:
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
 
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+
 private:
   class TodoCommentHandler;
   std::unique_ptr<TodoCommentHandler> Handler;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -406,6 +406,10 @@ Changes in existing checks
   <clang-tidy/checks/google/readability-casting>` check by adding fix-it
   notes for downcasts.
 
+- Improved :doc:`google-readability-todo
+  <clang-tidy/checks/google/readability-todo>` check to accept the new TODO
+  format from the Google Style Guide.
+
 - Improved :doc:`llvm-prefer-isa-or-dyn-cast-in-conditionals
   <clang-tidy/checks/llvm/prefer-isa-or-dyn-cast-in-conditionals>` check:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-todo.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-todo.rst
@@ -9,3 +9,14 @@ The relevant style guide section is
 https://google.github.io/styleguide/cppguide.html#TODO_Comments.
 
 Corresponding cpplint.py check: `readability/todo`
+
+Options
+-------
+
+.. option:: Style
+
+   A string specifying the TODO style for fix-it hints. Accepted values are
+   `Hyphen` and `Parentheses`. Default is `Hyphen`.
+
+   * `Hyphen` will format the fix-it as: ``// TODO: username - details``.
+   * `Parentheses` will format the fix-it as: ``// TODO(username): details``.

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo-hyphen.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo-hyphen.cpp
@@ -1,0 +1,40 @@
+// RUN: %check_clang_tidy %s google-readability-todo %t -- -config="{User: 'some user'}" --
+
+//   TODOfix this1
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
+// CHECK-FIXES: // TODO: some user - fix this1
+
+//   TODO fix this2
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
+// CHECK-FIXES: // TODO: some user - fix this2
+
+// TODO fix this3
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
+// CHECK-FIXES: // TODO: some user - fix this3
+
+// TODO: fix this4
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
+// CHECK-FIXES: // TODO: some user - fix this4
+
+// TODO: bug 12345 -
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing details in TODO
+
+// TODO: a message without a reference
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
+// CHECK-FIXES: // TODO: some user - a message without a reference
+
+//   TODO(clang)fix this5
+
+// TODO: foo - shave yaks
+// TODO:foo - no space bewteen semicolon and username
+// TODO: foo- no space bewteen username and dash
+// TODO:    foo - extra spaces between semicolon and username
+// TODO: foo   - extra spaces between username and dash
+// TODO: b/12345 - use a b/ prefix
+// TODO: bug 12345 - use a space in username/bug reference
+// TODO(foo):shave yaks
+// TODO(bar):
+// TODO(foo): paint bikeshed
+// TODO(b/12345): find the holy grail
+// TODO (b/12345): allow spaces before parentheses
+// TODO(asdf) allow missing semicolon

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo-parentheses.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s google-readability-todo %t -- -config="{User: 'some user'}" --
+// RUN: %check_clang_tidy %s google-readability-todo %t -- -config="{User: 'some user', CheckOptions: {google-readability-todo.Style: 'Parentheses'}}" --
 
 //   TODOfix this1
 // CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
@@ -16,8 +16,22 @@
 // CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
 // CHECK-FIXES: // TODO(some user): fix this4
 
+// TODO: bug 12345 -
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing details in TODO
+
+// TODO: a message without a reference
+// CHECK-MESSAGES: [[@LINE-1]]:1: warning: missing username/bug in TODO
+// CHECK-FIXES: // TODO(some user): a message without a reference
+
 //   TODO(clang)fix this5
 
+// TODO: foo - shave yaks
+// TODO:foo - no space bewteen semicolon and username
+// TODO: foo- no space bewteen username and dash
+// TODO:    foo - extra spaces between semicolon and username
+// TODO: foo   - extra spaces between username and dash
+// TODO: b/12345 - use a b/ prefix
+// TODO: bug 12345 - use a space in username/bug reference
 // TODO(foo):shave yaks
 // TODO(bar):
 // TODO(foo): paint bikeshed


### PR DESCRIPTION
The [Google style guide] now allows (and recommends) writing TODOs with the following format:

```cpp
// TODO: bug reference - details about what needs to be done.
```

With this change the checker accepts the new style and suggests in in the fix-it hint. The previous style is still accepted.

[Google style guide]: https://google.github.io/styleguide/cppguide.html#TODO_Comments