### PR TITLE
[SimplifyCFG] Simplify uncond br with icmp & select

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5122,7 +5122,7 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpInIt(
 /// case. This is called when we find an icmp instruction (a seteq/setne with a
 /// constant) and its following select instruction as the only TWO instruction
 /// in a block that ends with an uncond branch.  We are looking for a very
-/// specific pattern that occurs when "  
+/// specific pattern that occurs when "
 ///    if (A == 1) return C1;
 ///    if (A == 2) return C2;
 ///    if (A < 3) return C3;

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5165,8 +5165,8 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpSelectInIt(
     ICmpInst *ICI, SelectInst *Select, IRBuilder<> &Builder) {
   BasicBlock *BB = ICI->getParent();
 
-  // If the block has any PHIs in it or the icmp/select has multiple uses, it is too
-  // complex.
+  // If the block has any PHIs in it or the icmp/select has multiple uses, it is
+  // too complex.
   if (isa<PHINode>(BB->begin()) || !ICI->hasOneUse() || !Select->hasOneUse())
     return false;
 
@@ -5176,13 +5176,14 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpSelectInIt(
   BasicBlock *Pred = BB->getSinglePredecessor();
   if (!Pred || !isa<SwitchInst>(Pred->getTerminator()))
     return false;
-  
+
   Value *IcmpCond;
   ConstantInt *NewCaseVal;
   CmpPredicate Predicate;
 
   // Match icmp X, C
-  if (!match(ICI, m_ICmp(Predicate, m_Value(IcmpCond), m_ConstantInt(NewCaseVal))))
+  if (!match(ICI,
+             m_ICmp(Predicate, m_Value(IcmpCond), m_ConstantInt(NewCaseVal))))
     return false;
 
   Value *SelectCond, *SelectTrueVal, *SelectFalseVal;
@@ -5239,8 +5240,8 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpSelectInIt(
       isa<PHINode>(++BasicBlock::iterator(PHIUse)))
     return false;
 
-  // If the icmp is a SETEQ, then the default dest gets SelectFalseVal, the new edge gets
-  // SelectTrueVal in the PHI.
+  // If the icmp is a SETEQ, then the default dest gets SelectFalseVal, the new
+  // edge gets SelectTrueVal in the PHI.
   Value *DefaultCst = SelectFalseVal;
   Value *NewCst = SelectTrueVal;
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5014,7 +5014,7 @@ bool SimplifyCFGOpt::simplifyIndirectBrOnSelect(IndirectBrInst *IBI,
 bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpInIt(
     ICmpInst *ICI, IRBuilder<> &Builder) {
   // Select == nullptr means we assume that there is a hidden no-op select
-  // instruction of _ = `select %icmp, true, false` just after `%icmp = ...`
+  // instruction of `_ = select %icmp, true, false` just after `%icmp = icmp ...`
   return tryToSimplifyUncondBranchWithICmpSelectInIt(ICI, nullptr, Builder);
 }
 
@@ -5067,6 +5067,7 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpSelectInIt(
 
   // If the block has any PHIs in it or the icmp/select has multiple uses, it is
   // too complex.
+  /// TODO: support multi-phis in succ BB of select's BB.
   if (isa<PHINode>(BB->begin()) || !ICI->hasOneUse() ||
       (Select && !Select->hasOneUse()))
     return false;

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5160,7 +5160,7 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpSelectInIt(
 
   // Replace Select (which is used by the PHI for the default value) with
   // SelectFalseVal or SelectTrueVal depending on if ICI is EQ or NE.
-  if (!Select) {
+  if (Select) {
     Select->replaceAllUsesWith(DefaultCst);
     Select->eraseFromParent();
   } else {

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5014,7 +5014,7 @@ bool SimplifyCFGOpt::simplifyIndirectBrOnSelect(IndirectBrInst *IBI,
 bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpInIt(
     ICmpInst *ICI, IRBuilder<> &Builder) {
   // Select == nullptr means we assume that there is a hidden no-op select
-  // instruction of `_ = select %icmp, true, false` just after `%icmp = icmp ...`
+  // instruction of `_ = select %icmp, true, false` after `%icmp = icmp ...`
   return tryToSimplifyUncondBranchWithICmpSelectInIt(ICI, nullptr, Builder);
 }
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5020,7 +5020,7 @@ bool SimplifyCFGOpt::tryToSimplifyUncondBranchWithICmpInIt(
 
 /// Similar to tryToSimplifyUncondBranchWithICmpInIt, but handle a more generic
 /// case. This is called when we find an icmp instruction (a seteq/setne with a
-/// constant) and its following select instruction as the only TWO instruction
+/// constant) and its following select instruction as the only TWO instructions
 /// in a block that ends with an uncond branch.  We are looking for a very
 /// specific pattern that occurs when "
 ///    if (A == 1) return C1;

--- a/llvm/test/Transforms/SimplifyCFG/ARM/switch-to-lookup-table.ll
+++ b/llvm/test/Transforms/SimplifyCFG/ARM/switch-to-lookup-table.ll
@@ -15,8 +15,8 @@
 ; DISABLE-NOT: @{{.*}} = private unnamed_addr constant [3 x ptr] [ptr @c1, ptr @c2, ptr @c3]
 ; ENABLE:      @{{.*}} = private unnamed_addr constant [3 x ptr] [ptr @g1, ptr @g2, ptr @g3]
 ; DISABLE-NOT: @{{.*}} = private unnamed_addr constant [3 x ptr] [ptr @g1, ptr @g2, ptr @g3]
-; ENABLE:      @{{.*}} = private unnamed_addr constant [3 x ptr] [ptr @f1, ptr @f2, ptr @f3]
-; DISABLE-NOT: @{{.*}} = private unnamed_addr constant [3 x ptr] [ptr @f1, ptr @f2, ptr @f3]
+; ENABLE:      @{{.*}} = private unnamed_addr constant [4 x ptr] [ptr @f1, ptr @f2, ptr @f3, ptr @f4]
+; DISABLE-NOT: @{{.*}} = private unnamed_addr constant [4 x ptr] [ptr @f1, ptr @f2, ptr @f3, ptr @f4]
 
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7a--none-eabi"

--- a/llvm/test/Transforms/SimplifyCFG/switch-transformations-no-lut.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-transformations-no-lut.ll
@@ -410,13 +410,12 @@ define i1 @single_value_with_mask(i32 %x) {
 ; OPTNOLUT-NEXT:      i32 21, label %[[END]]
 ; OPTNOLUT-NEXT:      i32 48, label %[[END]]
 ; OPTNOLUT-NEXT:      i32 16, label %[[END]]
+; OPTNOLUT-NEXT:      i32 80, label %[[END]]
 ; OPTNOLUT-NEXT:    ]
 ; OPTNOLUT:       [[DEFAULT]]:
-; OPTNOLUT-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
-; OPTNOLUT-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i1 false, i1 true
 ; OPTNOLUT-NEXT:    br label %[[END]]
 ; OPTNOLUT:       [[END]]:
-; OPTNOLUT-NEXT:    [[RES:%.*]] = phi i1 [ false, %[[ENTRY]] ], [ false, %[[ENTRY]] ], [ false, %[[ENTRY]] ], [ false, %[[ENTRY]] ], [ [[SEL]], %[[DEFAULT]] ]
+; OPTNOLUT-NEXT:    [[RES:%.*]] = phi i1 [ false, %[[ENTRY]] ], [ false, %[[ENTRY]] ], [ false, %[[ENTRY]] ], [ false, %[[ENTRY]] ], [ true, %[[DEFAULT]] ], [ false, %[[ENTRY]] ]
 ; OPTNOLUT-NEXT:    ret i1 [[RES]]
 ;
 ; TTINOLUT-LABEL: define i1 @single_value_with_mask(

--- a/llvm/test/Transforms/SimplifyCFG/switch_create.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch_create.ll
@@ -1314,6 +1314,146 @@ if.end:
   ret void
 }
 
+define i32 @switch_with_icmp_select_after_it(i32 %x) {
+; CHECK-LABEL: @switch_with_icmp_select_after_it(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i32 18, label [[END:%.*]]
+; CHECK-NEXT:      i32 21, label [[END]]
+; CHECK-NEXT:      i32 48, label [[END]]
+; CHECK-NEXT:      i32 16, label [[END]]
+; CHECK-NEXT:    ]
+; CHECK:       default:
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 2, i32 3
+; CHECK-NEXT:    br label [[END]]
+; CHECK:       end:
+; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  switch i32 %x, label %default [
+  i32 18, label %end
+  i32 21, label %end
+  i32 48, label %end
+  i32 16, label %end
+  ]
+default:
+  %cmp = icmp eq i32 %x, 80
+  ; Create a new switch case BB for case 80.
+  %sel = select i1 %cmp, i32 2, i32 3
+  br label %end
+end:
+  %res = phi i32 [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ %sel, %default ]
+  ret i32 %res
+}
+
+define i32 @switch_with_icmp_select_after_it2(i32 %x) {
+; CHECK-LABEL: @switch_with_icmp_select_after_it2(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i32 18, label [[END:%.*]]
+; CHECK-NEXT:      i32 21, label [[END]]
+; CHECK-NEXT:      i32 48, label [[END]]
+; CHECK-NEXT:      i32 16, label [[END]]
+; CHECK-NEXT:    ]
+; CHECK:       default:
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 1, i32 3
+; CHECK-NEXT:    br label [[END]]
+; CHECK:       end:
+; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  switch i32 %x, label %default [
+  i32 18, label %end
+  i32 21, label %end
+  i32 48, label %end
+  i32 16, label %end
+  ]
+default:
+  %cmp = icmp eq i32 %x, 80
+  ; Should not create new case BB
+  %sel = select i1 %cmp, i32 1, i32 3
+  br label %end
+end:
+  %res = phi i32 [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ %sel, %default ]
+  ret i32 %res
+}
+
+define i32 @switch_with_icmp_select_after_it3(i32 %x) {
+; CHECK-LABEL: @switch_with_icmp_select_after_it3(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i32 18, label [[END:%.*]]
+; CHECK-NEXT:      i32 21, label [[END]]
+; CHECK-NEXT:      i32 48, label [[END]]
+; CHECK-NEXT:      i32 16, label [[END]]
+; CHECK-NEXT:    ]
+; CHECK:       default:
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 3, i32 1
+; CHECK-NEXT:    br label [[END]]
+; CHECK:       end:
+; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  switch i32 %x, label %default [
+  i32 18, label %end
+  i32 21, label %end
+  i32 48, label %end
+  i32 16, label %end
+  ]
+default:
+  %cmp = icmp eq i32 %x, 80
+  ; Should not create new case BB
+  %sel = select i1 %cmp, i32 3, i32 1
+  br label %end
+end:
+  %res = phi i32 [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ %sel, %default ]
+  ret i32 %res
+}
+
+; TODO: support this case (multi-phis).
+define i32 @switch_with_icmp_select_after_it_multi_phis(i32 %x) {
+; CHECK-LABEL: @switch_with_icmp_select_after_it_multi_phis(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i32 18, label [[END:%.*]]
+; CHECK-NEXT:      i32 21, label [[END]]
+; CHECK-NEXT:      i32 48, label [[END]]
+; CHECK-NEXT:      i32 16, label [[END]]
+; CHECK-NEXT:    ]
+; CHECK:       default:
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 2, i32 3
+; CHECK-NEXT:    br label [[END]]
+; CHECK:       end:
+; CHECK-NEXT:    [[RES1:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ 0, [[ENTRY]] ], [ 0, [[ENTRY]] ], [ 0, [[ENTRY]] ], [ 100, [[DEFAULT]] ]
+; CHECK-NEXT:    [[RES2:%.*]] = phi i32 [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
+; CHECK-NEXT:    [[RES:%.*]] = xor i32 [[RES1]], [[RES2]]
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  switch i32 %x, label %default [
+  i32 18, label %end
+  i32 21, label %end
+  i32 48, label %end
+  i32 16, label %end
+  ]
+default:
+  %cmp = icmp eq i32 %x, 80
+  %sel = select i1 %cmp, i32 2, i32 3
+  br label %end
+end:
+  %res1 = phi i32 [ 0, %entry ], [ 0, %entry ], [ 0, %entry ], [ 0, %entry ], [ 100, %default ]
+  %res2 = phi i32 [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ 1, %entry ], [ %sel, %default ]
+  %res = xor i32 %res1, %res2
+  ret i32 %res
+}
+
 !0 = !{!"function_entry_count", i32 100}
 !1 = !{!"branch_weights", i32 6, i32 10}
 ;.

--- a/llvm/test/Transforms/SimplifyCFG/switch_create.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch_create.ll
@@ -1322,13 +1322,14 @@ define i32 @switch_with_icmp_select_after_it(i32 %x) {
 ; CHECK-NEXT:      i32 21, label [[END]]
 ; CHECK-NEXT:      i32 48, label [[END]]
 ; CHECK-NEXT:      i32 16, label [[END]]
+; CHECK-NEXT:      i32 80, label [[SWITCH_EDGE:%.*]]
 ; CHECK-NEXT:    ]
+; CHECK:       switch.edge:
+; CHECK-NEXT:    br label [[END]]
 ; CHECK:       default:
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 2, i32 3
 ; CHECK-NEXT:    br label [[END]]
 ; CHECK:       end:
-; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
+; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 3, [[DEFAULT]] ], [ 2, [[SWITCH_EDGE]] ]
 ; CHECK-NEXT:    ret i32 [[RES]]
 ;
 entry:
@@ -1356,13 +1357,12 @@ define i32 @switch_with_icmp_select_after_it2(i32 %x) {
 ; CHECK-NEXT:      i32 21, label [[END]]
 ; CHECK-NEXT:      i32 48, label [[END]]
 ; CHECK-NEXT:      i32 16, label [[END]]
+; CHECK-NEXT:      i32 80, label [[END]]
 ; CHECK-NEXT:    ]
 ; CHECK:       default:
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 1, i32 3
 ; CHECK-NEXT:    br label [[END]]
 ; CHECK:       end:
-; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
+; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 3, [[DEFAULT]] ], [ 1, [[ENTRY]] ]
 ; CHECK-NEXT:    ret i32 [[RES]]
 ;
 entry:
@@ -1385,19 +1385,9 @@ end:
 define i32 @switch_with_icmp_select_after_it3(i32 %x) {
 ; CHECK-LABEL: @switch_with_icmp_select_after_it3(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT:%.*]] [
-; CHECK-NEXT:      i32 18, label [[END:%.*]]
-; CHECK-NEXT:      i32 21, label [[END]]
-; CHECK-NEXT:      i32 48, label [[END]]
-; CHECK-NEXT:      i32 16, label [[END]]
-; CHECK-NEXT:    ]
-; CHECK:       default:
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 80
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 80
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 3, i32 1
-; CHECK-NEXT:    br label [[END]]
-; CHECK:       end:
-; CHECK-NEXT:    [[RES:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ 1, [[ENTRY]] ], [ [[SEL]], [[DEFAULT]] ]
-; CHECK-NEXT:    ret i32 [[RES]]
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
 entry:
   switch i32 %x, label %default [


### PR DESCRIPTION
Previously, SimplifyCFG only simplified unconditional branches when they met a pattern (`swicth` -> `icmp` -> `br` -> `phi`) as follows:
```LLVM
   switch i8 %A, label %DEFAULT [ i8 1, label %end    i8 2, label %end ]
DEFAULT:
   %tmp = icmp eq i8 %A, 92
   br label %end
end:
   ... = phi i1 [ true, %entry ], [ %tmp, %DEFAULT ], [ true, %entry ]
```

This PR supports a new and more generic pattern (`switch` -> `icmp` -> `select` -> `br` -> `phi` ) to simplify unconditional branches as follows:
```LLVM
; BEFORE
case1:
  switch i32 %x, label %DEFAULT [ 
    i32 0, label %end    
    i32 1, label %case2 
  ]
case2:
  br label %end
DEFAULT:
  %tmp = icmp eq i32 %x, 2
  %val = select i1 %tmp, i32 V3, i32 V4
  br label %end
end:
  ... = phi i32 [ V1, %case1 ], [ V2, %case2 ], [ %val, %DEFAULT ]
```

We prefer to split the edge to 'end' so that there are TWO entries of V3/V4 to the PHI, merging the icmp & select into the switch, as follows:
```LLVM
; AFTER
case1:
  switch i32 %x, label %DEFAULT [
    i32 0, label %end
    i32 1, label %case2
    i32 2, label %case3
  ]
case2:
  br label %end
case3:
  br label %end
DEFAULT:
  br label %end
end:
  ... = phi i32 [ V1, %case1 ], [ V2, %case2 ], [ V3, %case3 ], [ V4, %DEFAULT]
```

Alive2 Proof: https://alive2.llvm.org/ce/z/jYHM4f
Promising Optimization Impact: https://github.com/dtcxzyw/llvm-opt-benchmark/pull/3006