### PR TITLE
[GlobalMerge]Prefer use global-merge-max-offset instead of the target-specific constant offset.

### DIFF
--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -196,6 +196,13 @@ class GlobalMerge : public FunctionPass {
 public:
   static char ID; // Pass identification, replacement for typeid.
 
+  explicit GlobalMerge() : FunctionPass(ID) {
+    Opt.MaxOffset = GlobalMergeMaxOffset;
+    Opt.MergeConstantGlobals = EnableGlobalMergeOnConst;
+    Opt.MergeConstAggressive = GlobalMergeAllConst;
+    initializeGlobalMergePass(*PassRegistry::getPassRegistry());
+  }
+
   explicit GlobalMerge(const TargetMachine *TM, unsigned MaximalOffset,
                        bool OnlyOptimizeForSize, bool MergeExternalGlobals,
                        bool MergeConstantGlobals, bool MergeConstAggressive)
@@ -765,8 +772,9 @@ Pass *llvm::createGlobalMergePass(const TargetMachine *TM, unsigned Offset,
   bool MergeConstAggressive = GlobalMergeAllConst.getNumOccurrences() > 0
                                   ? GlobalMergeAllConst
                                   : MergeConstAggressiveByDefault;
-  unsigned PreferOffset = GlobalMergeMaxOffset.getNumOccurrences() > 0 ?
-    GlobalMergeMaxOffset : Offset;
+  unsigned PreferOffset = GlobalMergeMaxOffset.getNumOccurrences() > 0
+                              ? GlobalMergeMaxOffset
+                              : Offset;
   return new GlobalMerge(TM, PreferOffset, OnlyOptimizeForSize, MergeExternal,
                          MergeConstant, MergeConstAggressive);
 }

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -196,13 +196,6 @@ class GlobalMerge : public FunctionPass {
 public:
   static char ID; // Pass identification, replacement for typeid.
 
-  explicit GlobalMerge() : FunctionPass(ID) {
-    Opt.MaxOffset = GlobalMergeMaxOffset;
-    Opt.MergeConstantGlobals = EnableGlobalMergeOnConst;
-    Opt.MergeConstAggressive = GlobalMergeAllConst;
-    initializeGlobalMergePass(*PassRegistry::getPassRegistry());
-  }
-
   explicit GlobalMerge(const TargetMachine *TM, unsigned MaximalOffset,
                        bool OnlyOptimizeForSize, bool MergeExternalGlobals,
                        bool MergeConstantGlobals, bool MergeConstAggressive)
@@ -772,7 +765,8 @@ Pass *llvm::createGlobalMergePass(const TargetMachine *TM, unsigned Offset,
   bool MergeConstAggressive = GlobalMergeAllConst.getNumOccurrences() > 0
                                   ? GlobalMergeAllConst
                                   : MergeConstAggressiveByDefault;
-  unsigned PreferOffset = GlobalMergeMaxOffset ? GlobalMergeMaxOffset : Offset;
+  unsigned PreferOffset = GlobalMergeMaxOffset.getNumOccurrences() > 0 ?
+    GlobalMergeMaxOffset : Offset;
   return new GlobalMerge(TM, PreferOffset, OnlyOptimizeForSize, MergeExternal,
                          MergeConstant, MergeConstAggressive);
 }

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -773,6 +773,6 @@ Pass *llvm::createGlobalMergePass(const TargetMachine *TM, unsigned Offset,
                                   ? GlobalMergeAllConst
                                   : MergeConstAggressiveByDefault;
   unsigned PreferOffset = GlobalMergeMaxOffset ? GlobalMergeMaxOffset : Offset;
-  return new GlobalMerge(TM, PerferOffset, OnlyOptimizeForSize, MergeExternal,
+  return new GlobalMerge(TM, PreferOffset, OnlyOptimizeForSize, MergeExternal,
                          MergeConstant, MergeConstAggressive);
 }

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -772,6 +772,7 @@ Pass *llvm::createGlobalMergePass(const TargetMachine *TM, unsigned Offset,
   bool MergeConstAggressive = GlobalMergeAllConst.getNumOccurrences() > 0
                                   ? GlobalMergeAllConst
                                   : MergeConstAggressiveByDefault;
-  return new GlobalMerge(TM, Offset, OnlyOptimizeForSize, MergeExternal,
+  unsigned PreferOffset = GlobalMergeMaxOffset ? GlobalMergeMaxOffset : Offset;
+  return new GlobalMerge(TM, PerferOffset, OnlyOptimizeForSize, MergeExternal,
                          MergeConstant, MergeConstAggressive);
 }

--- a/llvm/test/CodeGen/AArch64/global-merge.ll
+++ b/llvm/test/CodeGen/AArch64/global-merge.ll
@@ -1,17 +1,22 @@
 ; RUN: llc < %s -mtriple=aarch64-none-linux-gnu -O0 | FileCheck --check-prefix=NO-MERGE %s
+; RUN: llc < %s -mtriple=aarch64-none-linux-gnu -O1 | FileCheck --check-prefix=NO-MERGE %s
+; RUN: llc < %s -mtriple=aarch64-none-linux-gnu -O2 | FileCheck --check-prefix=NO-MERGE %s
+; RUN: llc < %s -mtriple=aarch64-none-linux-gnu -O3 | FileCheck %s
+; RUN: llc < %s -mtriple=aarch64-none-linux-gnu -O3 -global-merge-max-offset=0 | FileCheck %s --check-prefix=NO-MERGE
 ; RUN: llc < %s -mtriple=aarch64-none-linux-gnu -O0 -global-merge-on-external=true | FileCheck --check-prefix=NO-MERGE %s
 
 ; RUN: llc < %s -mtriple=aarch64-apple-ios -O0 | FileCheck %s --check-prefix=CHECK-APPLE-IOS-NO-MERGE
+; RUN: llc < %s -mtriple=aarch64-apple-ios -O1 | FileCheck %s --check-prefix=CHECK-APPLE-IOS-NO-MERGE
+; RUN: llc < %s -mtriple=aarch64-apple-ios -O2 | FileCheck %s --check-prefix=CHECK-APPLE-IOS-NO-MERGE
+; RUN: llc < %s -mtriple=aarch64-apple-ios -O3 | FileCheck %s --check-prefix=CHECK-APPLE-IOS
 ; RUN: llc < %s -mtriple=aarch64-apple-ios -O0 -global-merge-on-external=true | FileCheck %s --check-prefix=CHECK-APPLE-IOS-NO-MERGE
-
-; FIXME: add O1/O2 test for aarch64-none-linux-gnu and aarch64-apple-ios
 
 @m = internal global i32 0, align 4
 @n = internal global i32 0, align 4
 
 define void @f1(i32 %a1, i32 %a2) {
 ; CHECK-LABEL: f1:
-; CHECK: adrp x{{[0-9]+}}, _MergedGlobals
+; CHECK: adrp x{{[0-9]+}}, .L_MergedGlobals
 ; CHECK-NOT: adrp
 
 ; CHECK-APPLE-IOS-LABEL: f1:
@@ -22,9 +27,9 @@ define void @f1(i32 %a1, i32 %a2) {
   ret void
 }
 
-; CHECK:        .local _MergedGlobals
-; CHECK:        .comm  _MergedGlobals,8,8
+; CHECK:        .local .L_MergedGlobals
+; CHECK:        .comm  .L_MergedGlobals,8,4
 ; NO-MERGE-NOT: .local _MergedGlobals
 
-; CHECK-APPLE-IOS: .zerofill __DATA,__bss,__MergedGlobals,8,3
-; CHECK-APPLE-IOS-NO-MERGE-NOT: .zerofill __DATA,__bss,__MergedGlobals,8,3
+; CHECK-APPLE-IOS: .zerofill __DATA,__bss,__MergedGlobals,8,2
+; CHECK-APPLE-IOS-NO-MERGE-NOT: .zerofill __DATA,__bss,__MergedGlobals,8,2

--- a/llvm/test/CodeGen/ARM/global-merge-1.ll
+++ b/llvm/test/CodeGen/ARM/global-merge-1.ll
@@ -7,7 +7,7 @@
 ; RUN: llc %s -O3 -o - | FileCheck -check-prefix=MERGE %s
 ; RUN: llc %s -O3 -o - -arm-global-merge=false | FileCheck -check-prefix=NO-MERGE %s
 ; RUN: llc %s -O3 -o - -arm-global-merge=true | FileCheck -check-prefix=MERGE %s
-; RUN: llc %s -O3 -o - -arm-global-merge=true -global-merge-max-offse=0 | FileCheck -check-prefix=NO-MERGE %s
+; RUN: llc %s -O3 -o - -arm-global-merge=true -global-merge-max-offset=0 | FileCheck -check-prefix=NO-MERGE %s
 
 ; MERGE-NOT: .zerofill __DATA,__bss,_bar,20,2
 ; MERGE-NOT: .zerofill __DATA,__bss,_baz,20,2

--- a/llvm/test/CodeGen/ARM/global-merge-1.ll
+++ b/llvm/test/CodeGen/ARM/global-merge-1.ll
@@ -7,6 +7,7 @@
 ; RUN: llc %s -O3 -o - | FileCheck -check-prefix=MERGE %s
 ; RUN: llc %s -O3 -o - -arm-global-merge=false | FileCheck -check-prefix=NO-MERGE %s
 ; RUN: llc %s -O3 -o - -arm-global-merge=true | FileCheck -check-prefix=MERGE %s
+; RUN: llc %s -O3 -o - -arm-global-merge=true -global-merge-max-offse=0 | FileCheck -check-prefix=NO-MERGE %s
 
 ; MERGE-NOT: .zerofill __DATA,__bss,_bar,20,2
 ; MERGE-NOT: .zerofill __DATA,__bss,_baz,20,2


### PR DESCRIPTION
In the Dhrystone benchmark, I find some adjacent global not be merged, on the contrary the GCC's anchor optimize is work. Use global-merge-max-offset to set the max offset can yield similar results (still slightly different, at least we can control the offset).