### PR TITLE
[lldb-dap][test] skip io_redirection in debug builds

### DIFF
--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -642,6 +642,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
     @skipIfAsan
     @skipIfWindows
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
+    @skipIfBuildType(["debug"])
     def test_stdio_redirection_and_console(self):
         """
         Test stdio redirection and console.


### PR DESCRIPTION
Currently all `runInTerminal` test are skipped in debug builds because, when attaching it times out parsing the debug symbols of lldb-dap.

Add this test since it is running in teminal.