### PR TITLE
[LLDB] Skip TestMultipleSlides.py on Windows

### DIFF
--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -12,6 +12,9 @@ from lldbsuite.test import lldbutil
 class MultipleSlidesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    # DWARF doesn't include public symbols on Windows, so LLDB falls back to the PDB.
+    # Symbols don't have a size in the native PDB plugin.
+    @skipIfWindows
     def test_mulitple_slides(self):
         """Test that a binary can be slid multiple times correctly."""
         self.build()

--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -12,8 +12,9 @@ from lldbsuite.test import lldbutil
 class MultipleSlidesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    # DWARF doesn't include public symbols on Windows, so LLDB falls back to the PDB.
-    # Symbols don't have a size in the native PDB plugin.
+    # The intermediate object main.o is compiled without debug info, but
+    # a.out is linked with `-gdwarf` on Windows. This creates a PDB.
+    # However, in the native PDB plugin, the symbols don't have a size.
     @skipIfWindows
     def test_mulitple_slides(self):
         """Test that a binary can be slid multiple times correctly."""

--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -15,7 +15,7 @@ class MultipleSlidesTestCase(TestBase):
     # The intermediate object main.o is compiled without debug info, but
     # a.out is linked with `-gdwarf` on Windows. This creates a PDB.
     # However, in the native PDB plugin, the symbols don't have a size.
-    @skipIfWindows
+    @expectedFailureWindows
     def test_mulitple_slides(self):
         """Test that a binary can be slid multiple times correctly."""
         self.build()


### PR DESCRIPTION
After the default PDB plugin changed to the native one (#165363), this test failed, because it uses the size of public symbols and the native plugin sets the size to 0 (as PDB doesn't include this information explicitly). A PDB was built because the final executable in that test was linked with `-gdwarf`.