### PR TITLE
[TSan][Test-Only][Darwin] Fix typo in external.cpp again

### DIFF
--- a/compiler-rt/test/tsan/Darwin/external.cpp
+++ b/compiler-rt/test/tsan/Darwin/external.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
   // TEST3: WARNING: ThreadSanitizer: race on MyLibrary::MyObject
   // TEST3: {{Modifying|Read-only}} access of MyLibrary::MyObject at
   // TEST3: {{ObjectWrite|ObjectRead}}
-  // TEST3: Previous {{modifying|Read-only}} access of MyLibrary::MyObject at
+  // TEST3: Previous {{modifying|read-only}} access of MyLibrary::MyObject at
   // TEST3: {{ObjectWrite|ObjectRead}}
   // TEST3: Location is MyLibrary::MyObject of size 16 at
   // TEST3: {{ObjectCreate}}


### PR DESCRIPTION
In 2ecb748 I made an adjustment to the FileCheck for the external.cpp test; unfortunately I corrected both instances of read-only to Read-only when it should have just been the first.

This patch fixes it.

rdar://160818196