### PR TITLE
Filter out unemitted metadata before assertion in AIXAsmPrinter.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2750,6 +2750,10 @@ void PPCAIXAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   if (isSpecialLLVMGlobalArrayToSkip(GV) || isSpecialLLVMGlobalArrayForStaticInit(GV))
     return;
 
+  // Ignore non-emitted data.
+  if (GV->getSection() == "llvm.metadata")
+    return;
+
   // If the Global Variable has the toc-data attribute, it needs to be emitted
   // when we emit the .toc section.
   if (GV->hasAttribute("toc-data")) {

--- a/llvm/test/CodeGen/PowerPC/annotate-metadata.ll
+++ b/llvm/test/CodeGen/PowerPC/annotate-metadata.ll
@@ -1,0 +1,15 @@
+; RUN: llc -verify-machineinstrs -mcpu=pwr8 -mtriple powerpc-ibm-aix-xcoff < \
+; RUN: %s | FileCheck %s
+; RUN: llc -verify-machineinstrs -mcpu=pwr8 -mtriple powerpc64le-unknown-linux < \
+; RUN: %s | FileCheck %s
+
+@.str = private unnamed_addr constant [12 x i8] c"MY_METADATA\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr constant [10 x i8] c"my_file.c\00", section "llvm.metadata"
+@global.annotations = appending global [3 x { ptr, ptr, ptr, i32, ptr }] [{ ptr, ptr, ptr, i32, ptr } { ptr @a, ptr @.str, ptr @.str.1, i32 100, ptr null }, { ptr, ptr, ptr, i32, ptr } { ptr @b, ptr @.str, ptr @.str.1, i32 200, ptr null }, { ptr, ptr, ptr, i32, ptr } { ptr @c, ptr @.str, ptr @.str.1, i32 300, ptr null }], section "llvm.metadata"
+
+@a = global i32 1
+@b = global i32 2
+@c = global i32 3
+
+; CHECK-NOT: metadata
+; CHECK-NOT: annotations


### PR DESCRIPTION
Global annotations metadata would trigger an assertion during code emission on AIX. Filter out globals that are in the "llvm.metadata" section before reaching the assert. Adds a test to verify the metadata is not emitted on either ELF or XCOFF targets.