### PR TITLE
[clang-tidy] Fix `readability-container-data-pointer` check

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -103,7 +103,7 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
 
   const Expr *PrintedCE = CE->IgnoreParenImpCasts();
 
-  const SourceRange SrcRange = PrintedCE->getSourceRange();
+  SourceRange SrcRange = PrintedCE->getSourceRange();
 
   std::string ReplacementText{
       Lexer::getSourceText(CharSourceRange::getTokenRange(SrcRange),

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -84,7 +84,7 @@ void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
               arraySubscriptExpr(hasLHS(ContainerExpr), hasRHS(Zero)))))))
           .bind(AddressOfName);
 
-  Finder->addMatcher(traverse(TK_AsIs, AddressOfMatcher), this);
+  Finder->addMatcher(AddressOfMatcher, this);
 }
 
 void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -108,7 +108,7 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
                            *Result.SourceManager, getLangOpts())};
 
   const auto *OpCall = dyn_cast<CXXOperatorCallExpr>(CE);
-  bool NeedsParens =
+  const bool NeedsParens =
       OpCall ? (OpCall->getOperator() != OO_Subscript)
              : !isa<DeclRefExpr, MemberExpr, ArraySubscriptExpr, CallExpr>(CE);
   if (NeedsParens)

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -107,8 +107,11 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
       Lexer::getSourceText(CharSourceRange::getTokenRange(SrcRange),
                            *Result.SourceManager, getLangOpts())};
 
-  if (!isa<DeclRefExpr, ArraySubscriptExpr, CXXOperatorCallExpr, CallExpr,
-           MemberExpr>(CE))
+  const auto *OpCall = dyn_cast<CXXOperatorCallExpr>(CE);
+  bool NeedsParens =
+      OpCall ? (OpCall->getOperator() != OO_Subscript)
+             : !isa<DeclRefExpr, MemberExpr, ArraySubscriptExpr, CallExpr>(CE);
+  if (NeedsParens)
     ReplacementText = "(" + ReplacementText + ")";
 
   if (CE->getType()->isPointerType())

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -84,7 +84,7 @@ void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
               arraySubscriptExpr(hasLHS(ContainerExpr), hasRHS(Zero)))))))
           .bind(AddressOfName);
 
-  Finder->addMatcher(AddressOfMatcher, this);
+  Finder->addMatcher(traverse(TK_AsIs, AddressOfMatcher), this);
 }
 
 void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -103,7 +103,7 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
 
   const Expr *PrintedCE = CE->IgnoreParenImpCasts();
 
-  SourceRange SrcRange = PrintedCE->getSourceRange();
+  const SourceRange SrcRange = PrintedCE->getSourceRange();
 
   std::string ReplacementText{
       Lexer::getSourceText(CharSourceRange::getTokenRange(SrcRange),

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.h
@@ -34,7 +34,7 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
   std::optional<TraversalKind> getCheckTraversalKind() const override {
-    return TK_AsIs;
+    return TK_IgnoreUnlessSpelledInSource;
   }
 
 private:

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.h
@@ -34,7 +34,7 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
   std::optional<TraversalKind> getCheckTraversalKind() const override {
-    return TK_IgnoreUnlessSpelledInSource;
+    return TK_AsIs;
   }
 
 private:

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -430,7 +430,7 @@ Changes in existing checks
   in non-standard containers.
 
 - Improved :doc:`readability-container-data-pointer
-  <clang-tidy/checks/readability/container-data-pointer>`check by correctly
+  <clang-tidy/checks/readability/container-data-pointer>` check by correctly
   adding parentheses when the container expression is a dereference.
 
 - Improved :doc:`readability-container-size-empty

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -362,7 +362,7 @@ Changes in existing checks
 
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check to avoid false
-  positives when pointers is transferred to non-const references 
+  positives when pointers is transferred to non-const references
   and avoid false positives of function pointer and fix false
   positives on return of non-const pointer.
 
@@ -428,6 +428,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/container-contains>` to support string
   comparisons to ``npos``. Internal changes may cause new rare false positives
   in non-standard containers.
+
+- Improved :doc:`readability-container-data-pointer
+  <clang-tidy/checks/readability/container-data-pointer>`check by correctly
+  adding parentheses when the container expression is a dereference.
 
 - Improved :doc:`readability-container-size-empty
   <clang-tidy/checks/readability/container-size-empty>` check by correctly

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -157,8 +157,8 @@ void s(std::unique_ptr<std::vector<unsigned char>> p) {
   // CHECK-FIXES: f((*p).data());
 }
 
-template <typename T>
-void u(std::unique_ptr<T> p) {
+template <typename Cont>
+void u(std::unique_ptr<Cont> p) {
   f(&(*p)[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES: f((*p).data());

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -156,3 +156,14 @@ void s(std::unique_ptr<std::vector<unsigned char>> p) {
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES: f((*p).data());
 }
+
+void t(std::unique_ptr<container_without_data<unsigned char>> p) {
+  // p has no "data" member function, so no warning
+  f(&(*p)[0]);
+}
+
+template <typename T>
+void u(std::unique_ptr<T> p) {
+  // we don't know if 'T' will always have "data" member function, so no warning
+  f(&(*p)[0]);
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -156,12 +156,3 @@ void s(std::unique_ptr<std::vector<unsigned char>> p) {
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES: f((*p).data());
 }
-
-template <typename Cont>
-void u(std::unique_ptr<Cont> p) {
-  f(&(*p)[0]);
-  // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES: f((*p).data());
-}
-
-template void u<std::vector<int>>(std::unique_ptr<std::vector<int>>);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -35,6 +35,12 @@ template <typename T>
 struct enable_if<true, T> {
   typedef T type;
 };
+
+template <typename T>
+struct unique_ptr {
+  T &operator*() const;
+  T *operator->() const;
+};
 }
 
 template <typename T>
@@ -143,4 +149,10 @@ int *r() {
   return &holder.v[0];
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES: return holder.v.data();
+}
+
+void s(std::unique_ptr<std::vector<unsigned char>> p) {
+  f(&(*p)[0]);
+  // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES: f((*p).data());
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -156,3 +156,12 @@ void s(std::unique_ptr<std::vector<unsigned char>> p) {
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES: f((*p).data());
 }
+
+template <typename Cont>
+void u(std::unique_ptr<Cont> p) {
+  f(&(*p)[0]);
+  // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES: f((*p).data());
+}
+
+template void u<std::vector<int>>(std::unique_ptr<std::vector<int>>);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -157,8 +157,8 @@ void s(std::unique_ptr<std::vector<unsigned char>> p) {
   // CHECK-FIXES: f((*p).data());
 }
 
-template <typename Cont>
-void u(std::unique_ptr<Cont> p) {
+template <typename T>
+void u(std::unique_ptr<T> p) {
   f(&(*p)[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES: f((*p).data());


### PR DESCRIPTION
Fix issue in readability-container-data-pointer when the container expression is a dereference (e.g., `&(*p)[0]`). The previous fix-it suggested `*p.data()`, which changes semantics because `.` binds tighter than `*`. The fix now correctly suggests `(*p).data()`.

Closes [#164852](https://github.com/llvm/llvm-project/issues/164852)
