### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Assertion failure with coroutine body

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -578,6 +578,10 @@ public:
     return WithCachedResult(CS, [&]() { return VisitChildren(CS); });
   }
 
+  bool VisitCoroutineBodyStmt(const CoroutineBodyStmt *CBS) {
+    return WithCachedResult(CBS, [&]() { return VisitChildren(CBS); });
+  }
+
   bool VisitReturnStmt(const ReturnStmt *RS) {
     // A return statement is allowed as long as the return value is trivial.
     if (auto *RV = RS->getRetValue())

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures-co_await-assertion-failure.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures-co_await-assertion-failure.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=webkit.UncountedLambdaCapturesChecker -std=c++20 -verify %s
+// expected-no-diagnostics
+
+template<typename Arg>
+void foo(Arg&& arg)
+{
+    [&]{
+        co_await [&](auto&&... args) {
+        }(arg);
+    }();
+}


### PR DESCRIPTION
Fix the assertion failure in TrivialFunctionAnalysis::isTrivialImpl with a coroutine body by caching the result with WithCachedResult.