### PR TITLE
[llvm-cxxfilt] update docs to reflect #106233

### DIFF
--- a/llvm/docs/CommandGuide/llvm-cxxfilt.rst
+++ b/llvm/docs/CommandGuide/llvm-cxxfilt.rst
@@ -54,8 +54,7 @@ OPTIONS
 
 .. option:: --no-strip-underscore, -n
 
-  Do not strip a leading underscore. This is the default for all platforms
-  except Mach-O based hosts.
+  Do not strip a leading underscore. This is the default for all platforms.
 
 .. option:: --quote
 
@@ -64,7 +63,7 @@ OPTIONS
 .. option:: --strip-underscore, -_
 
   Strip a single leading underscore, if present, from each input name before
-  demangling. On by default on Mach-O based platforms.
+  demangling.
 
 .. option:: --types, -t
 


### PR DESCRIPTION
It looks like the documentation for `llvm-cxxfilt`'s `--[no-]strip-underscore` options weren't updated when https://github.com/llvm/llvm-project/pull/106233 was made.

CC @Michael137 (I don't have merge rights myself).