### PR TITLE
[llvm] Improve IR dump to files

### DIFF
--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -25,6 +25,7 @@
 #include "llvm/IR/DroppedVariableStatsIR.h"
 #include "llvm/IR/OptBisect.h"
 #include "llvm/IR/PassTimingInfo.h"
+#include "llvm/IR/PrintPasses.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
@@ -81,14 +82,6 @@ private:
   void pushPassRunDescriptor(StringRef PassID, Any IR, unsigned PassNumber);
   PassRunDescriptor popPassRunDescriptor(StringRef PassID);
 
-  enum class IRDumpFileSuffixType {
-    Before,
-    After,
-    Invalidated,
-  };
-
-  static StringRef
-  getFileSuffix(PrintIRInstrumentation::IRDumpFileSuffixType Type);
   std::string fetchDumpFilename(StringRef PassId, StringRef IRFileDisplayName,
                                 unsigned PassNumber,
                                 IRDumpFileSuffixType SuffixType);

--- a/llvm/lib/Analysis/CallGraphSCCPass.cpp
+++ b/llvm/lib/Analysis/CallGraphSCCPass.cpp
@@ -675,18 +675,20 @@ namespace {
 
     bool runOnSCC(CallGraphSCC &SCC) override {
       bool BannerPrinted = false;
+
+      IRDumpStream dmp("call-graph-scc", Banner, OS);
       auto PrintBannerOnce = [&]() {
         if (BannerPrinted)
           return;
-        OS << Banner;
+        dmp.os() << Banner;
         BannerPrinted = true;
       };
 
       bool NeedModule = llvm::forcePrintModuleIR();
       if (isFunctionInPrintList("*") && NeedModule) {
         PrintBannerOnce();
-        OS << "\n";
-        SCC.getCallGraph().getModule().print(OS, nullptr);
+        dmp.os() << "\n";
+        SCC.getCallGraph().getModule().print(dmp.os(), nullptr);
         return false;
       }
       bool FoundFunction = false;
@@ -696,18 +698,18 @@ namespace {
             FoundFunction = true;
             if (!NeedModule) {
               PrintBannerOnce();
-              F->print(OS);
+              F->print(dmp.os());
             }
           }
         } else if (isFunctionInPrintList("*")) {
           PrintBannerOnce();
-          OS << "\nPrinting <null> Function\n";
+          dmp.os() << "\nPrinting <null> Function\n";
         }
       }
       if (NeedModule && FoundFunction) {
         PrintBannerOnce();
-        OS << "\n";
-        SCC.getCallGraph().getModule().print(OS, nullptr);
+        dmp.os() << "\n";
+        SCC.getCallGraph().getModule().print(dmp.os(), nullptr);
       }
       return false;
     }

--- a/llvm/lib/Analysis/LoopPass.cpp
+++ b/llvm/lib/Analysis/LoopPass.cpp
@@ -51,7 +51,8 @@ public:
     auto BBI = llvm::find_if(L->blocks(), [](BasicBlock *BB) { return BB; });
     if (BBI != L->blocks().end() &&
         isFunctionInPrintList((*BBI)->getParent()->getName())) {
-      printLoop(*L, OS, Banner);
+      IRDumpStream dmp("loop", Banner, OS);
+      printLoop(*L, dmp.os(), Banner);
     }
     return false;
   }

--- a/llvm/lib/Analysis/RegionPass.cpp
+++ b/llvm/lib/Analysis/RegionPass.cpp
@@ -191,12 +191,14 @@ public:
   bool runOnRegion(Region *R, RGPassManager &RGM) override {
     if (!isFunctionInPrintList(R->getEntry()->getParent()->getName()))
       return false;
-    Out << Banner;
+
+    IRDumpStream dmp("region", Banner, Out);
+    dmp.os() << Banner;
     for (const auto *BB : R->blocks()) {
       if (BB)
-        BB->print(Out);
+        BB->print(dmp.os());
       else
-        Out << "Printing <null> Block";
+        dmp.os() << "Printing <null> Block";
     }
 
     return false;

--- a/llvm/lib/CodeGen/MachineFunctionPrinterPass.cpp
+++ b/llvm/lib/CodeGen/MachineFunctionPrinterPass.cpp
@@ -46,9 +46,10 @@ struct MachineFunctionPrinterPass : public MachineFunctionPass {
   bool runOnMachineFunction(MachineFunction &MF) override {
     if (!isFunctionInPrintList(MF.getName()))
       return false;
-    OS << "# " << Banner << ":\n";
+    IRDumpStream dmp("machine-function", Banner, OS);
+    dmp.os() << "# " << Banner << ":\n";
     auto *SIWrapper = getAnalysisIfAvailable<SlotIndexesWrapperPass>();
-    MF.print(OS, SIWrapper ? &SIWrapper->getSI() : nullptr);
+    MF.print(dmp.os(), SIWrapper ? &SIWrapper->getSI() : nullptr);
     return false;
   }
 };

--- a/llvm/lib/IR/LegacyPassManager.cpp
+++ b/llvm/lib/IR/LegacyPassManager.cpp
@@ -736,10 +736,10 @@ void PMTopLevelManager::schedulePass(Pass *P) {
   }
 
   if (PI && !PI->isAnalysis() && shouldPrintBeforePass(PI->getPassArgument())) {
-    Pass *PP =
-        P->createPrinterPass(dbgs(), ("*** IR Dump Before " + P->getPassName() +
-                                      " (" + PI->getPassArgument() + ") ***")
-                                         .str());
+    Pass *PP = P->createPrinterPass(
+        dbgs(),
+        IRDumpStream::buildBanner(P->getPassName(), PI->getPassArgument(),
+                                  IRDumpFileSuffixType::Before));
     PP->assignPassManager(activeStack, getTopLevelPassManagerType());
   }
 
@@ -747,10 +747,10 @@ void PMTopLevelManager::schedulePass(Pass *P) {
   P->assignPassManager(activeStack, getTopLevelPassManagerType());
 
   if (PI && !PI->isAnalysis() && shouldPrintAfterPass(PI->getPassArgument())) {
-    Pass *PP =
-        P->createPrinterPass(dbgs(), ("*** IR Dump After " + P->getPassName() +
-                                      " (" + PI->getPassArgument() + ") ***")
-                                         .str());
+    Pass *PP = P->createPrinterPass(
+        dbgs(),
+        IRDumpStream::buildBanner(P->getPassName(), PI->getPassArgument(),
+                                  IRDumpFileSuffixType::After));
     PP->assignPassManager(activeStack, getTopLevelPassManagerType());
   }
 }

--- a/llvm/test/Other/check-ir-dump-filenames.py
+++ b/llvm/test/Other/check-ir-dump-filenames.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python3
+
+import re
+import sys
+import os
+
+dir = sys.argv[1]
+pat = pat_arg = sys.argv[2:]
+pat = "".join(pat)
+pat = re.compile(pat)
+
+filenames = os.listdir(dir)
+if len(filenames) < 2:
+    print(f"expecting at least 2 files in {dir} but got {len(filenames)}")
+    sys.exit(1)
+
+
+def fndict(fn):
+    m = pat.match(fn)
+    if not m:
+        print(f"filename '{fn}' does not match pattern '{pat_arg}'")
+        sys.exit(1)
+    return m.groupdict()
+
+
+first = fndict(filenames[0])
+should_check_ordinal = "ordinal" in first
+should_check_suffix = "suffix" in first
+should_check_suffix_ordinal = should_check_suffix and "suffix_ordinal" in first
+should_check_before_after = should_check_suffix and should_check_ordinal
+
+should_check_pass_id = "pass_id" in first
+should_check_kind = "kind" in first
+should_check_pass_number = "pass_number" in first
+
+if should_check_ordinal:
+    filenames = sorted(filenames, key=lambda x: fndict(x)["ordinal"])
+first = fndict(filenames[0])
+second = fndict(filenames[1])
+
+
+def failed(msg):
+    print(f"error: {msg}")
+    sys.exit(1)
+
+
+def check(actual, expected, name):
+    if actual != expected:
+        failed(f"error: expected {name} '{expected}' but got '{actual}' ")
+
+
+# ------------------------------------------------------------------------------
+# ordinal
+# ------------------------------------------------------------------------------
+def check_ordinal(d, prev):
+    if not should_check_ordinal:
+        return
+    actual = int(d["ordinal"])
+    expected = int(prev["ordinal"]) + 1
+    check(actual, expected, "ordinal")
+
+
+# ------------------------------------------------------------------------------
+# suffix
+# ------------------------------------------------------------------------------
+suffix_ordinal_list = ["before", "after"]
+suffix_map = {}
+if should_check_before_after:
+    suffix_map |= {first["suffix"]: second["suffix"]}
+    suffix_map |= {second["suffix"]: first["suffix"]}
+
+
+def check_suffix(d, prev):
+    if not should_check_suffix:
+        return
+    suffix = d["suffix"]
+    if should_check_before_after:
+        if suffix not in suffix_map:
+            failed(f"suffix '{suffix}' not in {suffix_map}")
+        if prev is not None:
+            check(suffix, suffix_map[prev["suffix"]], "suffix")
+    else:
+        if suffix not in suffix_ordinal_list:
+            failed(f"suffix '{suffix}' not in {suffix_ordinal_list}")
+    if should_check_suffix_ordinal:
+        suffix_ordinal = int(d["suffix_ordinal"])
+        check(suffix_ordinal, suffix_ordinal_list.index(suffix), "suffix ordinal")
+
+
+# ------------------------------------------------------------------------------
+# pass number
+# ------------------------------------------------------------------------------
+def check_pass_number(d, prev):
+    if not should_check_pass_number or not should_check_before_after:
+        return
+    actual = d["pass_number"]
+    if d["suffix"] == "after":
+        expected = prev["pass_number"]
+        check(actual, expected, "pass number")
+
+
+# ------------------------------------------------------------------------------
+# pass id
+# ------------------------------------------------------------------------------
+def check_pass_id(d, prev):
+    if not should_check_pass_id or not should_check_before_after:
+        return
+    actual = d["pass_id"]
+    if d["suffix"] == "after":
+        expected = prev["pass_id"]
+        check(actual, expected, "pass id")
+
+
+# ------------------------------------------------------------------------------
+# kind
+# ------------------------------------------------------------------------------
+def check_kind(d, prev):
+    if not should_check_kind or not should_check_before_after:
+        return
+    actual = d["kind"]
+    if d["suffix"] == "after":
+        expected = prev["kind"]
+        check(actual, expected, "kind")
+
+
+# ------------------------------------------------------------------------------
+#
+# ------------------------------------------------------------------------------
+check_ordinal(first, {"ordinal": -1})
+
+prev = first
+filenames = filenames[1:]
+for fn in filenames:
+    d = fndict(fn)
+    check_ordinal(d, prev)
+    check_suffix(d, prev)
+    check_pass_id(d, prev)
+    check_pass_number(d, prev)
+    check_kind(d, prev)
+    prev = d

--- a/llvm/test/Other/dump-filenames.ll
+++ b/llvm/test/Other/dump-filenames.ll
@@ -1,0 +1,85 @@
+; REQUIRES: default_triple
+
+;-------------------------------------------------------------------------------
+; default 
+;-------------------------------------------------------------------------------
+; RUN: rm -rf %t/logs
+; RUN: llc %s -o - -O3 -print-after-all -print-before-all \
+; RUN:     -ir-dump-directory %t/logs
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<pass_number>[0-9]+)" \
+; RUN:     "-(?P<kind>module|function|machine-function)" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<suffix>before|after)"
+
+; RUN: rm -rf %t/logs
+; RUN: opt %s -disable-output -O3 -print-after-all -print-before-all \
+; RUN:     -ir-dump-directory %t/logs
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<pass_number>[0-9]+)" \
+; RUN:     "-(?P<kind>[0-9a-f]+-(module|((function|scc)-[0-9a-f]+)))" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<suffix>before|after)"
+
+; RUN: rm -rf %t/logs
+; RUN: llc %s -o - -O3 -print-before-all \
+; RUN:     -ir-dump-directory %t/logs
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<pass_number>[0-9]+)" \
+; RUN:     "-(?P<kind>module|function|machine-function)" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<before>before)"
+
+; RUN: rm -rf %t/logs
+; RUN: opt %s -disable-output -O3 -print-after-all \
+; RUN:     -ir-dump-directory %t/logs
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<pass_number>[0-9]+)" \
+; RUN:     "-(?P<kind>[0-9a-f]+-(module|((function|scc)-[0-9a-f]+)))" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<after>after)"
+
+;-------------------------------------------------------------------------------
+; sortable
+;-------------------------------------------------------------------------------
+; RUN: rm -rf %t/logs
+; RUN: llc %s -o - -O3 -print-after-all -print-before-all \
+; RUN:     -ir-dump-directory %t/logs \
+; RUN:     -ir-dump-filename-format sortable
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<ordinal>[0-9]{8})" \
+; RUN:     "-(?P<pass_ordinal>[0-9]{8})" \
+; RUN:     "-(?P<kind>module|function|machine-function)" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<suffix_ordinal>[01])" \
+; RUN:     "-(?P<suffix>before|after)"
+
+; RUN: rm -rf %t/logs
+; RUN: opt %s -disable-output -O3 -print-after-all -print-before-all \
+; RUN:     -ir-dump-directory %t/logs \
+; RUN:     -ir-dump-filename-format sortable
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<ordinal>[0-9]{8})" \
+; RUN:     "-(?P<pass_number>[0-9]+)" \
+; RUN:     "-(?P<kind>[0-9a-f]+-(module|((function|scc)-[0-9a-f]+)))" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<suffix_ordinal>[01])" \
+; RUN:     "-(?P<suffix>before|after)"
+
+;-------------------------------------------------------------------------------
+; thread id
+;-------------------------------------------------------------------------------
+; RUN: rm -rf %t/logs
+; RUN: llc %s -o - -O3 -print-after-all \
+; RUN:     -ir-dump-directory %t/logs \
+; RUN:     -ir-dump-filename-prepend-thread-id
+; RUN: %python %p/check-ir-dump-filenames.py %t/logs \
+; RUN:     "(?P<tid>[0-9]+)" \
+; RUN:     "-(?P<pass_number>[0-9]+)" \
+; RUN:     "-(?P<kind>module|function|machine-function)" \
+; RUN:     "-(?P<pass_id>.+)" \
+; RUN:     "-(?P<after>after)"
+
+define void @foo() {
+    ret void
+}


### PR DESCRIPTION
Primary changes are:
- Teaches legacy pass manager to honor `-ir-dump-directory`.
- Adds `-ir-dump-filename-format` which supports generation of filenames in (`ls`) sort order.
