### PR TITLE
[llvm][dwarfdump] Add --child-tags option to filter by DWARF tags

### DIFF
--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -138,7 +138,10 @@ OPTIONS
 
             Only dump children whose DWARF tag is one of the specified tags.
             Example usage:
-            `llvm-dwarfdump -t DW_TAG_structure_type -t DW_TAG_member -c`
+
+            .. code-block:: c
+
+              llvm-dwarfdump -t DW_TAG_structure_type -t DW_TAG_member -c
 
 .. option:: -x, --regex
 

--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -134,6 +134,12 @@ OPTIONS
 
             Abbreviate the description of type unit entries.
 
+.. option:: -t, --filter-child-tag
+
+            Only dump children whose DWARF tag is one of the specified tags.
+            Example usage:
+            `llvm-dwarfdump -t DW_TAG_structure_type -t DW_TAG_member -c`
+
 .. option:: -x, --regex
 
             Treat any <name> strings as regular expressions when searching

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -202,8 +202,6 @@ struct DIDumpOptions {
   bool ShowAddresses = true;
   bool ShowChildren = false;
   bool ShowParents = false;
-  /// List of DWARF tags to filter children by.
-  llvm::SmallVector<unsigned, 0> FilterChildTag;
   bool ShowForm = false;
   bool SummarizeTypes = false;
   bool Verbose = false;
@@ -213,6 +211,8 @@ struct DIDumpOptions {
   bool ShowAggregateErrors = false;
   bool PrintRegisterOnly = false;
   std::string JsonErrSummaryFile;
+  /// List of DWARF tags to filter children by.
+  llvm::SmallVector<unsigned, 0> FilterChildTag;
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -202,6 +202,8 @@ struct DIDumpOptions {
   bool ShowAddresses = true;
   bool ShowChildren = false;
   bool ShowParents = false;
+  /// List of DWARF tags to filter children by.
+  llvm::SmallVector<unsigned> ChildTagsFilter;
   bool ShowForm = false;
   bool SummarizeTypes = false;
   bool Verbose = false;

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -203,7 +203,7 @@ struct DIDumpOptions {
   bool ShowChildren = false;
   bool ShowParents = false;
   /// List of DWARF tags to filter children by.
-  llvm::SmallVector<unsigned> ChildTagsFilter;
+  llvm::SmallVector<unsigned> FilterChildTag;
   bool ShowForm = false;
   bool SummarizeTypes = false;
   bool Verbose = false;

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -203,7 +203,7 @@ struct DIDumpOptions {
   bool ShowChildren = false;
   bool ShowParents = false;
   /// List of DWARF tags to filter children by.
-  llvm::SmallVector<unsigned> FilterChildTag;
+  llvm::SmallVector<unsigned, 0> FilterChildTag;
   bool ShowForm = false;
   bool SummarizeTypes = false;
   bool Verbose = false;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -704,8 +704,8 @@ void DWARFDie::dump(raw_ostream &OS, unsigned Indent,
           DIDumpOptions ChildDumpOpts = DumpOpts;
           ChildDumpOpts.ShowParents = false;
           while (Child) {
-            if (DumpOpts.ChildTagsFilter.empty() ||
-                llvm::is_contained(DumpOpts.ChildTagsFilter, Child.getTag()))
+            if (DumpOpts.FilterChildTag.empty() ||
+                llvm::is_contained(DumpOpts.FilterChildTag, Child.getTag()))
               Child.dump(OS, Indent + 2, ChildDumpOpts);
             Child = Child.getSibling();
           }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -704,7 +704,9 @@ void DWARFDie::dump(raw_ostream &OS, unsigned Indent,
           DIDumpOptions ChildDumpOpts = DumpOpts;
           ChildDumpOpts.ShowParents = false;
           while (Child) {
-            Child.dump(OS, Indent + 2, ChildDumpOpts);
+            if (DumpOpts.ChildTagsFilter.empty() ||
+                llvm::is_contained(DumpOpts.ChildTagsFilter, Child.getTag()))
+              Child.dump(OS, Indent + 2, ChildDumpOpts);
             Child = Child.getSibling();
           }
         }

--- a/llvm/test/tools/llvm-dwarfdump/X86/child-tags-filter.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/child-tags-filter.yaml
@@ -1,0 +1,127 @@
+# Tests the --child-tags (-t) option.
+# RUN: yaml2obj %s -o %t.o
+# RUN: llvm-dwarfdump %t.o --child-tags=DW_TAG_structure_type | FileCheck %s --check-prefix=ONLY_STRUCT
+# RUN: llvm-dwarfdump %t.o -t DW_TAG_structure_type -t DW_TAG_namespace | FileCheck %s --check-prefix=STRUCT_AND_NS --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_member
+# RUN: llvm-dwarfdump %t.o -c --name=Foo -t DW_TAG_member | FileCheck %s --check-prefix=FOO_MEM --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
+# RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag -t DW_TAG_member | FileCheck %s --check-prefix=SINGLE_INVALID_TAG --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
+# RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag | FileCheck %s --check-prefix=ONLY_INVALID_TAGS --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace --implicit-check-not=DW_TAG_member
+# RUN: llvm-dwarfdump %t.o -c -p --name=Foo -t DW_TAG_member | FileCheck %s --check-prefix=FOO_MEM_WITH_PARENT --implicit-check-not=DW_TAG_subprogram
+# RUN: not llvm-dwarfdump %t.o --name=Foo -t DW_TAG_member 2>&1 | FileCheck %s --check-prefix=ERROR_NO_SHOW_CHILDREN
+
+# ONLY_STRUCT: DW_TAG_compile_unit
+# ONLY_STRUCT-NOT: DW_TAG_namespace
+# ONLY_STRUCT-NOT: DW_TAG_structure_type
+
+# STRUCT_AND_NS: DW_TAG_compile_unit
+# STRUCT_AND_NS: DW_TAG_namespace
+# STRUCT_AND_NS: DW_TAG_structure_type
+# STRUCT_AND_NS: DW_TAG_structure_type
+
+# FOO_MEM: DW_TAG_structure_type
+# FOO_MEM: DW_TAG_member
+# FOO_MEM: DW_TAG_member
+# FOO_MEM: DW_TAG_member
+# FOO_MEM-NOT: DW_TAG_structure_type
+# FOO_MEM-NOT: DW_TAG_member
+
+# SINGLE_INVALID_TAG: DW_TAG_structure_type
+# SINGLE_INVALID_TAG: DW_TAG_member
+# SINGLE_INVALID_TAG: DW_TAG_member
+# SINGLE_INVALID_TAG: DW_TAG_member
+# SINGLE_INVALID_TAG-NOT: DW_TAG_structure_type
+# SINGLE_INVALID_TAG-NOT: DW_TAG_member
+
+# ONLY_INVALID_TAGS: DW_TAG_structure_type
+# ONLY_INVALID_TAGS-NOT: DW_TAG_structure_type
+
+# FOO_MEM_WITH_PARENT: DW_TAG_compile_unit
+# FOO_MEM_WITH_PARENT: DW_TAG_namespace
+# FOO_MEM_WITH_PARENT: DW_TAG_structure_type
+# FOO_MEM_WITH_PARENT: DW_TAG_member
+# FOO_MEM_WITH_PARENT: DW_TAG_member
+# FOO_MEM_WITH_PARENT: DW_TAG_member
+# FOO_MEM_WITH_PARENT-NOT: DW_TAG_structure_type
+# FOO_MEM_WITH_PARENT-NOT: DW_TAG_member
+
+# ERROR_NO_SHOW_CHILDREN: incompatible arguments: --child-tags requires --show-children
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+DWARF:
+  debug_abbrev:
+    - Table:
+      # 1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+      # 2
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      # 3
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      # 4
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      # 5
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: handwritten
+        - AbbrCode: 2
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+          - CStr: Foo
+        - AbbrCode: 4
+          Values:
+            - CStr: mem1
+        - AbbrCode: 4
+          Values:
+            - CStr: mem2
+        - AbbrCode: 4
+          Values:
+            - CStr: mem3
+        - AbbrCode: 3
+          Values:
+            - CStr: NestedInFoo
+        - AbbrCode: 4
+          Values:
+            - CStr: NestedMem1
+        - AbbrCode: 4
+          Values:
+            - CStr: NestedMem2
+        - AbbrCode: 5
+          Values:
+            - CStr: NestedFunc
+        - AbbrCode: 0x0
+        - AbbrCode: 5
+          Values:
+            - CStr: FooFunc
+        - AbbrCode: 0x0
+        - AbbrCode: 0x0
+        - AbbrCode: 0x0

--- a/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
@@ -54,9 +54,10 @@
 # FOO_MEM_WITH_PARENT-NOT: DW_TAG_structure_type
 # FOO_MEM_WITH_PARENT-NOT: DW_TAG_member
 
-# RUN: not llvm-dwarfdump %t.o --name=Foo -t DW_TAG_member 2>&1 | FileCheck %s --check-prefix=ERROR_NO_SHOW_CHILDREN
+## Not specifying --show-children ignores the --filter-child-tag option.
+# RUN: llvm-dwarfdump %t.o --name=Foo -t DW_TAG_member 2>&1 | FileCheck %s --check-prefix=NO_SHOW_CHILDREN
 
-# ERROR_NO_SHOW_CHILDREN: incompatible arguments: --filter-child-tag requires --show-children
+# NO_SHOW_CHILDREN: DW_TAG_structure_type
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
@@ -67,31 +67,26 @@ FileHeader:
 DWARF:
   debug_abbrev:
     - Table:
-      # 1
       - Tag:      DW_TAG_compile_unit
         Children: DW_CHILDREN_yes
         Attributes:
           - Attribute: DW_AT_producer
             Form:      DW_FORM_string
-      # 2
       - Tag:      DW_TAG_namespace
         Children: DW_CHILDREN_yes
         Attributes:
           - Attribute: DW_AT_name
             Form:      DW_FORM_string
-      # 3
       - Tag:      DW_TAG_structure_type
         Children: DW_CHILDREN_yes
         Attributes:
           - Attribute: DW_AT_name
             Form:      DW_FORM_string
-      # 4
       - Tag:      DW_TAG_member
         Children: DW_CHILDREN_no
         Attributes:
           - Attribute: DW_AT_name
             Form:      DW_FORM_string
-      # 5
       - Tag:      DW_TAG_subprogram
         Children: DW_CHILDREN_no
         Attributes:

--- a/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
@@ -1,21 +1,23 @@
 ## Tests the --filter-child-tag (-t) option.
+
 # RUN: yaml2obj %s -o %t.o
+
 # RUN: llvm-dwarfdump %t.o --filter-child-tag=DW_TAG_structure_type | FileCheck %s --check-prefix=ONLY_STRUCT
-# RUN: llvm-dwarfdump %t.o -t DW_TAG_structure_type -t DW_TAG_namespace | FileCheck %s --check-prefix=STRUCT_AND_NS --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_member
-# RUN: llvm-dwarfdump %t.o -c --name=Foo -t DW_TAG_member | FileCheck %s --check-prefix=FOO_MEM --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
-# RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag -t DW_TAG_member | FileCheck %s --check-prefix=SINGLE_INVALID_TAG --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
-# RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag | FileCheck %s --check-prefix=ONLY_INVALID_TAGS --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace --implicit-check-not=DW_TAG_member
-# RUN: llvm-dwarfdump %t.o -c -p --name=Foo -t DW_TAG_member | FileCheck %s --check-prefix=FOO_MEM_WITH_PARENT --implicit-check-not=DW_TAG_subprogram
-# RUN: not llvm-dwarfdump %t.o --name=Foo -t DW_TAG_member 2>&1 | FileCheck %s --check-prefix=ERROR_NO_SHOW_CHILDREN
 
 # ONLY_STRUCT: DW_TAG_compile_unit
 # ONLY_STRUCT-NOT: DW_TAG_namespace
 # ONLY_STRUCT-NOT: DW_TAG_structure_type
 
+# RUN: llvm-dwarfdump %t.o -t DW_TAG_structure_type -t DW_TAG_namespace | \
+# RUN:     FileCheck %s --check-prefix=STRUCT_AND_NS --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_member
+
 # STRUCT_AND_NS: DW_TAG_compile_unit
 # STRUCT_AND_NS: DW_TAG_namespace
 # STRUCT_AND_NS: DW_TAG_structure_type
 # STRUCT_AND_NS: DW_TAG_structure_type
+
+# RUN: llvm-dwarfdump %t.o -c --name=Foo -t DW_TAG_member | \
+# RUN:     FileCheck %s --check-prefix=FOO_MEM --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
 
 # FOO_MEM: DW_TAG_structure_type
 # FOO_MEM: DW_TAG_member
@@ -24,6 +26,9 @@
 # FOO_MEM-NOT: DW_TAG_structure_type
 # FOO_MEM-NOT: DW_TAG_member
 
+# RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag -t DW_TAG_member | \
+# RUN:     FileCheck %s --check-prefix=SINGLE_INVALID_TAG --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
+
 # SINGLE_INVALID_TAG: DW_TAG_structure_type
 # SINGLE_INVALID_TAG: DW_TAG_member
 # SINGLE_INVALID_TAG: DW_TAG_member
@@ -31,8 +36,14 @@
 # SINGLE_INVALID_TAG-NOT: DW_TAG_structure_type
 # SINGLE_INVALID_TAG-NOT: DW_TAG_member
 
+# RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag | \
+# RUN:     FileCheck %s --check-prefix=ONLY_INVALID_TAGS --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace --implicit-check-not=DW_TAG_member
+
 # ONLY_INVALID_TAGS: DW_TAG_structure_type
 # ONLY_INVALID_TAGS-NOT: DW_TAG_structure_type
+
+# RUN: llvm-dwarfdump %t.o -c -p --name=Foo -t DW_TAG_member | \
+# RUN:     FileCheck %s --check-prefix=FOO_MEM_WITH_PARENT --implicit-check-not=DW_TAG_subprogram
 
 # FOO_MEM_WITH_PARENT: DW_TAG_compile_unit
 # FOO_MEM_WITH_PARENT: DW_TAG_namespace
@@ -42,6 +53,8 @@
 # FOO_MEM_WITH_PARENT: DW_TAG_member
 # FOO_MEM_WITH_PARENT-NOT: DW_TAG_structure_type
 # FOO_MEM_WITH_PARENT-NOT: DW_TAG_member
+
+# RUN: not llvm-dwarfdump %t.o --name=Foo -t DW_TAG_member 2>&1 | FileCheck %s --check-prefix=ERROR_NO_SHOW_CHILDREN
 
 # ERROR_NO_SHOW_CHILDREN: incompatible arguments: --filter-child-tag requires --show-children
 

--- a/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
@@ -1,6 +1,6 @@
-# Tests the --child-tags (-t) option.
+# Tests the --filter-child-tag (-t) option.
 # RUN: yaml2obj %s -o %t.o
-# RUN: llvm-dwarfdump %t.o --child-tags=DW_TAG_structure_type | FileCheck %s --check-prefix=ONLY_STRUCT
+# RUN: llvm-dwarfdump %t.o --filter-child-tag=DW_TAG_structure_type | FileCheck %s --check-prefix=ONLY_STRUCT
 # RUN: llvm-dwarfdump %t.o -t DW_TAG_structure_type -t DW_TAG_namespace | FileCheck %s --check-prefix=STRUCT_AND_NS --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_member
 # RUN: llvm-dwarfdump %t.o -c --name=Foo -t DW_TAG_member | FileCheck %s --check-prefix=FOO_MEM --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
 # RUN: llvm-dwarfdump %t.o -c --name=Foo -t not_a_tag -t DW_TAG_member | FileCheck %s --check-prefix=SINGLE_INVALID_TAG --implicit-check-not=DW_TAG_compile_unit --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_namespace
@@ -43,7 +43,7 @@
 # FOO_MEM_WITH_PARENT-NOT: DW_TAG_structure_type
 # FOO_MEM_WITH_PARENT-NOT: DW_TAG_member
 
-# ERROR_NO_SHOW_CHILDREN: incompatible arguments: --child-tags requires --show-children
+# ERROR_NO_SHOW_CHILDREN: incompatible arguments: --filter-child-tag requires --show-children
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/filter-child-tag.yaml
@@ -1,4 +1,4 @@
-# Tests the --filter-child-tag (-t) option.
+## Tests the --filter-child-tag (-t) option.
 # RUN: yaml2obj %s -o %t.o
 # RUN: llvm-dwarfdump %t.o --filter-child-tag=DW_TAG_structure_type | FileCheck %s --check-prefix=ONLY_STRUCT
 # RUN: llvm-dwarfdump %t.o -t DW_TAG_structure_type -t DW_TAG_namespace | FileCheck %s --check-prefix=STRUCT_AND_NS --implicit-check-not=DW_TAG_subprogram --implicit-check-not=DW_TAG_member

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -917,12 +917,6 @@ int main(int argc, char **argv) {
       Find.empty() && !FindAllApple)
     ShowChildren = true;
 
-  if (!ShowChildren && !FilterChildTag.empty()) {
-    WithColor::error() << "incompatible arguments: --filter-child-tag requires "
-                          "--show-children";
-    return 1;
-  }
-
   // Defaults to a.out if no filenames specified.
   if (InputFilenames.empty())
     InputFilenames.push_back("a.out");

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -244,13 +244,13 @@ static opt<bool>
 static alias ShowParentsAlias("p", desc("Alias for --show-parents."),
                               aliasopt(ShowParents), cl::NotHidden);
 
-static list<std::string>
-    ChildTags("child-tags",
-              desc("When --show-children is specified, show only DIEs with the "
-                   "specified DWARF tags."),
-              value_desc("list of DWARF tags"), cat(DwarfDumpCategory));
-static alias TagsAlias("t", desc("Alias for --child-tags."),
-                       aliasopt(ChildTags), cl::NotHidden);
+static list<std::string> FilterChildTag(
+    "filter-child-tag",
+    desc("When --show-children is specified, show only DIEs with the "
+         "specified DWARF tags."),
+    value_desc("list of DWARF tags"), cat(DwarfDumpCategory));
+static alias FilterChildTagAlias("t", desc("Alias for --filter-child-tag."),
+                                 aliasopt(FilterChildTag), cl::NotHidden);
 
 static opt<bool>
     ShowForm("show-form",
@@ -373,7 +373,7 @@ static DIDumpOptions getDumpOpts(DWARFContext &C) {
   DumpOpts.ShowAddresses = !Diff;
   DumpOpts.ShowChildren = ShowChildren;
   DumpOpts.ShowParents = ShowParents;
-  DumpOpts.ChildTagsFilter = makeTagVector(ChildTags);
+  DumpOpts.FilterChildTag = makeTagVector(FilterChildTag);
   DumpOpts.ShowForm = ShowForm;
   DumpOpts.SummarizeTypes = SummarizeTypes;
   DumpOpts.Verbose = Verbose;
@@ -917,9 +917,9 @@ int main(int argc, char **argv) {
       Find.empty() && !FindAllApple)
     ShowChildren = true;
 
-  if (!ShowChildren && !ChildTags.empty()) {
-    WithColor::error()
-        << "incompatible arguments: --child-tags requires --show-children";
+  if (!ShowChildren && !FilterChildTag.empty()) {
+    WithColor::error() << "incompatible arguments: --filter-child-tag requires "
+                          "--show-children";
     return 1;
   }
 


### PR DESCRIPTION
This patch adds a new option `--child-tags` (`-t` for short), which makes dwarfdump only dump children whose DWARF tag is in the list of tags specified by the user.

Motivating examples are:
* dumping all global variables in a CU
* dumping all non-static data members of a structure
* dumping all module import declarations of a CU
* etc.

For tags not known to dwarfdump, we pretend that the tag wasn't specified.

Note, this flag only takes effect when `--show-children` is set (either explicitly or implicitly). We error out when trying to use the flag without dumping children.

Example:
```
$ builds/release/bin/llvm-dwarfdump -t DW_TAG_structure_type a.out.dSYM                 
...
0x0000000c: DW_TAG_compile_unit
              DW_AT_producer    ("clang version 22.0.0git (git@github.com:Michael137/llvm-project.git 737da3347c2fb01dd403420cf83e9b8fbea32618)")
              DW_AT_language    (DW_LANG_C11)
              ...
0x0000002a:   DW_TAG_structure_type
                DW_AT_APPLE_block       (true)
                DW_AT_byte_size (0x20)

0x00000067:   DW_TAG_structure_type
                DW_AT_APPLE_block       (true)
                DW_AT_name      ("__block_descriptor")
                DW_AT_byte_size (0x10)
...
```

```
$ builds/release/bin/llvm-dwarfdump -t DW_TAG_structure_type -t DW_TAG_member a.out.dSYM
...
0x0000000c: DW_TAG_compile_unit
              DW_AT_producer    ("clang version 22.0.0git (git@github.com:Michael137/llvm-project.git 737da3347c2fb01dd403420cf83e9b8fbea32618)")
              DW_AT_language    (DW_LANG_C11)                                                             
              DW_AT_name        ("macro.c")                                                               
              ...                                              
0x0000002a:   DW_TAG_structure_type                                                                       
                DW_AT_APPLE_block       (true)                                                            
                DW_AT_byte_size (0x20)
                                                     
0x0000002c:     DW_TAG_member                 
                  DW_AT_name    ("__isa")                                                                 
                  DW_AT_type    (0x00000051 "void *")                                                     
                  DW_AT_data_member_location    (0x00)
                                                                                                          
0x00000033:     DW_TAG_member                                                                             
                  DW_AT_name    ("__flags")                                                               
                  DW_AT_type    (0x00000052 "int")                                                        
                  DW_AT_data_member_location    (0x08)
                                                                                                          
0x0000003a:     DW_TAG_member                                                                             
                  DW_AT_name    ("__reserved")
                  DW_AT_type    (0x00000052 "int")                                                        
                  DW_AT_data_member_location    (0x0c)                                                    

0x00000041:     DW_TAG_member
                  DW_AT_name    ("__FuncPtr")   
                  DW_AT_type    (0x00000056 "void (*)(int)")                                              
                  DW_AT_data_member_location    (0x10)                                         
                                                     
0x00000048:     DW_TAG_member                                                                             
                  DW_AT_name    ("__descriptor")                                                          
                  DW_AT_type    (0x00000062 "__block_descriptor *")
                  DW_AT_alignment       (8)
                  DW_AT_data_member_location    (0x18)                                                    
                                                     
0x00000067:   DW_TAG_structure_type                                                                       
                DW_AT_APPLE_block       (true)
                DW_AT_name      ("__block_descriptor")
                DW_AT_byte_size (0x10)                                                                    
                                                                                                          
0x0000006a:     DW_TAG_member              
                  DW_AT_name    ("reserved")                                                              
                  DW_AT_type    (0x00000079 "unsigned long")
                  DW_AT_data_member_location    (0x00)                                         
                                                     
0x00000071:     DW_TAG_member                                                                             
                  DW_AT_name    ("Size")                                                                  
                  DW_AT_type    (0x00000079 "unsigned long")
                  DW_AT_data_member_location    (0x08)             
...                                       
```