### PR TITLE
🍒 [lldb] Fix TestRealDefinition on older DWARF versions

### DIFF
--- a/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py
+++ b/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py
@@ -27,13 +27,11 @@ class TestRealDefinition(TestBase):
         # Run at stop at main
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
-        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
-
         # This should display correctly.
         self.expect(
             "frame variable foo->_bar->_hidden_ivar",
             VARIABLES_DISPLAYED_CORRECTLY,
-            substrs=["(NSString *)", "foo->_bar->_hidden_ivar = 0x"],
+            substrs=["foo->_bar->_hidden_ivar = 0x"],
         )
 
     def test_frame_var_after_stop_at_implementation(self):
@@ -54,11 +52,9 @@ class TestRealDefinition(TestBase):
         # Run at stop at main
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
-        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
-
         # This should display correctly.
         self.expect(
             "frame variable foo->_bar->_hidden_ivar",
             VARIABLES_DISPLAYED_CORRECTLY,
-            substrs=["(NSString *)", "foo->_bar->_hidden_ivar = 0x"],
+            substrs=["foo->_bar->_hidden_ivar = 0x"],
         )


### PR DESCRIPTION
Cherry-picks this fix from the Apple LLDB fork. Ever since we upstreamed https://github.com/llvm/llvm-project/pull/164011, this test is failing on our pre-DWARFv5 bots:
```
13:47:54  ======================================================================
13:47:54  FAIL: test_frame_var_after_stop_at_implementation_dsym (TestRealDefinition.TestRealDefinition)
13:47:54     Test that we can find the implementation for an objective C type
13:47:54  ----------------------------------------------------------------------
13:47:54  Traceback (most recent call last):
13:47:54    File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-matrix/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1804, in test_method
13:47:54      return attrvalue(self)
13:47:54    File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-matrix/llvm-project/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py", line 60, in test_frame_var_after_stop_at_implementation
13:47:54      self.expect(
13:47:54    File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-matrix/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 2416, in expect
13:47:54      self.runCmd(
13:47:54    File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-matrix/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1006, in runCmd
13:47:54      self.assertTrue(self.res.Succeeded(), msg + output)
13:47:54  AssertionError: False is not true : Variable(s) displayed correctly
13:47:54  Error output:
13:47:54  error: <user expression 0>:1:12: "_hidden_ivar" is not a member of "(id) _bar"
13:47:54     1 | foo->_bar->_hidden_ivar
13:47:54       | ^
```

Original commit message:

For a while, tests were run with `target.prefer-dynamic-value` overridden to `no-dynamic-values` – but the override was removed in [D132382](https://reviews.llvm.org/D132382). At that time, tests that failed were individually opted in to `no-dynamic-values`.

I don't recall specifics about `TestRealDefinition`, but it currently fails with `no-dynamic-values`, and that is correct behavior. This change removes the `no-dynamic-values` override.