### PR TITLE
[lld][macho] Ignore cstrings in bp orderer

### DIFF
--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -118,6 +118,10 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
         auto *isec = subsec.isec;
         if (!isec || isec->data.empty() || !isec->data.data())
           continue;
+        // CString section order is handled by
+        // {Deduplicated}CStringSection::finalizeContents()
+        if (isa<CStringInputSection>(isec) || isec->isFinal)
+          continue;
         // ConcatInputSections are entirely live or dead, so the offset is
         // irrelevant.
         if (isa<ConcatInputSection>(isec) && !isec->isLive(0))

--- a/lld/test/MachO/bp-section-orderer.s
+++ b/lld/test/MachO/bp-section-orderer.s
@@ -106,6 +106,11 @@ r3:
 r4:
   .quad s2
 
+# cstrings are ignored by runBalancedPartitioning()
+.cstring
+cstr:
+  .asciz "this is cstr"
+
 .bss
 bss0:
   .zero 10


### PR DESCRIPTION
`cstring` sections are laid out by `{Deduplicated}CStringSection::finalizeContents()` and ignores the order determined by `runBalancedPartitioning()`.

https://github.com/llvm/llvm-project/blob/e63f0f50fae479b4eaec98ac97de0745735a90b7/lld/MachO/SyntheticSections.cpp#L1729-L1746

Do not consider `cstring` sections or any section already finalized in `runBalancedPartitioning()`. This may result in fewer sections passed to BP, which could result in faster linktime and better results. In some large binaries, I didn't not see a meaningful difference in compressed size.