### PR TITLE
[GitHub] Move Copilot instructions for LLVM

### DIFF
--- a/.github/instructions/llvm.instructions.md
+++ b/.github/instructions/llvm.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: llvm/**/*
+---
+
 When performing a code review, pay close attention to code modifying a function's
 control flow. Could the change result in the corruption of performance profile
 data? Could the change result in invalid debug information, in particular for


### PR DESCRIPTION
GitHub allows specifying custom instructions for the GitHub Copilot reviewer [1]. Currently, we have a top level file, but GitHub supports having different instructions for different files, which requires creating an `instructions` subdirectory with multiple files and a patch it applies to.

This PR moves the top level file into a new `instructions` directory, and make it apply to the `llvm/` subdirectory. I spoke with Mircea at the Dev Meeting and that should match his original intent.

[1] https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review#customizing-copilots-reviews-with-custom-instructions