### PR TITLE
[Backport][MLIR] Properties.td fix from main commit 77f2560

### DIFF
--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -773,9 +773,10 @@ class OptionalProp<Property p, bit canDelegateParsing = 1>
   }];
   let writeToMlirBytecode = [{
     $_writer.writeOwnedBool($_storage.has_value());
-    if (!$_storage.has_value())
-      return;
-  }] # !subst("$_storage", "(*($_storage))", p.writeToMlirBytecode);
+    if ($_storage.has_value()) {
+      }] # !subst("$_storage", "(*($_storage))", p.writeToMlirBytecode) # [{
+    }
+  }];
 
   let hashProperty = !if(!empty(p.hashProperty), p.hashProperty,
     [{ hash_value($_storage.has_value() ? std::optional<::llvm::hash_code>{}] #


### PR DESCRIPTION
This PR backports the change from commit 77f256070f985029a53da5e76ecd85ca7686a7ea
on `main` to `release/21.x`. Only mlir/include/mlir/IR/Properties.td is affected.

This backport is requested for the LLVM 21 release to resolve the MLIR bytecode corruption issue.  
Thanks to the original author, @fabianmcg , for the fix!