### PR TITLE
[libc] Add "struct tm" declaration to <wchar.h>

### DIFF
--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -6,6 +6,9 @@ macros:
 types:
   - type_name: FILE
   - type_name: size_t
+  # TODO: Remove this once we have a function declaration using "struct tm"
+  # (wcsftime). We're declaring it here now, since libc++ expects
+  # forward-declaration of "struct tm" in the <wchar.h> header.
   - type_name: struct_tm
   - type_name: wint_t
   - type_name: wchar_t

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -6,6 +6,7 @@ macros:
 types:
   - type_name: FILE
   - type_name: size_t
+  - type_name: struct_tm
   - type_name: wint_t
   - type_name: wchar_t
   - type_name: mbstate_t


### PR DESCRIPTION
`<wchar.h>` should at least include the forward declaration of `struct tm`,
since it's needed for the `wcsftime` declaration (also, see https://man7.org/linux/man-pages/man0/wchar.h.0p.html).

Even though we don't yet have `wcsftime`, some downstream users (notably - libcxx) expects to see `struct tm`
declaration there, to re-declare it under `std` namespace: https://github.com/llvm/llvm-project/blob/c46bfed1a484d30cd251a9a225649d74e3bf0af5/libcxx/include/cwchar#L135

So, add this type declaration to llvm-libc version of `wchar.h` now.