### PR TITLE
[mlir][GPU][NFC] adds TODO messages for amdgpu-specific pattern relocation

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/PromoteShuffleToAMDGPU.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/PromoteShuffleToAMDGPU.cpp
@@ -26,6 +26,8 @@ namespace {
 
 constexpr amdgpu::Chipset kGfx950 = amdgpu::Chipset(9, 5, 0);
 
+// TODO: Move amdgpu specific patterns out of GPU dialect (#165811).
+
 /// Try to promote `gpu.shuffle` to `amdgpu.swizzle_bitmode`, width must be 64
 /// and offset must be a constant integer in the range [0, 31].
 struct PromoteShuffleToSwizzlePattern

--- a/mlir/lib/Dialect/GPU/Transforms/SubgroupReduceLowering.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/SubgroupReduceLowering.cpp
@@ -367,6 +367,8 @@ private:
   bool matchClustered = false;
 };
 
+// TODO: Move amdgpu specific patterns out of GPU dialect (#165811).
+
 static FailureOr<Value>
 createSubgroupDPPReduction(PatternRewriter &rewriter, gpu::SubgroupReduceOp op,
                            Value input, gpu::AllReduceOperation mode,


### PR DESCRIPTION
Adds TODO messages to signal future work to move misplaced patterns, see https://github.com/llvm/llvm-project/issues/165811.