### PR TITLE
[clang] Fix behavior of `-ibuiltininc` when passed alongside `-nostdinc`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -505,6 +505,7 @@ Bug Fixes to AST Handling
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed missing diagnostics of ``diagnose_if`` on templates involved in initialization. (#GH160776)
+- Fix `-ibuiltininc` compiler flag being ignored if `-nostdinc` is specified. (#GH165790)
 
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6172,7 +6172,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   // Pass options for controlling the default header search paths.
   if (Args.hasArg(options::OPT_nostdinc)) {
     CmdArgs.push_back("-nostdsysteminc");
-    CmdArgs.push_back("-nobuiltininc");
+    if (!Args.hasArg(options::OPT_ibuiltininc)) {
+      CmdArgs.push_back("-nobuiltininc");
+    }
   } else {
     if (Args.hasArg(options::OPT_nostdlibinc))
       CmdArgs.push_back("-nostdsysteminc");

--- a/clang/test/Driver/nostdinc-ibuiltininc.c
+++ b/clang/test/Driver/nostdinc-ibuiltininc.c
@@ -1,0 +1,10 @@
+// RUN: %clang -target x86_64-unknown-unknown -nostdinc -ibuiltininc -ffreestanding -fsyntax-only %s
+// RUN: %clang -target x86_64-unknown-unknown -ibuiltininc -nostdinc -ffreestanding -fsyntax-only %s
+
+#if !__has_include("stddef.h")
+#error "expected to be able to find compiler builtin headers!"
+#endif
+
+#if __has_include("stdlib.h")
+#error "expected to *not* be able to find standard C headers"
+#endif


### PR DESCRIPTION
Resolves #165790

- Don't add `-nobuiltininc` when `-ibuiltininc` is passed with `-nostdinc`
- Add tests