### PR TITLE
[LLDB][Editline] empty current line before `el_wgets`

### DIFF
--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1626,6 +1626,12 @@ bool Editline::GetLine(std::string &line, bool &interrupted) {
   m_editor_status = EditorStatus::Editing;
   m_revert_cursor_index = -1;
 
+  if (m_locked_output && m_output_stream_sp) {
+    FILE *f = m_locked_output->GetFile().GetStream();
+    fprintf(f, "\r" ANSI_CLEAR_RIGHT);
+    fflush(f);
+  }
+
   int count;
   auto input = el_wgets(m_editline, &count);
 

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1626,11 +1626,8 @@ bool Editline::GetLine(std::string &line, bool &interrupted) {
   m_editor_status = EditorStatus::Editing;
   m_revert_cursor_index = -1;
 
-  if (m_locked_output && m_output_stream_sp) {
-    FILE *f = m_locked_output->GetFile().GetStream();
-    fprintf(f, "\r" ANSI_CLEAR_RIGHT);
-    fflush(f);
-  }
+  lldbassert(m_output_stream_sp);
+  fprintf(m_locked_output->GetFile().GetStream(), "\r" ANSI_CLEAR_RIGHT);
 
   int count;
   auto input = el_wgets(m_editline, &count);

--- a/lldb/test/API/terminal/TestEditline.py
+++ b/lldb/test/API/terminal/TestEditline.py
@@ -94,7 +94,7 @@ class EditlineTest(PExpectTest):
         # after the prompt.
         self.child.send("foo")
         # Check that there are no escape codes.
-        self.child.expect(re.escape("\n(lldb) foo"))
+        self.child.expect(re.escape("\n\r\x1b[K(lldb) foo"))
 
     @skipIfAsan
     @skipIfEditlineSupportMissing


### PR DESCRIPTION
This PR fixes #157637 by printing ANSI sequence "\r\x1b[K" to empty the line before calling to `el_wgets`. Later when `el_wgets` prints the real prompt, all wrongly printed characters are removed from the terminal.