### PR TITLE
[ADT] Remove ArrayRef(std::nullopt_t)

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -66,10 +66,6 @@ namespace llvm {
     /// Construct an empty ArrayRef.
     /*implicit*/ ArrayRef() = default;
 
-    /// Construct an empty ArrayRef from std::nullopt.
-    /*implicit*/ LLVM_DEPRECATED("Use {} or ArrayRef<T>() instead", "{}")
-    ArrayRef(std::nullopt_t) {}
-
     /// Construct an ArrayRef from a single element.
     /*implicit*/ ArrayRef(const T &OneElt LLVM_LIFETIME_BOUND)
         : Data(&OneElt), Length(1) {}


### PR DESCRIPTION
ArrayRef(std::nullopt_t) has been deprecated since:

  commit 2529de5c935ad59e5f76d15890f857bf42817bc9
  Author: Kazu Hirata <kazu@google.com>
  Date:   Fri Jun 27 01:03:02 2025 -0700

Note that we've made at lease one release, llvmorg-21.1, with this
deprecation.
