### PR TITLE
[lldb][TypeSystem] Fix GetTypeInfo for vector and complex types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3965,9 +3965,9 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
     if (complex_type) {
       clang::QualType complex_element_type(complex_type->getElementType());
       if (complex_element_type->isIntegerType())
-        complex_type_flags |= eTypeIsFloat;
-      else if (complex_element_type->isFloatingType())
         complex_type_flags |= eTypeIsInteger;
+      else if (complex_element_type->isFloatingType())
+        complex_type_flags |= eTypeIsFloat;
     }
     return complex_type_flags;
   } break;
@@ -4062,12 +4062,17 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
     uint32_t vector_type_flags = eTypeHasChildren | eTypeIsVector;
     const clang::VectorType *vector_type = llvm::dyn_cast<clang::VectorType>(
         qual_type->getCanonicalTypeInternal());
-    if (vector_type) {
-      if (vector_type->isIntegerType())
-        vector_type_flags |= eTypeIsFloat;
-      else if (vector_type->isFloatingType())
-        vector_type_flags |= eTypeIsInteger;
-    }
+    if (!vector_type)
+      return 0;
+
+    QualType element_type = vector_type->getElementType();
+    if (element_type.isNull())
+      return 0;
+
+    if (element_type->isIntegerType())
+      vector_type_flags |= eTypeIsInteger;
+    else if (element_type->isFloatingType())
+      vector_type_flags |= eTypeIsFloat;
     return vector_type_flags;
   }
   default:

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1123,6 +1123,26 @@ TEST_F(TestTypeSystemClang, AddMethodToCXXRecordType_ParmVarDecls) {
   EXPECT_EQ(method_it->getParamDecl(1)->getDeclContext(), *method_it);
 }
 
+TEST_F(TestTypeSystemClang, TestGetTypeInfo) {
+  // Tests TypeSystemClang::GetTypeInfo
+
+  const ASTContext &ast = m_ast->getASTContext();
+
+  CompilerType complex_int = m_ast->GetType(ast.getComplexType(ast.IntTy));
+  EXPECT_TRUE(complex_int.GetTypeInfo() & eTypeIsInteger);
+
+  CompilerType complex_float = m_ast->GetType(ast.getComplexType(ast.FloatTy));
+  EXPECT_TRUE(complex_float.GetTypeInfo() & eTypeIsFloat);
+
+  CompilerType vector_of_int =
+      m_ast->GetType(ast.getVectorType(ast.IntTy, 1, VectorKind::Generic));
+  EXPECT_TRUE(vector_of_int.GetTypeInfo() & eTypeIsInteger);
+
+  CompilerType vector_of_float =
+      m_ast->GetType(ast.getVectorType(ast.FloatTy, 1, VectorKind::Generic));
+  EXPECT_TRUE(vector_of_float.GetTypeInfo() & eTypeIsFloat);
+}
+
 TEST_F(TestTypeSystemClang, AsmLabel_CtorDtor) {
   // Tests TypeSystemClang::DeclGetMangledName for constructors/destructors
   // with and without AsmLabels.

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1129,18 +1129,22 @@ TEST_F(TestTypeSystemClang, TestGetTypeInfo) {
   const ASTContext &ast = m_ast->getASTContext();
 
   CompilerType complex_int = m_ast->GetType(ast.getComplexType(ast.IntTy));
-  EXPECT_TRUE(complex_int.GetTypeInfo() & eTypeIsInteger);
+  EXPECT_EQ(complex_int.GetTypeInfo(),
+            (eTypeIsInteger | eTypeIsComplex | eTypeIsBuiltIn | eTypeHasValue));
 
   CompilerType complex_float = m_ast->GetType(ast.getComplexType(ast.FloatTy));
-  EXPECT_TRUE(complex_float.GetTypeInfo() & eTypeIsFloat);
+  EXPECT_EQ(complex_float.GetTypeInfo(),
+            (eTypeIsFloat | eTypeIsComplex | eTypeIsBuiltIn | eTypeHasValue));
 
   CompilerType vector_of_int =
       m_ast->GetType(ast.getVectorType(ast.IntTy, 1, VectorKind::Generic));
-  EXPECT_TRUE(vector_of_int.GetTypeInfo() & eTypeIsInteger);
+  EXPECT_EQ(vector_of_int.GetTypeInfo(),
+            (eTypeIsInteger | eTypeIsVector | eTypeHasChildren));
 
   CompilerType vector_of_float =
       m_ast->GetType(ast.getVectorType(ast.FloatTy, 1, VectorKind::Generic));
-  EXPECT_TRUE(vector_of_float.GetTypeInfo() & eTypeIsFloat);
+  EXPECT_EQ(vector_of_float.GetTypeInfo(),
+            (eTypeIsFloat | eTypeIsVector | eTypeHasChildren));
 }
 
 TEST_F(TestTypeSystemClang, AsmLabel_CtorDtor) {


### PR DESCRIPTION
We were setting these bits inverted. Not sure how this bug actually manifests, I just noticed when working on https://github.com/llvm/llvm-project/pull/165707. I suspect these types just aren't very frequently used.