### PR TITLE
[PowerPC][MC] Diagnose out of range branch fixups

### DIFF
--- a/llvm/test/MC/PowerPC/fixup-out-of-range.s
+++ b/llvm/test/MC/PowerPC/fixup-out-of-range.s
@@ -21,6 +21,31 @@ brcond14_misaligned:
 brcond14_misaligned_target:
     blr
 
+
+
+# CHECK: error: branch target out of range (32772 not between -32768 and 32764)
+brcond14abs_out_of_range_hi:
+    beqa 0, brcond14abs_target-.
+    .space 0x8000
+
+brcond14abs_target:
+    blr
+
+# CHECK: error: branch target out of range (-32772 not between -32768 and 32764)
+brcond14abs_out_of_range_lo:
+    .space 0x8004
+    beqa 0, brcond14abs_out_of_range_lo-.
+
+# CHECK: error: branch target not a multiple of four (5)
+brcond14abs_misaligned:
+    beqa 0, brcond14abs_misaligned_target-.
+    .byte 0
+
+brcond14abs_misaligned_target:
+    blr
+
+
+
 # CHECK: error: branch target out of range (33554436 not between -33554432 and 33554428)
 br24_out_of_range_hi:
     b br24_target
@@ -40,4 +65,27 @@ br24_misaligned:
     .byte 0
 
 br24_misaligned_target:
+    blr
+
+
+
+# CHECK: error: branch target out of range (33554436 not between -33554432 and 33554428)
+br24abs_out_of_range_hi:
+    ba br24abs_target-.
+    .space 0x2000000
+
+br24abs_target:
+    blr
+
+# CHECK: error: branch target out of range (-33554436 not between -33554432 and 33554428)
+br24abs_out_of_range_lo:
+    .space 0x2000004
+    ba br24abs_out_of_range_lo-.
+
+# CHECK: error: branch target not a multiple of four (5)
+br24abs_misaligned:
+    ba br24abs_misaligned_target-.
+    .byte 0
+
+br24abs_misaligned_target:
     blr

--- a/llvm/test/MC/PowerPC/fixup-out-of-range.s
+++ b/llvm/test/MC/PowerPC/fixup-out-of-range.s
@@ -1,0 +1,43 @@
+# RUN: not llvm-mc -triple powerpc64le-unknown-unknown -filetype=obj %s 2>&1 >/dev/null | FileCheck %s
+
+# CHECK: error: branch target out of range (32772 not between -32768 and 32764)
+brcond14_out_of_range_hi:
+    beq 0, brcond14_target
+    .space 0x8000
+
+brcond14_target:
+    blr
+
+# CHECK: error: branch target out of range (-32772 not between -32768 and 32764)
+brcond14_out_of_range_lo:
+    .space 0x8004
+    beq 0, brcond14_out_of_range_lo
+
+# CHECK: error: branch target not a multiple of four (5)
+brcond14_misaligned:
+    beq 0, brcond14_misaligned_target
+    .byte 0
+
+brcond14_misaligned_target:
+    blr
+
+# CHECK: error: branch target out of range (33554436 not between -33554432 and 33554428)
+br24_out_of_range_hi:
+    b br24_target
+    .space 0x2000000
+
+br24_target:
+    blr
+
+# CHECK: error: branch target out of range (-33554436 not between -33554432 and 33554428)
+br24_out_of_range_lo:
+    .space 0x2000004
+    b br24_out_of_range_lo
+
+# CHECK: error: branch target not a multiple of four (5)
+br24_misaligned:
+    b br24_misaligned_target
+    .byte 0
+
+br24_misaligned_target:
+    blr


### PR DESCRIPTION
Currently, out-of-range branch fixups will be silently miscompiled. GNU as will instead print an "operand out of range" error instead.

Check that the branch target fixups fit into the proper range and have low zero bits. The implementation is inspired by SystemZ: https://github.com/llvm/llvm-project/blob/0ed8e66f88b689c152245d6b968a06fa8e67b51f/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmBackend.cpp#L31

I'm not sure if there is any way to test the absolute cases. It looks like something like `beqa 0, 0x10000` already gets rejected during parsing.

(My actual interest here is not actually assembly usage, but LLVM failing to use the correct branch kind for reasons I've not tracked down yet. Currently this just silently truncates the branch target instead of producing an error.)