### PR TITLE
[MLIR][GPU] Broadcast via 2 scalar registers, not ds_swizzle

### DIFF
--- a/mlir/test/Dialect/GPU/subgroup-reduce-lowering.mlir
+++ b/mlir/test/Dialect/GPU/subgroup-reduce-lowering.mlir
@@ -412,8 +412,12 @@ gpu.module @kernels {
   //         lanes [16, 32) and [48, 64), respectively.
   // CHECK-GFX9: %[[BCAST15:.+]] = amdgpu.dpp %[[A3]] %[[A3]]  row_bcast_15(unit) {row_mask = 10 : i32} : f32
   // CHECK-GFX9: %[[SUM:.+]] = arith.addf %[[A3]], %[[BCAST15]] : f32
-  // CHECK-GFX9: %[[SWIZ:.+]] = amdgpu.swizzle_bitmode %[[SUM]] 0 31 0 : f32
-  // CHECK-GFX9: "test.consume"(%[[SWIZ]]) : (f32) -> ()
+  // CHECK-GFX9: %[[RLANE31:.+]] = rocdl.readlane %[[SUM]]{{.*}}c31
+  // CHECK-GFX9: %[[RLANE63:.+]] = rocdl.readlane %[[SUM]]{{.*}}c63
+  // CHECK-GFX9: %[[LANEID:.+]] = gpu.lane_id
+  // CHECK-GFX9: %[[CMP:.+]] = arith.cmpi ule, %[[LANEID]]{{.*}}c31
+  // CHECK-GFX9: %[[SEL:.+]] = arith.select %[[CMP]], %[[RLANE31]], %[[RLANE63]] : f32
+  // CHECK-GFX9: "test.consume"(%[[SEL]]) : (f32) -> ()
   //
   //   On gfx1030, the final step is to permute the lanes and perform final reduction:
   // CHECK-GFX10: rocdl.permlanex16


### PR DESCRIPTION
This PR changes the way we broadcast from 2 lanes to 64 lanes (lane 31 -> [0, 32) and lane 64 -> [32, 64)) as suggested in https://github.com/llvm/llvm-project/pull/165764 . The advantage of this approach is that it should in theory be faster because it doesn't use the LDS crossbar (or something). One disadvantage might be that it uses 2 scalar registers instead of no 0 (is that a valid concern, or is this never an issue on AMDGPU?). 

This code should ultimately migrate to a dialect/directory specific to AMDGPU. 
