### PR TITLE
[LTO] Preserve use list order in save-temps

### DIFF
--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -124,7 +124,7 @@ Error Config::addSaveTemps(std::string OutputFileName, bool UseInputModulePath,
       // directly and exit.
       if (EC)
         reportOpenError(Path, EC.message());
-      WriteBitcodeToFile(M, OS, /*ShouldPreserveUseListOrder=*/false);
+      WriteBitcodeToFile(M, OS, /*ShouldPreserveUseListOrder=*/true);
       return true;
     };
   };


### PR DESCRIPTION
save-temps is debugging functionality, so it should preserve use-lists to keep the optimization/codegen behavior of the dumped bitcode as close to the in-memory IR as possible.