### PR TITLE
[sanitizer-common] [Darwin] Provide warnings for common sandbox issues

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -960,7 +960,18 @@ static void DisableMmapExcGuardExceptions() {
       RTLD_DEFAULT, "task_set_exc_guard_behavior");
   if (set_behavior == nullptr) return;
   const task_exc_guard_behavior_t task_exc_guard_none = 0;
-  set_behavior(mach_task_self(), task_exc_guard_none);
+  kern_return_t res = set_behavior(mach_task_self(), task_exc_guard_none);
+  if (res != KERN_SUCCESS) {
+    Report(
+        "WARN: task_set_exc_guard_behavior returned %d (%s), "
+        "mmap may fail unexpectedly.\n",
+        res, mach_error_string(res));
+    if (res == KERN_DENIED) {
+      Report(
+          "HINT: Check that task_set_exc_guard_behavior is allowed by "
+          "sandbox.\n");
+    }
+  }
 }
 
 static void VerifyInterceptorsWorking();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -966,11 +966,10 @@ static void DisableMmapExcGuardExceptions() {
         "WARN: task_set_exc_guard_behavior returned %d (%s), "
         "mmap may fail unexpectedly.\n",
         res, mach_error_string(res));
-    if (res == KERN_DENIED) {
+    if (res == KERN_DENIED)
       Report(
           "HINT: Check that task_set_exc_guard_behavior is allowed by "
           "sandbox.\n");
-    }
   }
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -505,7 +505,7 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
   }
 
 #  if SANITIZER_APPLE
-  if (list.empty()) {
+  if (list->empty()) {
     Report(
         "WARN: No external symbolizers found. Symbols may be missing or "
         "unreliable.\n");

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -505,6 +505,13 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
   }
 
 #  if SANITIZER_APPLE
+  if (list.size() == 0) {
+    Report(
+        "WARN: No external symbolizers found. Symbols will be missing or "
+        "unreliable.\n");
+    Report(
+        "HINT: Is PATH set? Does sandbox allow file-read of /usr/bin/atos?\n");
+  }
   VReport(2, "Using dladdr symbolizer.\n");
   list->push_back(new (*allocator) DlAddrSymbolizer());
 #  endif  // SANITIZER_APPLE

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -505,9 +505,9 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
   }
 
 #  if SANITIZER_APPLE
-  if (list.size() == 0) {
+  if (list.empty()) {
     Report(
-        "WARN: No external symbolizers found. Symbols will be missing or "
+        "WARN: No external symbolizers found. Symbols may be missing or "
         "unreliable.\n");
     Report(
         "HINT: Is PATH set? Does sandbox allow file-read of /usr/bin/atos?\n");


### PR DESCRIPTION
We currently do not handle errors in task_set_exc_guard_behavior. If this fails, mmap can unexpectedly crash.
We also do not currently provide a clear warning if no external symbolizers are found.

rdar://163798535