### PR TITLE
 [yaml2obj][MachO] Fix crash from integer underflow with invalid cmdsize

### DIFF
--- a/llvm/lib/ObjectYAML/MachOEmitter.cpp
+++ b/llvm/lib/ObjectYAML/MachOEmitter.cpp
@@ -300,18 +300,18 @@ void MachOWriter::writeLoadCommands(raw_ostream &OS) {
     // specified test cases.
     // Prevent integer underflow if BytesWritten exceeds cmdsize.
     if (BytesWritten > LC.Data.load_command_data.cmdsize) {
-      const char *name = getLoadCommandName(LC.Data.load_command_data.cmd);
-      if (name)
-        WithColor::warning()
-            << "load command " << i << " " << name << " cmdsize too small ("
-            << LC.Data.load_command_data.cmdsize << " bytes) for actual size ("
-            << BytesWritten << " bytes)\n";
+      std::string Name;
+      const char *NameCStr = getLoadCommandName(LC.Data.load_command_data.cmd);
+      if (NameCStr)
+        Name = NameCStr;
       else
-        WithColor::warning()
-            << "load command " << i << " (0x"
-            << Twine::utohexstr(LC.Data.load_command_data.cmd)
-            << ") cmdsize too small (" << LC.Data.load_command_data.cmdsize
-            << " bytes) for actual size (" << BytesWritten << " bytes)\n";
+        Name = "(0x" + Twine::utohexstr(LC.Data.load_command_data.cmd).str() + ")";
+
+      WithColor::warning() << "load command " << i << " " << Name
+                           << " cmdsize too small ("
+                           << LC.Data.load_command_data.cmdsize
+                           << " bytes) for actual size (" << BytesWritten
+                           << " bytes)\n";
     }
     auto BytesRemaining = (BytesWritten < LC.Data.load_command_data.cmdsize)
                               ? LC.Data.load_command_data.cmdsize - BytesWritten

--- a/llvm/lib/ObjectYAML/MachOEmitter.cpp
+++ b/llvm/lib/ObjectYAML/MachOEmitter.cpp
@@ -305,7 +305,8 @@ void MachOWriter::writeLoadCommands(raw_ostream &OS) {
       if (NameCStr)
         Name = NameCStr;
       else
-        Name = "(0x" + Twine::utohexstr(LC.Data.load_command_data.cmd).str() + ")";
+        Name =
+            "(0x" + Twine::utohexstr(LC.Data.load_command_data.cmd).str() + ")";
 
       WithColor::warning() << "load command " << i << " " << Name
                            << " cmdsize too small ("

--- a/llvm/lib/ObjectYAML/MachOEmitter.cpp
+++ b/llvm/lib/ObjectYAML/MachOEmitter.cpp
@@ -305,8 +305,8 @@ void MachOWriter::writeLoadCommands(raw_ostream &OS) {
       if (NameCStr)
         Name = NameCStr;
       else
-        Name =
-            "(0x" + Twine::utohexstr(LC.Data.load_command_data.cmd).str() + ")";
+        Name = ("(0x" + Twine::utohexstr(LC.Data.load_command_data.cmd) + ")")
+                   .str();
 
       WithColor::warning() << "load command " << i << " " << Name
                            << " cmdsize too small ("

--- a/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
+++ b/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
@@ -1,13 +1,18 @@
 ## Test that yaml2obj handles load commands with cmdsize smaller than the
 ## actual structure size without crashing (due to integer underflow).
 
-# RUN: yaml2obj %s -o %t 2>&1 | FileCheck %s --check-prefix=WARNING
-# RUN: not llvm-readobj --file-headers %t 2>&1 | FileCheck %s --check-prefix=MALFORMED
+# RUN: yaml2obj %s --docnum=1 -o %t1 2>&1 | FileCheck %s --check-prefix=WARNING-KNOWN
+# RUN: not llvm-readobj --file-headers %t1 2>&1 | FileCheck %s --check-prefix=MALFORMED
 
-# WARNING: warning: load command 0 LC_SEGMENT_64 cmdsize too small (56 bytes) for actual size (72 bytes)
+# RUN: yaml2obj %s --docnum=2 -o %t2 2>&1 | FileCheck %s --check-prefix=WARNING-UNKNOWN
+
+# WARNING-KNOWN: warning: load command 0 LC_SEGMENT_64 cmdsize too small (56 bytes) for actual size (72 bytes)
 
 # MALFORMED: error: {{.*}}: truncated or malformed object (load command 0 LC_SEGMENT_64 cmdsize too small)
 
+# WARNING-UNKNOWN: warning: load command 0 (0xdeadbeef) cmdsize too small (8 bytes) for actual size (20 bytes)
+
+## Test with a known load command (LC_SEGMENT_64)
 --- !mach-o
 FileHeader:
   magic:           0xFEEDFACF
@@ -30,4 +35,21 @@ LoadCommands:
     initprot:        5
     nsects:          0
     flags:           0
+...
+
+## Test with an unknown load command value
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x01000007
+  cpusubtype:      0x00000003
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      20
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             0xDEADBEEF
+    cmdsize:         8
+    PayloadBytes:    [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C]
 ...

--- a/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
+++ b/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
@@ -1,18 +1,13 @@
 ## Test that yaml2obj handles load commands with cmdsize smaller than the
 ## actual structure size without crashing (due to integer underflow).
 
+## Test with a known load command (LC_SEGMENT_64).
 # RUN: yaml2obj %s --docnum=1 -o %t1 2>&1 | FileCheck %s --check-prefix=WARNING-KNOWN
 # RUN: not llvm-readobj --file-headers %t1 2>&1 | FileCheck %s --check-prefix=MALFORMED
-
-# RUN: yaml2obj %s --docnum=2 -o %t2 2>&1 | FileCheck %s --check-prefix=WARNING-UNKNOWN
 
 # WARNING-KNOWN: warning: load command 0 LC_SEGMENT_64 cmdsize too small (56 bytes) for actual size (72 bytes)
 
 # MALFORMED: error: {{.*}}: truncated or malformed object (load command 0 LC_SEGMENT_64 cmdsize too small)
-
-# WARNING-UNKNOWN: warning: load command 0 (0xdeadbeef) cmdsize too small (8 bytes) for actual size (20 bytes)
-
-## Test with a known load command (LC_SEGMENT_64)
 --- !mach-o
 FileHeader:
   magic:           0xFEEDFACF
@@ -37,7 +32,10 @@ LoadCommands:
     flags:           0
 ...
 
-## Test with an unknown load command value
+## Test with an unknown load command value.
+# RUN: yaml2obj %s --docnum=2 -o %t2 2>&1 | FileCheck %s --check-prefix=WARNING-UNKNOWN
+
+# WARNING-UNKNOWN: warning: load command 0 (0xdeadbeef) cmdsize too small (8 bytes) for actual size (20 bytes)
 --- !mach-o
 FileHeader:
   magic:           0xFEEDFACF

--- a/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
+++ b/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
@@ -8,6 +8,7 @@
 # WARNING-KNOWN: warning: load command 0 LC_SEGMENT_64 cmdsize too small (56 bytes) for actual size (72 bytes)
 
 # MALFORMED: error: {{.*}}: truncated or malformed object (load command 0 LC_SEGMENT_64 cmdsize too small)
+
 --- !mach-o
 FileHeader:
   magic:           0xFEEDFACF
@@ -36,6 +37,7 @@ LoadCommands:
 # RUN: yaml2obj %s --docnum=2 -o %t2 2>&1 | FileCheck %s --check-prefix=WARNING-UNKNOWN
 
 # WARNING-UNKNOWN: warning: load command 0 (0xdeadbeef) cmdsize too small (8 bytes) for actual size (20 bytes)
+
 --- !mach-o
 FileHeader:
   magic:           0xFEEDFACF

--- a/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
+++ b/llvm/test/ObjectYAML/MachO/load-cmdsize-too-small.yaml
@@ -1,10 +1,10 @@
-## Test that yaml2obj handles cmdsize that is too small for LC_SEGMENT_64
-## without crashing (due to integer underflow).
+## Test that yaml2obj handles load commands with cmdsize smaller than the
+## actual structure size without crashing (due to integer underflow).
 
 # RUN: yaml2obj %s -o %t 2>&1 | FileCheck %s --check-prefix=WARNING
 # RUN: not llvm-readobj --file-headers %t 2>&1 | FileCheck %s --check-prefix=MALFORMED
 
-# WARNING: warning: load command 25 cmdsize too small (56 bytes) for actual size (72 bytes)
+# WARNING: warning: load command 0 LC_SEGMENT_64 cmdsize too small (56 bytes) for actual size (72 bytes)
 
 # MALFORMED: error: {{.*}}: truncated or malformed object (load command 0 LC_SEGMENT_64 cmdsize too small)
 

--- a/llvm/test/ObjectYAML/MachO/segment-cmdsize-too-small.yaml
+++ b/llvm/test/ObjectYAML/MachO/segment-cmdsize-too-small.yaml
@@ -1,0 +1,33 @@
+## Test that yaml2obj handles cmdsize that is too small for LC_SEGMENT_64
+## without crashing (due to integer underflow).
+
+# RUN: yaml2obj %s -o %t 2>&1 | FileCheck %s --check-prefix=WARNING
+# RUN: not llvm-readobj --file-headers %t 2>&1 | FileCheck %s --check-prefix=MALFORMED
+
+# WARNING: warning: load command 25 cmdsize too small (56 bytes) for actual size (72 bytes)
+
+# MALFORMED: error: {{.*}}: truncated or malformed object (load command 0 LC_SEGMENT_64 cmdsize too small)
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x01000007
+  cpusubtype:      0x00000003
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      56
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         56          ## Should be 72 for LC_SEGMENT_64
+    segname:         '__TEXT'
+    vmaddr:          0x1000
+    vmsize:          0x10
+    fileoff:         0
+    filesize:        0
+    maxprot:         7
+    initprot:        5
+    nsects:          0
+    flags:           0
+...


### PR DESCRIPTION
yaml2obj would crash when processing Mach-O load commands with cmdsize smaller than the actual structure size e.g. LC_SEGMENT_64 with cmdsize=56 instead of 72. The crash occurred due to integer underflow when calculating padding: cmdsize - BytesWritten wraps to a large value when negative, causing a massive allocation attempt.