### PR TITLE
[clang-doc] create a separate cmake file for clang-doc's lit tests

### DIFF
--- a/clang-tools-extra/test/CMakeLists.txt
+++ b/clang-tools-extra/test/CMakeLists.txt
@@ -87,4 +87,7 @@ add_lit_testsuite(check-clang-extra "Running clang-tools-extra/test"
 
 add_lit_testsuites(CLANG-EXTRA ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CLANG_TOOLS_TEST_DEPS}
+   SKIP "^clang-doc"
   )
+
+add_subdirectory(clang-doc)

--- a/clang-tools-extra/test/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/test/clang-doc/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Specialize the clang-doc target to avoid building other projects
+add_lit_testsuite(check-clang-extra-clang-doc "Running clang-doc tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS clang-doc
+  DEPENDS ${LLVM_UTILS_DEPS}
+)


### PR DESCRIPTION
To avoid depending on all of the tools in clang-tools-extra, the
`check-clang-extra-clang-doc` target is specialized in its own CMake
file in clang-tools-extra/test/clang-doc. This eliminates around 800
files to be processed when building that target, plus linking every
tool. Similar to [#155929](https://github.com/llvm/llvm-project/pull/155929).