### PR TITLE
Fix getting section info in large mach-o files.

### DIFF
--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -447,7 +447,7 @@ public:
   uint64_t getSectionAddress(DataRefImpl Sec) const override;
   uint64_t getSectionIndex(DataRefImpl Sec) const override;
   uint64_t getSectionSize(DataRefImpl Sec) const override;
-  ArrayRef<uint8_t> getSectionContents(uint32_t Offset, uint64_t Size) const;
+  ArrayRef<uint8_t> getSectionContents(uint64_t Offset, uint64_t Size) const;
   Expected<ArrayRef<uint8_t>>
   getSectionContents(DataRefImpl Sec) const override;
   uint64_t getSectionAlignment(DataRefImpl Sec) const override;

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -1978,20 +1978,34 @@ uint64_t MachOObjectFile::getSectionSize(DataRefImpl Sec) const {
   return SectSize;
 }
 
-ArrayRef<uint8_t> MachOObjectFile::getSectionContents(uint32_t Offset,
+ArrayRef<uint8_t> MachOObjectFile::getSectionContents(uint64_t Offset,
                                                       uint64_t Size) const {
   return arrayRefFromStringRef(getData().substr(Offset, Size));
 }
 
 Expected<ArrayRef<uint8_t>>
 MachOObjectFile::getSectionContents(DataRefImpl Sec) const {
-  uint32_t Offset;
+  uint64_t Offset;
   uint64_t Size;
 
   if (is64Bit()) {
     MachO::section_64 Sect = getSection64(Sec);
     Offset = Sect.offset;
     Size = Sect.size;
+    // Check for large mach-o files where the section contents might exceed
+    // 4GB. MachO::section_64 objects only have 32 bit file offsets to the
+    // section contents and can overflow in dSYM files. We can track this and
+    // adjust the section offset to be 64 bit safe.
+    uint64_t SectOffsetAdjust = 0;
+    for (uint32_t SectIdx=0; SectIdx<Sec.d.a; ++SectIdx) {
+      MachO::section_64 CurrSect =
+          getStruct<MachO::section_64>(*this, Sections[SectIdx]);
+      const uint64_t EndSectFileOffset =
+          (uint64_t)CurrSect.offset + CurrSect.size;
+      if (EndSectFileOffset >= UINT32_MAX)
+        SectOffsetAdjust += EndSectFileOffset & 0xFFFFFFFF00000000ull;
+    }
+    Offset += SectOffsetAdjust;
   } else {
     MachO::section Sect = getSection(Sec);
     Offset = Sect.offset;

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2000,7 +2000,7 @@ MachOObjectFile::getSectionContents(DataRefImpl Sec) const {
     // will be returned stopping invalid section data from being returned.
     uint64_t PrevTrueOffset = 0;
     uint64_t SectOffsetAdjust = 0;
-    for (uint32_t SectIdx=0; SectIdx<Sec.d.a; ++SectIdx) {
+    for (uint32_t SectIdx = 0; SectIdx < Sec.d.a; ++SectIdx) {
       MachO::section_64 CurrSect =
           getStruct<MachO::section_64>(*this, Sections[SectIdx]);
       uint64_t CurrTrueOffset = (uint64_t)CurrSect.offset + SectOffsetAdjust;

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -1995,8 +1995,9 @@ MachOObjectFile::getSectionContents(DataRefImpl Sec) const {
     // Check for large mach-o files where the section contents might exceed
     // 4GB. MachO::section_64 objects only have 32 bit file offsets to the
     // section contents and can overflow in dSYM files. We can track this and
-    // adjust the section offset to be 64 bit safe.
-    // Assumes the sections are ordered.
+    // adjust the section offset to be 64 bit safe. If sections overflow then
+    // section ordering is enforced. If sections are not ordered, then an error
+    // will be returned stopping invalid section data from being returned.
     uint64_t PrevTrueOffset = 0;
     uint64_t SectOffsetAdjust = 0;
     for (uint32_t SectIdx=0; SectIdx<Sec.d.a; ++SectIdx) {

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2005,7 +2005,8 @@ MachOObjectFile::getSectionContents(DataRefImpl Sec) const {
           getStruct<MachO::section_64>(*this, Sections[SectIdx]);
       uint64_t CurrTrueOffset = (uint64_t)CurrSect.offset + SectOffsetAdjust;
       if ((SectOffsetAdjust > 0) && (PrevTrueOffset > CurrTrueOffset))
-        return malformedError("section data exceeds 4GB and are not ordered");
+        return malformedError("section data exceeds 4GB and section file "
+                              "offsets are not ordered");
       const uint64_t EndSectFileOffset =
           (uint64_t)CurrSect.offset + CurrSect.size;
       if (EndSectFileOffset > UINT32_MAX)


### PR DESCRIPTION
Mach-o has 32 bit file offsets in the MachO::section_64 structs. dSYM files can contain sections whose start offset exceeds UINT32_MAX, which means the MachO::section_64.offset will get truncated. We can calculate when this happens and properly adjust the section offset to be 64 bit safe. This means tools can get the correct section contents for large dSYM files and allows tools that parse DWARF, like llvm-gsymutil, to be able to load and convert these files correctly.