### PR TITLE
[cfi][test] use more robust test patterns

### DIFF
--- a/compiler-rt/test/cfi/anon-namespace.cpp
+++ b/compiler-rt/test/cfi/anon-namespace.cpp
@@ -73,8 +73,8 @@ int main() {
   A *a = mkb();
   break_optimization(a);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type '(anonymous namespace)::B' failed during base-to-derived cast

--- a/compiler-rt/test/cfi/bad-cast.cpp
+++ b/compiler-rt/test/cfi/bad-cast.cpp
@@ -92,8 +92,8 @@ int main(int argc, char **argv) {
   B *b = new B;
   break_optimization(b);
 
-  // FAIL: 1
-  // PASS: 1
+  // FAIL: {{^1$}}
+  // PASS: {{^1$}}
   fprintf(stderr, "1\n");
 
   A a;

--- a/compiler-rt/test/cfi/base-derived-destructor.cpp
+++ b/compiler-rt/test/cfi/base-derived-destructor.cpp
@@ -77,8 +77,8 @@ class B : public A<B> {
 };
 
 int main() {
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type 'B' failed during base-to-derived cast

--- a/compiler-rt/test/cfi/icall/bad-signature.c
+++ b/compiler-rt/test/cfi/icall/bad-signature.c
@@ -13,15 +13,15 @@ void f() {
 }
 
 int main() {
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type 'void (int)' failed during indirect function call
   // CFI-DIAG: f defined here
   ((void (*)(int))f)(42); // UB here
 
-  // CFI-NOT: 2
-  // NCFI: 2
+  // CFI-NOT: {{^2$}}
+  // NCFI: {{^2$}}
   fprintf(stderr, "2\n");
 }

--- a/compiler-rt/test/cfi/icall/external-call.c
+++ b/compiler-rt/test/cfi/icall/external-call.c
@@ -12,7 +12,7 @@
 #include <math.h>
 
 int main(int argc, char **argv) {
-  // CFI: 1
+  // CFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   double (*fn)(double);
@@ -23,6 +23,6 @@ int main(int argc, char **argv) {
 
   fn(atof(argv[2]));
 
-  // CFI: 2
+  // CFI: {{^2$}}
   fprintf(stderr, "2\n");
 }

--- a/compiler-rt/test/cfi/icall/wrong-signature-mixed-lto.c
+++ b/compiler-rt/test/cfi/icall/wrong-signature-mixed-lto.c
@@ -29,13 +29,13 @@ int f() {
 void f();
 
 int main() {
-  // CFI: 1
+  // CFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   void (*volatile p)() = &f;
   p();
 
-  // CFI-NOT: 2
+  // CFI-NOT: {{^2$}}
   fprintf(stderr, "2\n");
 }
 #endif

--- a/compiler-rt/test/cfi/multiple-inheritance.cpp
+++ b/compiler-rt/test/cfi/multiple-inheritance.cpp
@@ -52,8 +52,8 @@ int main(int argc, char **argv) {
   C *c = new C;
   break_optimization(c);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   if (argc > 1) {

--- a/compiler-rt/test/cfi/nvcall.cpp
+++ b/compiler-rt/test/cfi/nvcall.cpp
@@ -45,8 +45,8 @@ int main() {
   A *a = new A;
   break_optimization(a);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type 'B' failed during non-virtual call

--- a/compiler-rt/test/cfi/overwrite.cpp
+++ b/compiler-rt/test/cfi/overwrite.cpp
@@ -45,8 +45,8 @@ int main() {
   *((void **)a) = fake_vtable + 2; // UB here
   break_optimization(a);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-NOT: foo

--- a/compiler-rt/test/cfi/sibling.cpp
+++ b/compiler-rt/test/cfi/sibling.cpp
@@ -42,13 +42,13 @@ int main() {
   B *b = new B;
   break_optimization(b);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   ((C *)b)->f(); // UB here
 
-  // CFI-NOT: 2
-  // NCFI: 2
+  // CFI-NOT: {{^2$}}
+  // NCFI: {{^2$}}
   fprintf(stderr, "2\n");
 }

--- a/compiler-rt/test/cfi/simple-fail.cpp
+++ b/compiler-rt/test/cfi/simple-fail.cpp
@@ -85,8 +85,8 @@ int main() {
   A *a = new A;
   break_optimization(a);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type 'B' failed during cast to unrelated type

--- a/compiler-rt/test/cfi/vdtor.cpp
+++ b/compiler-rt/test/cfi/vdtor.cpp
@@ -42,8 +42,8 @@ int main() {
   A *a = new A;
   break_optimization(a);
 
-  // CFI: 1
-  // NCFI: 1
+  // CFI: {{^1$}}
+  // NCFI: {{^1$}}
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type 'B' failed during virtual call


### PR DESCRIPTION
When test output contains extra data (such as debug logs), tests can become flaky if there are strings like '12':
the problem is that after successfully finding '1' in '12', the pattern '^2$' will find a full match in '2' following '1' (mentioned in #165899).

To prevent this, use patterns that search for '1' or '2' as standalone strings on their own line.