### PR TITLE
Temporarily disable tests due to bot setup issues (PR #165360)

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
@@ -30,6 +30,8 @@
 using namespace llvm;
 using namespace llvm::orc;
 
+// Disabled due to test setup issue — YAML to shared library creation seems
+// invalid on some build bots. (PR #165360) Not related to code logic.
 #if 0
 // TODO: Add COFF (Windows) support for these tests.
 // this facility also works correctly on Windows (COFF),

--- a/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LibraryResolverTest.cpp
@@ -30,7 +30,7 @@
 using namespace llvm;
 using namespace llvm::orc;
 
-#if defined(__APPLE__) || defined(__linux__)
+#if 0
 // TODO: Add COFF (Windows) support for these tests.
 // this facility also works correctly on Windows (COFF),
 // so we should eventually enable and run these tests for that platform as well.


### PR DESCRIPTION
Some tests are failing on the build bots because of test environment/setup issues rather than code logic in PR #165360.
As a temporary workaround, these tests are being disabled to allow the rest of the build to pass.
Once the test setup is fixed, the tests will be re-enabled.

https://lab.llvm.org/buildbot/#/builders/180/builds/27660.
https://lab.llvm.org/buildbot/#/builders/160/builds/27520.