### PR TITLE
[sanitizer-common] [Darwin] Fix overlapping dyld segment addresses

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps.h
@@ -104,12 +104,6 @@ class MemoryMappingLayout : public MemoryMappingLayoutBase {
   // Adds all mapped objects into a vector.
   void DumpListOfModules(InternalMmapVectorNoCtor<LoadedModule> *modules);
 
-#  if SANITIZER_APPLE
-  // Verify that the memory mapping is well-formed. (e.g. mappings do not
-  // overlap)
-  bool Verify();
-#  endif
-
  protected:
 #if SANITIZER_APPLE
   virtual const ImageHeader *CurrentImageHeader();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps.h
@@ -104,6 +104,12 @@ class MemoryMappingLayout : public MemoryMappingLayoutBase {
   // Adds all mapped objects into a vector.
   void DumpListOfModules(InternalMmapVectorNoCtor<LoadedModule> *modules);
 
+#  if SANITIZER_APPLE
+  // Verify that the memory mapping is well-formed. (e.g. mappings do not
+  // overlap)
+  bool Verify();
+#  endif
+
  protected:
 #if SANITIZER_APPLE
   virtual const ImageHeader *CurrentImageHeader();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -257,18 +257,18 @@ static bool NextSegmentLoad(MemoryMappedSegment *segment,
   if (((const load_command *)lc)->cmd == kLCSegment) {
     const SegmentCommand* sc = (const SegmentCommand *)lc;
     if (strncmp(sc->segname, "__LINKEDIT", sizeof("__LINKEDIT")) == 0) {
-      // The LINKEDIT sections alias, so we ignore these sections to
-      // ensure our mappings are disjoint.
+      // The LINKEDIT sections are for internal linker use, and may alias
+      // with the LINKEDIT section for other modules. (If we included them,
+      // our memory map would contain overlappping sections.)
       return false;
     }
 
     uptr base_virt_addr;
-    if (layout_data->current_image == kDyldImageIdx) {
+    if (layout_data->current_image == kDyldImageIdx)
       base_virt_addr = (uptr)_dyld_get_image_slide(get_dyld_hdr());
-    } else {
+    else
       base_virt_addr =
           (uptr)_dyld_get_image_vmaddr_slide(layout_data->current_image);
-    }
 
     segment->start = sc->vmaddr + base_virt_addr;
     segment->end = segment->start + sc->vmsize;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -56,14 +56,14 @@ static void NextSectionLoad(LoadedModule *module, MemoryMappedSegmentData *data,
                           sc->sectname);
 }
 
-static bool VerifyMemoryMapping(MemoryMappingLayout *mapping) {
+static bool VerifyMemoryMapping(MemoryMappingLayout* mapping) {
   InternalMmapVector<LoadedModule> modules;
-  modules.reserve(128); // matches DumpProcessMap
+  modules.reserve(128);  // matches DumpProcessMap
   mapping->DumpListOfModules(&modules);
 
   InternalMmapVector<LoadedModule::AddressRange> segments;
   for (uptr i = 0; i < modules.size(); ++i) {
-    for (auto &range : modules[i].ranges()) {
+    for (auto& range : modules[i].ranges()) {
       segments.push_back(range);
     }
   }
@@ -86,7 +86,8 @@ static bool VerifyMemoryMapping(MemoryMappingLayout *mapping) {
     if (cur_start < prev_end) {
       well_formed = false;
       VReport(2, "Overlapping mappings: %s start = %p, %s end = %p\n",
-              segments[i].name, (void*)cur_start, segments[i-1].name, (void*)prev_end);
+              segments[i].name, (void*)cur_start, segments[i - 1].name,
+              (void*)prev_end);
       if (!invalid_module_map_reported) {
         Report(
             "WARN: Invalid dyld module map detected. This is most likely a bug "
@@ -100,7 +101,6 @@ static bool VerifyMemoryMapping(MemoryMappingLayout *mapping) {
   mapping->Reset();
   return well_formed;
 }
-
 
 void MemoryMappedSegment::AddAddressRanges(LoadedModule *module) {
   // Don't iterate over sections when the caller hasn't set up the

--- a/compiler-rt/test/asan/TestCases/Darwin/asan-verify-module-map.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan-verify-module-map.cpp
@@ -1,0 +1,20 @@
+// This test simply checks that the "Invalid module map" warning is not printed
+// in the output of a backtrace.
+
+// RUN: %clangxx_asan -O0 -g %s -o %t.executable
+// RUN: %env_asan_opts="print_module_map=2" not %run %t.executable 2>&1 | FileCheck %s
+
+// CHECK-NOT: WARN: Invalid module map
+
+#include <cstdlib>
+
+extern "C" void foo(int *a) { *a = 5; }
+
+int main() {
+  int *a = (int *)malloc(sizeof(int));
+  if (!a)
+    return 0;
+  free(a);
+  foo(a);
+  return 0;
+}

--- a/compiler-rt/test/asan/TestCases/Darwin/asan-verify-module-map.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan-verify-module-map.cpp
@@ -1,20 +1,25 @@
 // This test simply checks that the "Invalid dyld module map" warning is not printed
 // in the output of a backtrace.
 
-// RUN: %clangxx_asan -O0 -g %s -o %t.executable
-// RUN: %env_asan_opts="print_module_map=2" not %run %t.executable 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -DSHARED_LIB -g %s -dynamiclib -o %t.dylib
+// RUN: %clangxx_asan -O0 -g %s %t.dylib -o %t.executable
+// RUN: %env_asan_opts="print_module_map=2" not %run %t.executable 2>&1 | FileCheck %s -DDYLIB=%t.dylib
 
 // CHECK-NOT: WARN: Invalid dyld module map
+// CHECK-DAG: 0x{{.*}}-0x{{.*}} [[DYLIB]]
+// CHECK-DAG: 0x{{.*}}-0x{{.*}} {{.*}}libsystem
 
-#include <cstdlib>
-
+#ifdef SHARED_LIB
 extern "C" void foo(int *a) { *a = 5; }
+#else
+#  include <cstdlib>
+
+extern "C" void foo(int *a);
 
 int main() {
   int *a = (int *)malloc(sizeof(int));
-  if (!a)
-    return 0;
   free(a);
   foo(a);
   return 0;
 }
+#endif

--- a/compiler-rt/test/asan/TestCases/Darwin/asan-verify-module-map.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan-verify-module-map.cpp
@@ -1,10 +1,10 @@
-// This test simply checks that the "Invalid module map" warning is not printed
+// This test simply checks that the "Invalid dyld module map" warning is not printed
 // in the output of a backtrace.
 
 // RUN: %clangxx_asan -O0 -g %s -o %t.executable
 // RUN: %env_asan_opts="print_module_map=2" not %run %t.executable 2>&1 | FileCheck %s
 
-// CHECK-NOT: WARN: Invalid module map
+// CHECK-NOT: WARN: Invalid dyld module map
 
 #include <cstdlib>
 


### PR DESCRIPTION
This fixes two problems:
- dyld itself resides within the shared cache. MemoryMappingLayout incorrectly computes the slide for dyld's segments, causing them to (appear to) overlap with other modules. This can cause symbolication issues.
- The MemoryMappingLayout ranges on Darwin are not disjoint due to the fact that the LINKEDIT segments overlap for each module. We now ignore these segments to ensure the mapping is disjoint.

This adds a check for disjointness, and a runtime warning if this is ever violated (as that suggests issues in the sanitizer memory mapping). There is now a test to ensure that these problems do not recur.

rdar://163149325