### PR TITLE
[AArch64] Optimize memset to use NEON DUP instruction for more sizes

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -4157,16 +4157,20 @@ public:
     }
   };
 
-  /// Determines the optimal series of memory ops to replace the memset / memcpy.
-  /// Return true if the number of memory ops is below the threshold (Limit).
-  /// Note that this is always the case when Limit is ~0.
-  /// It returns the types of the sequence of memory ops to perform
-  /// memset / memcpy by reference.
-  virtual bool
-  findOptimalMemOpLowering(LLVMContext &Context, std::vector<EVT> &MemOps,
-                           unsigned Limit, const MemOp &Op, unsigned DstAS,
-                           unsigned SrcAS,
-                           const AttributeList &FuncAttributes) const;
+  /// Determines the optimal series of memory ops to replace the memset /
+  /// memcpy. Return true if the number of memory ops is below the threshold
+  /// (Limit). Note that this is always the case when Limit is ~0. It returns
+  /// the types of the sequence of memory ops to perform memset / memcpy by
+  /// reference. If LargestVT is non-null, the target may set it to the largest
+  /// EVT that should be used for generating the memset value (e.g., for vector
+  /// splats). If LargestVT is null or left unchanged, the caller will compute
+  /// it from MemOps.
+  virtual bool findOptimalMemOpLowering(LLVMContext &Context,
+                                        std::vector<EVT> &MemOps,
+                                        unsigned Limit, const MemOp &Op,
+                                        unsigned DstAS, unsigned SrcAS,
+                                        const AttributeList &FuncAttributes,
+                                        EVT *LargestVT = nullptr) const;
 
   /// Check to see if the specified operand of the specified instruction is a
   /// constant integer.  If so, check to see if there are any bits set in the

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -8426,20 +8426,6 @@ static SDValue getMemsetValue(SDValue Value, EVT VT, SelectionDAG &DAG,
   if (!IntVT.isInteger())
     IntVT = EVT::getIntegerVT(*DAG.getContext(), IntVT.getSizeInBits());
 
-  // For repeated-byte patterns, generate a vector splat instead of MUL to
-  // enable efficient lowering to DUP on targets like AArch64.
-  // Only do this on AArch64 targets to avoid breaking other architectures.
-  const TargetMachine &TM = DAG.getTarget();
-  if (NumBits > 8 && VT.isInteger() && !VT.isVector() &&
-      (NumBits == 32 || NumBits == 64) &&
-      TM.getTargetTriple().getArch() == Triple::aarch64) {
-    // Generate a vector of bytes: v4i8 for i32, v8i8 for i64
-    EVT ByteVecTy = EVT::getVectorVT(*DAG.getContext(), MVT::i8, NumBits / 8);
-    SDValue VecSplat = DAG.getSplatBuildVector(ByteVecTy, dl, Value);
-    // Bitcast back to the target integer type
-    return DAG.getNode(ISD::BITCAST, dl, IntVT, VecSplat);
-  }
-
   Value = DAG.getNode(ISD::ZERO_EXTEND, dl, IntVT, Value);
   if (NumBits > 8) {
     // Use a multiplication with 0x010101... to extend the input to the
@@ -8972,6 +8958,12 @@ static SDValue getMemsetStores(SelectionDAG &DAG, const SDLoc &dl,
   for (unsigned i = 0; i < NumMemOps; i++) {
     EVT VT = MemOps[i];
     unsigned VTSize = VT.getSizeInBits() / 8;
+    // Skip stores when Size is already 0. This can happen when an oversized
+    // store was added to MemOps but the actual memset size was already
+    // covered by previous stores (e.g., when using extraction from a larger
+    // vector splat).
+    if (Size == 0)
+      continue;
     if (VTSize > Size) {
       // Issuing an unaligned load / store pair  that overlaps with the previous
       // pair. Adjust the offset accordingly.

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -218,7 +218,7 @@ TargetLowering::makeLibCall(SelectionDAG &DAG, RTLIB::Libcall LC, EVT RetVT,
 bool TargetLowering::findOptimalMemOpLowering(
     LLVMContext &Context, std::vector<EVT> &MemOps, unsigned Limit,
     const MemOp &Op, unsigned DstAS, unsigned SrcAS,
-    const AttributeList &FuncAttributes) const {
+    const AttributeList &FuncAttributes, EVT *LargestVT) const {
   if (Limit != ~unsigned(0) && Op.isMemcpyWithFixedDstAlign() &&
       Op.getSrcAlign() < Op.getDstAlign())
     return false;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -261,6 +261,12 @@ public:
   LLT getOptimalMemOpLLT(const MemOp &Op,
                          const AttributeList &FuncAttributes) const override;
 
+  bool
+  findOptimalMemOpLowering(LLVMContext &Context, std::vector<EVT> &MemOps,
+                           unsigned Limit, const MemOp &Op, unsigned DstAS,
+                           unsigned SrcAS,
+                           const AttributeList &FuncAttributes) const override;
+
   /// Return true if the addressing mode represented by AM is legal for this
   /// target, for a load/store of the specified type.
   bool isLegalAddressingMode(const DataLayout &DL, const AddrMode &AM, Type *Ty,

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -480,6 +480,9 @@ public:
                               MachineBasicBlock::instr_iterator &MBBI,
                               const TargetInstrInfo *TII) const override;
 
+  bool shallExtractConstSplatVectorElementToStore(
+      Type *VectorTy, unsigned ElemSizeInBits, unsigned &Index) const override;
+
   /// Enable aggressive FMA fusion on targets that want it.
   bool enableAggressiveFMAFusion(EVT VT) const override;
 

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -261,11 +261,11 @@ public:
   LLT getOptimalMemOpLLT(const MemOp &Op,
                          const AttributeList &FuncAttributes) const override;
 
-  bool
-  findOptimalMemOpLowering(LLVMContext &Context, std::vector<EVT> &MemOps,
-                           unsigned Limit, const MemOp &Op, unsigned DstAS,
-                           unsigned SrcAS,
-                           const AttributeList &FuncAttributes) const override;
+  bool findOptimalMemOpLowering(LLVMContext &Context, std::vector<EVT> &MemOps,
+                                unsigned Limit, const MemOp &Op, unsigned DstAS,
+                                unsigned SrcAS,
+                                const AttributeList &FuncAttributes,
+                                EVT *LargestVT = nullptr) const override;
 
   /// Return true if the addressing mode represented by AM is legal for this
   /// target, for a load/store of the specified type.

--- a/llvm/lib/Target/ARM/ARMTargetTransformInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetTransformInfo.cpp
@@ -1216,7 +1216,8 @@ int ARMTTIImpl::getNumMemOps(const IntrinsicInst *I) const {
   std::vector<EVT> MemOps;
   LLVMContext &C = F->getContext();
   if (getTLI()->findOptimalMemOpLowering(C, MemOps, Limit, MOp, DstAddrSpace,
-                                         SrcAddrSpace, F->getAttributes()))
+                                         SrcAddrSpace, F->getAttributes(),
+                                         nullptr))
     return MemOps.size() * Factor;
 
   // If we can't find an optimal memop lowering, return the default cost

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -1433,7 +1433,7 @@ bool SystemZTargetLowering::isLegalAddressingMode(const DataLayout &DL,
 bool SystemZTargetLowering::findOptimalMemOpLowering(
     LLVMContext &Context, std::vector<EVT> &MemOps, unsigned Limit,
     const MemOp &Op, unsigned DstAS, unsigned SrcAS,
-    const AttributeList &FuncAttributes) const {
+    const AttributeList &FuncAttributes, EVT *LargestVT) const {
   const int MVCFastLen = 16;
 
   if (Limit != ~unsigned(0)) {
@@ -1446,8 +1446,8 @@ bool SystemZTargetLowering::findOptimalMemOpLowering(
       return false; // Memset zero: Use XC
   }
 
-  return TargetLowering::findOptimalMemOpLowering(Context, MemOps, Limit, Op,
-                                                  DstAS, SrcAS, FuncAttributes);
+  return TargetLowering::findOptimalMemOpLowering(
+      Context, MemOps, Limit, Op, DstAS, SrcAS, FuncAttributes, LargestVT);
 }
 
 EVT SystemZTargetLowering::getOptimalMemOpType(

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.h
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.h
@@ -125,11 +125,11 @@ public:
   bool allowsMisalignedMemoryAccesses(EVT VT, unsigned AS, Align Alignment,
                                       MachineMemOperand::Flags Flags,
                                       unsigned *Fast) const override;
-  bool
-  findOptimalMemOpLowering(LLVMContext &Context, std::vector<EVT> &MemOps,
-                           unsigned Limit, const MemOp &Op, unsigned DstAS,
-                           unsigned SrcAS,
-                           const AttributeList &FuncAttributes) const override;
+  bool findOptimalMemOpLowering(LLVMContext &Context, std::vector<EVT> &MemOps,
+                                unsigned Limit, const MemOp &Op, unsigned DstAS,
+                                unsigned SrcAS,
+                                const AttributeList &FuncAttributes,
+                                EVT *LargestVT = nullptr) const override;
   EVT getOptimalMemOpType(LLVMContext &Context, const MemOp &Op,
                           const AttributeList &FuncAttributes) const override;
   bool isTruncateFree(Type *, Type *) const override;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-memset.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-memset.mir
@@ -98,10 +98,8 @@ body:             |
     ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[TRUNC]](s8)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 72340172838076673
     ; CHECK-NEXT: [[MUL:%[0-9]+]]:_(s64) = G_MUL [[ZEXT]], [[C]]
-    ; CHECK-NEXT: G_STORE [[MUL]](s64), [[COPY]](p0) :: (store (s64) into %ir.dst, align 1)
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 8
-    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](s64)
-    ; CHECK-NEXT: G_STORE [[MUL]](s64), [[PTR_ADD]](p0) :: (store (s64) into %ir.dst + 8, align 1)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MUL]](s64), [[MUL]](s64)
+    ; CHECK-NEXT: G_STORE [[BUILD_VECTOR]](<2 x s64>), [[COPY]](p0) :: (store (<2 x s64>) into %ir.dst, align 1)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(s32) = COPY $w1
@@ -158,10 +156,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4629771061636907072
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[COPY]](p0) :: (store (s64) into %ir.dst, align 1)
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 8
-    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](s64)
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[PTR_ADD]](p0) :: (store (s64) into %ir.dst + 8, align 1)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[C]](s64), [[C]](s64)
+    ; CHECK-NEXT: G_STORE [[BUILD_VECTOR]](<2 x s64>), [[COPY]](p0) :: (store (<2 x s64>) into %ir.dst, align 1)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(s8) = G_CONSTANT i8 64
@@ -220,10 +216,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4629771061636907072
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[COPY]](p0) :: (store (s64) into %ir.dst, align 1)
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 8
-    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](s64)
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[PTR_ADD]](p0) :: (store (s64) into %ir.dst + 8, align 1)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[C]](s64), [[C]](s64)
+    ; CHECK-NEXT: G_STORE [[BUILD_VECTOR]](<2 x s64>), [[COPY]](p0) :: (store (<2 x s64>) into %ir.dst, align 1)
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s16) = G_CONSTANT i16 16448
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C3]](s64)
@@ -252,10 +246,8 @@ body:             |
     ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[TRUNC]](s8)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 72340172838076673
     ; CHECK-NEXT: [[MUL:%[0-9]+]]:_(s64) = G_MUL [[ZEXT]], [[C]]
-    ; CHECK-NEXT: G_STORE [[MUL]](s64), [[COPY]](p0) :: (store (s64) into %ir.dst, align 1)
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 8
-    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](s64)
-    ; CHECK-NEXT: G_STORE [[MUL]](s64), [[PTR_ADD]](p0) :: (store (s64) into %ir.dst + 8, align 1)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MUL]](s64), [[MUL]](s64)
+    ; CHECK-NEXT: G_STORE [[BUILD_VECTOR]](<2 x s64>), [[COPY]](p0) :: (store (<2 x s64>) into %ir.dst, align 1)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(s32) = COPY $w1

--- a/llvm/test/CodeGen/AArch64/aarch64-mops.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-mops.ll
@@ -429,22 +429,16 @@ define void @memset_10(ptr %dst, i32 %value) {
 ;
 ; SDAG-WITHOUT-MOPS-O2-LABEL: memset_10:
 ; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
-; SDAG-WITHOUT-MOPS-O2-NEXT:    // kill: def $w1 killed $w1 def $x1
-; SDAG-WITHOUT-MOPS-O2-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; SDAG-WITHOUT-MOPS-O2-NEXT:    and x9, x1, #0xff
-; SDAG-WITHOUT-MOPS-O2-NEXT:    mul x8, x9, x8
-; SDAG-WITHOUT-MOPS-O2-NEXT:    str x8, [x0]
-; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w8, [x0, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    dup	v0.16b, w1
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str	h0, [x0, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str	d0, [x0]
 ; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
 ;
 ; SDAG-MOPS-O2-LABEL: memset_10:
 ; SDAG-MOPS-O2:       // %bb.0: // %entry
-; SDAG-MOPS-O2-NEXT:    // kill: def $w1 killed $w1 def $x1
-; SDAG-MOPS-O2-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; SDAG-MOPS-O2-NEXT:    and x9, x1, #0xff
-; SDAG-MOPS-O2-NEXT:    mul x8, x9, x8
-; SDAG-MOPS-O2-NEXT:    str x8, [x0]
-; SDAG-MOPS-O2-NEXT:    strh w8, [x0, #8]
+; SDAG-MOPS-O2-NEXT:    dup	v0.16b, w1
+; SDAG-MOPS-O2-NEXT:    str	h0, [x0, #8]
+; SDAG-MOPS-O2-NEXT:    str	d0, [x0]
 ; SDAG-MOPS-O2-NEXT:    ret
 entry:
   %value_trunc = trunc i32 %value to i8
@@ -495,22 +489,16 @@ define void @memset_10_volatile(ptr %dst, i32 %value) {
 ;
 ; SDAG-WITHOUT-MOPS-O2-LABEL: memset_10_volatile:
 ; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
-; SDAG-WITHOUT-MOPS-O2-NEXT:    // kill: def $w1 killed $w1 def $x1
-; SDAG-WITHOUT-MOPS-O2-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; SDAG-WITHOUT-MOPS-O2-NEXT:    and x9, x1, #0xff
-; SDAG-WITHOUT-MOPS-O2-NEXT:    mul x8, x9, x8
-; SDAG-WITHOUT-MOPS-O2-NEXT:    str x8, [x0]
-; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w8, [x0, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    dup	v0.16b, w1
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str	h0, [x0, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str	d0, [x0]
 ; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
 ;
 ; SDAG-MOPS-O2-LABEL: memset_10_volatile:
 ; SDAG-MOPS-O2:       // %bb.0: // %entry
-; SDAG-MOPS-O2-NEXT:    // kill: def $w1 killed $w1 def $x1
-; SDAG-MOPS-O2-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; SDAG-MOPS-O2-NEXT:    and x9, x1, #0xff
-; SDAG-MOPS-O2-NEXT:    mul x8, x9, x8
-; SDAG-MOPS-O2-NEXT:    str x8, [x0]
-; SDAG-MOPS-O2-NEXT:    strh w8, [x0, #8]
+; SDAG-MOPS-O2-NEXT:    dup	v0.16b, w1
+; SDAG-MOPS-O2-NEXT:    str	h0, [x0, #8]
+; SDAG-MOPS-O2-NEXT:    str	d0, [x0]
 ; SDAG-MOPS-O2-NEXT:    ret
 entry:
   %value_trunc = trunc i32 %value to i8

--- a/llvm/test/CodeGen/AArch64/aarch64-mops.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-mops.ll
@@ -391,45 +391,39 @@ entry:
 define void @memset_10(ptr %dst, i32 %value) {
 ; GISel-WITHOUT-MOPS-O0-LABEL: memset_10:
 ; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
-; GISel-WITHOUT-MOPS-O0-NEXT:    // implicit-def: $x8
-; GISel-WITHOUT-MOPS-O0-NEXT:    mov w8, w1
-; GISel-WITHOUT-MOPS-O0-NEXT:    and x8, x8, #0xff
-; GISel-WITHOUT-MOPS-O0-NEXT:    mov x9, #72340172838076673 // =0x101010101010101
-; GISel-WITHOUT-MOPS-O0-NEXT:    mul x8, x8, x9
-; GISel-WITHOUT-MOPS-O0-NEXT:    str x8, [x0]
-; GISel-WITHOUT-MOPS-O0-NEXT:    // kill: def $w8 killed $w8 killed $x8
+; GISel-WITHOUT-MOPS-O0-NEXT:    and w8, w1, #0xff
+; GISel-WITHOUT-MOPS-O0-NEXT:    mov w9, #16843009 // =0x1010101
+; GISel-WITHOUT-MOPS-O0-NEXT:    mul w8, w8, w9
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w8, [x0, #4]
 ; GISel-WITHOUT-MOPS-O0-NEXT:    strh w8, [x0, #8]
 ; GISel-WITHOUT-MOPS-O0-NEXT:    ret
 ;
 ; GISel-WITHOUT-MOPS-O3-LABEL: memset_10:
 ; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
-; GISel-WITHOUT-MOPS-O3-NEXT:    // kill: def $w1 killed $w1 def $x1
-; GISel-WITHOUT-MOPS-O3-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; GISel-WITHOUT-MOPS-O3-NEXT:    and x9, x1, #0xff
-; GISel-WITHOUT-MOPS-O3-NEXT:    mul x8, x9, x8
-; GISel-WITHOUT-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    mov w8, #16843009 // =0x1010101
+; GISel-WITHOUT-MOPS-O3-NEXT:    and w9, w1, #0xff
+; GISel-WITHOUT-MOPS-O3-NEXT:    mul w8, w9, w8
+; GISel-WITHOUT-MOPS-O3-NEXT:    stp w8, w8, [x0]
 ; GISel-WITHOUT-MOPS-O3-NEXT:    strh w8, [x0, #8]
 ; GISel-WITHOUT-MOPS-O3-NEXT:    ret
 ;
 ; GISel-MOPS-O0-LABEL: memset_10:
 ; GISel-MOPS-O0:       // %bb.0: // %entry
-; GISel-MOPS-O0-NEXT:    // implicit-def: $x8
-; GISel-MOPS-O0-NEXT:    mov w8, w1
-; GISel-MOPS-O0-NEXT:    and x8, x8, #0xff
-; GISel-MOPS-O0-NEXT:    mov x9, #72340172838076673 // =0x101010101010101
-; GISel-MOPS-O0-NEXT:    mul x8, x8, x9
-; GISel-MOPS-O0-NEXT:    str x8, [x0]
-; GISel-MOPS-O0-NEXT:    // kill: def $w8 killed $w8 killed $x8
+; GISel-MOPS-O0-NEXT:    and w8, w1, #0xff
+; GISel-MOPS-O0-NEXT:    mov w9, #16843009 // =0x1010101
+; GISel-MOPS-O0-NEXT:    mul w8, w8, w9
+; GISel-MOPS-O0-NEXT:    str w8, [x0]
+; GISel-MOPS-O0-NEXT:    str w8, [x0, #4]
 ; GISel-MOPS-O0-NEXT:    strh w8, [x0, #8]
 ; GISel-MOPS-O0-NEXT:    ret
 ;
 ; GISel-MOPS-O3-LABEL: memset_10:
 ; GISel-MOPS-O3:       // %bb.0: // %entry
-; GISel-MOPS-O3-NEXT:    // kill: def $w1 killed $w1 def $x1
-; GISel-MOPS-O3-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; GISel-MOPS-O3-NEXT:    and x9, x1, #0xff
-; GISel-MOPS-O3-NEXT:    mul x8, x9, x8
-; GISel-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-MOPS-O3-NEXT:    mov w8, #16843009 // =0x1010101
+; GISel-MOPS-O3-NEXT:    and w9, w1, #0xff
+; GISel-MOPS-O3-NEXT:    mul w8, w9, w8
+; GISel-MOPS-O3-NEXT:    stp w8, w8, [x0]
 ; GISel-MOPS-O3-NEXT:    strh w8, [x0, #8]
 ; GISel-MOPS-O3-NEXT:    ret
 ;
@@ -461,45 +455,41 @@ entry:
 define void @memset_10_volatile(ptr %dst, i32 %value) {
 ; GISel-WITHOUT-MOPS-O0-LABEL: memset_10_volatile:
 ; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
-; GISel-WITHOUT-MOPS-O0-NEXT:    // implicit-def: $x8
-; GISel-WITHOUT-MOPS-O0-NEXT:    mov w8, w1
-; GISel-WITHOUT-MOPS-O0-NEXT:    and x8, x8, #0xff
-; GISel-WITHOUT-MOPS-O0-NEXT:    mov x9, #72340172838076673 // =0x101010101010101
-; GISel-WITHOUT-MOPS-O0-NEXT:    mul x8, x8, x9
-; GISel-WITHOUT-MOPS-O0-NEXT:    str x8, [x0]
-; GISel-WITHOUT-MOPS-O0-NEXT:    // kill: def $w8 killed $w8 killed $x8
+; GISel-WITHOUT-MOPS-O0-NEXT:    and w8, w1, #0xff
+; GISel-WITHOUT-MOPS-O0-NEXT:    mov w9, #16843009 // =0x1010101
+; GISel-WITHOUT-MOPS-O0-NEXT:    mul w8, w8, w9
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w8, [x0, #4]
 ; GISel-WITHOUT-MOPS-O0-NEXT:    strh w8, [x0, #8]
 ; GISel-WITHOUT-MOPS-O0-NEXT:    ret
 ;
 ; GISel-WITHOUT-MOPS-O3-LABEL: memset_10_volatile:
 ; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
-; GISel-WITHOUT-MOPS-O3-NEXT:    // kill: def $w1 killed $w1 def $x1
-; GISel-WITHOUT-MOPS-O3-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; GISel-WITHOUT-MOPS-O3-NEXT:    and x9, x1, #0xff
-; GISel-WITHOUT-MOPS-O3-NEXT:    mul x8, x9, x8
-; GISel-WITHOUT-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    mov w8, #16843009 // =0x1010101
+; GISel-WITHOUT-MOPS-O3-NEXT:    and w9, w1, #0xff
+; GISel-WITHOUT-MOPS-O3-NEXT:    mul w8, w9, w8
+; GISel-WITHOUT-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str w8, [x0, #4]
 ; GISel-WITHOUT-MOPS-O3-NEXT:    strh w8, [x0, #8]
 ; GISel-WITHOUT-MOPS-O3-NEXT:    ret
 ;
 ; GISel-MOPS-O0-LABEL: memset_10_volatile:
 ; GISel-MOPS-O0:       // %bb.0: // %entry
-; GISel-MOPS-O0-NEXT:    // implicit-def: $x8
-; GISel-MOPS-O0-NEXT:    mov w8, w1
-; GISel-MOPS-O0-NEXT:    and x8, x8, #0xff
-; GISel-MOPS-O0-NEXT:    mov x9, #72340172838076673 // =0x101010101010101
-; GISel-MOPS-O0-NEXT:    mul x8, x8, x9
-; GISel-MOPS-O0-NEXT:    str x8, [x0]
-; GISel-MOPS-O0-NEXT:    // kill: def $w8 killed $w8 killed $x8
+; GISel-MOPS-O0-NEXT:    and w8, w1, #0xff
+; GISel-MOPS-O0-NEXT:    mov w9, #16843009 // =0x1010101
+; GISel-MOPS-O0-NEXT:    mul w8, w8, w9
+; GISel-MOPS-O0-NEXT:    str w8, [x0]
+; GISel-MOPS-O0-NEXT:    str w8, [x0, #4]
 ; GISel-MOPS-O0-NEXT:    strh w8, [x0, #8]
 ; GISel-MOPS-O0-NEXT:    ret
 ;
 ; GISel-MOPS-O3-LABEL: memset_10_volatile:
 ; GISel-MOPS-O3:       // %bb.0: // %entry
-; GISel-MOPS-O3-NEXT:    // kill: def $w1 killed $w1 def $x1
-; GISel-MOPS-O3-NEXT:    mov x8, #72340172838076673 // =0x101010101010101
-; GISel-MOPS-O3-NEXT:    and x9, x1, #0xff
-; GISel-MOPS-O3-NEXT:    mul x8, x9, x8
-; GISel-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-MOPS-O3-NEXT:    mov w8, #16843009 // =0x1010101
+; GISel-MOPS-O3-NEXT:    and w9, w1, #0xff
+; GISel-MOPS-O3-NEXT:    mul w8, w9, w8
+; GISel-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-MOPS-O3-NEXT:    str w8, [x0, #4]
 ; GISel-MOPS-O3-NEXT:    strh w8, [x0, #8]
 ; GISel-MOPS-O3-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/arm64-memset-inline.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-memset-inline.ll
@@ -331,7 +331,7 @@ define void @memset_8_stack() {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    .cfi_offset w30, -16
 ; CHECK-NEXT:    mov x8, #-6148914691236517206
-; CHECK-NEXT:    stp x30, x8, [sp, #-16]! // 8-byte Folded Spill
+; CHECK-NEXT:    stp x30, x8, [sp, #-16]!
 ; CHECK-NEXT:    add x0, sp, #8
 ; CHECK-NEXT:    bl something
 ; CHECK-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
@@ -367,14 +367,14 @@ define void @memset_16_stack() {
 ; CHECK-LABEL: memset_16_stack:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #32
+; CHECK-NEXT:    str x30, [sp, #16] // 8-byte{{.*}}Spill
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    .cfi_offset w30, -16
-; CHECK-NEXT:    mov x8, #-6148914691236517206
+; CHECK-NEXT:    movi v0.16b, #170
 ; CHECK-NEXT:    mov x0, sp
-; CHECK-NEXT:    stp x8, x30, [sp, #8] // 8-byte Folded Spill
-; CHECK-NEXT:    str x8, [sp]
+; CHECK-NEXT:    str q0, [sp]
 ; CHECK-NEXT:    bl something
-; CHECK-NEXT:    ldr x30, [sp, #16] // 8-byte Reload
+; CHECK-NEXT:    ldr x30, [sp, #16] // 8-byte{{.*}}Reload
 ; CHECK-NEXT:    add sp, sp, #32
 ; CHECK-NEXT:    ret
   %buf = alloca [16 x i8], align 1
@@ -390,10 +390,10 @@ define void @memset_20_stack() {
 ; CHECK-NEXT:    str x30, [sp, #32] // 8-byte Spill
 ; CHECK-NEXT:    .cfi_def_cfa_offset 48
 ; CHECK-NEXT:    .cfi_offset w30, -16
-; CHECK-NEXT:    mov x8, #-6148914691236517206
-; CHECK-NEXT:    add x0, sp, #8
-; CHECK-NEXT:    stp x8, x8, [sp, #8]
-; CHECK-NEXT:    str w8, [sp, #24]
+; CHECK-NEXT:    movi v0.16b, #170
+; CHECK-NEXT:    mov x0, sp
+; CHECK-NEXT:    str q0, [sp]
+; CHECK-NEXT:    str s0, [sp, #16]
 ; CHECK-NEXT:    bl something
 ; CHECK-NEXT:    ldr x30, [sp, #32] // 8-byte Reload
 ; CHECK-NEXT:    add sp, sp, #48
@@ -411,11 +411,10 @@ define void @memset_26_stack() {
 ; CHECK-NEXT:    str x30, [sp, #32] // 8-byte Spill
 ; CHECK-NEXT:    .cfi_def_cfa_offset 48
 ; CHECK-NEXT:    .cfi_offset w30, -16
-; CHECK-NEXT:    mov x8, #-6148914691236517206
+; CHECK-NEXT:    movi v0.16b, #170
 ; CHECK-NEXT:    mov x0, sp
-; CHECK-NEXT:    stp x8, x8, [sp, #8]
-; CHECK-NEXT:    str x8, [sp]
-; CHECK-NEXT:    strh w8, [sp, #24]
+; CHECK-NEXT:    stur q0, [sp, #10]
+; CHECK-NEXT:    str q0, [sp]
 ; CHECK-NEXT:    bl something
 ; CHECK-NEXT:    ldr x30, [sp, #32] // 8-byte Reload
 ; CHECK-NEXT:    add sp, sp, #48
@@ -454,10 +453,9 @@ define void @memset_40_stack() {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 64
 ; CHECK-NEXT:    .cfi_offset w30, -16
 ; CHECK-NEXT:    movi v0.16b, #170
-; CHECK-NEXT:    mov x8, #-6148914691236517206
 ; CHECK-NEXT:    mov x0, sp
-; CHECK-NEXT:    str x8, [sp, #32]
 ; CHECK-NEXT:    stp q0, q0, [sp]
+; CHECK-NEXT:    str d0, [sp, #32]
 ; CHECK-NEXT:    bl something
 ; CHECK-NEXT:    ldr x30, [sp, #48] // 8-byte Reload
 ; CHECK-NEXT:    add sp, sp, #64
@@ -497,11 +495,10 @@ define void @memset_72_stack() {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 96
 ; CHECK-NEXT:    .cfi_offset w30, -16
 ; CHECK-NEXT:    movi v0.16b, #170
-; CHECK-NEXT:    mov x8, #-6148914691236517206
 ; CHECK-NEXT:    mov x0, sp
-; CHECK-NEXT:    str x8, [sp, #64]
 ; CHECK-NEXT:    stp q0, q0, [sp]
 ; CHECK-NEXT:    stp q0, q0, [sp, #32]
+; CHECK-NEXT:    str d0, [sp, #64]
 ; CHECK-NEXT:    bl something
 ; CHECK-NEXT:    ldr x30, [sp, #80] // 8-byte Reload
 ; CHECK-NEXT:    add sp, sp, #96

--- a/llvm/test/CodeGen/AArch64/arm64-memset-inline.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-memset-inline.ll
@@ -346,15 +346,15 @@ define void @memset_12_stack() {
 ; CHECK-LABEL: memset_12_stack:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #32
-; CHECK-NEXT:    str x30, [sp, #16] // 8-byte Spill
+; CHECK-NEXT:    str x30, [sp, #16] // 8-byte{{.*}}Spill
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    .cfi_offset w30, -16
-; CHECK-NEXT:    mov x8, #-6148914691236517206
+; CHECK-NEXT:    movi v0.16b, #170
 ; CHECK-NEXT:    mov x0, sp
-; CHECK-NEXT:    str x8, [sp]
-; CHECK-NEXT:    str w8, [sp, #8]
+; CHECK-NEXT:    str s0, [sp, #8]
+; CHECK-NEXT:    str d0, [sp]
 ; CHECK-NEXT:    bl something
-; CHECK-NEXT:    ldr x30, [sp, #16] // 8-byte Reload
+; CHECK-NEXT:    ldr x30, [sp, #16] // 8-byte{{.*}}Reload
 ; CHECK-NEXT:    add sp, sp, #32
 ; CHECK-NEXT:    ret
   %buf = alloca [12 x i8], align 1

--- a/llvm/test/CodeGen/AArch64/memcpy-scoped-aa.ll
+++ b/llvm/test/CodeGen/AArch64/memcpy-scoped-aa.ll
@@ -78,17 +78,16 @@ define i32 @test_memmove(ptr nocapture %p, ptr nocapture readonly %q) {
 }
 
 ; MIR-LABEL: name: test_memset
-; MIR:      %2:gpr64 = MOVi64imm -6148914691236517206
-; MIR-NEXT: STRXui %2, %0, 1 :: (store (s64) into %ir.p0 + 8, align 4, !alias.scope ![[SET0]], !noalias ![[SET1]])
-; MIR-NEXT: STRXui %2, %0, 0 :: (store (s64) into %ir.p0, align 4, !alias.scope ![[SET0]], !noalias ![[SET1]])
+; MIR:      %2:fpr128 = MOVIv16b_ns 170
+; MIR-NEXT: STRQui killed %2, %0, 0 :: (store (s128) into %ir.p0, align 4, !alias.scope ![[SET0]], !noalias ![[SET1]])
 define i32 @test_memset(ptr nocapture %p, ptr nocapture readonly %q) {
 ; CHECK-LABEL: test_memset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ldp w10, w11, [x1]
+; CHECK-NEXT:    movi v0.16b, #170
 ; CHECK-NEXT:    mov x8, x0
-; CHECK-NEXT:    mov x9, #-6148914691236517206 // =0xaaaaaaaaaaaaaaaa
-; CHECK-NEXT:    stp x9, x9, [x8]
-; CHECK-NEXT:    add w0, w10, w11
+; CHECK-NEXT:    ldp w9, w10, [x1]
+; CHECK-NEXT:    add w0, w9, w10
+; CHECK-NEXT:    str q0, [x8]
 ; CHECK-NEXT:    ret
   %p0 = bitcast ptr %p to ptr
   tail call void @llvm.memset.p0.i64(ptr noundef nonnull align 4 dereferenceable(16) %p0, i8 170, i64 16, i1 false), !alias.scope !2, !noalias !4

--- a/llvm/test/CodeGen/AArch64/memset-inline.ll
+++ b/llvm/test/CodeGen/AArch64/memset-inline.ll
@@ -17,11 +17,17 @@ define void @memset_1(ptr %a, i8 %value) nounwind {
 }
 
 define void @memset_2(ptr %a, i8 %value) nounwind {
-; ALL-LABEL: memset_2:
-; ALL:       // %bb.0:
-; ALL-NEXT:    bfi w1, w1, #8, #24
-; ALL-NEXT:    strh w1, [x0]
-; ALL-NEXT:    ret
+; GPR-LABEL: memset_2:
+; GPR:       // %bb.0:
+; GPR-NEXT:    bfi w1, w1, #8, #24
+; GPR-NEXT:    strh w1, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_2:
+; NEON:       // %bb.0:
+; NEON-NEXT:    dup	v0.16b, w1
+; NEON-NEXT:    str	h0, [x0]
+; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 2, i1 0)
   ret void
 }
@@ -377,12 +383,19 @@ define void @memset_16_const_128(ptr %a) nounwind {
 ; Test cases for non-power-of-two lengths
 
 define void @memset_3(ptr %a, i8 %value) nounwind {
-; ALL-LABEL: memset_3:
-; ALL:       // %bb.0:
-; ALL-NEXT:    strb w1, [x0, #2]
-; ALL-NEXT:    bfi w1, w1, #8, #24
-; ALL-NEXT:    strh w1, [x0]
-; ALL-NEXT:    ret
+; GPR-LABEL: memset_3:
+; GPR:       // %bb.0:
+; GPR-NEXT:    strb w1, [x0, #2]
+; GPR-NEXT:    bfi w1, w1, #8, #24
+; GPR-NEXT:    strh w1, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_3:
+; NEON:       // %bb.0:
+; NEON-NEXT:    dup	v0.16b, w1
+; NEON-NEXT:    strb	w1, [x0, #2]
+; NEON-NEXT:    str	h0, [x0]
+; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 3, i1 0)
   ret void
 }
@@ -399,11 +412,9 @@ define void @memset_5(ptr %a, i8 %value) nounwind {
 ;
 ; NEON-LABEL: memset_5:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    mov w8, #16843009
-; NEON-NEXT:    and w9, w1, #0xff
-; NEON-NEXT:    mul w8, w9, w8
-; NEON-NEXT:    strb w8, [x0, #4]
-; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    dup	v0.16b, w1
+; NEON-NEXT:    strb	w1, [x0, #4]
+; NEON-NEXT:    str	s0, [x0]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 5, i1 0)
   ret void
@@ -421,11 +432,9 @@ define void @memset_6(ptr %a, i8 %value) nounwind {
 ;
 ; NEON-LABEL: memset_6:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    mov w8, #16843009
-; NEON-NEXT:    and w9, w1, #0xff
-; NEON-NEXT:    mul w8, w9, w8
-; NEON-NEXT:    strh w8, [x0, #4]
-; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    dup	v0.16b, w1
+; NEON-NEXT:    str	h0, [x0, #4]
+; NEON-NEXT:    str	s0, [x0]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 6, i1 0)
   ret void
@@ -443,11 +452,10 @@ define void @memset_7(ptr %a, i8 %value) nounwind {
 ;
 ; NEON-LABEL: memset_7:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    mov w8, #16843009
-; NEON-NEXT:    and w9, w1, #0xff
-; NEON-NEXT:    mul w8, w9, w8
-; NEON-NEXT:    stur w8, [x0, #3]
-; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    dup	v0.16b, w1
+; NEON-NEXT:    strb	w1, [x0, #6]
+; NEON-NEXT:    str	h0, [x0, #4]
+; NEON-NEXT:    str	s0, [x0]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 7, i1 0)
   ret void
@@ -466,12 +474,9 @@ define void @memset_12(ptr %a, i8 %value) nounwind {
 ;
 ; NEON-LABEL: memset_12:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    // kill: def $w1 killed $w1 def $x1
-; NEON-NEXT:    mov x8, #72340172838076673
-; NEON-NEXT:    and x9, x1, #0xff
-; NEON-NEXT:    mul x8, x9, x8
-; NEON-NEXT:    str x8, [x0]
-; NEON-NEXT:    str w8, [x0, #8]
+; NEON-NEXT:    dup	v0.16b, w1
+; NEON-NEXT:    str	s0, [x0, #8]
+; NEON-NEXT:    str	d0, [x0]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 12, i1 0)
   ret void

--- a/llvm/test/CodeGen/AArch64/memset-inline.ll
+++ b/llvm/test/CodeGen/AArch64/memset-inline.ll
@@ -37,7 +37,7 @@ define void @memset_4(ptr %a, i8 %value) nounwind {
 ;
 ; NEON-LABEL: memset_4:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    dup v0.8b, w1
+; NEON-NEXT:    dup v0.16b, w1
 ; NEON-NEXT:    str s0, [x0]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 4, i1 0)
@@ -56,7 +56,7 @@ define void @memset_8(ptr %a, i8 %value) nounwind {
 ;
 ; NEON-LABEL: memset_8:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    dup v0.8b, w1
+; NEON-NEXT:    dup v0.16b, w1
 ; NEON-NEXT:    str d0, [x0]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 8, i1 0)
@@ -316,5 +316,163 @@ define void @aligned_bzero_64(ptr %a) nounwind {
 ; NEON-NEXT:    stp q0, q0, [x0, #32]
 ; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr align 64 %a, i8 0, i64 64, i1 0)
+  ret void
+}
+
+; /////////////////////////////////////////////////////////////////////////////
+; Test cases for non-zero constants
+
+define void @memset_4_const_42(ptr %a) nounwind {
+; GPR-LABEL: memset_4_const_42:
+; GPR:       // %bb.0:
+; GPR-NEXT:    mov w8, #10794
+; GPR-NEXT:    movk w8, #10794, lsl #16
+; GPR-NEXT:    str w8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_4_const_42:
+; NEON:       // %bb.0:
+; NEON-NEXT:    mov w8, #10794
+; NEON-NEXT:    movk w8, #10794, lsl #16
+; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 42, i64 4, i1 0)
+  ret void
+}
+
+define void @memset_8_const_255(ptr %a) nounwind {
+; GPR-LABEL: memset_8_const_255:
+; GPR:       // %bb.0:
+; GPR-NEXT:    mov x8, #-1
+; GPR-NEXT:    str x8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_8_const_255:
+; NEON:       // %bb.0:
+; NEON-NEXT:    mov x8, #-1
+; NEON-NEXT:    str x8, [x0]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 255, i64 8, i1 0)
+  ret void
+}
+
+define void @memset_16_const_128(ptr %a) nounwind {
+; GPR-LABEL: memset_16_const_128:
+; GPR:       // %bb.0:
+; GPR-NEXT:    adrp
+; GPR-NEXT:    ldr q0,
+; GPR-NEXT:    str q0, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_16_const_128:
+; NEON:       // %bb.0:
+; NEON-NEXT:    movi v0.16b, #128
+; NEON-NEXT:    str q0, [x0]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 128, i64 16, i1 0)
+  ret void
+}
+
+; /////////////////////////////////////////////////////////////////////////////
+; Test cases for non-power-of-two lengths
+
+define void @memset_3(ptr %a, i8 %value) nounwind {
+; ALL-LABEL: memset_3:
+; ALL:       // %bb.0:
+; ALL-NEXT:    strb w1, [x0, #2]
+; ALL-NEXT:    bfi w1, w1, #8, #24
+; ALL-NEXT:    strh w1, [x0]
+; ALL-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 3, i1 0)
+  ret void
+}
+
+define void @memset_5(ptr %a, i8 %value) nounwind {
+; GPR-LABEL: memset_5:
+; GPR:       // %bb.0:
+; GPR-NEXT:    mov w8, #16843009
+; GPR-NEXT:    and w9, w1, #0xff
+; GPR-NEXT:    mul w8, w9, w8
+; GPR-NEXT:    strb w8, [x0, #4]
+; GPR-NEXT:    str w8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_5:
+; NEON:       // %bb.0:
+; NEON-NEXT:    mov w8, #16843009
+; NEON-NEXT:    and w9, w1, #0xff
+; NEON-NEXT:    mul w8, w9, w8
+; NEON-NEXT:    strb w8, [x0, #4]
+; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 5, i1 0)
+  ret void
+}
+
+define void @memset_6(ptr %a, i8 %value) nounwind {
+; GPR-LABEL: memset_6:
+; GPR:       // %bb.0:
+; GPR-NEXT:    mov w8, #16843009
+; GPR-NEXT:    and w9, w1, #0xff
+; GPR-NEXT:    mul w8, w9, w8
+; GPR-NEXT:    strh w8, [x0, #4]
+; GPR-NEXT:    str w8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_6:
+; NEON:       // %bb.0:
+; NEON-NEXT:    mov w8, #16843009
+; NEON-NEXT:    and w9, w1, #0xff
+; NEON-NEXT:    mul w8, w9, w8
+; NEON-NEXT:    strh w8, [x0, #4]
+; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 6, i1 0)
+  ret void
+}
+
+define void @memset_7(ptr %a, i8 %value) nounwind {
+; GPR-LABEL: memset_7:
+; GPR:       // %bb.0:
+; GPR-NEXT:    mov w8, #16843009
+; GPR-NEXT:    and w9, w1, #0xff
+; GPR-NEXT:    mul w8, w9, w8
+; GPR-NEXT:    stur w8, [x0, #3]
+; GPR-NEXT:    str w8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_7:
+; NEON:       // %bb.0:
+; NEON-NEXT:    mov w8, #16843009
+; NEON-NEXT:    and w9, w1, #0xff
+; NEON-NEXT:    mul w8, w9, w8
+; NEON-NEXT:    stur w8, [x0, #3]
+; NEON-NEXT:    str w8, [x0]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 7, i1 0)
+  ret void
+}
+
+define void @memset_12(ptr %a, i8 %value) nounwind {
+; GPR-LABEL: memset_12:
+; GPR:       // %bb.0:
+; GPR-NEXT:    // kill: def $w1 killed $w1 def $x1
+; GPR-NEXT:    mov x8, #72340172838076673
+; GPR-NEXT:    and x9, x1, #0xff
+; GPR-NEXT:    mul x8, x9, x8
+; GPR-NEXT:    str x8, [x0]
+; GPR-NEXT:    str w8, [x0, #8]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_12:
+; NEON:       // %bb.0:
+; NEON-NEXT:    // kill: def $w1 killed $w1 def $x1
+; NEON-NEXT:    mov x8, #72340172838076673
+; NEON-NEXT:    and x9, x1, #0xff
+; NEON-NEXT:    mul x8, x9, x8
+; NEON-NEXT:    str x8, [x0]
+; NEON-NEXT:    str w8, [x0, #8]
+; NEON-NEXT:    ret
+  tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 12, i1 0)
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/memset-inline.ll
+++ b/llvm/test/CodeGen/AArch64/memset-inline.ll
@@ -27,39 +27,57 @@ define void @memset_2(ptr %a, i8 %value) nounwind {
 }
 
 define void @memset_4(ptr %a, i8 %value) nounwind {
-; ALL-LABEL: memset_4:
-; ALL:       // %bb.0:
-; ALL-NEXT:    mov w8, #16843009
-; ALL-NEXT:    and w9, w1, #0xff
-; ALL-NEXT:    mul w8, w9, w8
-; ALL-NEXT:    str w8, [x0]
-; ALL-NEXT:    ret
+; GPR-LABEL: memset_4:
+; GPR:       // %bb.0:
+; GPR-NEXT:    mov w8, #16843009
+; GPR-NEXT:    and w9, w1, #0xff
+; GPR-NEXT:    mul w8, w9, w8
+; GPR-NEXT:    str w8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_4:
+; NEON:       // %bb.0:
+; NEON-NEXT:    dup v0.8b, w1
+; NEON-NEXT:    str s0, [x0]
+; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 4, i1 0)
   ret void
 }
 
 define void @memset_8(ptr %a, i8 %value) nounwind {
-; ALL-LABEL: memset_8:
-; ALL:       // %bb.0:
-; ALL-NEXT:    // kill: def $w1 killed $w1 def $x1
-; ALL-NEXT:    mov x8, #72340172838076673
-; ALL-NEXT:    and x9, x1, #0xff
-; ALL-NEXT:    mul x8, x9, x8
-; ALL-NEXT:    str x8, [x0]
-; ALL-NEXT:    ret
+; GPR-LABEL: memset_8:
+; GPR:       // %bb.0:
+; GPR-NEXT:    // kill: def $w1 killed $w1 def $x1
+; GPR-NEXT:    mov x8, #72340172838076673
+; GPR-NEXT:    and x9, x1, #0xff
+; GPR-NEXT:    mul x8, x9, x8
+; GPR-NEXT:    str x8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_8:
+; NEON:       // %bb.0:
+; NEON-NEXT:    dup v0.8b, w1
+; NEON-NEXT:    str d0, [x0]
+; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 8, i1 0)
   ret void
 }
 
 define void @memset_16(ptr %a, i8 %value) nounwind {
-; ALL-LABEL: memset_16:
-; ALL:       // %bb.0:
-; ALL-NEXT:    // kill: def $w1 killed $w1 def $x1
-; ALL-NEXT:    mov x8, #72340172838076673
-; ALL-NEXT:    and x9, x1, #0xff
-; ALL-NEXT:    mul x8, x9, x8
-; ALL-NEXT:    stp x8, x8, [x0]
-; ALL-NEXT:    ret
+; GPR-LABEL: memset_16:
+; GPR:       // %bb.0:
+; GPR-NEXT:    // kill: def $w1 killed $w1 def $x1
+; GPR-NEXT:    mov x8, #72340172838076673
+; GPR-NEXT:    and x9, x1, #0xff
+; GPR-NEXT:    mul x8, x9, x8
+; GPR-NEXT:    stp x8, x8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: memset_16:
+; NEON:       // %bb.0:
+; NEON-NEXT:    dup v0.16b, w1
+; NEON-NEXT:    str q0, [x0]
+; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 16, i1 0)
   ret void
 }
@@ -110,14 +128,20 @@ define void @memset_64(ptr %a, i8 %value) nounwind {
 ; /////////////////////////////////////////////////////////////////////////////
 
 define void @aligned_memset_16(ptr align 16 %a, i8 %value) nounwind {
-; ALL-LABEL: aligned_memset_16:
-; ALL:       // %bb.0:
-; ALL-NEXT:    // kill: def $w1 killed $w1 def $x1
-; ALL-NEXT:    mov x8, #72340172838076673
-; ALL-NEXT:    and x9, x1, #0xff
-; ALL-NEXT:    mul x8, x9, x8
-; ALL-NEXT:    stp x8, x8, [x0]
-; ALL-NEXT:    ret
+; GPR-LABEL: aligned_memset_16:
+; GPR:       // %bb.0:
+; GPR-NEXT:    // kill: def $w1 killed $w1 def $x1
+; GPR-NEXT:    mov x8, #72340172838076673
+; GPR-NEXT:    and x9, x1, #0xff
+; GPR-NEXT:    mul x8, x9, x8
+; GPR-NEXT:    stp x8, x8, [x0]
+; GPR-NEXT:    ret
+;
+; NEON-LABEL: aligned_memset_16:
+; NEON:       // %bb.0:
+; NEON-NEXT:    dup v0.16b, w1
+; NEON-NEXT:    str q0, [x0]
+; NEON-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr align 16 %a, i8 %value, i64 16, i1 0)
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/memset-vs-memset-inline.ll
+++ b/llvm/test/CodeGen/AArch64/memset-vs-memset-inline.ll
@@ -7,11 +7,8 @@ declare void @llvm.memset.inline.p0.i64(ptr nocapture, i8, i64, i1) nounwind
 define void @test1(ptr %a, i8 %value) nounwind {
 ; CHECK-LABEL: test1:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-NEXT:    mov x8, #72340172838076673
-; CHECK-NEXT:    and x9, x1, #0xff
-; CHECK-NEXT:    mul x8, x9, x8
-; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    dup v0.16b, w1
+; CHECK-NEXT:    str d0, [x0]
 ; CHECK-NEXT:    ret
   tail call void @llvm.memset.inline.p0.i64(ptr %a, i8 %value, i64 8, i1 0)
   ret void

--- a/llvm/test/CodeGen/AArch64/mops-register-alias.ll
+++ b/llvm/test/CodeGen/AArch64/mops-register-alias.ll
@@ -3,12 +3,11 @@
 define void @call_memset_intrinsic() #0 {
 ; CHECK-LABEL: call_memset_intrinsic:
 ; CHECK:       // %bb.0: // %entry
-; CHECK:         setp [x{{[0-9]+}}]!, x{{[0-9]+}}!, x{{[0-9]+}}
-; CHECK-NOT:     setp [x{{[0-9]+}}]!, x[[REG:[0-9]+]]!, x[[REG]]
-; CHECK-NEXT:    setm [x{{[0-9]+}}]!, x{{[0-9]+}}!, x{{[0-9]+}}
-; CHECK-NOT:     setm [x{{[0-9]+}}]!, x[[REG:[0-9]+]]!, x[[REG]]
-; CHECK-NEXT:    sete [x{{[0-9]+}}]!, x{{[0-9]+}}!, x{{[0-9]+}}
-; CHECK-NOT:     sete [x{{[0-9]+}}]!, x[[REG:[0-9]+]]!, x[[REG]]
+; CHECK:         movi v0.16b, #64
+; CHECK-NEXT:    stp q0, q0, [sp]
+; CHECK-NEXT:    stp q0, q0, [sp, #32]
+; CHECK-NEXT:    stp q0, q0, [sp, #64]
+; CHECK-NEXT:    stp q0, q0, [sp, #96]
 entry:
 
     %V0 = alloca [65 x i8], align 1

--- a/llvm/test/Instrumentation/HWAddressSanitizer/stack-coloring.ll
+++ b/llvm/test/Instrumentation/HWAddressSanitizer/stack-coloring.ll
@@ -9,7 +9,7 @@ target triple = "aarch64-unknown-linux-android29"
 
 ; REQUIRES: aarch64-registered-target
 
-; COLOR: sub	sp, sp, #240
+; COLOR: sub	sp, sp, #256
 ; NOCOLOR: sub	sp, sp, #384
 
 define i32 @myCall_w2(i32 %in) sanitize_hwaddress {


### PR DESCRIPTION
This change improves memset code generation for non-zero values on AArch64 by using NEON's DUP instruction instead of
the less efficient multiplication with 0x01010101 pattern.

For small sizes, the value is extracted from a larger DUP.  For non-power-of-two sizes, overlapping stores are used in some cases.

TargetLowering::findOptimalMemOpLowering is modified to allow explicitly specifying the size of the constant in cases where the constant is larger than the store operations.

Fixes #165949 