### PR TITLE
[Support] Join threads when stopping ThreadPoolExecutor

### DIFF
--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -97,7 +97,6 @@ public:
         T.detach();
       else
         T.join();
-    Threads.clear();
   }
 
   ~ThreadPoolExecutor() override { stop(); }
@@ -196,22 +195,8 @@ private:
 Executor *Executor::getDefaultExecutor() {
 #ifdef _WIN32
   // The ManagedStatic enables the ThreadPoolExecutor to be stopped via
-  // llvm_shutdown() which allows a "clean" fast exit, e.g. via _exit(). This
-  // stops the thread pool and waits for any worker thread creation to complete
-  // but does not wait for the threads to finish. The wait for worker thread
-  // creation to complete is important as it prevents intermittent crashes on
-  // Windows due to a race condition between thread creation and process exit.
-  //
-  // The ThreadPoolExecutor will only be destroyed when the static unique_ptr to
-  // it is destroyed, i.e. in a normal full exit. The ThreadPoolExecutor
-  // destructor ensures it has been stopped and waits for worker threads to
-  // finish. The wait is important as it prevents intermittent crashes on
-  // Windows when the process is doing a full exit.
-  //
-  // The Windows crashes appear to only occur with the MSVC static runtimes and
-  // are more frequent with the debug static runtime.
-  //
-  // This also prevents intermittent deadlocks on exit with the MinGW runtime.
+  // llvm_shutdown() on Windows. This is important to avoid various race
+  // conditions at process exit that can cause crashes or deadlocks.
 
   static ManagedStatic<ThreadPoolExecutor, ThreadPoolExecutor::Creator,
                        ThreadPoolExecutor::Deleter>


### PR DESCRIPTION
When building LLVM as DLL, the `ThreadPoolExecutor` can cause deadlocks on Windows.

The threads were previously only joined when the destructor of the `ThreadPoolExecutor` is called, not when it's stopped. Destruction happens when unloading the DLL, when the global destructors are called.

On Windows, `std::thread` uses `FreeLibraryAndExitThread` to cleanup a thread. This requires access to the loader lock, when a thread terminates.
However, when destroying the pool, the loader lock is also held, as the DLL is being unloaded.
If the threads did not end fast enough, the destructor would wait for them to join. At the same time, the threads would wait for the destructor to release the loader lock.

Joining the threads when stopping the pool fixes that, as it ensures the threads are stopped when calling `llvm_shutdown`, outside the loader lock.
