### PR TITLE
[libc] allow UnitTest suite to be compiled on darwin

### DIFF
--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -83,7 +83,7 @@ add_unittest_framework_library(
 )
 
 set(libc_death_test_srcs LibcDeathTestExecutors.cpp)
-if(${LIBC_TARGET_OS} STREQUAL "linux")
+if(${LIBC_TARGET_OS} STREQUAL "linux" OR ${LIBC_TARGET_OS} STREQUAL "darwin")
   list(APPEND libc_death_test_srcs ExecuteFunctionUnix.cpp)
 endif()
 


### PR DESCRIPTION
ExecuteFunctionUnix.cpp which is guarded by this check should reliably work
on darwin as it only uses POSIX API - nothing specific to linux.
