### PR TITLE
[LLVM-C] Add binding to `BitcodeReader::getBitcodeProducerString`

### DIFF
--- a/llvm/include/llvm-c/BitReader.h
+++ b/llvm/include/llvm-c/BitReader.h
@@ -85,6 +85,15 @@ LLVM_C_ABI LLVMBool LLVMGetBitcodeModule2(LLVMMemoryBufferRef MemBuf,
                                           LLVMModuleRef *OutM);
 
 /**
+ * Reads the producer string from the bitcode header in the given memory
+ * buffer. Returns 0 on success. The produced string must be disposed with
+ * LLVMDisposeMessage.
+ */
+LLVM_C_ABI LLVMBool LLVMGetBitcodeProducerString(LLVMMemoryBufferRef MemBuf,
+                                                 char **OutProducer,
+                                                 char **OutMessage);
+
+/**
  * @}
  */
 

--- a/llvm/lib/Bitcode/Reader/BitReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitReader.cpp
@@ -130,3 +130,24 @@ LLVMBool LLVMGetBitcodeModule2(LLVMMemoryBufferRef MemBuf,
                                LLVMModuleRef *OutM) {
   return LLVMGetBitcodeModuleInContext2(LLVMGetGlobalContext(), MemBuf, OutM);
 }
+
+LLVMBool LLVMGetBitcodeProducerString(LLVMMemoryBufferRef MemBuf,
+                                      char **OutProducer, char **OutMessage) {
+  MemoryBufferRef Buf = unwrap(MemBuf)->getMemBufferRef();
+
+  Expected<std::string> ProducerOrErr = getBitcodeProducerString(Buf);
+  if (!ProducerOrErr) {
+    std::string Message;
+    handleAllErrors(ProducerOrErr.takeError(),
+                    [&](ErrorInfoBase &EIB) { Message = EIB.message(); });
+    if (OutMessage)
+      *OutMessage = strdup(Message.c_str());
+    if (OutProducer)
+      *OutProducer = nullptr;
+    return 1;
+  }
+
+  if (OutProducer)
+    *OutProducer = strdup(ProducerOrErr->c_str());
+  return 0;
+}

--- a/llvm/test/Bindings/llvm-c/producer_string.ll
+++ b/llvm/test/Bindings/llvm-c/producer_string.ll
@@ -1,0 +1,2 @@
+; RUN: llvm-as < %s | llvm-c-test --module-get-producer-string | FileCheck %s
+; CHECK: LLVM{{[0-9]+.*}}

--- a/llvm/tools/llvm-c-test/llvm-c-test.h
+++ b/llvm/tools/llvm-c-test/llvm-c-test.h
@@ -28,6 +28,7 @@ LLVMModuleRef llvm_load_module(LLVMContextRef C, bool Lazy, bool New);
 int llvm_module_dump(bool Lazy, bool New);
 int llvm_module_list_functions(void);
 int llvm_module_list_globals(void);
+int llvm_module_get_producer_string(void);
 
 // calc.c
 int llvm_calc(void);

--- a/llvm/tools/llvm-c-test/main.c
+++ b/llvm/tools/llvm-c-test/main.c
@@ -33,6 +33,10 @@ static void print_usage(void) {
           "    Read bitcode from stdin - list summary of functions\n\n");
   fprintf(stderr, "  * --module-list-globals\n");
   fprintf(stderr, "    Read bitcode from stdin - list summary of globals\n\n");
+  fprintf(stderr, "  * --module-get-producer-string\n");
+  fprintf(
+      stderr,
+      "    Read bitcode from stdin - print the producer identification\n\n");
   fprintf(stderr, "  * --targets-list\n");
   fprintf(stderr, "    List available targets\n\n");
   fprintf(stderr, "  * --object-list-sections\n");
@@ -79,6 +83,8 @@ int main(int argc, char **argv) {
     return llvm_module_list_functions();
   } else if (argc == 2 && !strcmp(argv[1], "--module-list-globals")) {
     return llvm_module_list_globals();
+  } else if (argc == 2 && !strcmp(argv[1], "--module-get-producer-string")) {
+    return llvm_module_get_producer_string();
   } else if (argc == 2 && !strcmp(argv[1], "--targets-list")) {
     return llvm_targets_list();
   } else if (argc == 2 && !strcmp(argv[1], "--object-list-sections")) {


### PR DESCRIPTION
Add `LLVMGetBircodeProducerString` function in LLVM C API that binds to `BitcodeReader::getBitcodeProducerString` in LLVM C++ API.