### PR TITLE
[ADT] Deprecate variadic `StringSwitch::Cases`. NFC.

### DIFF
--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -89,6 +89,7 @@ public:
     return CasesImpl(CaseStrings, Value);
   }
 
+  [[deprecated("Pass cases in std::initializer_list instead")]]
   StringSwitch &Cases(StringLiteral S0, StringLiteral S1, T Value) {
     return CasesImpl({S0, S1}, Value);
   }


### PR DESCRIPTION
Suggest the initializer_list overload instead.

For more context, see https://github.com/llvm/llvm-project/pull/163117.