### PR TITLE
[mlir][linalg] Reject unsigned pooling on non-integer element types

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -579,13 +579,23 @@ public:
       return arith::MinSIOp::create(builder, arg0.getLoc(), arg0, arg1);
     case BinaryFn::max_unsigned:
       assert(!allComplex);
-      if (allFloatingPoint)
-        return arith::MaximumFOp::create(builder, arg0.getLoc(), arg0, arg1);
+      if (!allInteger || allBool) {
+        if (emitError) {
+          emitError() << "unsupported operation: unsigned max not on uint";
+          return nullptr;
+        }
+        llvm_unreachable("unsupported operation: unsigned max not on uint");
+      }
       return arith::MaxUIOp::create(builder, arg0.getLoc(), arg0, arg1);
     case BinaryFn::min_unsigned:
       assert(!allComplex);
-      if (allFloatingPoint)
-        return arith::MinimumFOp::create(builder, arg0.getLoc(), arg0, arg1);
+      if (!allInteger || allBool) {
+        if (emitError) {
+          emitError() << "unsupported operation: unsigned min not on uint";
+          return nullptr;
+        }
+        llvm_unreachable("unsupported operation: unsigned min not on uint");
+      }
       return arith::MinUIOp::create(builder, arg0.getLoc(), arg0, arg1);
     case BinaryFn::powf:
       assert(allFloatingPoint);

--- a/mlir/python/mlir/dialects/linalg/opdsl/lang/emitter.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/lang/emitter.py
@@ -532,9 +532,9 @@ class _BodyBuilder:
         raise NotImplementedError("Unsupported 'max' operands: {lhs}, {rhs}")
 
     def _binary_max_unsigned(self, lhs: Value, rhs: Value) -> Value:
-        if _is_floating_point_type(lhs.type):
-            return arith.MaximumFOp(lhs, rhs).result
-        if _is_integer_type(lhs.type) or _is_index_type(lhs.type):
+        if (
+            _is_integer_type(lhs.type) and not _is_bool_type(lhs.type)
+        ) or _is_index_type(lhs.type):
             return arith.MaxUIOp(lhs, rhs).result
         raise NotImplementedError("Unsupported 'max_unsigned' operands: {lhs}, {rhs}")
 
@@ -546,9 +546,9 @@ class _BodyBuilder:
         raise NotImplementedError("Unsupported 'min' operands: {lhs}, {rhs}")
 
     def _binary_min_unsigned(self, lhs: Value, rhs: Value) -> Value:
-        if _is_floating_point_type(lhs.type):
-            return arith.MinimumFOp(lhs, rhs).result
-        if _is_integer_type(lhs.type) or _is_index_type(lhs.type):
+        if (
+            _is_integer_type(lhs.type) and not _is_bool_type(lhs.type)
+        ) or _is_index_type(lhs.type):
             return arith.MinUIOp(lhs, rhs).result
         raise NotImplementedError("Unsupported 'min_unsigned' operands: {lhs}, {rhs}")
 
@@ -632,6 +632,12 @@ def _is_integer_type(t: Type) -> bool:
 
 def _is_index_type(t: Type) -> bool:
     return IndexType.isinstance(t)
+
+
+def _is_bool_type(t: Type) -> bool:
+    if not IntegerType.isinstance(t):
+        return False
+    return IntegerType(t).width == 1
 
 
 def _get_floating_point_width(t: Type) -> int:

--- a/mlir/test/Dialect/Linalg/convolution/roundtrip-convolution.mlir
+++ b/mlir/test/Dialect/Linalg/convolution/roundtrip-convolution.mlir
@@ -481,19 +481,6 @@ func.func @pooling_nhwc_min_unsigned_integer(%input: tensor<?x?x?x?xi32>, %filte
 
 // -----
 
-func.func @pooling_nhwc_min_unsigned_float(%input: tensor<?x?x?x?xf32>, %filter: tensor<?x?xf32>, %output: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-  %0 = linalg.pooling_nhwc_min_unsigned
-         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-         ins (%input, %filter: tensor<?x?x?x?xf32>, tensor<?x?xf32>)
-         outs (%output: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-  return %0 : tensor<?x?x?x?xf32>
-}
-//      CHECK: @pooling_nhwc_min_unsigned_float
-//      CHECK:   linalg.pooling_nhwc_min
-// CHECK-SAME:      dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>
-
-// -----
-
 func.func @pooling_nchw_sum(%input: tensor<?x?x?x?xf32>, %filter: tensor<?x?xf32>, %output: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
   %0 = linalg.pooling_nchw_sum
          {dilations = dense<2> : tensor<2xi64>, strides = dense<3> : tensor<2xi64>}

--- a/mlir/test/Dialect/Linalg/invalid.mlir
+++ b/mlir/test/Dialect/Linalg/invalid.mlir
@@ -2076,4 +2076,3 @@ func.func @matmul_invalid_mixed_types(%t: tensor<?xf16>, %f: vector<4xf16>)
                                 outs(%f : vector<4xf16>) -> tensor<?xf16>
   func.return %0, %f : tensor<?xf16>, vector<4xf16>
 }
-

--- a/mlir/test/Dialect/Linalg/invalid.mlir
+++ b/mlir/test/Dialect/Linalg/invalid.mlir
@@ -1957,3 +1957,31 @@ func.func @matmul_invalid_mixed_types(%t: tensor<?xf16>, %f: vector<4xf16>)
                                 outs(%f : vector<4xf16>) -> tensor<?xf16>
   func.return %0, %f : tensor<?xf16>, vector<4xf16>
 }
+
+// -----
+
+func.func @pooling_nhwc_max_unsigned_non_integer_elem_type(
+    %input: tensor<1x4x4x1xf32>,
+    %filter: tensor<2x2xf32>,
+    %init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32> {
+  // expected-error @+1 {{unsupported operation: unsigned max not on uint}}
+  %0 = linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                        strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<1x4x4x1xf32>, tensor<2x2xf32>)
+      outs (%init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
+  return %0 : tensor<1x2x2x1xf32>
+}
+
+// -----
+
+func.func @pooling_nhwc_min_unsigned_non_integer_elem_type(
+    %input: tensor<1x4x4x1xf32>,
+    %filter: tensor<2x2xf32>,
+    %init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32> {
+  // expected-error @+1 {{unsupported operation: unsigned min not on uint}}
+  %0 = linalg.pooling_nhwc_min_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                        strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<1x4x4x1xf32>, tensor<2x2xf32>)
+      outs (%init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
+  return %0 : tensor<1x2x2x1xf32>
+}

--- a/mlir/test/Dialect/Linalg/invalid.mlir
+++ b/mlir/test/Dialect/Linalg/invalid.mlir
@@ -1931,6 +1931,125 @@ func.func @reduce_non_operation_name(%arg0: tensor<4xf32>, %arg1: tensor<f32>) -
 
 // -----
 
+//===----------------------------------------------------------------------===//
+// linalg.pooling_nhwc_*
+//===----------------------------------------------------------------------===//
+
+func.func @pooling_nhwc_max_unsigned_float_type(
+    %input: tensor<1x4x4x1xf32>,
+    %filter: tensor<2x2xf32>,
+    %init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32> {
+  // expected-error @+1 {{unsupported operation: unsigned max not on uint}}
+  %0 = linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                        strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<1x4x4x1xf32>, tensor<2x2xf32>)
+      outs (%init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
+  return %0 : tensor<1x2x2x1xf32>
+}
+
+// -----
+
+func.func @pooling_nhwc_max_unsigned_i1(
+    %input: tensor<1x4x4x1xi1>,
+    %filter: tensor<2x2xi1>,
+    %init_val: tensor<1x2x2x1xi1>) -> tensor<1x2x2x1xi1> {
+  // expected-error @+1 {{unsupported operation: unsigned max not on uint}}
+  %0 = linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                        strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<1x4x4x1xi1>, tensor<2x2xi1>)
+      outs (%init_val: tensor<1x2x2x1xi1>) -> tensor<1x2x2x1xi1>
+  return %0 : tensor<1x2x2x1xi1>
+}
+
+// -----
+
+func.func @pooling_nhwc_min_unsigned_float_type(
+    %input: tensor<1x4x4x1xf32>,
+    %filter: tensor<2x2xf32>,
+    %init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32> {
+  // expected-error @+1 {{unsupported operation: unsigned min not on uint}}
+  %0 = linalg.pooling_nhwc_min_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                        strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<1x4x4x1xf32>, tensor<2x2xf32>)
+      outs (%init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
+  return %0 : tensor<1x2x2x1xf32>
+}
+
+// -----
+
+func.func @pooling_nhwc_min_unsigned_i1(
+    %input: tensor<1x4x4x1xi1>,
+    %filter: tensor<2x2xi1>,
+    %init_val: tensor<1x2x2x1xi1>) -> tensor<1x2x2x1xi1> {
+  // expected-error @+1 {{unsupported operation: unsigned min not on uint}}
+  %0 = linalg.pooling_nhwc_min_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                        strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<1x4x4x1xi1>, tensor<2x2xi1>)
+      outs (%init_val: tensor<1x2x2x1xi1>) -> tensor<1x2x2x1xi1>
+  return %0 : tensor<1x2x2x1xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// linalg.pooling_nwc_*
+//===----------------------------------------------------------------------===//
+
+func.func @pooling_nwc_max_unsigned_float_type(
+    %input: tensor<1x4x1xf32>,
+    %filter: tensor<2xf32>,
+    %init_val: tensor<1x2x1xf32>) -> tensor<1x2x1xf32> {
+  // expected-error @+1 {{unsupported operation: unsigned max not on uint}}
+  %0 = linalg.pooling_nwc_max_unsigned {dilations = dense<1> : tensor<1xi64>,
+                                       strides = dense<1> : tensor<1xi64>}
+      ins (%input, %filter: tensor<1x4x1xf32>, tensor<2xf32>)
+      outs (%init_val: tensor<1x2x1xf32>) -> tensor<1x2x1xf32>
+  return %0 : tensor<1x2x1xf32>
+}
+
+// -----
+
+func.func @pooling_nwc_max_unsigned_i1(
+    %input: tensor<1x4x1xi1>,
+    %filter: tensor<2xi1>,
+    %init_val: tensor<1x2x1xi1>) -> tensor<1x2x1xi1> {
+  // expected-error @+1 {{unsupported operation: unsigned max not on uint}}
+  %0 = linalg.pooling_nwc_max_unsigned {dilations = dense<1> : tensor<1xi64>,
+                                       strides = dense<1> : tensor<1xi64>}
+      ins (%input, %filter: tensor<1x4x1xi1>, tensor<2xi1>)
+      outs (%init_val: tensor<1x2x1xi1>) -> tensor<1x2x1xi1>
+  return %0 : tensor<1x2x1xi1>
+}
+
+// -----
+
+func.func @pooling_nwc_min_unsigned_float_type(
+    %input: tensor<1x4x1xf32>,
+    %filter: tensor<2xf32>,
+    %init_val: tensor<1x2x1xf32>) -> tensor<1x2x1xf32> {
+  // expected-error @+1 {{unsupported operation: unsigned min not on uint}}
+  %0 = linalg.pooling_nwc_min_unsigned {dilations = dense<1> : tensor<1xi64>,
+                                       strides = dense<1> : tensor<1xi64>}
+      ins (%input, %filter: tensor<1x4x1xf32>, tensor<2xf32>)
+      outs (%init_val: tensor<1x2x1xf32>) -> tensor<1x2x1xf32>
+  return %0 : tensor<1x2x1xf32>
+}
+
+// -----
+
+func.func @pooling_nwc_min_unsigned_i1(
+    %input: tensor<1x4x1xi1>,
+    %filter: tensor<2xi1>,
+    %init_val: tensor<1x2x1xi1>) -> tensor<1x2x1xi1> {
+  // expected-error @+1 {{unsupported operation: unsigned min not on uint}}
+  %0 = linalg.pooling_nwc_min_unsigned {dilations = dense<1> : tensor<1xi64>,
+                                       strides = dense<1> : tensor<1xi64>}
+      ins (%input, %filter: tensor<1x4x1xi1>, tensor<2xi1>)
+      outs (%init_val: tensor<1x2x1xi1>) -> tensor<1x2x1xi1>
+  return %0 : tensor<1x2x1xi1>
+}
+
+// -----
 
 //===----------------------------------------------------------------------===//
 // Tests for generic infrastructure for named Ops. The actual Ops used are
@@ -1958,30 +2077,3 @@ func.func @matmul_invalid_mixed_types(%t: tensor<?xf16>, %f: vector<4xf16>)
   func.return %0, %f : tensor<?xf16>, vector<4xf16>
 }
 
-// -----
-
-func.func @pooling_nhwc_max_unsigned_non_integer_elem_type(
-    %input: tensor<1x4x4x1xf32>,
-    %filter: tensor<2x2xf32>,
-    %init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32> {
-  // expected-error @+1 {{unsupported operation: unsigned max not on uint}}
-  %0 = linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
-                                        strides = dense<1> : tensor<2xi64>}
-      ins (%input, %filter: tensor<1x4x4x1xf32>, tensor<2x2xf32>)
-      outs (%init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
-  return %0 : tensor<1x2x2x1xf32>
-}
-
-// -----
-
-func.func @pooling_nhwc_min_unsigned_non_integer_elem_type(
-    %input: tensor<1x4x4x1xf32>,
-    %filter: tensor<2x2xf32>,
-    %init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32> {
-  // expected-error @+1 {{unsupported operation: unsigned min not on uint}}
-  %0 = linalg.pooling_nhwc_min_unsigned {dilations = dense<1> : tensor<2xi64>,
-                                        strides = dense<1> : tensor<2xi64>}
-      ins (%input, %filter: tensor<1x4x4x1xf32>, tensor<2x2xf32>)
-      outs (%init_val: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
-  return %0 : tensor<1x2x2x1xf32>
-}

--- a/mlir/test/Dialect/Linalg/named-ops-fail.mlir
+++ b/mlir/test/Dialect/Linalg/named-ops-fail.mlir
@@ -80,20 +80,6 @@ func.func @divu_broadcast(%arg0: memref<8x16xi32>, %arg1: memref<4x8x16xi32>, %a
 
 // -----
 
-func.func @pooling_nhwc_max_unsigned_float(
-    %input: tensor<?x?x?x?xf32>,
-    %filter: tensor<?x?xf32>,
-    %init_val: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-  // CHECK: unsupported operation: unsigned max not on uint
-  linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
-                                    strides = dense<1> : tensor<2xi64>}
-      ins (%input, %filter: tensor<?x?x?x?xf32>, tensor<?x?xf32>)
-     outs (%init_val: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-  return %init_val : tensor<?x?x?x?xf32>
-}
-
-// -----
-
 func.func @exp_type_cast(%arg: memref<4x8x16xf16>, %out: memref<4x8x16xf32>) {
   // CHECK: operand 1 ('f16') doesn't match the element type of the enclosing linalg.generic op ('f32')
   linalg.exp ins(%arg : memref<4x8x16xf16>) outs(%out: memref<4x8x16xf32>)

--- a/mlir/test/Dialect/Linalg/named-ops-fail.mlir
+++ b/mlir/test/Dialect/Linalg/named-ops-fail.mlir
@@ -80,6 +80,20 @@ func.func @divu_broadcast(%arg0: memref<8x16xi32>, %arg1: memref<4x8x16xi32>, %a
 
 // -----
 
+func.func @pooling_nhwc_max_unsigned_float(
+    %input: tensor<?x?x?x?xf32>,
+    %filter: tensor<?x?xf32>,
+    %init_val: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  // CHECK: unsupported operation: unsigned max not on uint
+  linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
+                                    strides = dense<1> : tensor<2xi64>}
+      ins (%input, %filter: tensor<?x?x?x?xf32>, tensor<?x?xf32>)
+     outs (%init_val: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  return %init_val : tensor<?x?x?x?xf32>
+}
+
+// -----
+
 func.func @exp_type_cast(%arg: memref<4x8x16xf16>, %out: memref<4x8x16xf32>) {
   // CHECK: operand 1 ('f16') doesn't match the element type of the enclosing linalg.generic op ('f32')
   linalg.exp ins(%arg : memref<4x8x16xf16>) outs(%out: memref<4x8x16xf32>)
@@ -349,4 +363,3 @@ func.func @select_wrong_condition_type(%arg0: memref<4x8x16xf32>, %arg1: memref<
   linalg.select ins(%arg0, %arg1, %arg2 : memref<4x8x16xf32>, memref<4x8x16xf32>, memref<4x8x16xf32>) outs(%arg3: memref<4x8x16xf32>)
   return
 }
-

--- a/mlir/test/Dialect/Linalg/named-ops.mlir
+++ b/mlir/test/Dialect/Linalg/named-ops.mlir
@@ -707,11 +707,11 @@ func.func @pooling_nhwc_max_tensor(%input: tensor<1x4x4x1xf32>) -> tensor<1x2x2x
 
 // -----
 
-// CHECK-LABEL: func @pooling_nhwc_max_unsigned_tensor
+// CHECK-LABEL: func @pooling_nhwc_max_unsigned_i32
 // CHECK:         %{{.+}} = linalg.pooling_nhwc_max_unsigned
 // CHECK-SAME:      ins(%{{.+}}, %{{.+}} : tensor<1x4x4x1xi32>, tensor<3x3xi32>)
 // CHECK-SAME:      outs(%{{.+}} : tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
-func.func @pooling_nhwc_max_unsigned_tensor(%input: tensor<1x4x4x1xi32>) -> tensor<1x2x2x1xi32> {
+func.func @pooling_nhwc_max_unsigned_i32(%input: tensor<1x4x4x1xi32>) -> tensor<1x2x2x1xi32> {
   %fake = tensor.empty() : tensor<3x3xi32>
   %init = tensor.empty() : tensor<1x2x2x1xi32>
   %cst = arith.constant 0 : i32
@@ -720,6 +720,25 @@ func.func @pooling_nhwc_max_unsigned_tensor(%input: tensor<1x4x4x1xi32>) -> tens
     ins(%input, %fake: tensor<1x4x4x1xi32>, tensor<3x3xi32>)
     outs(%fill: tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
   return %res : tensor<1x2x2x1xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @pooling_nwc_max_unsigned_i32
+// CHECK:         %{{.+}} = linalg.pooling_nwc_max_unsigned
+// CHECK-SAME:      dilations = dense<1> : tensor<1xi64>
+// CHECK-SAME:      strides = dense<1> : tensor<1xi64>
+// CHECK-SAME:      ins(%{{.+}}, %{{.+}} : tensor<1x4x1xi32>, tensor<3xi32>)
+// CHECK-SAME:      outs(%{{.+}} : tensor<1x2x1xi32>) -> tensor<1x2x1xi32>
+func.func @pooling_nwc_max_unsigned_i32(%input: tensor<1x4x1xi32>) -> tensor<1x2x1xi32> {
+  %fake = tensor.empty() : tensor<3xi32>
+  %init = tensor.empty() : tensor<1x2x1xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%init : tensor<1x2x1xi32>) -> tensor<1x2x1xi32>
+  %res = linalg.pooling_nwc_max_unsigned {dilations = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>}
+    ins(%input, %fake: tensor<1x4x1xi32>, tensor<3xi32>)
+    outs(%fill: tensor<1x2x1xi32>) -> tensor<1x2x1xi32>
+  return %res : tensor<1x2x1xi32>
 }
 
 // -----
@@ -1034,11 +1053,11 @@ func.func @pooling_nhwc_min_tensor(%input: tensor<1x4x4x1xf32>) -> tensor<1x2x2x
 
 // -----
 
-// CHECK-LABEL: func @pooling_nhwc_min_unsigned_tensor
+// CHECK-LABEL: func @pooling_nhwc_min_unsigned_i32
 // CHECK:         %{{.+}} = linalg.pooling_nhwc_min_unsigned
 // CHECK-SAME:      ins(%{{.+}}, %{{.+}} : tensor<1x4x4x1xi32>, tensor<3x3xi32>)
 // CHECK-SAME:      outs(%{{.+}} : tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
-func.func @pooling_nhwc_min_unsigned_tensor(%input: tensor<1x4x4x1xi32>) -> tensor<1x2x2x1xi32> {
+func.func @pooling_nhwc_min_unsigned_i32(%input: tensor<1x4x4x1xi32>) -> tensor<1x2x2x1xi32> {
   %fake = tensor.empty() : tensor<3x3xi32>
   %init = tensor.empty() : tensor<1x2x2x1xi32>
   %cst = arith.constant 0 : i32
@@ -1047,6 +1066,25 @@ func.func @pooling_nhwc_min_unsigned_tensor(%input: tensor<1x4x4x1xi32>) -> tens
     ins(%input, %fake: tensor<1x4x4x1xi32>, tensor<3x3xi32>)
     outs(%fill: tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
   return %res : tensor<1x2x2x1xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @pooling_nwc_min_unsigned_i32
+// CHECK:         %{{.+}} = linalg.pooling_nwc_min_unsigned
+// CHECK-SAME:      dilations = dense<1> : tensor<1xi64>
+// CHECK-SAME:      strides = dense<1> : tensor<1xi64>
+// CHECK-SAME:      ins(%{{.+}}, %{{.+}} : tensor<1x4x1xi32>, tensor<3xi32>)
+// CHECK-SAME:      outs(%{{.+}} : tensor<1x2x1xi32>) -> tensor<1x2x1xi32>
+func.func @pooling_nwc_min_unsigned_i32(%input: tensor<1x4x1xi32>) -> tensor<1x2x1xi32> {
+  %fake = tensor.empty() : tensor<3xi32>
+  %init = tensor.empty() : tensor<1x2x1xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%init : tensor<1x2x1xi32>) -> tensor<1x2x1xi32>
+  %res = linalg.pooling_nwc_min_unsigned {dilations = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>}
+    ins(%input, %fake: tensor<1x4x1xi32>, tensor<3xi32>)
+    outs(%fill: tensor<1x2x1xi32>) -> tensor<1x2x1xi32>
+  return %res : tensor<1x2x1xi32>
 }
 
 // -----

--- a/mlir/test/Dialect/Linalg/named-ops.mlir
+++ b/mlir/test/Dialect/Linalg/named-ops.mlir
@@ -706,6 +706,23 @@ func.func @pooling_nhwc_max_tensor(%input: tensor<1x4x4x1xf32>) -> tensor<1x2x2x
 }
 
 // -----
+
+// CHECK-LABEL: func @pooling_nhwc_max_unsigned_tensor
+// CHECK:         %{{.+}} = linalg.pooling_nhwc_max_unsigned
+// CHECK-SAME:      ins(%{{.+}}, %{{.+}} : tensor<1x4x4x1xi32>, tensor<3x3xi32>)
+// CHECK-SAME:      outs(%{{.+}} : tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
+func.func @pooling_nhwc_max_unsigned_tensor(%input: tensor<1x4x4x1xi32>) -> tensor<1x2x2x1xi32> {
+  %fake = tensor.empty() : tensor<3x3xi32>
+  %init = tensor.empty() : tensor<1x2x2x1xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%init : tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
+  %res = linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%input, %fake: tensor<1x4x4x1xi32>, tensor<3x3xi32>)
+    outs(%fill: tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
+  return %res : tensor<1x2x2x1xi32>
+}
+
+// -----
 // CHECK-LABEL: func @pooling_nwc_max_tensor
 // CHECK:         %{{.+}} = linalg.pooling_nwc_max
 // CHECK-SAME:      dilations = dense<1> : tensor<1xi64>
@@ -1013,6 +1030,23 @@ func.func @pooling_nhwc_min_tensor(%input: tensor<1x4x4x1xf32>) -> tensor<1x2x2x
     ins(%input, %fake: tensor<1x4x4x1xf32>, tensor<3x3xf32>)
     outs(%fill: tensor<1x2x2x1xf32>) -> tensor<1x2x2x1xf32>
   return %res : tensor<1x2x2x1xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @pooling_nhwc_min_unsigned_tensor
+// CHECK:         %{{.+}} = linalg.pooling_nhwc_min_unsigned
+// CHECK-SAME:      ins(%{{.+}}, %{{.+}} : tensor<1x4x4x1xi32>, tensor<3x3xi32>)
+// CHECK-SAME:      outs(%{{.+}} : tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
+func.func @pooling_nhwc_min_unsigned_tensor(%input: tensor<1x4x4x1xi32>) -> tensor<1x2x2x1xi32> {
+  %fake = tensor.empty() : tensor<3x3xi32>
+  %init = tensor.empty() : tensor<1x2x2x1xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%init : tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
+  %res = linalg.pooling_nhwc_min_unsigned {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%input, %fake: tensor<1x4x4x1xi32>, tensor<3x3xi32>)
+    outs(%fill: tensor<1x2x2x1xi32>) -> tensor<1x2x2x1xi32>
+  return %res : tensor<1x2x2x1xi32>
 }
 
 // -----

--- a/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
@@ -131,10 +131,10 @@ func.func @pooling_nhwc_max(%input: tensor<?x1x?x?xf32>, %filter: tensor<1x?xf32
 }
 
 // CHECK-LABEL: @pooling_nhwc_max_unsigned
-// CHECK-SAME: %[[ARG0:.+]]: tensor<?x1x?x?xf32>,
-// CHECK-SAME: %[[ARG1:.+]]: tensor<1x?xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<?x1x?x?xf32>
-func.func @pooling_nhwc_max_unsigned(%input: tensor<?x1x?x?xf32>, %filter: tensor<1x?xf32>, %init: tensor<?x1x?x?xf32>) -> tensor<?x1x?x?xf32> {
+// CHECK-SAME: %[[ARG0:.+]]: tensor<?x1x?x?xi32>,
+// CHECK-SAME: %[[ARG1:.+]]: tensor<1x?xi32>
+// CHECK-SAME: %[[ARG2:.+]]: tensor<?x1x?x?xi32>
+func.func @pooling_nhwc_max_unsigned(%input: tensor<?x1x?x?xi32>, %filter: tensor<1x?xi32>, %init: tensor<?x1x?x?xi32>) -> tensor<?x1x?x?xi32> {
   // CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]]
   // CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]]
   // CHECK: %[[SLICE2:.+]] = tensor.extract_slice %[[ARG2]]
@@ -142,10 +142,10 @@ func.func @pooling_nhwc_max_unsigned(%input: tensor<?x1x?x?xf32>, %filter: tenso
   // CHECK: %[[RES:.+]] = tensor.insert_slice %[[SLICERES]] into %[[ARG2]]
   %0 = linalg.pooling_nhwc_max_unsigned {dilations = dense<1> : tensor<2xi64>,
                                 strides = dense<1> : tensor<2xi64>}
-     ins (%input, %filter: tensor<?x1x?x?xf32>, tensor<1x?xf32>)
-    outs (%init: tensor<?x1x?x?xf32>) -> tensor<?x1x?x?xf32>
+     ins (%input, %filter: tensor<?x1x?x?xi32>, tensor<1x?xi32>)
+    outs (%init: tensor<?x1x?x?xi32>) -> tensor<?x1x?x?xi32>
   // CHECK: return %[[RES]]
-  return %0 : tensor<?x1x?x?xf32>
+  return %0 : tensor<?x1x?x?xi32>
 }
 
 // CHECK-LABEL: @pooling_nhwc_min
@@ -167,10 +167,10 @@ func.func @pooling_nhwc_min(%input: tensor<?x1x?x?xf32>, %filter: tensor<1x?xf32
 }
 
 // CHECK-LABEL: @pooling_nhwc_min_unsigned
-// CHECK-SAME: %[[ARG0:.+]]: tensor<?x1x?x?xf32>,
-// CHECK-SAME: %[[ARG1:.+]]: tensor<1x?xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<?x1x?x?xf32>
-func.func @pooling_nhwc_min_unsigned(%input: tensor<?x1x?x?xf32>, %filter: tensor<1x?xf32>, %init: tensor<?x1x?x?xf32>) -> tensor<?x1x?x?xf32> {
+// CHECK-SAME: %[[ARG0:.+]]: tensor<?x1x?x?xi32>,
+// CHECK-SAME: %[[ARG1:.+]]: tensor<1x?xi32>
+// CHECK-SAME: %[[ARG2:.+]]: tensor<?x1x?x?xi32>
+func.func @pooling_nhwc_min_unsigned(%input: tensor<?x1x?x?xi32>, %filter: tensor<1x?xi32>, %init: tensor<?x1x?x?xi32>) -> tensor<?x1x?x?xi32> {
   // CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]]
   // CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]]
   // CHECK: %[[SLICE2:.+]] = tensor.extract_slice %[[ARG2]]
@@ -178,10 +178,10 @@ func.func @pooling_nhwc_min_unsigned(%input: tensor<?x1x?x?xf32>, %filter: tenso
   // CHECK: %[[RES:.+]] = tensor.insert_slice %[[SLICERES]] into %[[ARG2]]
   %0 = linalg.pooling_nhwc_min_unsigned {dilations = dense<1> : tensor<2xi64>,
                                 strides = dense<1> : tensor<2xi64>}
-     ins (%input, %filter: tensor<?x1x?x?xf32>, tensor<1x?xf32>)
-    outs (%init: tensor<?x1x?x?xf32>) -> tensor<?x1x?x?xf32>
+     ins (%input, %filter: tensor<?x1x?x?xi32>, tensor<1x?xi32>)
+    outs (%init: tensor<?x1x?x?xi32>) -> tensor<?x1x?x?xi32>
   // CHECK: return %[[RES]]
-  return %0 : tensor<?x1x?x?xf32>
+  return %0 : tensor<?x1x?x?xi32>
 }
 
 // CHECK-LABEL: @pooling_nchw_max

--- a/mlir/test/python/dialects/linalg/opdsl/emit_pooling.py
+++ b/mlir/test/python/dialects/linalg/opdsl/emit_pooling.py
@@ -150,3 +150,51 @@ with Context() as ctx, Location.unknown():
 
 
 print(module)
+
+with Context() as ctx, Location.unknown():
+    module = Module.create()
+    with InsertionPoint(module.body):
+        f32 = F32Type.get()
+        bool_t = IntegerType.get_signless(1)
+
+        # CHECK: bool_max_unsigned_error: Unsupported 'max_unsigned' operands
+        @func.FuncOp.from_py_func(
+            RankedTensorType.get((1, 4, 16, 1), f32),
+            RankedTensorType.get((2, 2), f32),
+            RankedTensorType.get((1, 2, 4, 1), bool_t),
+        )
+        def test_bool_i1_max_unsigned_pooling_error(input, shape, init_result):
+            try:
+                pooling_poly(
+                    input,
+                    shape,
+                    outs=[init_result],
+                    reduce=BinaryFn.max_unsigned,
+                    cast=TypeFn.cast_unsigned,
+                    strides=[2, 4],
+                    dilations=[1, 2],
+                )
+            except NotImplementedError as e:
+                print(f"bool_max_unsigned_error: {e}")
+            return init_result
+
+        # CHECK: float_max_unsigned_error: Unsupported 'max_unsigned' operands
+        @func.FuncOp.from_py_func(
+            RankedTensorType.get((1, 4, 16, 1), f32),
+            RankedTensorType.get((2, 2), f32),
+            RankedTensorType.get((1, 2, 4, 1), f32),
+        )
+        def test_f32f32_max_unsigned_pooling_error(input, shape, init_result):
+            try:
+                pooling_poly(
+                    input,
+                    shape,
+                    outs=[init_result],
+                    reduce=BinaryFn.max_unsigned,
+                    cast=TypeFn.cast_unsigned,
+                    strides=[2, 4],
+                    dilations=[1, 2],
+                )
+            except NotImplementedError as e:
+                print(f"float_max_unsigned_error: {e}")
+            return init_result


### PR DESCRIPTION
Fixes: #164800 

Ensures unsigned pooling ops in Linalg stay in the integer domain: the lowering now rejects floating/bool inputs with a clear diagnostic, new regression tests lock in both the error path and a valid integer example, and transform decompositions are updated to reflect the integer typing.

CC: @banach-space 