### PR TITLE
[MLIR][Python] Make check-mlir-python depend on runner utils

### DIFF
--- a/mlir/test/python/CMakeLists.txt
+++ b/mlir/test/python/CMakeLists.txt
@@ -11,9 +11,7 @@ add_public_tablegen_target(MLIRPythonTestIncGen)
 
 add_subdirectory(lib)
 
-set(MLIR_PYTHON_TEST_DEPENDS MLIRPythonModules mlir-runner)
-# These two targets are required by ExecutionEngine test cases.
-list(APPEND MLIR_PYTHON_TEST_DEPENDS mlir_c_runner_utils mlir_runner_utils)
+set(MLIR_PYTHON_TEST_DEPENDS MLIRPythonModules mlir-runner mlir_c_runner_utils mlir_runner_utils)
 if(NOT MLIR_STANDALONE_BUILD)
   list(APPEND MLIR_PYTHON_TEST_DEPENDS FileCheck count not)
 endif()

--- a/mlir/test/python/CMakeLists.txt
+++ b/mlir/test/python/CMakeLists.txt
@@ -12,6 +12,8 @@ add_public_tablegen_target(MLIRPythonTestIncGen)
 add_subdirectory(lib)
 
 set(MLIR_PYTHON_TEST_DEPENDS MLIRPythonModules mlir-runner)
+# These two targets are required by ExecutionEngine test cases.
+list(APPEND MLIR_PYTHON_TEST_DEPENDS mlir_c_runner_utils mlir_runner_utils)
 if(NOT MLIR_STANDALONE_BUILD)
   list(APPEND MLIR_PYTHON_TEST_DEPENDS FileCheck count not)
 endif()


### PR DESCRIPTION
`ninja check-mlir-python` will fail in the recent main branch due to missing shared libraries (`libmlir_runner_utils.so` and `libmlir_c_runner_utils.so`).

This PR adds `mlir_c_runner_utils` and `mlir_runner_utils` into dependencies of `check-mlir-python` so it will make sure that these libraries are available before the test cases are executed.

```
[4350/4351] Running the MLIR Python regression tests
FAIL: MLIR :: python/execution_engine.py (92 of 99)
******************** TEST 'MLIR :: python/execution_engine.py' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
# RUN: at line 1
env MLIR_RUNNER_UTILS=/llvm-project/build/lib/libmlir_runner_utils.so MLIR_C_RUNNER_UTILS=/llvm-project/build/lib/libmlir_c_runner_utils.so /python-env/bin/python3 /llvm-project/mlir/test/python/execution_engine.py 2>&1 | /llvm-project/build/bin/FileCheck /llvm-project/mlir/test/python/execution_engine.py
# executed command: env MLIR_RUNNER_UTILS=/llvm-project/build/lib/libmlir_runner_utils.so MLIR_C_RUNNER_UTILS=/llvm-project/build/lib/libmlir_c_runner_utils.so /python-env/bin/python3 /llvm-project/mlir/test/python/execution_engine.py
# note: command had no output on stdout or stderr
# error: command failed with exit status: 1
# executed command: /llvm-project/build/bin/FileCheck /llvm-project/mlir/test/python/execution_engine.py
# .---command stderr------------
# | /llvm-project/mlir/test/python/execution_engine.py:741:16: error: CHECK-LABEL: expected string not found in input
# | # CHECK-LABEL: TEST: testNanoTime
# |                ^
# | <stdin>:62:24: note: scanning from here
# | TEST: testSharedLibLoad
# |                        ^
# | <stdin>:73:68: note: possible intended match here
# |  File "/llvm-project/mlir/test/python/execution_engine.py", line 732, in testSharedLibLoad
# |                                                                    ^
# | 
# | Input file: <stdin>
# | Check file: /llvm-project/mlir/test/python/execution_engine.py
# | 
# | -dump-input=help explains the following input dump.
# | 
# | Input was:
# | <<<<<<
# |              .
# |              .
# |              .
# |             57: TEST: testF8E5M2Memref 
# |             58:  
# |             59: TEST: testDynamicMemrefAdd2D 
# |             60: True 
# |             61:  
# |             62: TEST: testSharedLibLoad 
# | label:741'0                            X error: no match found
# |             63: Failed to create MemoryBuffer for: /llvm-project/build/lib/libmlir_runner_utils.so 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             64: Error: No such file or directory 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             65: Failed to create MemoryBuffer for: /llvm-project/build/lib/libmlir_c_runner_utils.so 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             66: Error: No such file or directory 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             67: JIT session error: Symbols not found: [ _mlir_ciface_printMemrefF32 ] 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             68: Traceback (most recent call last): 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             69:  File "/llvm-project/mlir/test/python/execution_engine.py", line 737, in <module> 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             70:  run(testSharedLibLoad) 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~
# |             71:  File "/llvm-project/mlir/test/python/execution_engine.py", line 35, in run 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             72:  f() 
# | label:741'0     ~~~~~
# |             73:  File "/llvm-project/mlir/test/python/execution_engine.py", line 732, in testSharedLibLoad 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# | label:741'1                                                                        ?                        possible intended match
# |             74:  execution_engine.invoke("main", arg0_memref_ptr) 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             75:  File "/llvm-project/build/tools/mlir/python_packages/mlir_core/mlir/execution_engine.py", line 31, in invoke 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             76:  func = self.lookup(name) 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
# |             77:  ^^^^^^^^^^^^^^^^^ 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~
# |             78:  File "/llvm-project/build/tools/mlir/python_packages/mlir_core/mlir/execution_engine.py", line 22, in lookup 
# | label:741'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# |              .
# |              .
# |              .
# | >>>>>>
# `-----------------------------
# error: command failed with exit status: 1

--

********************
********************
Failed Tests (1):
  MLIR :: python/execution_engine.py


Testing Time: 2.60s

Total Discovered Tests: 99
  Unsupported:  2 (2.02%)
  Passed     : 96 (96.97%)
  Failed     :  1 (1.01%)
FAILED: tools/mlir/test/python/CMakeFiles/check-mlir-python /llvm-project/build/tools/mlir/test/python/CMakeFiles/check-mlir-python 
cd /llvm-project/build/tools/mlir/test/python && /python-env/bin/python3 /llvm-project/build/./bin/llvm-lit -sv /llvm-project/build/tools/mlir/test/python
ninja: build stopped: subcommand failed.
```