### PR TITLE
[Github] Truncate Bug Emails when Necessary

### DIFF
--- a/.github/workflows/llvm-bugs.yml
+++ b/.github/workflows/llvm-bugs.yml
@@ -39,6 +39,12 @@ jobs:
               repo: context.repo.repo
             })
             .then((issue) => {
+              var maybeTruncatedBody = issue.data.body;
+              if (maybeTruncatedBody.length > 15000) {
+                maybeTruncatedBody = maybeTruncatedBody.substring(0,
+                    15000) +
+                  "<truncated>Please see the issue for the entire body."
+              }
               const payload = {
                 author : issue.data.user.login,
                 issue  : issue.data.number,


### PR DESCRIPTION
Mailgun limits the size of an email payload to 16k. Truncate the issue body, which should be the largest part around 15k and point the user to Github to see the rest.

Fixes #165020