### PR TITLE
[AArch64] Use nullptr instead of NULL (NFC)

### DIFF
--- a/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
@@ -37,9 +37,9 @@ static std::string AArch64InstPrinterTestPrintAlignedLabel(uint64_t value) {
   MCInstrInfo MII;
   MCRegisterInfo MRI;
   MCSubtargetInfo STI(Triple(""), "", "", "", {},
-                      ArrayRef((SubtargetFeatureKV *)NULL, (size_t)0),
-                      ArrayRef((SubtargetSubTypeKV *)NULL, (size_t)0), NULL,
-                      NULL, NULL, NULL, NULL, NULL);
+                      ArrayRef((SubtargetFeatureKV *)nullptr, (size_t)0),
+                      ArrayRef((SubtargetSubTypeKV *)nullptr, (size_t)0),
+                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   MCContext Ctx(Triple(""), &MAI, &MRI, &STI);
   MCInst MI;
 

--- a/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
@@ -36,10 +36,8 @@ static std::string AArch64InstPrinterTestPrintAlignedLabel(uint64_t value) {
   MCAsmInfo MAI;
   MCInstrInfo MII;
   MCRegisterInfo MRI;
-  MCSubtargetInfo STI(Triple(""), "", "", "", {},
-                      ArrayRef((SubtargetFeatureKV *)nullptr, (size_t)0),
-                      ArrayRef((SubtargetSubTypeKV *)nullptr, (size_t)0),
-                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  MCSubtargetInfo STI(Triple(""), "", "", "", {}, {}, {}, nullptr, nullptr,
+                      nullptr, nullptr, nullptr, nullptr);
   MCContext Ctx(Triple(""), &MAI, &MRI, &STI);
   MCInst MI;
 


### PR DESCRIPTION
Identified with modernize-use-nullptr.
