### PR TITLE
[llvm] Allow Rust personality name to contain arbitrary prefix

### DIFF
--- a/llvm/lib/IR/EHPersonalities.cpp
+++ b/llvm/lib/IR/EHPersonalities.cpp
@@ -47,7 +47,8 @@ EHPersonality llvm::classifyEHPersonality(const Value *Pers) {
       .Case("__C_specific_handler", EHPersonality::MSVC_TableSEH)
       .Case("__CxxFrameHandler3", EHPersonality::MSVC_CXX)
       .Case("ProcessCLRException", EHPersonality::CoreCLR)
-      .Case("rust_eh_personality", EHPersonality::Rust)
+      // Rust mangles its personality function, so we can't test exact equality.
+      .EndsWith("rust_eh_personality", EHPersonality::Rust)
       .Case("__gxx_wasm_personality_v0", EHPersonality::Wasm_CXX)
       .Case("__xlcxx_personality_v1", EHPersonality::XL_CXX)
       .Case("__zos_cxx_personality_v2", EHPersonality::ZOS_CXX)
@@ -77,7 +78,8 @@ StringRef llvm::getEHPersonalityName(EHPersonality Pers) {
   case EHPersonality::CoreCLR:
     return "ProcessCLRException";
   case EHPersonality::Rust:
-    return "rust_eh_personality";
+    llvm_unreachable(
+        "Cannot get personality name of Rust personality, since it is mangled");
   case EHPersonality::Wasm_CXX:
     return "__gxx_wasm_personality_v0";
   case EHPersonality::XL_CXX:


### PR DESCRIPTION
LLVM needs to figure out the type of EH personality for various reasons. To do this, it currently matches against a hardcoded list of names. In Rust, we would like to mangle our personality function to better support linking multiple Rust standard libraries via staticlib. We have currently mangled all symbols except the personality, which remains unmangled because of this LLVM hardcoding.

Instead, this now does a suffix match of the personality name, which will work with the mangling scheme used for these internal symbols (e.g. `_RNvCseCSg29WUqSe_7___rustc12___rust_alloc`).

Companion Rust PR: https://github.com/rust-lang/rust/pull/148413