### PR TITLE
[MLIR] Add reduction interface with tester to mlir-reduce

### DIFF
--- a/mlir/include/mlir/Reducer/ReductionPatternInterface.h
+++ b/mlir/include/mlir/Reducer/ReductionPatternInterface.h
@@ -47,6 +47,7 @@ public:
   /// tensor<?xindex> with a known rank and type, e.g. tensor<1xi32>, or
   /// replacing an operation with a constant.
   virtual void populateReductionPatterns(RewritePatternSet &patterns) const = 0;
+  virtual void populateReductionPatternsWithTester(RewritePatternSet &patterns, Tester &tester) const {}
 
 protected:
   DialectReductionPatternInterface(Dialect *dialect) : Base(dialect) {}
@@ -65,17 +66,6 @@ protected:
 ///       RewritePatternSet &patterns, Tester &tester) {
 ///       patterns.add<PatternWithTester>(patterns.getContext(), tester);
 ///   }
-class DialectReductionPatternWithTesterInterface
-    : public DialectInterface::Base<
-          DialectReductionPatternWithTesterInterface> {
-public:
-  virtual void populateReductionPatterns(RewritePatternSet &patterns,
-                                         Tester &tester) const = 0;
-
-protected:
-  DialectReductionPatternWithTesterInterface(Dialect *dialect)
-      : Base(dialect) {}
-};
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Reducer/ReductionPatternInterface.h
+++ b/mlir/include/mlir/Reducer/ReductionPatternInterface.h
@@ -10,6 +10,7 @@
 #define MLIR_REDUCER_REDUCTIONPATTERNINTERFACE_H
 
 #include "mlir/IR/DialectInterface.h"
+#include "mlir/Reducer/Tester.h"
 
 namespace mlir {
 
@@ -49,6 +50,31 @@ public:
 
 protected:
   DialectReductionPatternInterface(Dialect *dialect) : Base(dialect) {}
+};
+
+/// This interface extends the `dialectreductionpatterninterface` by allowing
+/// reduction patterns to use a `Tester` instance. Some reduction patterns may
+/// need to run tester to determine whether certain transformations preserve the
+/// "interesting" behavior of the program. This is mostly useful when pattern
+/// should choose between multiple modifications.
+/// Implementation follows the same logic as the
+/// `dialectreductionpatterninterface`.
+///
+/// Example:
+///   MyDialectReductionPatternWithTester::populateReductionPatterns(
+///       RewritePatternSet &patterns, Tester &tester) {
+///       patterns.add<PatternWithTester>(patterns.getContext(), tester);
+///   }
+class DialectReductionPatternWithTesterInterface
+    : public DialectInterface::Base<
+          DialectReductionPatternWithTesterInterface> {
+public:
+  virtual void populateReductionPatterns(RewritePatternSet &patterns,
+                                         Tester &tester) const = 0;
+
+protected:
+  DialectReductionPatternWithTesterInterface(Dialect *dialect)
+      : Base(dialect) {}
 };
 
 } // namespace mlir

--- a/mlir/include/mlir/Reducer/ReductionPatternInterface.h
+++ b/mlir/include/mlir/Reducer/ReductionPatternInterface.h
@@ -47,26 +47,18 @@ public:
   /// tensor<?xindex> with a known rank and type, e.g. tensor<1xi32>, or
   /// replacing an operation with a constant.
   virtual void populateReductionPatterns(RewritePatternSet &patterns) const = 0;
-  virtual void populateReductionPatternsWithTester(RewritePatternSet &patterns, Tester &tester) const {}
+
+  /// This method extends `populateReductionPatterns` by allowing reduction
+  /// patterns to use a `Tester` instance. Some reduction patterns may need to
+  /// run tester to determine whether certain transformations preserve the
+  /// "interesting" behavior of the program. This is mostly useful when pattern
+  /// should choose between multiple modifications.
+  virtual void populateReductionPatternsWithTester(RewritePatternSet &patterns,
+                                                   Tester &tester) const {}
 
 protected:
   DialectReductionPatternInterface(Dialect *dialect) : Base(dialect) {}
 };
-
-/// This interface extends the `dialectreductionpatterninterface` by allowing
-/// reduction patterns to use a `Tester` instance. Some reduction patterns may
-/// need to run tester to determine whether certain transformations preserve the
-/// "interesting" behavior of the program. This is mostly useful when pattern
-/// should choose between multiple modifications.
-/// Implementation follows the same logic as the
-/// `dialectreductionpatterninterface`.
-///
-/// Example:
-///   MyDialectReductionPatternWithTester::populateReductionPatterns(
-///       RewritePatternSet &patterns, Tester &tester) {
-///       patterns.add<PatternWithTester>(patterns.getContext(), tester);
-///   }
-
 } // namespace mlir
 
 #endif // MLIR_REDUCER_REDUCTIONPATTERNINTERFACE_H

--- a/mlir/include/mlir/Reducer/Tester.h
+++ b/mlir/include/mlir/Reducer/Tester.h
@@ -36,6 +36,9 @@ public:
     Untested,
   };
 
+  Tester() = default;
+  Tester(const Tester &) = default;
+
   Tester(StringRef testScript, ArrayRef<std::string> testScriptArgs);
 
   /// Runs the interestingness testing script on a MLIR test case file. Returns
@@ -45,6 +48,9 @@ public:
 
   /// Return whether the file in the given path is interesting.
   Interestingness isInteresting(StringRef testCase) const;
+
+  void setTestScript(StringRef script) { testScript = script; }
+  void setTestScriptArgs(ArrayRef<std::string> args) { testScriptArgs = args; }
 
 private:
   StringRef testScript;

--- a/mlir/lib/Reducer/ReductionTreePass.cpp
+++ b/mlir/lib/Reducer/ReductionTreePass.cpp
@@ -175,27 +175,12 @@ public:
   using Base::Base;
 
   // Collect the reduce patterns defined by each dialect.
-  void populateReductionPatterns(RewritePatternSet &pattern) const {
-    for (const DialectReductionPatternInterface &interface : *this)
-      interface.populateReductionPatterns(pattern);
-  }
-};
-
-//===----------------------------------------------------------------------===//
-// Reduction Pattern With Tester Interface Collection
-//===----------------------------------------------------------------------===//
-
-class ReductionPatternWithTesterInterfaceCollection
-    : public DialectInterfaceCollection<
-          DialectReductionPatternWithTesterInterface> {
-public:
-  using Base::Base;
-
-  // Collect the reduce patterns defined by each dialect.
   void populateReductionPatterns(RewritePatternSet &pattern,
                                  Tester &tester) const {
-    for (const DialectReductionPatternWithTesterInterface &interface : *this)
-      interface.populateReductionPatterns(pattern, tester);
+    for (const DialectReductionPatternInterface &interface : *this) {
+      interface.populateReductionPatterns(pattern);
+      interface.populateReductionPatternsWithTester(pattern, tester);
+    }
   }
 };
 
@@ -232,11 +217,7 @@ LogicalResult ReductionTreePass::initialize(MLIRContext *context) {
   RewritePatternSet patterns(context);
 
   ReductionPatternInterfaceCollection reducePatternCollection(context);
-  reducePatternCollection.populateReductionPatterns(patterns);
-
-  ReductionPatternWithTesterInterfaceCollection
-      reducePatternWithTesterCollection(context);
-  reducePatternWithTesterCollection.populateReductionPatterns(patterns, tester);
+  reducePatternCollection.populateReductionPatterns(patterns, tester);
 
   reducerPatterns = std::move(patterns);
   return success();


### PR DESCRIPTION
Currently, we don't have support for patterns that need access to a `Tester` instance in `mlir-reduce`. This PR adds `DialectReductionPatternWithTesterInterface` to the set of supported interfaces. Dialects can implement this interface to inject the tester into their pattern classes.