### PR TITLE
compiler-rt: Use LLVM_THIRD_PARTY_DIR for siphash include

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -64,7 +64,7 @@ include(CMakePushCheckState)
 option(COMPILER_RT_BUILTINS_HIDE_SYMBOLS
   "Do not export any symbols from the static library." ON)
 
-include_directories(../../../third-party/siphash/include)
+include_directories(${LLVM_THIRD_PARTY_DIR}/siphash/include)
 
 # TODO: Need to add a mechanism for logging errors when builtin source files are
 # added to a sub-directory and not this CMakeLists file.


### PR DESCRIPTION
Introduced by https://github.com/llvm/llvm-project/commit/7f3afab9181d83f92771293ad3b6c00ac62800fd but currently unused in compiler-rt leading to build errors with COMPILER_RT_STANDALONE_BUILD=ON