### PR TITLE
[Clang] FunctionEffects: properly extract the type of a bound member member function from a CallExpr.

### DIFF
--- a/clang/lib/Sema/SemaFunctionEffects.cpp
+++ b/clang/lib/Sema/SemaFunctionEffects.cpp
@@ -1208,8 +1208,17 @@ private:
         return true;
       }
 
-      // No Decl, just an Expr. Just check based on its type.
-      checkIndirectCall(Call, CalleeExpr->getType());
+      // No Decl, just an Expr. Just check based on its type. Bound member
+      // functions are a special expression type and need to be specially
+      // unpacked.
+      QualType CalleeExprQT = CalleeExpr->getType();
+      if (CalleeExpr->isBoundMemberFunction(Outer.S.getASTContext())) {
+        QualType QT = Expr::findBoundMemberType(CalleeExpr);
+        if (!QT.isNull()) {
+          CalleeExprQT = QT;
+        }
+      }
+      checkIndirectCall(Call, CalleeExprQT);
 
       return true;
     }

--- a/clang/lib/Sema/SemaFunctionEffects.cpp
+++ b/clang/lib/Sema/SemaFunctionEffects.cpp
@@ -1214,9 +1214,8 @@ private:
       QualType CalleeExprQT = CalleeExpr->getType();
       if (CalleeExpr->isBoundMemberFunction(Outer.S.getASTContext())) {
         QualType QT = Expr::findBoundMemberType(CalleeExpr);
-        if (!QT.isNull()) {
+        if (!QT.isNull())
           CalleeExprQT = QT;
-        }
       }
       checkIndirectCall(Call, CalleeExprQT);
 

--- a/clang/test/Sema/attr-nonblocking-constraints.cpp
+++ b/clang/test/Sema/attr-nonblocking-constraints.cpp
@@ -236,9 +236,22 @@ void nb13() [[clang::nonblocking]] { nb12(); }
 struct PTMFTester {
 	typedef void (PTMFTester::*ConvertFunction)() [[clang::nonblocking]];
 
+	ConvertFunction mConvertFunc;
+
 	void convert() [[clang::nonblocking]];
 
-	ConvertFunction mConvertFunc;
+	template <typename T>
+	struct Holder {
+		T value;
+		
+		T& operator*() { return value; }
+	};
+
+
+	void ptmfInExpr(Holder<ConvertFunction>& holder) [[clang::nonblocking]]
+	{
+		(this->*(*holder))(); // This should not generate a warning.
+	}
 };
 
 void PTMFTester::convert() [[clang::nonblocking]]


### PR DESCRIPTION
There's a bug illustrated by this example:

```
template <typename T>
struct Holder {
	T value;
	
	T& operator*() { return value; }
};

struct X {
	using Dispatch = float (X::*)() [[clang::nonblocking]];
    
	void fails(Holder<Dispatch>& holder) [[clang::nonblocking]]
	{
		(this->*(*holder))();   <<< the expression is incorrectly determined not to be nonblocking
	}

	void succeeds(Holder<Dispatch>& holder) [[clang::nonblocking]]
	{
		auto func = *holder;
		(this->*func)();
	}
};
```

In both cases we have a `CXXMemberCallExpr`.  In `succeeds`, the expression refers to a `Decl` (`func`) and gets a useful PTMF type.  In `fails`, the expression does not refer to a `Decl` and its type is special, printed as `bound member function`.  `Expr` provides a method for extracting the true type so we can use that in this situation.