### PR TITLE
[llvm-lit] Add `sparc64` to the list of BE triple

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -474,7 +474,7 @@ if config.host_ldflags.find("-m32") < 0 and any(
 config.available_features.add("host-byteorder-" + sys.byteorder + "-endian")
 if config.target_triple:
     if re.match(
-        r"(aarch64_be|arc|armeb|bpfeb|lanai|m68k|mips|mips64|powerpc|powerpc64|sparc|sparcv9|s390x|s390|tce|thumbeb)-.*",
+        r"(aarch64_be|arc|armeb|bpfeb|lanai|m68k|mips|mips64|powerpc|powerpc64|sparc|sparcv9|sparc64|s390x|s390|tce|thumbeb)-.*",
         config.target_triple,
     ):
         config.available_features.add("target-byteorder-big-endian")


### PR DESCRIPTION
Linux uses `sparc64` triple name on 64-bit SPARCs.
This should fix the test failure in discriminated-union.ll.