### PR TITLE
[CodeGen][NFC] Remove one meaningless `equal_to` specialization

### DIFF
--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -361,13 +361,6 @@ template <> struct hash<llvm::rdf::RegisterAggr> {
   }
 };
 
-template <> struct equal_to<llvm::rdf::RegisterAggr> {
-  bool operator()(const llvm::rdf::RegisterAggr &A,
-                  const llvm::rdf::RegisterAggr &B) const {
-    return A == B;
-  }
-};
-
 } // namespace std
 
 namespace llvm::rdf {


### PR DESCRIPTION
The `std::equal_to<llvm::rdf::RegisterAggr>` specialization (introduced in 9521704553e8a330cfdf5a0611885680073178b2) does the same things as the primary `std::equal_to` template. This is valid but meaningless. As a result, it's perhaps better to remove this full specialization.