### PR TITLE
[libc++abi] Use `= default;` for `OutputBuffer`'s destructor

### DIFF
--- a/libcxxabi/src/demangle/Utility.h
+++ b/libcxxabi/src/demangle/Utility.h
@@ -81,7 +81,7 @@ public:
   OutputBuffer(const OutputBuffer &) = delete;
   OutputBuffer &operator=(const OutputBuffer &) = delete;
 
-  virtual ~OutputBuffer() {}
+  virtual ~OutputBuffer() = default;
 
   operator std::string_view() const {
     return std::string_view(Buffer, CurrentPosition);


### PR DESCRIPTION
This mirrors the change in 4eed68357e4361b3a3aeb349dec2612cfb74c8cc to libcxxabi, which is necessary for fixing CI failure.