### PR TITLE
[clang] Migrate away from a soft-deprecated constructor of APInt (NFC)

### DIFF
--- a/clang/include/clang/AST/APNumericStorage.h
+++ b/clang/include/clang/AST/APNumericStorage.h
@@ -41,7 +41,7 @@ protected:
   llvm::APInt getIntValue() const {
     unsigned NumWords = llvm::APInt::getNumWords(BitWidth);
     if (NumWords > 1)
-      return llvm::APInt(BitWidth, NumWords, pVal);
+      return llvm::APInt(BitWidth, llvm::ArrayRef(pVal, NumWords));
     else
       return llvm::APInt(BitWidth, VAL);
   }

--- a/clang/include/clang/AST/APNumericStorage.h
+++ b/clang/include/clang/AST/APNumericStorage.h
@@ -42,8 +42,7 @@ protected:
     unsigned NumWords = llvm::APInt::getNumWords(BitWidth);
     if (NumWords > 1)
       return llvm::APInt(BitWidth, llvm::ArrayRef(pVal, NumWords));
-    else
-      return llvm::APInt(BitWidth, VAL);
+    return llvm::APInt(BitWidth, VAL);
   }
   void setIntValue(const ASTContext &C, const llvm::APInt &Val);
 };

--- a/clang/include/clang/AST/AbstractBasicReader.h
+++ b/clang/include/clang/AST/AbstractBasicReader.h
@@ -173,7 +173,7 @@ public:
     llvm::SmallVector<uint64_t, 4> data;
     for (uint32_t i = 0; i != numWords; ++i)
       data.push_back(asImpl().readUInt64());
-    return llvm::APInt(bitWidth, numWords, &data[0]);
+    return llvm::APInt(bitWidth, data);
   }
 
   llvm::FixedPointSemantics readFixedPointSemantics() {

--- a/clang/lib/AST/ByteCode/Floating.h
+++ b/clang/lib/AST/ByteCode/Floating.h
@@ -45,7 +45,8 @@ private:
     if (singleWord())
       return APFloat(getSemantics(), APInt(BitWidth, Val));
     unsigned NumWords = numWords();
-    return APFloat(getSemantics(), APInt(BitWidth, NumWords, Memory));
+    return APFloat(getSemantics(),
+                   APInt(BitWidth, llvm::ArrayRef(Memory, NumWords)));
   }
 
 public:

--- a/clang/lib/AST/ByteCode/IntegralAP.h
+++ b/clang/lib/AST/ByteCode/IntegralAP.h
@@ -63,7 +63,7 @@ public:
     if (singleWord())
       return APInt(BitWidth, Val, Signed);
     unsigned NumWords = llvm::APInt::getNumWords(BitWidth);
-    return llvm::APInt(BitWidth, NumWords, Memory);
+    return llvm::APInt(BitWidth, llvm::ArrayRef(Memory, NumWords));
   }
 
 public:


### PR DESCRIPTION
We have:

/// Once all uses of this constructor are migrated to other constructors,
/// consider marking this overload ""= delete" to prevent calls from being
/// incorrectly bound to the APInt(unsigned, uint64_t, bool) constructor.
LLVM_ABI APInt(unsigned numBits, unsigned numWords, const uint64_t bigVal[]);

This patch migrates away from this soft-deprecated constructor.
