### PR TITLE
[mlir] Migrate away from a soft-deprecated constructor of APInt (NFC)

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -407,8 +407,8 @@ Parser::parseFloatFromIntegerLiteral(std::optional<APFloat> &result,
                      "hexadecimal float constant out of range for type");
   }
 
-  APInt truncatedValue(typeSizeInBits, intValue.getNumWords(),
-                       intValue.getRawData());
+  APInt truncatedValue(typeSizeInBits, llvm::ArrayRef(intValue.getRawData(),
+                                                      intValue.getNumWords()));
   result.emplace(semantics, truncatedValue);
   return success();
 }

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -407,8 +407,8 @@ Parser::parseFloatFromIntegerLiteral(std::optional<APFloat> &result,
                      "hexadecimal float constant out of range for type");
   }
 
-  APInt truncatedValue(typeSizeInBits, llvm::ArrayRef(intValue.getRawData(),
-                                                      intValue.getNumWords()));
+  APInt truncatedValue(typeSizeInBits,
+                       ArrayRef(intValue.getRawData(), intValue.getNumWords()));
   result.emplace(semantics, truncatedValue);
   return success();
 }


### PR DESCRIPTION
We have:

/// Once all uses of this constructor are migrated to other constructors,
/// consider marking this overload ""= delete" to prevent calls from being
/// incorrectly bound to the APInt(unsigned, uint64_t, bool) constructor.
LLVM_ABI APInt(unsigned numBits, unsigned numWords, const uint64_t bigVal[]);

This patch migrates away from this soft-deprecated constructor.
