### PR TITLE
[AMDGPU] Enable i8 GEP promotion for vector allocas

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -457,21 +457,24 @@ static Value *GEPToVectorIndex(GetElementPtrInst *GEP, AllocaInst *Alloca,
   const auto &VarOffset = VarOffsets.front();
   APInt OffsetQuot;
   APInt::sdivrem(VarOffset.second, VecElemSize, OffsetQuot, Rem);
-
-  Value *Scaled = nullptr;
+  Value *Offset = VarOffset.first;
   if (Rem != 0 || OffsetQuot.isZero()) {
     unsigned ElemSizeShift = Log2_64(VecElemSize);
-    Scaled = Builder.CreateLShr(VarOffset.first, ElemSizeShift);
+    SimplifyQuery SQ(DL);
+    SQ.CxtI = GEP;
+    KnownBits KB = computeKnownBits(VarOffset.first, SQ);
+    // Bail out if the index may point into the middle of an element.
+    if (KB.countMinTrailingZeros() < ElemSizeShift)
+      return nullptr;
+
+    Value *Scaled = Builder.CreateLShr(VarOffset.first, ElemSizeShift);
     if (Instruction *NewInst = dyn_cast<Instruction>(Scaled))
       NewInsts.push_back(NewInst);
+
+    Offset = Scaled;
     OffsetQuot = APInt(BW, 1);
     Rem = 0;
   }
-
-  Value *Offset = VarOffset.first;
-
-  if (Scaled)
-    Offset = Scaled;
 
   if (!isa<IntegerType>(Offset->getType()))
     return nullptr;

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -458,7 +458,7 @@ static Value *GEPToVectorIndex(GetElementPtrInst *GEP, AllocaInst *Alloca,
   APInt OffsetQuot;
   APInt::sdivrem(VarOffset.second, VecElemSize, OffsetQuot, Rem);
   Value *Offset = VarOffset.first;
-  if (Rem != 0 || OffsetQuot.isZero()) {
+  if (Rem != 0) {
     unsigned ElemSizeShift = Log2_64(VecElemSize);
     SimplifyQuery SQ(DL);
     SQ.CxtI = GEP;

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
@@ -250,6 +250,26 @@ bb2:
   store i32 0, ptr addrspace(5) %extractelement
   ret void
 }
+
+define amdgpu_kernel void @scalar_alloca_vector_gep_i8(ptr %buffer, float %data, i32 %index) {
+; CHECK-LABEL: define amdgpu_kernel void @scalar_alloca_vector_gep_i8(
+; CHECK-SAME: ptr [[BUFFER:%.*]], float [[DATA:%.*]], i32 [[INDEX:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <3 x float> poison
+; CHECK-NEXT:    [[VEC:%.*]] = load <3 x float>, ptr [[BUFFER]], align 16
+; CHECK-NEXT:    [[TMP1:%.*]] = lshr i32 [[INDEX]], 2
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <3 x float> [[VEC]], float [[DATA]], i32 [[TMP1]]
+; CHECK-NEXT:    store <3 x float> [[TMP2]], ptr [[BUFFER]], align 16
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %vec = load <3 x float>, ptr %buffer
+  store <3 x float> %vec, ptr addrspace(5) %alloca
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %alloca, i32 %index
+  store float %data, ptr addrspace(5) %elt, align 4
+  %updated = load <3 x float>, ptr addrspace(5) %alloca, align 16
+  store <3 x float> %updated, ptr %buffer, align 16
+  ret void
+}
 ;.
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[RNG1]] = !{i32 0, i32 1025}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
@@ -295,6 +295,41 @@ define amdgpu_kernel void @scalar_alloca_vector_gep_i8_4_or_8(ptr %buffer, float
   ret void
 }
 
+define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_8(ptr %buffer, float %data, i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_8(
+; CHECK-SAME: ptr [[BUFFER:%.*]], float [[DATA:%.*]], i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <8 x float> poison
+; CHECK-NEXT:    [[VEC:%.*]] = load <3 x float>, ptr [[BUFFER]], align 16
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <3 x float> [[VEC]], i64 0
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <8 x float> [[ALLOCA]], float [[TMP1]], i32 0
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <3 x float> [[VEC]], i64 1
+; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x float> [[TMP2]], float [[TMP3]], i32 1
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <3 x float> [[VEC]], i64 2
+; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <8 x float> [[TMP4]], float [[TMP5]], i32 2
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 4, i32 8
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[INDEX]], 2
+; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <8 x float> [[TMP6]], float [[DATA]], i32 [[TMP7]]
+; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <8 x float> [[TMP8]], i32 0
+; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <3 x float> poison, float [[TMP9]], i64 0
+; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <8 x float> [[TMP8]], i32 1
+; CHECK-NEXT:    [[TMP12:%.*]] = insertelement <3 x float> [[TMP10]], float [[TMP11]], i64 1
+; CHECK-NEXT:    [[TMP13:%.*]] = extractelement <8 x float> [[TMP8]], i32 2
+; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <3 x float> [[TMP12]], float [[TMP13]], i64 2
+; CHECK-NEXT:    store <3 x float> [[TMP14]], ptr [[BUFFER]], align 16
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca [2 x <3 x float>], align 16, addrspace(5)
+  %row = getelementptr inbounds [2 x <3 x float>], ptr addrspace(5) %alloca, i32 0, i32 0
+  %vec = load <3 x float>, ptr %buffer
+  store <3 x float> %vec, ptr addrspace(5) %row, align 16
+  %index = select i1 %idx_sel, i32 4, i32 8
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %row, i32 %index
+  store float %data, ptr addrspace(5) %elt, align 4
+  %updated = load <3 x float>, ptr addrspace(5) %row, align 16
+  store <3 x float> %updated, ptr %buffer, align 16
+  ret void
+}
+
 define amdgpu_kernel void @scalar_alloca_vector_gep_i8_4_or_5_no_promote(ptr %buffer, float %data, i1 %idx_sel) {
 ; CHECK-LABEL: define amdgpu_kernel void @scalar_alloca_vector_gep_i8_4_or_5_no_promote(
 ; CHECK-SAME: ptr [[BUFFER:%.*]], float [[DATA:%.*]], i1 [[IDX_SEL:%.*]]) {
@@ -332,6 +367,42 @@ define amdgpu_kernel void @scalar_alloca_vector_gep_i8_4_or_5_no_promote(ptr %bu
   store <3 x float> %updated, ptr %buffer, align 16
   ret void
 }
+
+define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(ptr %buffer, float %data, i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(
+; CHECK-SAME: ptr [[BUFFER:%.*]], float [[DATA:%.*]], i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <8 x float> poison
+; CHECK-NEXT:    [[VEC:%.*]] = load <3 x float>, ptr [[BUFFER]], align 16
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <3 x float> [[VEC]], i64 0
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <8 x float> [[ALLOCA]], float [[TMP1]], i32 0
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <3 x float> [[VEC]], i64 1
+; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x float> [[TMP2]], float [[TMP3]], i32 1
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <3 x float> [[VEC]], i64 2
+; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <8 x float> [[TMP4]], float [[TMP5]], i32 2
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 4, i32 8
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[INDEX]], 2
+; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <8 x float> [[TMP6]], float [[DATA]], i32 [[TMP7]]
+; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <8 x float> [[TMP8]], i32 0
+; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <3 x float> poison, float [[TMP9]], i64 0
+; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <8 x float> [[TMP8]], i32 1
+; CHECK-NEXT:    [[TMP12:%.*]] = insertelement <3 x float> [[TMP10]], float [[TMP11]], i64 1
+; CHECK-NEXT:    [[TMP13:%.*]] = extractelement <8 x float> [[TMP8]], i32 2
+; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <3 x float> [[TMP12]], float [[TMP13]], i64 2
+; CHECK-NEXT:    store <3 x float> [[TMP14]], ptr [[BUFFER]], align 16
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca [2 x <3 x float>], align 16, addrspace(5)
+  %row = getelementptr inbounds [2 x <3 x float>], ptr addrspace(5) %alloca, i32 0, i32 0
+  %vec = load <3 x float>, ptr %buffer
+  store <3 x float> %vec, ptr addrspace(5) %row, align 16
+  %index = select i1 %idx_sel, i32 4, i32 8
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %row, i32 %index
+  store float %data, ptr addrspace(5) %elt, align 4
+  %updated = load <3 x float>, ptr addrspace(5) %row, align 16
+  store <3 x float> %updated, ptr %buffer, align 16
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[RNG1]] = !{i32 0, i32 1025}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
@@ -371,23 +371,14 @@ define amdgpu_kernel void @scalar_alloca_vector_gep_i8_4_or_5_no_promote(ptr %bu
 define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(ptr %buffer, float %data, i1 %idx_sel) {
 ; CHECK-LABEL: define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(
 ; CHECK-SAME: ptr [[BUFFER:%.*]], float [[DATA:%.*]], i1 [[IDX_SEL:%.*]]) {
-; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <8 x float> poison
+; CHECK-NEXT:    [[ALLOCA:%.*]] = alloca [2 x <3 x float>], align 16, addrspace(5)
+; CHECK-NEXT:    [[ROW:%.*]] = getelementptr inbounds [2 x <3 x float>], ptr addrspace(5) [[ALLOCA]], i32 0, i32 0
 ; CHECK-NEXT:    [[VEC:%.*]] = load <3 x float>, ptr [[BUFFER]], align 16
-; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <3 x float> [[VEC]], i64 0
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <8 x float> [[ALLOCA]], float [[TMP1]], i32 0
-; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <3 x float> [[VEC]], i64 1
-; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x float> [[TMP2]], float [[TMP3]], i32 1
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <3 x float> [[VEC]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <8 x float> [[TMP4]], float [[TMP5]], i32 2
-; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 4, i32 8
-; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[INDEX]], 2
-; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <8 x float> [[TMP6]], float [[DATA]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <8 x float> [[TMP8]], i32 0
-; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <3 x float> poison, float [[TMP9]], i64 0
-; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <8 x float> [[TMP8]], i32 1
-; CHECK-NEXT:    [[TMP12:%.*]] = insertelement <3 x float> [[TMP10]], float [[TMP11]], i64 1
-; CHECK-NEXT:    [[TMP13:%.*]] = extractelement <8 x float> [[TMP8]], i32 2
-; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <3 x float> [[TMP12]], float [[TMP13]], i64 2
+; CHECK-NEXT:    store <3 x float> [[VEC]], ptr addrspace(5) [[ROW]], align 16
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 4, i32 5
+; CHECK-NEXT:    [[ELT:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(5) [[ROW]], i32 [[INDEX]]
+; CHECK-NEXT:    store float [[DATA]], ptr addrspace(5) [[ELT]], align 4
+; CHECK-NEXT:    [[TMP14:%.*]] = load <3 x float>, ptr addrspace(5) [[ROW]], align 16
 ; CHECK-NEXT:    store <3 x float> [[TMP14]], ptr [[BUFFER]], align 16
 ; CHECK-NEXT:    ret void
 ;
@@ -395,7 +386,7 @@ define amdgpu_kernel void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(
   %row = getelementptr inbounds [2 x <3 x float>], ptr addrspace(5) %alloca, i32 0, i32 0
   %vec = load <3 x float>, ptr %buffer
   store <3 x float> %vec, ptr addrspace(5) %row, align 16
-  %index = select i1 %idx_sel, i32 4, i32 8
+  %index = select i1 %idx_sel, i32 4, i32 5
   %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %row, i32 %index
   store float %data, ptr addrspace(5) %elt, align 4
   %updated = load <3 x float>, ptr addrspace(5) %row, align 16


### PR DESCRIPTION
This patch adds support for the pattern:
```llvm
  %index = select i1 %idx_sel, i32 0, i32 4
  %elt = getelementptr inbounds i8, ptr addrspace(5) %alloca, i32 %index
```
by scaling the byte offset to an element index (index >> log2(ElemSize)),
allowing the vector element to be updated with insertelement instead of using
scratch memory. 