### PR TITLE
[AllocToken, Clang] Add intptr_t as pointer in TypeHashPointerSplit mode

### DIFF
--- a/clang/lib/AST/InferAlloc.cpp
+++ b/clang/lib/AST/InferAlloc.cpp
@@ -34,10 +34,10 @@ typeContainsPointer(QualType T,
   for (QualType CurrentT = T; const auto *TT = CurrentT->getAs<TypedefType>();
        CurrentT = TT->getDecl()->getUnderlyingType()) {
     const IdentifierInfo *II = TT->getDecl()->getIdentifier();
-    // Special Case: Syntactically uintptr_t is not a pointer; semantically,
-    // however, very likely used as such. Therefore, classify uintptr_t as a
-    // pointer, too.
-    if (II && II->isStr("uintptr_t"))
+    // Special Case: Syntactically intptr and uintptr_t are not pointers;
+    // semantically, however, very likely used as such. Therefore, classify
+    // intptr_t and uintptr_t as pointers, too.
+    if (II && (II->isStr("intptr_t") || II->isStr("uintptr_t")))
       return true;
   }
 

--- a/clang/test/CodeGenCXX/alloc-token-pointer.cpp
+++ b/clang/test/CodeGenCXX/alloc-token-pointer.cpp
@@ -2,6 +2,7 @@
 
 #include "../Analysis/Inputs/system-header-simulator-cxx.h"
 
+typedef __INTPTR_TYPE__ intptr_t;
 typedef __UINTPTR_TYPE__ uintptr_t;
 
 extern "C" {
@@ -187,6 +188,13 @@ uptr *test_uintptr_isptr2() {
   return new uptr;
 }
 
+using iptr = intptr_t;
+// CHECK-LABEL: define dso_local noundef ptr @_Z17test_intptr_isptrv(
+// CHECK: call noalias noundef nonnull ptr @_Znwm(i64 noundef 8){{.*}} !alloc_token [[META_INTPTRT:![0-9]+]]
+iptr *test_intptr_isptr() {
+  return new iptr;
+}
+
 // CHECK: [[META_INT]] = !{!"int", i1 false}
 // CHECK: [[META_INTPTR]] = !{!"int *", i1 true}
 // CHECK: [[META_ULONG]] = !{!"unsigned long", i1 false}
@@ -195,3 +203,4 @@ uptr *test_uintptr_isptr2() {
 // CHECK: [[META_VIRTUALTESTCLASS]] = !{!"VirtualTestClass", i1 true}
 // CHECK: [[META_MYSTRUCTUINTPTR]] = !{!"MyStructUintptr", i1 true}
 // CHECK: [[META_UINTPTR]] = !{!"unsigned long", i1 true}
+// CHECK: [[META_INTPTRT]] = !{!"long", i1 true}


### PR DESCRIPTION
Similarly to `uintptr_t` we treat `intptr_t` as a pointer type.

Link: https://discourse.llvm.org/t/rfc-a-framework-for-allocator-partitioning-hints/87434