### PR TITLE
[X86] combineTruncate - trunc(srl(load(p),amt)) -> load(p+amt/8) - ensure we merge the full / truncated load chains

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54529,8 +54529,7 @@ static SDValue combineTruncate(SDNode *N, SelectionDAG &DAG,
         SDValue NewLoad =
             DAG.getLoad(VT, DL, Ld->getChain(), NewPtr, Ld->getPointerInfo(),
                         Align(), Ld->getMemOperand()->getFlags());
-        DAG.ReplaceAllUsesOfValueWith(Src.getOperand(0).getValue(1),
-                                      NewLoad.getValue(1));
+        DAG.makeEquivalentMemoryOrdering(Ld, NewLoad);
         return NewLoad;
       }
     }


### PR DESCRIPTION
The full load might persist so ensure that the chains are merged into a token factor instead of just transferring the chain to the new load

Noticed while trying to fix the regression reported from #165540