### PR TITLE
[ASan][Test-Only] Allow read of size 2 in strcmp.c test

### DIFF
--- a/compiler-rt/test/asan/TestCases/strcmp.c
+++ b/compiler-rt/test/asan/TestCases/strcmp.c
@@ -14,6 +14,8 @@ int main(int argc, char **argv) {
   assert(strcmp(s1 - 1, s2));
 
   // CHECK: {{.*ERROR: AddressSanitizer: stack-buffer-underflow on address}}
-  // CHECK: READ of size 1
+  // Very rarely `s1[-1]` happens to be '1', resulting in `strcmp` needing to
+  // check 2 bytes before failing, rather than 1 - this should still pass
+  // CHECK: READ of size {{[12]}}
   return 0;
 }


### PR DESCRIPTION
Occasionally this test fails on Darwin due to `CHECK: READ of size 1` not matching the actual output `CHECK: READ of size 2`. This can happen when the memory before the string `s1` happens to match the first character of `s2`.

This patch allows for `READ of size 2` to pass in order to account for the above circumstances.

rdar://151317947