### PR TITLE
[flang] Explicit interface externals are constant expressions

### DIFF
--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -379,8 +379,11 @@ bool IsInitialProcedureTarget(const semantics::Symbol &symbol) {
       common::visitors{
           [&](const semantics::SubprogramDetails &subp) {
             return !subp.isDummy() && !subp.stmtFunction() &&
-                symbol.owner().kind() != semantics::Scope::Kind::MainProgram &&
-                symbol.owner().kind() != semantics::Scope::Kind::Subprogram;
+                ((symbol.owner().kind() !=
+                         semantics::Scope::Kind::MainProgram &&
+                     symbol.owner().kind() !=
+                         semantics::Scope::Kind::Subprogram) ||
+                    ultimate.attrs().test(semantics::Attr::EXTERNAL));
           },
           [](const semantics::SubprogramNameDetails &x) {
             return x.kind() != semantics::SubprogramKind::Internal;

--- a/flang/test/Semantics/structconst12.f90
+++ b/flang/test/Semantics/structconst12.f90
@@ -1,0 +1,12 @@
+!RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+!CHECK: TYPE(t) :: x = t(pp=f)
+!CHECK-NOT: error:
+interface
+  function f()
+  end
+end interface
+type t
+  procedure(f), nopass, pointer :: pp
+end type
+type(t) :: x = t(pp=f)
+end


### PR DESCRIPTION
... but the constant expression test didn't allow for them, so they weren't working in initializers.