### PR TITLE
[C23] Correctly handle missing embed with -MG

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -209,6 +209,8 @@ C23 Feature Support
   `WG14 N2710 <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2710.htm>`_.
 - Fixed accepting as compatible unnamed tag types with the same fields within
   the same translation unit but from different types.
+- ``-MG`` now silences the "file not found" errors with ``#embed`` when
+  scanning for dependencies and encountering an unknown file. #GH165632
 
 Non-comprehensive list of changes in this release
 -------------------------------------------------

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -75,6 +75,17 @@ struct DepCollectorPPCallbacks : public PPCallbacks {
                                     /*IsMissing*/ false);
   }
 
+  bool EmbedFileNotFound(StringRef FileName) override {
+    DepCollector.maybeAddDependency(
+        llvm::sys::path::remove_leading_dotslash(FileName),
+        /*FromModule*/ false,
+        /*IsSystem*/ false,
+        /*IsModuleFile*/ false,
+        /*IsMissing*/ false);
+    // Return true to silence the file not found diagnostic.
+    return true;
+  }
+
   void InclusionDirective(SourceLocation HashLoc, const Token &IncludeTok,
                           StringRef FileName, bool IsAngled,
                           CharSourceRange FilenameRange,

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -81,7 +81,7 @@ struct DepCollectorPPCallbacks : public PPCallbacks {
         /*FromModule*/ false,
         /*IsSystem*/ false,
         /*IsModuleFile*/ false,
-        /*IsMissing*/ false);
+        /*IsMissing*/ true);
     // Return true to silence the file not found diagnostic.
     return true;
   }

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -78,10 +78,10 @@ struct DepCollectorPPCallbacks : public PPCallbacks {
   bool EmbedFileNotFound(StringRef FileName) override {
     DepCollector.maybeAddDependency(
         llvm::sys::path::remove_leading_dotslash(FileName),
-        /*FromModule=*/ false,
-        /*IsSystem=*/ false,
-        /*IsModuleFile=*/ false,
-        /*IsMissing=*/ true);
+        /*FromModule=*/false,
+        /*IsSystem=*/false,
+        /*IsModuleFile=*/false,
+        /*IsMissing=*/true);
     // Return true to silence the file not found diagnostic.
     return true;
   }

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -78,10 +78,10 @@ struct DepCollectorPPCallbacks : public PPCallbacks {
   bool EmbedFileNotFound(StringRef FileName) override {
     DepCollector.maybeAddDependency(
         llvm::sys::path::remove_leading_dotslash(FileName),
-        /*FromModule*/ false,
-        /*IsSystem*/ false,
-        /*IsModuleFile*/ false,
-        /*IsMissing*/ true);
+        /*FromModule=*/ false,
+        /*IsSystem=*/ false,
+        /*IsModuleFile=*/ false,
+        /*IsMissing=*/ true);
     // Return true to silence the file not found diagnostic.
     return true;
   }

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -4018,7 +4018,7 @@ void Preprocessor::HandleEmbedDirective(SourceLocation HashLoc, Token &EmbedTok,
       this->LookupEmbedFile(Filename, isAngled, true, LookupFromFile);
   if (!MaybeFileRef) {
     // could not find file
-    if (Callbacks && Callbacks->EmbedFileNotFound(OriginalFilename)) {
+    if (Callbacks && Callbacks->EmbedFileNotFound(Filename)) {
       return;
     }
     Diag(FilenameTok, diag::err_pp_file_not_found) << Filename;

--- a/clang/test/Driver/mg.c
+++ b/clang/test/Driver/mg.c
@@ -1,5 +1,7 @@
-// RUN: %clang -M -MG -include nonexistent-preinclude.h %s | FileCheck %s
+// RUN: %clang -M -MG -include nonexistent-preinclude.h -std=c23 %s | FileCheck %s
 // CHECK: nonexistent-preinclude.h
 // CHECK: nonexistent-ppinclude.h
+// CHECK: nonexistent-embed
 
 #include "nonexistent-ppinclude.h"
+#embed "nonexistent-embed"


### PR DESCRIPTION
-MG is supposed to suppress "file not found" diagnostics and instead treat those as generated files for purposes of dependency scanning. Clang was previously emitting the diagnostic instead of emitting the name of the embedded file.

Fixes #165632