### PR TITLE
[clang-tidy][doc] add more information in twine-local's document

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/twine-local.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/twine-local.rst
@@ -14,3 +14,21 @@ should be generally avoided.
   // becomes
 
   static std::string Moo = (Twine("bark") + "bah").str();
+
+The ``llvm::Twine`` does not own the memory of its contents, so it is not
+recommended to use ``Twine`` created from temporary strings or string literals.
+
+.. code-block:: c++
+
+  static Twine getModuleIdentifier(StringRef moduleName) {
+    return moduleName + "_module";
+  }
+  void foo() {
+    Twine result = getModuleIdentifier(std::string{"abc"} + "def");
+    // temporary std::string is destroyed here, result is dangling
+  }
+
+After applying this fix-it hints, the code will use ``std::string`` instead of
+``Twine`` for local variables. However, ``llvm::Twine`` has lots of methods that
+are incompatible with ``std::string``, so the user may need to adjust the code
+manually after applying the fix-it hints.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/twine-local.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/twine-local.rst
@@ -15,7 +15,7 @@ should be generally avoided.
 
   static std::string Moo = (Twine("bark") + "bah").str();
 
-The ``llvm::Twine`` does not own the memory of its contents, so it is not
+The ``Twine`` does not own the memory of its contents, so it is not
 recommended to use ``Twine`` created from temporary strings or string literals.
 
 .. code-block:: c++
@@ -29,6 +29,6 @@ recommended to use ``Twine`` created from temporary strings or string literals.
   }
 
 After applying this fix-it hints, the code will use ``std::string`` instead of
-``Twine`` for local variables. However, ``llvm::Twine`` has lots of methods that
+``Twine`` for local variables. However, ``Twine`` has lots of methods that
 are incompatible with ``std::string``, so the user may need to adjust the code
 manually after applying the fix-it hints.


### PR DESCRIPTION
explain more about use-after-free in llvm-twine-local
add note about manually adjusting code after applying fix-it.
fixed: #154810
