### PR TITLE
[Clang] [Docs] Add some CMake example code for linking against libclang

### DIFF
--- a/clang/docs/LibClang.rst
+++ b/clang/docs/LibClang.rst
@@ -38,6 +38,7 @@ Code example
 
 .. code-block:: cpp
 
+  // main.cpp
   #include <clang-c/Index.h>
   #include <iostream>
 
@@ -56,6 +57,18 @@ Code example
     }
     CXCursor cursor = clang_getTranslationUnitCursor(unit); //Obtain a cursor at the root of the translation unit
   }
+
+.. code-block:: cmake
+
+  # CMakeLists.txt
+  cmake_minimum_required(VERSION 3.30)
+  project(my_clang_tool VERSION 0.1.0)
+
+  find_package(Clang CONFIG REQUIRED)
+
+  add_executable(my_clang_tool main.cpp)
+  target_include_directories(my_clang_tool PRIVATE ${CLANG_INCLUDE_DIRS})
+  target_link_libraries(my_clang_tool PRIVATE libclang)
 
 Visiting elements of an AST
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -283,6 +296,7 @@ Complete example code
 
 .. code-block:: cpp
 
+  // main.cpp
   #include <clang-c/Index.h>
   #include <iostream>
 
@@ -356,6 +370,17 @@ Complete example code
     );
   }
 
+.. code-block:: cmake
+
+  # CMakeLists.txt
+  cmake_minimum_required(VERSION 3.30)
+  project(my_clang_tool VERSION 0.1.0)
+
+  find_package(Clang CONFIG REQUIRED)
+
+  add_executable(my_clang_tool main.cpp)
+  target_include_directories(my_clang_tool PRIVATE ${CLANG_INCLUDE_DIRS})
+  target_link_libraries(my_clang_tool PRIVATE libclang)
 
 .. _Index.h: https://github.com/llvm/llvm-project/blob/main/clang/include/clang-c/Index.h
 

--- a/clang/docs/LibClang.rst
+++ b/clang/docs/LibClang.rst
@@ -61,7 +61,7 @@ Code example
 .. code-block:: cmake
 
   # CMakeLists.txt
-  cmake_minimum_required(VERSION 3.30)
+  cmake_minimum_required(VERSION 3.20)
   project(my_clang_tool VERSION 0.1.0)
 
   find_package(Clang CONFIG REQUIRED)
@@ -373,7 +373,7 @@ Complete example code
 .. code-block:: cmake
 
   # CMakeLists.txt
-  cmake_minimum_required(VERSION 3.30)
+  cmake_minimum_required(VERSION 3.20)
   project(my_clang_tool VERSION 0.1.0)
 
   find_package(Clang CONFIG REQUIRED)

--- a/clang/docs/LibClang.rst
+++ b/clang/docs/LibClang.rst
@@ -64,6 +64,10 @@ Code example
   cmake_minimum_required(VERSION 3.20)
   project(my_clang_tool VERSION 0.1.0)
 
+  # This will find the default system installation of Clang; if you want to
+  # use a different build of clang, pass -DClang_DIR=/foobar/lib/cmake/clang
+  # to the CMake configure command, where /foobar is the build directory where
+  # you built Clang.
   find_package(Clang CONFIG REQUIRED)
 
   add_executable(my_clang_tool main.cpp)
@@ -376,6 +380,10 @@ Complete example code
   cmake_minimum_required(VERSION 3.20)
   project(my_clang_tool VERSION 0.1.0)
 
+  # This will find the default system installation of Clang; if you want to
+  # use a different build of clang, pass -DClang_DIR=/foobar/lib/cmake/clang
+  # to the CMake configure command, where /foobar is the build directory where
+  # you built Clang.
   find_package(Clang CONFIG REQUIRED)
 
   add_executable(my_clang_tool main.cpp)


### PR DESCRIPTION
Though we have a few code examples in our documentation that show how to *use* libclang, we never actually show how to *link* against it. I myself mostly figured this out through trial and error some time ago, and I’ve since had to explain it to others on several occasions, so I thought adding some very minimal CMake example code might be helpful.