### PR TITLE
[libc++][hardening] Update documentation in the light of P3878.

### DIFF
--- a/libcxx/docs/Hardening.rst
+++ b/libcxx/docs/Hardening.rst
@@ -305,11 +305,11 @@ Notes:
   behavior; the ``observe`` semantic is meant to make adopting hardening easier
   but should not be used outside of the adoption period;
 - C++26 wording for Library Hardening precludes a conforming Hardened
-  implementation from using the Contracts ``ignore`` semantic when evaluating
-  hardened preconditions in the Library. Libc++ allows using this semantic for
-  hardened preconditions, but please be aware that using ``ignore`` does not
-  produce a conforming "Hardened" implementation, unlike the other semantics
-  above.
+  implementation from using a Contracts' non-terminating semantic (i.e.,
+  ``ignore`` or ``observe``) when evaluating hardened preconditions in the
+  Library. Libc++ allows using these semantics for hardened preconditions, but
+  please be aware that using ``ignore`` or ``observe`` does not produce
+  a conforming "Hardened" implementation, unlike the terminating semantics above.
 
 The default assertion semantics are as follows:
 

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -193,10 +193,10 @@ _LIBCPP_HARDENING_MODE_DEBUG
 // Notes:
 // - Continuing execution after a hardening check fails results in undefined behavior; the `observe` semantic is meant
 //   to make adopting hardening easier but should not be used outside of this scenario;
-// - C++26 wording for Library Hardening precludes a conforming Hardened implementation from using the Contracts
-//   `ignore` semantic when evaluating hardened preconditions in the Library. Libc++ allows using this semantic for
-//   hardened preconditions, however, be aware that using `ignore` does not produce a conforming "Hardened"
-//   implementation, unlike the other semantics above.
+// - C++26 wording for Library Hardening precludes a conforming Hardened implementation from using a Contracts'
+//   non-terminating semantic (i.e., `ignore` or ``observe``) when evaluating hardened preconditions in the Library.
+//   Libc++ allows using these semantics for hardened preconditions, however, be aware that using `ignore` or `observe`
+//   does not produce a conforming "Hardened" implementation, unlike the terminating semantics above.
 // clang-format off
 #  define _LIBCPP_ASSERTION_SEMANTIC_IGNORE        (1 << 1)
 #  define _LIBCPP_ASSERTION_SEMANTIC_OBSERVE       (1 << 2)


### PR DESCRIPTION
With P3878 applied to the Standard, a Hardened implementation is no
longer allowed to use the `observe` semantic (the new wording requires
a terminating semantic to be used); update the documentation to note
that using `observe` is same as `ignore`, i.e., does not result in
a conforming Hardened implementation.
