### PR TITLE
[IVDesc] Check loop-preheader for loop-legality when pass-remarks enabled

### DIFF
--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -282,7 +282,9 @@ bool RecurrenceDescriptor::AddReductionVar(
 
   // Obtain the reduction start value from the value that comes from the loop
   // preheader.
-  Value *RdxStart = Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());
+  Value *RdxStart;
+  if (TheLoop->getLoopPreheader())
+    RdxStart = Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());
 
   // ExitInstruction is the single value which is used outside the loop.
   // We only allow for a single reduction value to be used outside the loop.
@@ -648,6 +650,9 @@ bool RecurrenceDescriptor::AddReductionVar(
   //       kept simple enough.
   collectCastInstrs(TheLoop, ExitInstruction, RecurrenceType, CastInsts,
                     MinWidthCastToRecurrenceType);
+
+  if (!RdxStart)
+    return false;
 
   // We found a reduction var if we have reached the original phi node and we
   // only have a single instruction with out-of-loop users.
@@ -1689,6 +1694,9 @@ bool InductionDescriptor::isInductionPHI(
   // the current Phi is not present inside the loop header.
   assert(Phi->getParent() == TheLoop->getHeader() &&
          "Invalid Phi node, not present in loop header");
+
+  if (!TheLoop->getLoopPreheader())
+    return false;
 
   Value *StartValue =
       Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -283,9 +283,10 @@ bool RecurrenceDescriptor::AddReductionVar(
   // Obtain the reduction start value from the value that comes from the loop
   // preheader.
   Value *RdxStart;
-  if (TheLoop->getLoopPreheader())
-    RdxStart = Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());
+  if (!TheLoop->getLoopPreheader())
+    return false;
 
+  RdxStart = Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());
   // ExitInstruction is the single value which is used outside the loop.
   // We only allow for a single reduction value to be used outside the loop.
   // This includes users of the reduction, variables (which form a cycle
@@ -650,9 +651,6 @@ bool RecurrenceDescriptor::AddReductionVar(
   //       kept simple enough.
   collectCastInstrs(TheLoop, ExitInstruction, RecurrenceType, CastInsts,
                     MinWidthCastToRecurrenceType);
-
-  if (!RdxStart)
-    return false;
 
   // We found a reduction var if we have reached the original phi node and we
   // only have a single instruction with out-of-loop users.

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -279,14 +279,12 @@ bool RecurrenceDescriptor::AddReductionVar(
   if (isMinMaxReductionPhiWithUsersOutsideReductionChain(Phi, Kind, TheLoop,
                                                          RedDes))
     return true;
-
   // Obtain the reduction start value from the value that comes from the loop
   // preheader.
-  Value *RdxStart;
   if (!TheLoop->getLoopPreheader())
     return false;
 
-  RdxStart = Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());
+  Value *RdxStart = Phi->getIncomingValueForBlock(TheLoop->getLoopPreheader());
   // ExitInstruction is the single value which is used outside the loop.
   // We only allow for a single reduction value to be used outside the loop.
   // This includes users of the reduction, variables (which form a cycle

--- a/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
@@ -1,0 +1,24 @@
+; RUN: opt < %s -passes=loop-vectorize -pass-remarks=loop-vectorize -debug -disable-output 2>&1 | FileCheck %s
+; REQUIRES: asserts
+
+; Make sure LV legal bails out when the loop doesn't have a legal pre-header.
+; CHECK-LABEL: 'not_exist_preheader'
+; CHECK: LV: Not vectorizing: Loop doesn't have a legal pre-header.
+define void @not_exist_preheader(ptr %dst, ptr %arg) nounwind uwtable {
+entry:
+  indirectbr ptr %arg, [label %0, label %loop]
+
+0:
+  unreachable
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %loop]
+  %gep = getelementptr inbounds i32, ptr %dst, i32 %iv
+  store i32 0, ptr %gep, align 4
+  %iv.next = add i32 %iv, 1
+  %cmp = icmp slt i32 %iv.next, 4
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
@@ -9,7 +9,7 @@ entry:
   indirectbr ptr %arg, [label %exit.0, label %loop]
 
 exit.0:
-  unreachable
+  ret void
 
 loop:
   %iv = phi i32 [0, %entry], [%iv.next, %loop]

--- a/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
@@ -6,9 +6,9 @@
 ; CHECK: LV: Not vectorizing: Loop doesn't have a legal pre-header.
 define void @not_exist_preheader(ptr %dst, ptr %arg) nounwind uwtable {
 entry:
-  indirectbr ptr %arg, [label %0, label %loop]
+  indirectbr ptr %arg, [label %exit.0, label %loop]
 
-0:
+exit.0:
   unreachable
 
 loop:


### PR DESCRIPTION
When `-pass-remarks=loop-vectorize` is specified, the subsequent logic is executed to display detailed debug messages even if no PreHeader exists in the loop.

Therefore, an assert occurs when the `getLoopPreHeader()` function is called. This commit resolves that issue.

Fixed: #165377