### PR TITLE
[MLIR][ODS] Re-enable direct implementation of type interfaces with method bodies

### DIFF
--- a/mlir/test/lib/Dialect/Test/TestTypeDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestTypeDefs.td
@@ -470,4 +470,11 @@ def TestMemrefType : Test_Type<"TestMemref",
   }];
 }
 
+// Test implementation of an interface with methods specifying a
+// method body
+def TestBaseBody : Test_Type<"TestBaseBody",
+    [DeclareTypeInterfaceMethods<TestBaseTypeInterfacePrintTypeA>]> {
+  let mnemonic = "test_base_body";
+}
+
 #endif // TEST_TYPEDEFS

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -637,8 +637,10 @@ void DefGen::emitTraitMethods(const InterfaceTrait &trait) {
   for (auto &method : iface.getMethods()) {
     // Don't declare if the method has a body. Or if the method has a default
     // implementation and the def didn't request that it always be declared.
-    if (method.getBody() || (method.getDefaultImplementation() &&
-                             !alwaysDeclared.count(method.getName()))) {
+    if (method.getBody())
+      continue;
+    if (method.getDefaultImplementation() &&
+        !alwaysDeclared.count(method.getName())) {
       genTraitMethodUsingDecl(trait, method);
       continue;
     }


### PR DESCRIPTION
Since commit 842622bf8bea782e9d9865ed78b0d8643f098122 adding support for overloading interface methods, a `using` directive is emitted for any interface method that does not require emission of a trait method, including for methods that define a method body.

However, methods directly specifying a body (e.g., via the `methodBody` parameter of `InterfaceMethod`) are implemented directly in the interface class and are therefore not present in the associated trait. The generated `using` directive then referes to a non-existent method of the trait, resulting in an error upon compilation of the generated code.

This patch changes `DefGen::emitTraitMethods()`, such that `genTraitMethodUsingDecl()` is not invoked for interface methods with a body anymore.