### PR TITLE
[libc] Enable the FPU in Arm startup code

### DIFF
--- a/libc/startup/baremetal/arm/start.cpp
+++ b/libc/startup/baremetal/arm/start.cpp
@@ -134,12 +134,16 @@ namespace LIBC_NAMESPACE_DECL {
 #ifdef __ARM_FP
 // Enable FPU
 #if __ARM_ARCH_PROFILE == 'M'
+  // Based on
+  // https://developer.arm.com/documentation/dui0646/c/Cortex-M7-Peripherals/Floating-Point-Unit/Enabling-the-FPU
   // Set CPACR cp10 and cp11
   auto cpacr = (volatile uint32_t *const)0xE000ED88;
   *cpacr |= (0xF << 20);
   __dsb(0xF);
   __isb(0xF);
 #elif __ARM_ARCH_PROFILE == 'A' || __ARM_ARCH_PROFILE == 'R'
+  // Based on
+  // https://developer.arm.com/documentation/dui0472/m/Compiler-Coding-Practices/Enabling-NEON-and-FPU-for-bare-metal
   // Set CPACR cp10 and cp11
   uint32_t cpacr = __arm_rsr("p15:0:c1:c0:2");
   cpacr |= (0xF << 20);

--- a/libc/startup/baremetal/arm/start.cpp
+++ b/libc/startup/baremetal/arm/start.cpp
@@ -144,12 +144,12 @@ namespace LIBC_NAMESPACE_DECL {
   uint32_t cpacr = __arm_rsr("p15:0:c1:c0:2");
   cpacr |= (0xF << 20);
   __arm_wsr("p15:0:c1:c0:2", cpacr);
+  __isb(0xF);
   // Set FPEXC.EN
   uint32_t fpexc;
   __asm__ __volatile__("vmrs %0, FPEXC" : "=r"(fpexc) : :);
   fpexc |= (1 << 30);
   __asm__ __volatile__("vmsr FPEXC, %0" : : "r"(fpexc) :);
-  __isb(0xF);
 #endif
 #endif
 


### PR DESCRIPTION
This patch enables the FPU in Arm startup code, which is required to run tests on Arm configurations with hardware floating-point support.