### PR TITLE
[libc][math] Refactor the `math_errhandling` macro definition

### DIFF
--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -42,13 +42,35 @@
 #define FP_LLOGBNAN LONG_MAX
 #endif
 
-#if defined(__NVPTX__) || defined(__AMDGPU__) || defined(__FAST_MATH__)
-#define math_errhandling 0
-#elif defined(__NO_MATH_ERRNO__)
+// Math error handling. Target support is assumed to be existent unless
+// explicitly disabled.
+#if defined(__NVPTX__) || defined(__AMDGPU__) || defined(__FAST_MATH__) ||     \
+    defined(__NO_MATH_ERRNO__)
+#define __LIBC_SUPPORTS_MATH_ERRNO 0
+#else
+#define __LIBC_SUPPORTS_MATH_ERRNO 1
+#endif
+
+#if (defined(__arm__) || defined(_M_ARM) || defined(__thumb__) ||              \
+     defined(__aarch64__) || defined(_M_ARM64)) &&                             \
+    !defined(__ARM_FP)
+#define __LIBC_SUPPORTS_MATH_ERREXCEPT 0
+#else
+#define __LIBC_SUPPORTS_MATH_ERREXCEPT 1
+#endif
+
+#if __LIBC_SUPPORTS_MATH_ERRNO && __LIBC_SUPPORTS_MATH_ERREXCEPT
+#define math_errhandling (MATH_ERRNO | MATH_ERREXCEPT)
+#elif __LIBC_SUPPORTS_MATH_ERRNO
+#define math_errhandling (MATH_ERRNO)
+#elif __LIBC_SUPPORTS_MATH_ERREXCEPT
 #define math_errhandling (MATH_ERREXCEPT)
 #else
-#define math_errhandling (MATH_ERRNO | MATH_ERREXCEPT)
+#define math_errhandling 0
 #endif
+
+#undef __LIBC_SUPPORTS_MATH_ERRNO
+#undef __LIBC_SUPPORTS_MATH_ERREXCEPT
 
 // POSIX math constants
 // https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/math.h.html

--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -51,9 +51,9 @@
 #define __LIBC_SUPPORTS_MATH_ERRNO 1
 #endif
 
-#if (defined(__arm__) || defined(_M_ARM) || defined(__thumb__) ||              \
+#if defined(__FAST_MATH__) || ((defined(__arm__) || defined(_M_ARM) || defined(__thumb__) ||              \
      defined(__aarch64__) || defined(_M_ARM64)) &&                             \
-    !defined(__ARM_FP)
+    !defined(__ARM_FP))
 #define __LIBC_SUPPORTS_MATH_ERREXCEPT 0
 #else
 #define __LIBC_SUPPORTS_MATH_ERREXCEPT 1

--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -51,9 +51,10 @@
 #define __LIBC_SUPPORTS_MATH_ERRNO 1
 #endif
 
-#if defined(__FAST_MATH__) || ((defined(__arm__) || defined(_M_ARM) || defined(__thumb__) ||              \
-     defined(__aarch64__) || defined(_M_ARM64)) &&                             \
-    !defined(__ARM_FP))
+#if defined(__FAST_MATH__) ||                                                  \
+    ((defined(__arm__) || defined(_M_ARM) || defined(__thumb__) ||             \
+      defined(__aarch64__) || defined(_M_ARM64)) &&                            \
+     !defined(__ARM_FP))
 #define __LIBC_SUPPORTS_MATH_ERREXCEPT 0
 #else
 #define __LIBC_SUPPORTS_MATH_ERREXCEPT 1


### PR DESCRIPTION
This patch refactors the logic to define each component of the `math_errhandling` macro.

It assumes that math error handling is supported by the target and the C library unless otherwise disabled in the preprocessor logic.

In addition to the refactoring, the support for error handling via exceptions is explicitly disabled for Arm targets with no FPU, that is, where `__ARM_FP` is not defined. This is because LLVM libc does not provide a floating-point environment for Arm no-FP configurations (or at least one with support for FP exceptions).