### PR TITLE
Revert "Fix bazel build issue after #166157"

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -87,7 +87,6 @@ cc_library(
         "//lldb:TargetHeaders",
         "//lldb:Utility",
         "//llvm:Support",
-        "//clang:codegen",
     ],
 )
 


### PR DESCRIPTION
Reverts llvm/llvm-project#166358 as this was fixed by 51269e220da64637b780791a28fb187cbc36084d