### PR TITLE
[NFC] [Build Fix] Fix failing test case due to missing host arch.

### DIFF
--- a/clang/test/Driver/hip-spirv-translator-new-driver.c
+++ b/clang/test/Driver/hip-spirv-translator-new-driver.c
@@ -2,7 +2,7 @@
 // The input and output files cannot be the same.
 
 // RUN: %clang --offload-new-driver -### -save-temps -nogpuinc -nogpulib \
-// RUN: --offload-arch=amdgcnspirv -x hip %s 2>&1 \
+// RUN: --target=x86_64-unknown-linux-gnu --offload-arch=amdgcnspirv -x hip %s 2>&1 \
 // RUN: | FileCheck %s
 
 // CHECK-NOT: {{".*clang-linker-wrapper.*"}} {{.*}} "-o" "[[OUTPUT_FILE:.*.o]]" {{.*}}"[[OUTPUT_FILE]]"


### PR DESCRIPTION
This fixes a typo introduced in #165606 which makes the test case fail.