### PR TITLE
[NVPTX][Tests] Avoid writing test output to readonly dir

### DIFF
--- a/llvm/test/CodeGen/NVPTX/cmpxchg-unsupported-syncscope.err.ll
+++ b/llvm/test/CodeGen/NVPTX/cmpxchg-unsupported-syncscope.err.ll
@@ -1,4 +1,4 @@
-; RUN: not llc -mcpu=sm_100a -mtriple=nvptx64 -mattr=+ptx86 %s 2>&1 | FileCheck %s
+; RUN: not llc -mcpu=sm_100a -mtriple=nvptx64 -mattr=+ptx86 %s -o /dev/null 2>&1 | FileCheck %s
 
 ; Test that we get a clear error message when using an unsupported syncscope.
 


### PR DESCRIPTION
Omitting `-o /dev/null` may try to write output to the current dir, which may not have write permissions on some build systems.

This fixes the test added by #165737