### PR TITLE
[flang] Improve warning text

### DIFF
--- a/flang/lib/Evaluate/common.cpp
+++ b/flang/lib/Evaluate/common.cpp
@@ -16,25 +16,26 @@ namespace Fortran::evaluate {
 void FoldingContext::RealFlagWarnings(
     const RealFlags &flags, const char *operation) {
   static constexpr auto warning{common::UsageWarning::FoldingException};
+  if (!realFlagWarningContext_.empty()) {
+    // Override 'operation' with a string like
+    // "compilation-time evaluation of a call to '...'"
+    operation = realFlagWarningContext_.c_str();
+  }
   if (flags.test(RealFlag::Overflow)) {
-    Warn(warning, "overflow on %s%s"_warn_en_US, operation,
-        realFlagWarningContext_);
+    Warn(warning, "overflow on %s"_warn_en_US, operation);
   }
   if (flags.test(RealFlag::DivideByZero)) {
     if (std::strcmp(operation, "division") == 0) {
-      Warn(warning, "division by zero%s"_warn_en_US, realFlagWarningContext_);
+      Warn(warning, "division by zero"_warn_en_US);
     } else {
-      Warn(warning, "division by zero on %s%s"_warn_en_US, operation,
-          realFlagWarningContext_);
+      Warn(warning, "division by zero on %s"_warn_en_US, operation);
     }
   }
   if (flags.test(RealFlag::InvalidArgument)) {
-    Warn(warning, "invalid argument on %s%s"_warn_en_US, operation,
-        realFlagWarningContext_);
+    Warn(warning, "invalid argument on %s"_warn_en_US, operation);
   }
   if (flags.test(RealFlag::Underflow)) {
-    Warn(warning, "underflow on %s%s"_warn_en_US, operation,
-        realFlagWarningContext_);
+    Warn(warning, "underflow on %s"_warn_en_US, operation);
   }
 }
 

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -1052,7 +1052,7 @@ std::optional<HostRuntimeWrapper> GetHostRuntimeWrapper(const std::string &name,
                 .value());
       }
       auto restorer{context.SetRealFlagWarningContext(
-          " after folding a call to '"s + name + "'"s)};
+          "compilation-time evaluation of a call to '"s + name + "'"s)};
       return Fold(context,
           ConvertToType(
               resultType, hostFolderWithChecks(context, std::move(args)))

--- a/flang/test/Evaluate/folding33.f90
+++ b/flang/test/Evaluate/folding33.f90
@@ -1,4 +1,4 @@
 !RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
-!CHECK: warning: overflow on REAL(4) to REAL(2) conversion after folding a call to 'exp' [-Wfolding-exception]
+!CHECK: warning: overflow on compilation-time evaluation of a call to 'exp' [-Wfolding-exception]
 print *, exp((11.265625_2,1._2))
 end


### PR DESCRIPTION
When an overflow or other floating-point exception occurs at compilation time while folding a conversion of a math library call to a smaller type, don't confuse the user by mentioning the conversion; just note that the exception was noted while folding the intrinsic function.