### PR TITLE
[AIX] unsupport gcc triple test case on aix NFC

### DIFF
--- a/flang/test/Driver/gcc-triple.f90
+++ b/flang/test/Driver/gcc-triple.f90
@@ -1,4 +1,4 @@
-!! UNSUPPORTED: system-windows
+!! UNSUPPORTED: system-windows, system-aix
 
 !! Test that --gcc-triple option is working as expected.
 


### PR DESCRIPTION
This new test case breaks the buildbot starting https://lab.llvm.org/buildbot/#/builders/201/builds/6934. The corresponding clang test case sets the target triple to avoid failures. 