### PR TITLE
[AMDGPU][MC] Disallow nogds in ds_gws_* instructions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -5330,6 +5330,15 @@ bool AMDGPUAsmParser::validateDS(const MCInst &Inst,
 // DS_GWS opcodes must use even aligned registers.
 bool AMDGPUAsmParser::validateGWS(const MCInst &Inst,
                                   const OperandVector &Operands) {
+  // Disallow "nogds".
+  // In ds_gws_* instructions, gds is always the last operand.
+  auto GDSOprnd = static_cast<AMDGPUOperand &>(*Operands.back());
+  assert(GDSOprnd.isGDS());
+  if (GDSOprnd.getImm() == 0) {
+    Error(GDSOprnd.getStartLoc(), "nogds is not allowed");
+    return false;
+  }
+
   if (!getFeatureBits()[AMDGPU::FeatureGFX90AInsts])
     return true;
 

--- a/llvm/test/MC/AMDGPU/gfx10_asm_ds_err.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_ds_err.s
@@ -1,0 +1,38 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+
+ds_gws_sema_release_all nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_release_all offset:4660 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v0 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v0 offset:0 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v0 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v0 offset:4660 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p offset:0 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v0 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v0 offset:0 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed

--- a/llvm/test/MC/AMDGPU/gfx11_asm_ds_err.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_ds_err.s
@@ -1,0 +1,37 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+
+ds_gws_barrier v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_release_all nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_release_all offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed

--- a/llvm/test/MC/AMDGPU/gfx7_asm_ds_err.s
+++ b/llvm/test/MC/AMDGPU/gfx7_asm_ds_err.s
@@ -1,0 +1,37 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=bonaire %s 2>&1 | FileCheck --implicit-check-not=error: %s
+
+ds_gws_sema_release_all offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_release_all nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v255 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed

--- a/llvm/test/MC/AMDGPU/gfx8_asm_ds_err.s
+++ b/llvm/test/MC/AMDGPU/gfx8_asm_ds_err.s
@@ -1,0 +1,37 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=tonga %s 2>&1 | FileCheck --implicit-check-not=error: %s
+
+ds_gws_sema_release_all offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_release_all nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v255 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed

--- a/llvm/test/MC/AMDGPU/gfx9_asm_ds_err.s
+++ b/llvm/test/MC/AMDGPU/gfx9_asm_ds_err.s
@@ -1,0 +1,37 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx900 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+
+ds_gws_sema_release_all offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_release_all nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_init v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_v nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_br v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_sema_p nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v1 offset:65535 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed
+
+ds_gws_barrier v1 nogds
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: nogds is not allowed


### PR DESCRIPTION
The ds_gws_* instructions require gds as an operand. However, when nogds is given, it is treated the same as gds. This patch fixes this to disallow nogds.