### PR TITLE
[MISched][NFC] Rename isUnbufferedGroup to isReservedGroup

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -1038,7 +1038,7 @@ public:
   getNextResourceCycle(const MCSchedClassDesc *SC, unsigned PIdx,
                        unsigned ReleaseAtCycle, unsigned AcquireAtCycle);
 
-  bool isUnbufferedGroup(unsigned PIdx) const {
+  bool isReservedGroup(unsigned PIdx) const {
     return SchedModel->getProcResource(PIdx)->SubUnitsIdxBegin &&
            !SchedModel->getProcResource(PIdx)->BufferSize;
   }

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -2559,7 +2559,7 @@ init(ScheduleDAGMI *dag, const TargetSchedModel *smodel, SchedRemainder *rem) {
     for (unsigned i = 0; i < ResourceCount; ++i) {
       ReservedCyclesIndex[i] = NumUnits;
       NumUnits += SchedModel->getProcResource(i)->NumUnits;
-      if (isUnbufferedGroup(i)) {
+      if (isReservedGroup(i)) {
         auto SubUnits = SchedModel->getProcResource(i)->SubUnitsIdxBegin;
         for (unsigned U = 0, UE = SchedModel->getProcResource(i)->NumUnits;
              U != UE; ++U)
@@ -2631,7 +2631,7 @@ SchedBoundary::getNextResourceCycle(const MCSchedClassDesc *SC, unsigned PIdx,
   assert(NumberOfInstances > 0 &&
          "Cannot have zero instances of a ProcResource");
 
-  if (isUnbufferedGroup(PIdx)) {
+  if (isReservedGroup(PIdx)) {
     // If any subunits are used by the instruction, report that the
     // subunits of the resource group are available at the first cycle
     // in which the unit is available, effectively removing the group


### PR DESCRIPTION
In both ScheduleDAGInstrs and MachineScheduler, we call `BufferSize = 0` as _reserved_ and `BufferSize = 1` as _unbuffered_. This convention is stem from the fact that we set `SUnit::hasReservedResource` to true when any of the SUnit's consumed resources has BufferSize equal to zero; set `SUnit::isUnbuffered` to true when any of its consumed resources has BufferSize equal to one.

However, `SchedBoundary::isUnbufferedGroup` doesn't really follow this convention: it returns true when the resource in question is a `ProcResGroup` and its BufferSize equals to **zero** rather than one. This could be really confusing for the reader. This patch renames this function to `isReservedGroup` in aligned with the convention mentioned above.

NFC.