### PR TITLE
[BPF] Remove dead code related to __bpf_trap global var

### DIFF
--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -176,10 +176,6 @@ void BPFAsmPrinter::emitInstruction(const MachineInstr *MI) {
         if (const GlobalValue *GV = Op.getGlobal())
           if (GV->getName() == BPF_TRAP)
             SawTrapCall = true;
-      } else if (Op.isSymbol()) {
-        if (const MCSymbol *Sym = Op.getMCSymbol())
-          if (Sym->getName() == BPF_TRAP)
-            SawTrapCall = true;
       }
     }
   }


### PR DESCRIPTION
In [1], the symbol __bpf_trap (macro BPF_TRAP) is removed if it is not used in the code. In the discussion in [1], it is found that the branch "if (Op.isSymbol())" is actually always false. Remove it to avoid confusion.

  [1] https://github.com/llvm/llvm-project/pull/166003