### PR TITLE
[mlir] generate-test-checks.py does not remove blank lines

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -234,10 +234,18 @@ def process_source_lines(source_lines, note, args):
     source_split_re = re.compile(args.source_delim_regex)
 
     source_segments = [[]]
+    skip_next_empty_line = False
     for line in source_lines:
         # Remove previous note.
-        if line in note:
+        if line and line in note:
+            skip_next_empty_line = True
             continue
+        # Skip the first empty line after the note
+        if skip_next_empty_line and not line:
+            skip_next_empty_line = False
+            continue
+        if line:
+            skip_next_empty_line = False
         # Remove previous CHECK lines.
         if line.find(args.check_prefix) != -1:
             continue


### PR DESCRIPTION
When we generate test checks into the original test file (inplace), it was incorrectly removing empty lines.

I tested this by running

```
my-downstream-opt-tool file.mlir -mypass | python3 ~/llvm-project/mlir/utils/generate-test-checks.py --source file.mlir -i
```