### PR TITLE
[CodeCompletion] Consider header files without extension, if...

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -70,6 +70,9 @@ Hover
 Code completion
 ^^^^^^^^^^^^^^^
 
+- Now also provides include files without extension, if they are in a directory
+  only called ``include``.
+
 Code actions
 ^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -10372,7 +10372,8 @@ void SemaCodeCompletion::CodeCompleteIncludedFile(llvm::StringRef Dir,
     const StringRef &Dirname = llvm::sys::path::filename(Dir);
     const bool isQt = Dirname.starts_with("Qt") || Dirname == "ActiveQt";
     const bool ExtensionlessHeaders =
-        IsSystem || isQt || Dir.ends_with(".framework/Headers");
+        IsSystem || isQt || Dir.ends_with(".framework/Headers") ||
+        IncludeDir.ends_with("/include") || IncludeDir.ends_with("\\include");
     std::error_code EC;
     unsigned Count = 0;
     for (auto It = FS.dir_begin(Dir, EC);

--- a/clang/test/CodeCompletion/included-files.cpp
+++ b/clang/test/CodeCompletion/included-files.cpp
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir %t && cp %s %t/main.cc && mkdir %t/a && mkdir %t/QtCore && mkdir %t/Headers %t/Some.framework %t/Some.framework/Headers
+// RUN: rm -rf %t && mkdir %t && cp %s %t/main.cc && mkdir %t/a && mkdir %t/QtCore && mkdir %t/Headers %t/Some.framework %t/Some.framework/Headers %t/include %t/include/Headers
 // RUN: touch %t/foo.h %t/foo.hxx %t/foo.cc %t/a/foosys %t/a/foosys.h %t/QtCore/foosys %t/QtCore/foo.h
-// RUN: touch %t/Headers/foosys %t/Headers/foo.h %t/Some.framework/Headers/foosys %t/Some.framework/Headers/foo.h
+// RUN: touch %t/Headers/foosys %t/Headers/foo.h %t/Some.framework/Headers/foosys %t/Some.framework/Headers/foo.h %t/include/Headers/foosys
 
 // Quoted string shows header-ish files from CWD, and all from system.
 #include "foo.h"
@@ -56,3 +56,8 @@
 // CHECK-8-NOT: foo.cc>
 // CHECK-8: foo.h>
 // CHECK-8-NOT: foosys>
+
+// But simply naming a directory "include" is enough to allow extension-less headers.
+#include <Headers/foosys>
+// RUN: %clang -fsyntax-only -isystem %t/a -I %t/include -Xclang -code-completion-at=%t/main.cc:61:21 %t/main.cc -fms-compatibility | FileCheck -check-prefix=CHECK-9 %s
+// CHECK-9: foosys>


### PR DESCRIPTION
... the path passed to -I ends with /include.

I've brought it up, when the special handling for Qt was added (https://reviews.llvm.org/D112996#3349609) but got no feedback.