### PR TITLE
[BOLT][AArch64] Skip as many zeros as possible in padding validation

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1010,14 +1010,12 @@ bool BinaryContext::hasValidCodePadding(const BinaryFunction &BF) {
     return Offset - StartOffset;
   };
 
-  // Skip a sequence of zero bytes. For AArch64 we only skip 4 bytes of zeros
-  // in case the following zeros belong to constant island or veneer.
+  // Skip a sequence of zero bytes. For AArch64 we only skip 4's exact
+  // multiple number of zeros in case the following zeros belong to veneer.
   auto skipZeros = [&]() {
     const uint64_t StartOffset = Offset;
     uint64_t CurrentOffset = Offset;
-    for (; CurrentOffset < BF.getMaxSize() &&
-           (!isAArch64() || CurrentOffset < StartOffset + 4);
-         ++CurrentOffset)
+    for (; CurrentOffset < BF.getMaxSize(); ++CurrentOffset)
       if ((*FunctionData)[CurrentOffset] != 0)
         break;
 


### PR DESCRIPTION
We are skipping four zero's at a time when validating code padding in case that the next zero would be part of an instruction or constant island, and for functions that have large amount of padding (like due to hugify), this could be very slow. We now change the validation to skip as many as possible but still need to be 4's exact multiple number of zero's. No valid instruction has encoding as 0x00000000 and even if we stumble into some constant island, the API `BinaryFunction::isInConstantIsland()` has been made to find the size between the asked address and the end of island (#164037), so this should be safe.