### PR TITLE
[libc] Fix fprintf_test assuming specific errnos.

### DIFF
--- a/libc/test/src/stdio/fprintf_test.cpp
+++ b/libc/test/src/stdio/fprintf_test.cpp
@@ -83,7 +83,7 @@ TEST(LlvmLibcFPrintfTest, WriteToFile) {
   written =
       LIBC_NAMESPACE::fprintf(file, "Writing to a read only file should fail.");
   EXPECT_LT(written, 0);
-  ASSERT_ERRNO_EQ(EBADF);
+  ASSERT_ERRNO_FAILURE();
 
   ASSERT_EQ(printf_test::fclose(file), 0);
 }
@@ -100,7 +100,7 @@ TEST(LlvmLibcFPrintfTest, NullPtrCheck) {
   int ret =
       LIBC_NAMESPACE::fprintf(file, "hello %n", static_cast<int *>(nullptr));
   EXPECT_LT(ret, 0);
-  ASSERT_ERRNO_EQ(EINVAL);
+  ASSERT_ERRNO_FAILURE();
 
   ASSERT_EQ(printf_test::fclose(file), 0);
 }


### PR DESCRIPTION
The patch #166382 fixed most of these, but missed the fprintf_test ones.