### PR TITLE
AMDGPU: Add and clarify reserved address spaces

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -883,8 +883,9 @@ supported for the ``amdgcn`` target.
      Buffer Fat Pointer                    7               N/A         N/A              160     0
      Buffer Resource                       8               N/A         V#               128     0x00000000000000000000000000000000
      Buffer Strided Pointer (experimental) 9               *TODO*
-     *reserved for downstream use*         10
-     *reserved for downstream use*         11
+     *reserved for future use*             10
+     *reserved for future use*             11
+     *reserved for downstream use (LLPC)*  12
      Streamout Registers                   128             N/A         GS_REGS
      ===================================== =============== =========== ================ ======= ============================
 


### PR DESCRIPTION
Address spaces 10 and 11 are reserved for future use in the sense that we plain to upstream their use.

Address space 12 is used by LLPC. It is used in a workaround for an issue with SMEM accesses to PRT buffers that is specific to the LLPC ecosystem and makes no sense to upstream.

commit-id:707231b4