### PR TITLE
[libc++] Guard uses of `is_transparent` and `iterator_concept`

### DIFF
--- a/libcxx/include/__filesystem/path_iterator.h
+++ b/libcxx/include/__filesystem/path_iterator.h
@@ -37,7 +37,9 @@ public:
 
 public:
   typedef input_iterator_tag iterator_category;
-  typedef bidirectional_iterator_tag iterator_concept;
+#  if _LIBCPP_STD_VER >= 20
+  using iterator_concept = bidirectional_iterator_tag;
+#  endif
 
   typedef path value_type;
   typedef ptrdiff_t difference_type;

--- a/libcxx/include/__functional/identity.h
+++ b/libcxx/include/__functional/identity.h
@@ -30,7 +30,9 @@ struct __identity {
     return std::forward<_Tp>(__t);
   }
 
+#if _LIBCPP_STD_VER >= 14
   using is_transparent = void;
+#endif
 };
 
 template <>

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -351,16 +351,20 @@ struct iterator_traits<_Tp*> {
 template <class _Tp>
 using __iterator_category _LIBCPP_NODEBUG = typename _Tp::iterator_category;
 
+#if _LIBCPP_STD_VER >= 20
 template <class _Tp>
 using __iterator_concept _LIBCPP_NODEBUG = typename _Tp::iterator_concept;
+#endif
 
 template <class _Tp, class _Up>
 using __has_iterator_category_convertible_to _LIBCPP_NODEBUG =
     is_convertible<__detected_or_t<__nat, __iterator_category, iterator_traits<_Tp> >, _Up>;
 
+#if _LIBCPP_STD_VER >= 20
 template <class _Tp, class _Up>
 using __has_iterator_concept_convertible_to _LIBCPP_NODEBUG =
     is_convertible<__detected_or_t<__nat, __iterator_concept, _Tp>, _Up>;
+#endif
 
 template <class _Tp>
 using __has_input_iterator_category _LIBCPP_NODEBUG = __has_iterator_category_convertible_to<_Tp, input_iterator_tag>;


### PR DESCRIPTION
Before C++14/20, `is_transparent` and `iterator_concept` were not reserved at all respectively, and users might define them as macros.