### PR TITLE
[ADT] Add static_assert to llvm::to_address for function types

### DIFF
--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -142,7 +142,10 @@ struct identity // NOLINT(readability-identifier-naming)
 /// The std::pointer_traits<>::to_address(p) variations of these overloads has
 /// not been implemented.
 template <class Ptr> auto to_address(const Ptr &P) { return P.operator->(); }
-template <class T> constexpr T *to_address(T *P) { return P; }
+template <class T> constexpr T *to_address(T *P) {
+  static_assert(!std::is_function_v<T>);
+  return P;
+}
 
 //===----------------------------------------------------------------------===//
 //     Features from C++23


### PR DESCRIPTION
This patch aligns llvm::to_address with C++20 std::to_address by
adding a static_assert to prevent instantiation with function types.
The C++20 standard says that std::to_address is ill-formed on a
function type.
