### PR TITLE
[Hexagon] Remove redundant declarations (NFC)

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonQFPOptimizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonQFPOptimizer.cpp
@@ -104,13 +104,6 @@ const std::map<unsigned short, unsigned short> QFPInstMap{
     {Hexagon::V6_vmpy_qf32_sf, Hexagon::V6_vmpy_qf32}};
 } // namespace
 
-namespace llvm {
-
-FunctionPass *createHexagonQFPOptimizer();
-void initializeHexagonQFPOptimizerPass(PassRegistry &);
-
-} // namespace llvm
-
 namespace {
 
 struct HexagonQFPOptimizer : public MachineFunctionPass {


### PR DESCRIPTION
These two functions are decalred in Hexagon.h.

Identified with readability-redundant-declaration.
