### PR TITLE
[ORC][LibraryResolver] Fix ensureFilterBuilt assertion failure and concurrency issue.

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryResolver.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryResolver.cpp
@@ -226,19 +226,18 @@ void LibraryResolver::resolveSymbolsInLibrary(
           return EnumerateResult::Continue;
         },
         Opts);
-
-    if (DiscoveredSymbols.empty()) {
-      LLVM_DEBUG(dbgs() << "  No symbols and remove library : "
-                        << Lib.getFullPath() << "\n";);
-      LibMgr.removeLibrary(Lib.getFullPath());
-      return;
-    }
   };
 
   if (!Lib.hasFilter()) {
     LLVM_DEBUG(dbgs() << "Building filter for library: " << Lib.getFullPath()
                       << "\n";);
     enumerateSymbolsIfNeeded();
+    if (DiscoveredSymbols.empty()) {
+      LLVM_DEBUG(dbgs() << "  No symbols and remove library : "
+                        << Lib.getFullPath() << "\n";);
+      LibMgr.removeLibrary(Lib.getFullPath());
+      return;
+    }
     SmallVector<StringRef> SymbolVec;
     SymbolVec.reserve(DiscoveredSymbols.size());
     for (const auto &KV : DiscoveredSymbols)
@@ -288,8 +287,8 @@ void LibraryResolver::searchSymbolsInLibraries(
 
     SymbolSearchContext Ctx(Q);
     while (!Ctx.allResolved()) {
-
-      for (auto &Lib : LibMgr.getView(S, K)) {
+      auto Libs = LibMgr.getLibraries(S, K);
+      for (auto &Lib : Libs) {
         if (Ctx.hasSearched(Lib.get()))
           continue;
 

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryScanner.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryScanner.cpp
@@ -50,7 +50,7 @@ void handleError(Error Err, StringRef context = "") {
 }
 
 bool ObjectFileLoader::isArchitectureCompatible(const object::ObjectFile &Obj) {
-  Triple HostTriple(sys::getDefaultTargetTriple());
+  Triple HostTriple(sys::getProcessTriple());
   Triple ObjTriple = Obj.makeTriple();
 
   LLVM_DEBUG({


### PR DESCRIPTION
- Fixed architecture compatibility check.
Previously, we used `sys::getDefaultTriple()`, which caused issues on build bots
using cross-compilation. We now ensure that the target architecture where the
shared library (.so) is run or loaded matches the architecture it was built for.

- Fixed ensureFilterBuilt assertion failure.

- Replaced use of FilteredView with a safer alternative for concurrent environments.
The old FilteredView approach iterated over shared state without sufficient
synchronization, which could lead to invalid accesses when libraries were being
added or removed concurrently.