### PR TITLE
[NFC][CodeGen] Replace loop with "if !empty()"

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2368,9 +2368,8 @@ static QualType GeneralizeTransparentUnion(QualType Ty) {
   const RecordDecl *UD = UT->getDecl()->getDefinitionOrSelf();
   if (!UD->hasAttr<TransparentUnionAttr>())
     return Ty;
-  for (const auto *it : UD->fields()) {
-    return it->getType();
-  }
+  if (!UD->fields().empty())
+    return UD->fields().begin()->getType();
   return Ty;
 }
 


### PR DESCRIPTION
The loop iterates once and returns the first element.
Replace it with "if !empty()" to make it more explicit.

Follow up to https://github.com/llvm/llvm-project/pull/158193.
