### PR TITLE
[BasicTTI] Only split vectors with even element counts in getCastInstrCost

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -1333,6 +1333,11 @@ public:
           TargetLowering::TypeSplitVector;
       if ((SplitSrc || SplitDst) && SrcVTy->getElementCount().isVector() &&
           DstVTy->getElementCount().isVector()) {
+        auto SrcEltCnt = SrcVTy->getElementCount();
+        auto DstEltCnt = DstVTy->getElementCount();
+        if (!SrcEltCnt.isKnownEven() || !DstEltCnt.isKnownEven()) {
+            return InstructionCost::getInvalid();
+        }
         Type *SplitDstTy = VectorType::getHalfElementsVectorType(DstVTy);
         Type *SplitSrcTy = VectorType::getHalfElementsVectorType(SrcVTy);
         const T *TTI = thisT();

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -1331,13 +1331,8 @@ public:
       bool SplitDst =
           TLI->getTypeAction(Dst->getContext(), TLI->getValueType(DL, Dst)) ==
           TargetLowering::TypeSplitVector;
-      if ((SplitSrc || SplitDst) && SrcVTy->getElementCount().isVector() &&
-          DstVTy->getElementCount().isVector()) {
-        auto SrcEltCnt = SrcVTy->getElementCount();
-        auto DstEltCnt = DstVTy->getElementCount();
-        if (!SrcEltCnt.isKnownEven() || !DstEltCnt.isKnownEven()) {
-            return InstructionCost::getInvalid();
-        }
+      if ((SplitSrc || SplitDst) && SrcVTy->getElementCount().isKnownEven() &&
+          DstVTy->getElementCount().isKnownEven()) {
         Type *SplitDstTy = VectorType::getHalfElementsVectorType(DstVTy);
         Type *SplitSrcTy = VectorType::getHalfElementsVectorType(SrcVTy);
         const T *TTI = thisT();

--- a/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
@@ -1,11 +1,10 @@
-; RUN: opt -mtriple=aarch64-unknown-linux-gnu -passes=vector-combine %s -S -o - | FileCheck %s
+; RUN: opt -mtriple=aarch64-unknown-linux-gnu -mattr=+sve -passes=vector-combine %s -S -o - | FileCheck %s
 
 target triple = "aarch64-unknown-linux-gnu"
 
 define <vscale x 4 x i16> @interleave2_same_const_splat_nxv4i16() {
 ;CHECK-LABEL: @interleave2_same_const_splat_nxv4i16(
-;CHECK: call <vscale x 4 x i16> @llvm.vector.interleave2
-;CHECK: ret <vscale x 4 x i16> %retval
+;CHECK: ret <vscale x 4 x i16> bitcast (<vscale x 2 x i32> splat (i32 196611) to <vscale x 4 x i16>)
   %retval = call <vscale x 4 x i16> @llvm.vector.interleave2.nxv4i16(<vscale x 2 x i16> splat(i16 3), <vscale x 2 x i16> splat(i16 3))
   ret <vscale x 4 x i16> %retval
 }

--- a/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
@@ -1,10 +1,11 @@
-; RUN: opt -mtriple=aarch64-unknown-linux-gnu -mattr=+sve -passes=vector-combine %s -S -o - | FileCheck %s
+; RUN: opt -mtriple=aarch64-unknown-linux-gnu  -passes=vector-combine %s -S -o - | FileCheck %s
 
 target triple = "aarch64-unknown-linux-gnu"
 
 define <vscale x 4 x i16> @interleave2_same_const_splat_nxv4i16() {
 ;CHECK-LABEL: @interleave2_same_const_splat_nxv4i16(
-;CHECK: ret <vscale x 4 x i16> bitcast (<vscale x 2 x i32> splat (i32 196611) to <vscale x 4 x i16>)
+;CHECK: call <vscale x 4 x i16> @llvm.vector.interleave2
+;CHECK: ret <vscale x 4 x i16> %retval
   %retval = call <vscale x 4 x i16> @llvm.vector.interleave2.nxv4i16(<vscale x 2 x i16> splat(i16 3), <vscale x 2 x i16> splat(i16 3))
   ret <vscale x 4 x i16> %retval
 }

--- a/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
@@ -1,0 +1,11 @@
+; RUN: opt -mtriple=aarch64-unknown-linux-gnu -passes=vector-combine %s -S -o - | FileCheck %s
+
+target triple = "aarch64-unknown-linux-gnu"
+
+define <vscale x 4 x i16> @interleave2_same_const_splat_nxv4i16() {
+;CHECK-LABEL: @interleave2_same_const_splat_nxv4i16(
+;CHECK: call <vscale x 4 x i16> @llvm.vector.interleave2
+;CHECK: ret <vscale x 4 x i16> %retval
+  %retval = call <vscale x 4 x i16> @llvm.vector.interleave2.nxv4i16(<vscale x 2 x i16> splat(i16 3), <vscale x 2 x i16> splat(i16 3))
+  ret <vscale x 4 x i16> %retval
+}

--- a/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/sve-interleave-splat.ll
@@ -1,4 +1,4 @@
-; RUN: opt -mtriple=aarch64-unknown-linux-gnu  -passes=vector-combine %s -S -o - | FileCheck %s
+; RUN: opt -passes=vector-combine %s -S -o - | FileCheck %s
 
 target triple = "aarch64-unknown-linux-gnu"
 


### PR DESCRIPTION
Fixes #166320