### PR TITLE
[mlir] Expose output strategies of TimingManager

### DIFF
--- a/mlir/include/mlir/Support/Timing.h
+++ b/mlir/include/mlir/Support/Timing.h
@@ -477,8 +477,7 @@ void applyDefaultTimingManagerCLOptions(DefaultTimingManager &tm);
 /// be used in combination with DefaultTimingManager::setOutput() to use
 /// MLIR-provided output format.
 std::unique_ptr<OutputStrategy>
-createDefaultOutputStrategy(DefaultTimingManager::OutputFormat fmt,
-                            raw_ostream &os);
+createOutputStrategy(DefaultTimingManager::OutputFormat fmt, raw_ostream &os);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Support/Timing.h
+++ b/mlir/include/mlir/Support/Timing.h
@@ -473,9 +473,8 @@ void registerDefaultTimingManagerCLOptions();
 /// 'registerDefaultTimingManagerOptions' to a `DefaultTimingManager`.
 void applyDefaultTimingManagerCLOptions(DefaultTimingManager &tm);
 
-/// Return a default output strategy for the specified format. This function can
-/// be used in combination with DefaultTimingManager::setOutput() to use
-/// MLIR-provided output format.
+/// Create an output strategy for the specified format, to be passed to
+/// DefaultTimingManager::setOutput().
 std::unique_ptr<OutputStrategy>
 createOutputStrategy(DefaultTimingManager::OutputFormat fmt, raw_ostream &os);
 

--- a/mlir/include/mlir/Support/Timing.h
+++ b/mlir/include/mlir/Support/Timing.h
@@ -473,6 +473,13 @@ void registerDefaultTimingManagerCLOptions();
 /// 'registerDefaultTimingManagerOptions' to a `DefaultTimingManager`.
 void applyDefaultTimingManagerCLOptions(DefaultTimingManager &tm);
 
+/// Return a default output strategy for the specified format. This function can
+/// be used in combination with DefaultTimingManager::setOutput() to use
+/// MLIR-provided output format.
+std::unique_ptr<OutputStrategy>
+createDefaultOutputStrategy(DefaultTimingManager::OutputFormat fmt,
+                            raw_ostream &os);
+
 } // namespace mlir
 
 #endif // MLIR_SUPPORT_TIMING_H

--- a/mlir/lib/Support/Timing.cpp
+++ b/mlir/lib/Support/Timing.cpp
@@ -619,11 +619,18 @@ void mlir::applyDefaultTimingManagerCLOptions(DefaultTimingManager &tm) {
     return;
   tm.setEnabled(options->timing);
   tm.setDisplayMode(options->displayMode);
+  tm.setOutput(
+      createDefaultOutputStrategy(options->outputFormat, llvm::errs()));
+}
 
-  std::unique_ptr<OutputStrategy> printer;
-  if (options->outputFormat == OutputFormat::Text)
-    printer = std::make_unique<OutputTextStrategy>(llvm::errs());
-  else if (options->outputFormat == OutputFormat::Json)
-    printer = std::make_unique<OutputJsonStrategy>(llvm::errs());
-  tm.setOutput(std::move(printer));
+std::unique_ptr<OutputStrategy>
+mlir::createDefaultOutputStrategy(DefaultTimingManager::OutputFormat fmt,
+                                  raw_ostream &os) {
+  switch (fmt) {
+  case OutputFormat::Text:
+    return std::make_unique<OutputTextStrategy>(os);
+  case OutputFormat::Json:
+    return std::make_unique<OutputJsonStrategy>(os);
+  }
+  llvm_unreachable("Invalid output format");
 }

--- a/mlir/lib/Support/Timing.cpp
+++ b/mlir/lib/Support/Timing.cpp
@@ -619,13 +619,12 @@ void mlir::applyDefaultTimingManagerCLOptions(DefaultTimingManager &tm) {
     return;
   tm.setEnabled(options->timing);
   tm.setDisplayMode(options->displayMode);
-  tm.setOutput(
-      createDefaultOutputStrategy(options->outputFormat, llvm::errs()));
+  tm.setOutput(createOutputStrategy(options->outputFormat, llvm::errs()));
 }
 
 std::unique_ptr<OutputStrategy>
-mlir::createDefaultOutputStrategy(DefaultTimingManager::OutputFormat fmt,
-                                  raw_ostream &os) {
+mlir::createOutputStrategy(DefaultTimingManager::OutputFormat fmt,
+                           raw_ostream &os) {
   switch (fmt) {
   case OutputFormat::Text:
     return std::make_unique<OutputTextStrategy>(os);


### PR DESCRIPTION
After the original API change to DefaultTimingManager::setOutput() (see 362aa434cc31ccca96749a6db8cd97f5b7d71206), users are forced to provide their own implementation of OutputStrategy. However, default MLIR implementations are usually sufficient. Expose Text and Json strategies via factory-like method to avoid the problem in downstream projects.