### PR TITLE
[Polly] Check for ISL errors after schedule optimization

### DIFF
--- a/polly/lib/Transform/ScheduleOptimizer.cpp
+++ b/polly/lib/Transform/ScheduleOptimizer.cpp
@@ -927,8 +927,23 @@ static void runIslScheduleOptimizer(
     walkScheduleTreeForStatistics(Schedule, 2);
   }
 
+  // Check for why any computation could have failed
   if (MaxOpGuard.hasQuotaExceeded()) {
     POLLY_DEBUG(dbgs() << "Schedule optimizer calculation exceeds ISL quota\n");
+    return;
+  } else if (isl_ctx_last_error(Ctx) != isl_error_none) {
+    const char *File = isl_ctx_last_error_file(Ctx);
+    int Line = isl_ctx_last_error_line(Ctx);
+    const char *Msg = isl_ctx_last_error_msg(Ctx);
+    POLLY_DEBUG(
+        dbgs()
+        << "ISL reported an error during the computation of a new schedule at "
+        << File << ":" << Line << ": " << Msg);
+    isl_ctx_reset_error(Ctx);
+    return;
+  } else if (Schedule.is_null()) {
+    POLLY_DEBUG(dbgs() << "Schedule optimizer did not compute a new schedule "
+                          "for unknown reasons\n");
     return;
   }
 


### PR DESCRIPTION
When ISL encounters an internal error, it sets the error flag, but it is not isl_error_quota that was already checked. Check for general errors and abort the schedule optimization if that happens, instead of continuing on the "good" path.

The error occured when compiling llvm-test-suite's MultiSource/Applications/JM/lencod/leaky_bucket.c with Polly enabled. Not adding a test case because it depends on ISL internals. We do not want to a test case to depend on which version of ISL is used.