### PR TITLE
[NFC][CUDA][HIP] Print the triple when there's no mcpu

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1058,7 +1058,11 @@ void CompilerInstance::printDiagnosticStats() {
       if (!getLangOpts().CUDAIsDevice) {
         OS << " when compiling for host";
       } else {
-        OS << " when compiling for " << getTargetOpts().CPU;
+        OS << " when compiling for ";
+        if (getTargetOpts().CPU.empty())
+          OS << getTarget().getTriple().str();//"SPIR-V";
+        else
+          OS << getTargetOpts().CPU;
       }
     }
     OS << ".\n";

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1058,11 +1058,9 @@ void CompilerInstance::printDiagnosticStats() {
       if (!getLangOpts().CUDAIsDevice) {
         OS << " when compiling for host";
       } else {
-        OS << " when compiling for ";
-        if (getTargetOpts().CPU.empty())
-          OS << getTarget().getTriple().str();//"SPIR-V";
-        else
-          OS << getTargetOpts().CPU;
+        OS << " when compiling for "
+           << (!getTargetOpts().CPU.empty() ? getTargetOpts().CPU
+                                            : getTarget().getTriple().str());
       }
     }
     OS << ".\n";

--- a/clang/test/SemaCUDA/error-includes-mode.cu
+++ b/clang/test/SemaCUDA/error-includes-mode.cu
@@ -1,7 +1,16 @@
 // RUN: not %clang_cc1 -fsyntax-only %s 2>&1 | FileCheck --check-prefix HOST %s
 // RUN: not %clang_cc1 -triple nvptx-unknown-unknown -target-cpu sm_35 \
 // RUN:   -fcuda-is-device -fsyntax-only %s 2>&1 | FileCheck --check-prefix SM35 %s
+// RUN: not %clang_cc1 -triple spirv64-unknown-unknown \
+// RUN:   -fcuda-is-device -fsyntax-only %s 2>&1 | FileCheck --check-prefix SPIRV %s
+// RUN: not %clang_cc1 -triple spirv64-amd-amdhsa \
+// RUN:   -fcuda-is-device -fsyntax-only %s 2>&1 | FileCheck --check-prefix AMDGCNSPIRV %s
+// RUN: not %clang_cc1 -triple spirv64-intel-unknown \
+// RUN:   -fcuda-is-device -fsyntax-only %s 2>&1 | FileCheck --check-prefix INTELSPIRV %s
 
 // HOST: 1 error generated when compiling for host
 // SM35: 1 error generated when compiling for sm_35
+// SPIRV: 1 error generated when compiling for spirv64-unknown-unknown
+// AMDGCNSPIRV: 1 error generated when compiling for spirv64-amd-amdhsa
+// INTELSPIRV: 1 error generated when compiling for spirv64-intel-unknown
 error;


### PR DESCRIPTION
It is possible to run into situations where no mcpu is specified for an offload device side compilation. Currently, this'd lead to a rather uninformative blank being presented as the target for a failing compilation, when messaging the error count. This patch changes things so that if there is no `-mcpu` we print the triple, which is slightly more helpful, especially when there are multiple offload targets for a single compilation.