### PR TITLE
[libcxxabi][demangle] Fix the cp-to-llvm.sh sync script to copy all headers

### DIFF
--- a/libcxxabi/src/demangle/cp-to-llvm.sh
+++ b/libcxxabi/src/demangle/cp-to-llvm.sh
@@ -42,6 +42,7 @@ copy_files() {
     chmod -w $dst/README.txt
 
     for I in $hdrs ; do
+	    echo "Copying ${src}/$I to ${dst}/$I"
 	    rm -f $dst/$I
 	    dash=$(echo "$I---------------------------" | cut -c -27 |\
 		       sed 's|[^-]*||')
@@ -53,6 +54,6 @@ copy_files() {
 }
 
 if [[ $ANSWER =~ ^[Yy]$ ]]; then
-    copy_files . $LLVM_DEMANGLE_DIR $HDRS
-    copy_files ../../test $LLVM_TESTING_DIR $TEST_HDRS
+    copy_files . $LLVM_DEMANGLE_DIR "${HDRS}"
+    copy_files ../../test $LLVM_TESTING_DIR "${TEST_HDRS}"
 fi


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/137947 I refactored the script and added a `copy_files` function, which takes the header files to copy as an argument.

But because the list of headers is a space separated string, we need to quote the string. Otherwise we would just copy the first header in the list.

This patch also adds an `echo` statement in the `copy_files` loop to print the source/destination. Confirming that the files are copied as expected.
```
$ libcxxabi/src/demangle/cp-to-llvm.sh
This will overwrite the copies of ItaniumDemangle.h ItaniumNodes.def StringViewExtras.h Utility.h in ../../../llvm/include/llvm/Demangle and DemangleTestCases.inc in ../../../llvm/include/llvm/Demangle/../Testing/Demangle; are you sure? [y/N]y
Copying ./ItaniumDemangle.h to ../../../llvm/include/llvm/Demangle/ItaniumDemangle.h
Copying ./ItaniumNodes.def to ../../../llvm/include/llvm/Demangle/ItaniumNodes.def
Copying ./StringViewExtras.h to ../../../llvm/include/llvm/Demangle/StringViewExtras.h
Copying ./Utility.h to ../../../llvm/include/llvm/Demangle/Utility.h
Copying ../../test/DemangleTestCases.inc to ../../../llvm/include/llvm/Demangle/../Testing/Demangle/DemangleTestCases.inc
```

Luckily there weren't any out-of-sync changes introduced in the meantime.