### PR TITLE
[Flang][OpenMP] Add Lowering support for lastprivate in taskloops

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -342,7 +342,8 @@ void DataSharingProcessor::insertLastPrivateCompare(mlir::Operation *op) {
   if (!hasLastPrivate)
     return;
 
-  if (mlir::isa<mlir::omp::WsloopOp>(op) || mlir::isa<mlir::omp::SimdOp>(op)) {
+  if (mlir::isa<mlir::omp::WsloopOp>(op) || mlir::isa<mlir::omp::SimdOp>(op) ||
+      mlir::isa<mlir::omp::TaskloopOp>(op)) {
     mlir::omp::LoopRelatedClauseOps result;
     llvm::SmallVector<const semantics::Symbol *> iv;
     collectLoopRelatedInfo(converter, converter.getCurrentLocation(), eval,
@@ -408,7 +409,7 @@ void DataSharingProcessor::insertLastPrivateCompare(mlir::Operation *op) {
   } else {
     TODO(converter.getCurrentLocation(),
          "lastprivate clause in constructs other than "
-         "simd/worksharing-loop");
+         "simd/worksharing-loop/taskloop");
   }
 }
 

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1775,9 +1775,9 @@ static void genTaskloopClauses(lower::AbstractConverter &converter,
 
   cp.processTODO<clause::Allocate, clause::Collapse, clause::Default,
                  clause::Final, clause::If, clause::InReduction,
-                 clause::Lastprivate, clause::Mergeable, clause::Nogroup,
-                 clause::Priority, clause::Reduction, clause::Shared,
-                 clause::Untied>(loc, llvm::omp::Directive::OMPD_taskloop);
+                 clause::Mergeable, clause::Nogroup, clause::Priority,
+                 clause::Reduction, clause::Shared, clause::Untied>(
+      loc, llvm::omp::Directive::OMPD_taskloop);
 }
 
 static void genTaskwaitClauses(lower::AbstractConverter &converter,

--- a/flang/test/Lower/OpenMP/taskloop-lastprivate.f90
+++ b/flang/test/Lower/OpenMP/taskloop-lastprivate.f90
@@ -1,0 +1,25 @@
+! Test the lastprivate clause when used with the taskloop construct
+! RUN: bbc -emit-hlfir -fopenmp -fopenmp-version=45 %s -o - 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=45 %s -o - 2>&1 | FileCheck %s
+
+! CHECK-LABEL: omp.private
+! CHECK-SAME: {type = private} @[[I_PRIVATE:.*]] : i32
+! CHECK-LABEL: omp.private
+! CHECK-SAME: {type = private} @[[LAST_I_PRIVATE:.*]] : i32
+
+! CHECK: %[[ALLOCA_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFlastprivateEi"}
+! CHECK: %[[DECLARE_I:.*]]:2 = hlfir.declare %[[ALLOCA_I]] {uniq_name = "_QFlastprivateEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[ALLOCA_LAST_I:.*]] = fir.alloca i32 {bindc_name = "last_i", uniq_name = "_QFlastprivateElast_i"}
+! CHECK: %[[DECLARE_LAST_I:.*]]:2 = hlfir.declare %[[ALLOCA_LAST_I]] {uniq_name = "_QFlastprivateElast_i"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+
+subroutine lastprivate()
+   integer :: i, last_i
+
+   ! CHECK: omp.taskloop
+   ! CHECK-SAME: private(@[[LAST_I_PRIVATE]] %[[DECLARE_LAST_I]]#0 -> %arg0, @[[I_PRIVATE]] %[[DECLARE_I]]#0 -> %arg1 : !fir.ref<i32>, !fir.ref<i32>) {
+   !$omp taskloop lastprivate(last_i)
+   do i=1,10
+       last_i = i
+   end do
+   !$omp end taskloop
+end


### PR DESCRIPTION
lastprivate support already exists within the DataSharingProcessor,
so this can be extended to include the use of taskloops to enable
AST->FIR lowering. The related error message has also been updated
to indicate that taskloops are now supported.