### PR TITLE
[MsDemangle] Use NodeList over SmallVector for target names

### DIFF
--- a/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -15,8 +15,6 @@
 
 #include "llvm/Demangle/MicrosoftDemangle.h"
 
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Demangle/DemangleConfig.h"
 #include "llvm/Demangle/MicrosoftDemangleNodes.h"
@@ -279,13 +277,16 @@ demanglePointerCVQualifiers(std::string_view &MangledName) {
   DEMANGLE_UNREACHABLE;
 }
 
-static NodeArrayNode *smallVecToNodeArray(ArenaAllocator &Arena,
-                                          ArrayRef<Node *> Vec) {
-  NodeArrayNode *Arr = Arena.alloc<NodeArrayNode>();
-  Arr->Count = Vec.size();
-  Arr->Nodes = Arena.allocArray<Node *>(Vec.size());
-  std::memcpy(Arr->Nodes, Vec.data(), Vec.size() * sizeof(Node *));
-  return Arr;
+static NodeArrayNode *nodeListToNodeArray(ArenaAllocator &Arena, NodeList *Head,
+                                          size_t Count) {
+  NodeArrayNode *N = Arena.alloc<NodeArrayNode>();
+  N->Count = Count;
+  N->Nodes = Arena.allocArray<Node *>(Count);
+  for (size_t I = 0; I < Count; ++I) {
+    N->Nodes[I] = Head->N;
+    Head = Head->Next;
+  }
+  return N;
 }
 
 std::string_view Demangler::copyString(std::string_view Borrowed) {
@@ -335,17 +336,28 @@ Demangler::demangleSpecialTableSymbolNode(std::string_view &MangledName,
 
   std::tie(STSN->Quals, IsMember) = demangleQualifiers(MangledName);
 
-  SmallVector<Node *, 1> TargetNames;
+  NodeList *TargetCurrent = nullptr;
+  NodeList *TargetHead = nullptr;
+  size_t Count = 0;
   while (!consumeFront(MangledName, '@')) {
+    ++Count;
+
+    NodeList *Next = Arena.alloc<NodeList>();
+    if (TargetCurrent)
+      TargetCurrent->Next = Next;
+    else
+      TargetHead = Next;
+
+    TargetCurrent = Next;
     QualifiedNameNode *QN = demangleFullyQualifiedTypeName(MangledName);
     if (Error)
       return nullptr;
     assert(QN);
-    TargetNames.push_back(QN);
+    TargetCurrent->N = QN;
   }
 
-  if (!TargetNames.empty())
-    STSN->TargetNames = smallVecToNodeArray(Arena, TargetNames);
+  if (Count > 0)
+    STSN->TargetNames = nodeListToNodeArray(Arena, TargetHead, Count);
 
   return STSN;
 }
@@ -1625,18 +1637,6 @@ Demangler::demangleNameScopePiece(std::string_view &MangledName) {
     return demangleLocallyScopedNamePiece(MangledName);
 
   return demangleSimpleName(MangledName, /*Memorize=*/true);
-}
-
-static NodeArrayNode *nodeListToNodeArray(ArenaAllocator &Arena, NodeList *Head,
-                                          size_t Count) {
-  NodeArrayNode *N = Arena.alloc<NodeArrayNode>();
-  N->Count = Count;
-  N->Nodes = Arena.allocArray<Node *>(Count);
-  for (size_t I = 0; I < Count; ++I) {
-    N->Nodes[I] = Head->N;
-    Head = Head->Next;
-  }
-  return N;
 }
 
 QualifiedNameNode *


### PR DESCRIPTION
Using `SmallVector` would introduce a dependency cycle (see https://github.com/llvm/llvm-project/pull/155630#discussion_r2495268497), so this uses a NodeList.