### PR TITLE
[ProfCheck][NFC] fix argument order for call to setExplicitlyUnknownBranchWeightsIfProfiled

### DIFF
--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -1691,7 +1691,7 @@ Value *AtomicExpandImpl::insertRMWCmpXchgLoop(
   // Atomic RMW expands to a cmpxchg loop, Since precise branch weights
   // cannot be easily determined here, we mark the branch as "unknown" (50/50)
   // to prevent misleading optimizations.
-  setExplicitlyUnknownBranchWeightsIfProfiled(*CondBr, *F, DEBUG_TYPE);
+  setExplicitlyUnknownBranchWeightsIfProfiled(*CondBr, DEBUG_TYPE, F);
 
   Builder.SetInsertPoint(ExitBB, ExitBB->begin());
   return NewLoaded;

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -1691,7 +1691,7 @@ Value *AtomicExpandImpl::insertRMWCmpXchgLoop(
   // Atomic RMW expands to a cmpxchg loop, Since precise branch weights
   // cannot be easily determined here, we mark the branch as "unknown" (50/50)
   // to prevent misleading optimizations.
-  setExplicitlyUnknownBranchWeightsIfProfiled(*CondBr, DEBUG_TYPE, F);
+  setExplicitlyUnknownBranchWeightsIfProfiled(*CondBr, DEBUG_TYPE);
 
   Builder.SetInsertPoint(ExitBB, ExitBB->begin());
   return NewLoaded;


### PR DESCRIPTION
- fix argument order for call to setExplicitlyUnknownBranchWeightsIfProfiled
