### PR TITLE
[flang][OpenMP] Detect complex part designators in atomic variables

### DIFF
--- a/flang/lib/Semantics/check-omp-atomic.cpp
+++ b/flang/lib/Semantics/check-omp-atomic.cpp
@@ -590,9 +590,11 @@ void OmpStructureChecker::CheckAtomicVariable(
 
   CheckAtomicType(syms.back(), source, atom.AsFortran(), checkTypeOnPointer);
 
-  if (IsAllocatable(syms.back()) && !IsArrayElement(atom)) {
-    context_.Say(source, "Atomic variable %s cannot be ALLOCATABLE"_err_en_US,
-        atom.AsFortran());
+  if (!IsArrayElement(atom) && !ExtractComplexPart(atom)) {
+    if (IsAllocatable(syms.back())) {
+      context_.Say(source, "Atomic variable %s cannot be ALLOCATABLE"_err_en_US,
+          atom.AsFortran());
+    }
   }
 }
 

--- a/flang/test/Lower/OpenMP/atomic-update-capture-complex-part.f90
+++ b/flang/test/Lower/OpenMP/atomic-update-capture-complex-part.f90
@@ -1,0 +1,17 @@
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
+
+! Check that this compiles successfully.
+
+!CHECK: omp.atomic.capture
+!CHECK: omp.atomic.read
+!CHECK: omp.atomic.update
+subroutine f00
+  implicit none
+  real :: c
+  complex, allocatable :: x
+  !$omp atomic update capture
+    c = x%re
+    x%re = x%re + 1.0
+  !$omp end atomic
+end
+


### PR DESCRIPTION
Complex part designators do not have their own symbols. A symbol obtained for the expression `x%re` will be the symbol for `x`, and in this case x is allowed to be allocatable.

Fixes https://github.com/llvm/llvm-project/issues/166278.