### PR TITLE
[DebugInfo] Fix line 0 records incorrectly having is_stmt set

### DIFF
--- a/llvm/test/DebugInfo/X86/line-0-no-is-stmt.ll
+++ b/llvm/test/DebugInfo/X86/line-0-no-is-stmt.ll
@@ -1,0 +1,33 @@
+; Test that line 0 records don't have is_stmt set
+; This tests the fix for LLVM issue #33870 (Bugzilla #34522)
+;
+; When scopeLine is 0, the initial location directive should not have is_stmt set.
+
+; RUN: %llc_dwarf -mtriple=x86_64-unknown-linux -O0 -filetype=obj < %s | llvm-dwarfdump --debug-line - | FileCheck %s
+
+; The line table entry for line 0 should exist but not have "is_stmt" in its Flags
+; CHECK: Address
+; CHECK: 0x{{[0-9a-f]+}} 0 0
+; CHECK-NOT: is_stmt
+; CHECK: end_sequence
+
+define void @foo() !dbg !6 {
+entry:
+  ret void, !dbg !9
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.c", directory: "/tmp")
+!2 = !{i32 2, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{}
+; scopeLine is 0 (line 0 should not have is_stmt)
+!6 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 10, type: !7, scopeLine: 0, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !5)
+!7 = !DISubroutineType(types: !8)
+!8 = !{null}
+; Line 0 location (should not have is_stmt)
+!9 = !DILocation(line: 0, column: 0, scope: !6)

--- a/llvm/test/DebugInfo/X86/line-nonzero-has-is-stmt.ll
+++ b/llvm/test/DebugInfo/X86/line-nonzero-has-is-stmt.ll
@@ -1,0 +1,30 @@
+; Test that non-zero line records DO have is_stmt set
+; This is for comparison with line 0 behavior (issue #33870 / Bugzilla #34522)
+;
+; When scopeLine is non-zero, the initial location directive should have is_stmt set.
+
+; RUN: %llc_dwarf -mtriple=x86_64-unknown-linux -O0 -filetype=obj < %s | llvm-dwarfdump --debug-line - | FileCheck %s
+
+; With scopeLine=10, we should see line 10 with is_stmt and prologue_end
+; CHECK: 0x{{[0-9a-f]+}} 10 {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} is_stmt prologue_end
+
+define void @bar() !dbg !6 {
+entry:
+  ret void, !dbg !9
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.c", directory: "/tmp")
+!2 = !{i32 2, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{}
+; scopeLine is 10 (non-zero line should have is_stmt)
+!6 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 10, type: !7, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !5)
+!7 = !DISubroutineType(types: !8)
+!8 = !{null}
+; Line 10 location (should have is_stmt)
+!9 = !DILocation(line: 10, column: 5, scope: !6)


### PR DESCRIPTION
Fixes issue #33870

Line 0 debug records should not have the is_stmt flag set in DWARF. This change ensures is_stmt is only set for non-zero line numbers.

Changes made in DwarfDebug.cpp:
- beginInstruction: Only set is_stmt for prologue_end if line != 0
- beginInstruction: Only set is_stmt for key instructions if line != 0
- emitInitialLocDirective: Set is_stmt=0 if scopeLine == 0

Test results: All 576 X86 DebugInfo tests pass.