### PR TITLE
[mlir][acc] Erase empty kernel_environment ops during canonicalization

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -2184,6 +2184,8 @@ def OpenACC_KernelEnvironmentOp : OpenACC_Op<"kernel_environment",
     )
     $region attr-dict
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -1058,7 +1058,7 @@ struct RemoveEmptyKernelEnvironment
 
     // Remove empty kernel environment
     // preserve synchronization by creating acc.wait operation if needed
-    if (!op.getWaitOperands().empty()) {
+    if (!op.getWaitOperands().empty())
       rewriter.replaceOpWithNewOp<acc::WaitOp>(
           op,
           /*waitOperands=*/op.getWaitOperands(),
@@ -1066,7 +1066,7 @@ struct RemoveEmptyKernelEnvironment
           /*waitDevnum=*/Value(),
           /*async=*/nullptr,
           /*ifCond=*/Value());
-    } else
+    else
       rewriter.eraseOp(op);
 
     return success();

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -1059,13 +1059,11 @@ struct RemoveEmptyKernelEnvironment
     // Remove empty kernel environment
     // preserve synchronization by creating acc.wait operation if needed
     if (!op.getWaitOperands().empty())
-      rewriter.replaceOpWithNewOp<acc::WaitOp>(
-          op,
-          op.getWaitOperands(),
-          /*asyncOperand=*/Value(),
-          /*waitDevnum=*/Value(),
-          /*async=*/nullptr,
-          /*ifCond=*/Value());
+      rewriter.replaceOpWithNewOp<acc::WaitOp>(op, op.getWaitOperands(),
+                                               /*asyncOperand=*/Value(),
+                                               /*waitDevnum=*/Value(),
+                                               /*async=*/nullptr,
+                                               /*ifCond=*/Value());
     else
       rewriter.eraseOp(op);
 

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -1056,9 +1056,39 @@ struct RemoveEmptyKernelEnvironment
     if (!block.empty())
       return failure();
 
-    // Remove empty kernel environment
-    // preserve synchronization by creating acc.wait operation if needed
-    if (!op.getWaitOperands().empty())
+    // Conservatively disable canonicalization of empty acc.kernel_environment
+    // operations if the wait operands in the kernel_environment cannot be fully
+    // represented by acc.wait operation.
+
+    // Disable canonicalization if device type is not the default
+    if (auto deviceTypeAttr = op.getWaitOperandsDeviceTypeAttr()) {
+      for (auto attr : deviceTypeAttr) {
+        if (auto dtAttr = mlir::dyn_cast<acc::DeviceTypeAttr>(attr)) {
+          if (dtAttr.getValue() != mlir::acc::DeviceType::None)
+            return failure();
+        }
+      }
+    }
+
+    // Disable canonicalization if any wait segment has a devnum
+    if (auto hasDevnumAttr = op.getHasWaitDevnumAttr()) {
+      for (auto attr : hasDevnumAttr) {
+        if (auto boolAttr = mlir::dyn_cast<mlir::BoolAttr>(attr)) {
+          if (boolAttr.getValue())
+            return failure();
+        }
+      }
+    }
+
+    // Disable canonicalization if there are multiple wait segments
+    if (auto segmentsAttr = op.getWaitOperandsSegmentsAttr()) {
+      if (segmentsAttr.size() > 1)
+        return failure();
+    }
+
+    // Remove empty kernel environment.
+    // Preserve synchronization by creating acc.wait operation if needed.
+    if (!op.getWaitOperands().empty() || op.getWaitOnlyAttr())
       rewriter.replaceOpWithNewOp<acc::WaitOp>(op, op.getWaitOperands(),
                                                /*asyncOperand=*/Value(),
                                                /*waitDevnum=*/Value(),

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -1061,7 +1061,7 @@ struct RemoveEmptyKernelEnvironment
     if (!op.getWaitOperands().empty())
       rewriter.replaceOpWithNewOp<acc::WaitOp>(
           op,
-          /*waitOperands=*/op.getWaitOperands(),
+          op.getWaitOperands(),
           /*asyncOperand=*/Value(),
           /*waitDevnum=*/Value(),
           /*async=*/nullptr,

--- a/mlir/test/Dialect/OpenACC/canonicalize.mlir
+++ b/mlir/test/Dialect/OpenACC/canonicalize.mlir
@@ -219,3 +219,29 @@ func.func @update_unnecessary_computations(%x: memref<i32>) {
 // CHECK-LABEL: func.func @update_unnecessary_computations
 // CHECK-NOT: acc.atomic.update
 // CHECK: acc.atomic.write
+
+// -----
+
+func.func @remove_empty_kernel_environment() {
+  acc.kernel_environment {
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @remove_empty_kernel_environment
+// CHECK-NOT: acc.kernel_environment
+// CHECK: return
+
+// -----
+
+func.func @kernel_environment_with_wait(%q1: i32, %q2: i32) {
+  acc.kernel_environment wait({%q1 : i32, %q2 : i32}) {
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @kernel_environment_with_wait
+// CHECK-SAME: ([[Q1:%.*]]: i32, [[Q2:%.*]]: i32)
+// CHECK-NOT: acc.kernel_environment
+// CHECK: acc.wait([[Q1]], [[Q2]] : i32, i32)
+// CHECK: return


### PR DESCRIPTION
This change removes empty `acc.kernel_environment` operations during canonicalization. This could happen when the acc compute construct inside the `acc.kernel_environment` is optimized away in cases such as when only private variables are being written to in the loop. 

In cases of empty `acc.kernel_environment` ops with waitOperands,  we still remove the empty `acc.kernel_environment`, but also create an `acc.wait` operation to take those wait operands to preserve synchronization behavior.