### PR TITLE
[LLDB] Fix debuginfo ELF files overwriting Unified Section List

### DIFF
--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -96,8 +96,8 @@ public:
   /// information.
   uint64_t GetDebugInfoSize() const;
 
-  // Callback to decide of two matching sections should be used in the merged
-  // output.
+  // Callback to decide which of two matching sections should be used in the
+  // merged output.
   using MergeCallback =
       std::function<lldb::SectionSP(lldb::SectionSP, lldb::SectionSP)>;
 

--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -96,6 +96,17 @@ public:
   /// information.
   uint64_t GetDebugInfoSize() const;
 
+  // Callback to decide of two matching sections should be used in the merged
+  // output.
+  using MergeCallback =
+      std::function<lldb::SectionSP(lldb::SectionSP, lldb::SectionSP)>;
+
+  // Function that merges two different sections into a new output list. All
+  // unique sections will be checked for conflict and resolved using the
+  // supplied merging callback.
+  static std::shared_ptr<SectionList> Merge(SectionList &lhs, SectionList &rhs,
+                                            MergeCallback filter);
+
 protected:
   collection m_sections;
 };

--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -46,6 +46,8 @@ public:
   /// Create an empty list.
   SectionList() = default;
 
+  SectionList(const SectionList &lhs);
+
   SectionList &operator=(const SectionList &rhs);
 
   size_t AddSection(const lldb::SectionSP &section_sp);
@@ -104,8 +106,8 @@ public:
   // Function that merges two different sections into a new output list. All
   // unique sections will be checked for conflict and resolved using the
   // supplied merging callback.
-  static std::shared_ptr<SectionList> Merge(SectionList &lhs, SectionList &rhs,
-                                            MergeCallback filter);
+  static SectionList Merge(SectionList &lhs, SectionList &rhs,
+                           MergeCallback filter);
 
 protected:
   collection m_sections;

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -683,13 +683,14 @@ uint64_t SectionList::GetDebugInfoSize() const {
   return debug_info_size;
 }
 
-std::shared_ptr<SectionList> SectionList::Merge(SectionList &lhs, SectionList &rhs, MergeCallback filter) {
+std::shared_ptr<SectionList>
+SectionList::Merge(SectionList &lhs, SectionList &rhs, MergeCallback filter) {
   std::shared_ptr<SectionList> output_sp = std::make_shared<SectionList>();
 
   // Iterate through all the sections in lhs and see if we have matches in
   // the rhs list.
   for (const auto &lhs_section : lhs) {
-    auto rhs_section = rhs.FindSectionByType(lhs_section->GetType(), true);
+    auto rhs_section = rhs.FindSectionByID(lhs_section->GetID());
     if (rhs_section)
       output_sp->AddSection(filter(lhs_section, rhs_section));
     else
@@ -697,9 +698,9 @@ std::shared_ptr<SectionList> SectionList::Merge(SectionList &lhs, SectionList &r
   }
 
   // Now that we've visited all possible duplicates, we can iterate over
-  // the rhs and take any values not in lhs. 
+  // the rhs and take any values not in lhs.
   for (const auto &rhs_section : rhs) {
-    auto lhs_section  = lhs.FindSectionByType(rhs_section->GetType(), true);
+    auto lhs_section = lhs.FindSectionByID(rhs_section->GetID());
     // Because we already visited everything overlapping between rhs
     // and lhs, any section not in lhs is unique and can be output.
     if (!lhs_section)

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -691,10 +691,9 @@ SectionList::Merge(SectionList &lhs, SectionList &rhs, MergeCallback filter) {
   // the rhs list.
   for (const auto &lhs_section : lhs) {
     auto rhs_section = rhs.FindSectionByName(lhs_section->GetName());
-    if (rhs_section) {
-      assert(lhs_section->GetName() == rhs_section->GetName());
+    if (rhs_section)
       output_sp->AddSection(filter(lhs_section, rhs_section));
-    } else
+    else
       output_sp->AddSection(lhs_section);
   }
 

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -690,17 +690,18 @@ SectionList::Merge(SectionList &lhs, SectionList &rhs, MergeCallback filter) {
   // Iterate through all the sections in lhs and see if we have matches in
   // the rhs list.
   for (const auto &lhs_section : lhs) {
-    auto rhs_section = rhs.FindSectionByID(lhs_section->GetID());
-    if (rhs_section)
+    auto rhs_section = rhs.FindSectionByName(lhs_section->GetName());
+    if (rhs_section) {
+      assert(lhs_section->GetName() == rhs_section->GetName());
       output_sp->AddSection(filter(lhs_section, rhs_section));
-    else
+    } else
       output_sp->AddSection(lhs_section);
   }
 
   // Now that we've visited all possible duplicates, we can iterate over
   // the rhs and take any values not in lhs.
   for (const auto &rhs_section : rhs) {
-    auto lhs_section = lhs.FindSectionByID(rhs_section->GetID());
+    auto lhs_section = lhs.FindSectionByName(rhs_section->GetName());
     // Because we already visited everything overlapping between rhs
     // and lhs, any section not in lhs is unique and can be output.
     if (!lhs_section)

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -683,6 +683,32 @@ uint64_t SectionList::GetDebugInfoSize() const {
   return debug_info_size;
 }
 
+std::shared_ptr<SectionList> SectionList::Merge(SectionList &lhs, SectionList &rhs, MergeCallback filter) {
+  std::shared_ptr<SectionList> output_sp = std::make_shared<SectionList>();
+
+  // Iterate through all the sections in lhs and see if we have matches in
+  // the rhs list.
+  for (const auto &lhs_section : lhs) {
+    auto rhs_section = rhs.FindSectionByType(lhs_section->GetType(), true);
+    if (rhs_section)
+      output_sp->AddSection(filter(lhs_section, rhs_section));
+    else
+      output_sp->AddSection(lhs_section);
+  }
+
+  // Now that we've visited all possible duplicates, we can iterate over
+  // the rhs and take any values not in lhs. 
+  for (const auto &rhs_section : rhs) {
+    auto lhs_section  = lhs.FindSectionByType(rhs_section->GetType(), true);
+    // Because we already visited everything overlapping between rhs
+    // and lhs, any section not in lhs is unique and can be output.
+    if (!lhs_section)
+      output_sp->AddSection(rhs_section);
+  }
+
+  return output_sp;
+}
+
 namespace llvm {
 namespace json {
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -151,7 +151,7 @@ lldb::SectionSP MergeSections(lldb::SectionSP lhs, lldb::SectionSP rhs) {
   // We want to take the greater of two sections. If LHS and RHS are both
   // SHT_NOBITS, we should default to LHS. If RHS has a bigger section,
   // indicating it has data that wasn't stripped, we should take that instead.
-  return lhs->GetFileSize() > rhs->GetFileSize() ? lhs : rhs;
+  return rhs->GetFileSize() > lhs->GetFileSize() ? rhs : lhs;
 }
 } // end anonymous namespace
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -142,6 +142,7 @@ lldb::SectionSP MergeSections(lldb::SectionSP lhs, lldb::SectionSP rhs) {
   lldb::ModuleSP lhs_module_parent = lhs->GetModule();
   lldb::ModuleSP rhs_module_parent = rhs->GetModule();
   assert(lhs_module_parent && rhs_module_parent);
+
   // Now that we're taking the lhs, we should do some sanity checks to warn the
   // user if this debuginfo/dwp looks invalid. However if RHS is SHT_NO_BITS
   // we want to ignore the size comparison.

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -1992,9 +1992,8 @@ void ObjectFileELF::CreateSections(SectionList &unified_section_list) {
 
   // Merge the two adding any new sections, and overwriting any existing
   // sections that are SHT_NOBITS
-  std::shared_ptr<SectionList> merged_section_list =
+  unified_section_list =
       SectionList::Merge(unified_section_list, *m_sections_up, MergeSections);
-  unified_section_list = *merged_section_list;
 
   // If there's a .gnu_debugdata section, we'll try to read the .symtab that's
   // embedded in there and replace the one in the original object file (if any).

--- a/lldb/test/API/python_api/module_section/Makefile
+++ b/lldb/test/API/python_api/module_section/Makefile
@@ -1,8 +1,6 @@
 CFLAGS_EXTRAS := -D__STDC_LIMIT_MACROS
 ENABLE_THREADS := YES
-CXX_SOURCES := main.cpp
+CXX_SOURCES := main.cpp b.cpp c.cpp
 MAKE_DSYM :=NO
-
-
 
 include Makefile.rules

--- a/lldb/test/API/python_api/module_section/Makefile
+++ b/lldb/test/API/python_api/module_section/Makefile
@@ -1,6 +1,8 @@
 CFLAGS_EXTRAS := -D__STDC_LIMIT_MACROS
 ENABLE_THREADS := YES
-CXX_SOURCES := main.cpp b.cpp c.cpp
+CXX_SOURCES := main.cpp
 MAKE_DSYM :=NO
+
+
 
 include Makefile.rules

--- a/lldb/test/API/python_api/unified_section_list/Makefile
+++ b/lldb/test/API/python_api/unified_section_list/Makefile
@@ -1,0 +1,5 @@
+CXX_SOURCES := main.cpp
+
+SPLIT_DEBUG_SYMBOLS := YES
+
+include Makefile.rules

--- a/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
+++ b/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
@@ -49,3 +49,184 @@ class ModuleUnifiedSectionList(TestBase):
         debug_info_section = main_exe_module.FindSection(".debug_info")
         self.assertTrue(debug_info_section.IsValid())
         self.assertGreater(debug_info_section.file_size, 0)
+
+    def test_unified_section_list_overwrite_larger_section(self):
+        """
+        Test the merging of an ELF file with another ELF File where all the new sections are bigger, validating we
+        overwrite .comment from SHT_NOBITS to the new SHT_PROGBITS section and the smaller .text with the larger
+        .text
+        """
+        exe = self.getBuildArtifact("a.out")
+        self.yaml2obj("main.yaml", exe)
+
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        main_exe_module = target.GetModuleAtIndex(0)
+
+        # First we verify out .text section is the expected BEC0FFEE
+        text_before_merge = main_exe_module.FindSection(".text")
+        self.assertTrue(text_before_merge.IsValid())
+        error = lldb.SBError()
+        section_content = text_before_merge.data.ReadRawData(
+            error, 0, text_before_merge.data.size
+        )
+        self.assertTrue(error.Success())
+        self.assertEqual(section_content, bytes.fromhex("BEC0FFEE"))
+
+        # .comment in main.yaml should be SHT_NOBITS, and size 0
+        comment_before_merge = main_exe_module.FindSection(".comment")
+        self.assertTrue(comment_before_merge.IsValid())
+        self.assertEqual(comment_before_merge.data.size, 0)
+
+        # yamlize the main.largertext.yaml and force symbol loading
+        debug_info = self.getBuildArtifact("a.out.debug")
+        self.yaml2obj("main.largertext.yaml", debug_info)
+
+        ci = self.dbg.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(f"target symbols add {debug_info}", res)
+        self.assertTrue(res.Succeeded())
+
+        # verify we took the larger .text section
+        main_exe_module_after_merge = target.GetModuleAtIndex(0)
+        text_after_merge = main_exe_module_after_merge.FindSection(".text")
+        self.assertTrue(text_after_merge.IsValid())
+        self.assertGreater(text_after_merge.data.size, text_before_merge.data.size)
+        section_content_after_merge = text_after_merge.data.ReadRawData(
+            error, 0, text_after_merge.data.size
+        )
+        self.assertTrue(error.Success())
+        self.assertEqual(section_content_after_merge, bytes.fromhex("BEC0FFEEEEFF0CEB"))
+
+        # in main.largertext.yaml comment is not SHT_NOBITS, and so we should see
+        # the size > 0 and equal to BAADF00D
+        comment_after_merge = main_exe_module_after_merge.FindSection(".comment")
+        self.assertTrue(comment_after_merge.IsValid())
+        comment_content_after_merge = comment_after_merge.data.ReadRawData(
+            error, 0, comment_after_merge.data.size
+        )
+
+        self.assertTrue(error.Success())
+        self.assertEqual(comment_content_after_merge, bytes.fromhex("BAADF00D"))
+
+    def test_unified_section_list_overwrite_smaller_section(self):
+        """
+        Test the merging of an ELF file with another ELF File where all the existing sections are bigger, validating we don't
+        overwrite with the SHT_NOBITS for .comment or the smaller .text section.
+        """
+        exe = self.getBuildArtifact("a.out")
+        self.yaml2obj("main.largertext.yaml", exe)
+
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        main_exe_module = target.GetModuleAtIndex(0)
+
+        # Same as above test but inverse, verify our larger .text section
+        # is the expected BEC0FFEE palindrome
+        text_before_merge = main_exe_module.FindSection(".text")
+        self.assertTrue(text_before_merge.IsValid())
+        error = lldb.SBError()
+        section_content = text_before_merge.data.ReadRawData(
+            error, 0, text_before_merge.data.size
+        )
+        self.assertTrue(error.Success())
+        self.assertEqual(section_content, bytes.fromhex("BEC0FFEEEEFF0CEB"))
+
+        # Comment is SHT_PROGBITS on the larger yaml and should remain
+        # the same after merge.
+        comment_before_merge = main_exe_module.FindSection(".comment")
+        self.assertTrue(comment_before_merge.IsValid())
+        comment_content = comment_before_merge.data.ReadRawData(
+            error, 0, comment_before_merge.data.size
+        )
+
+        self.assertTrue(error.Success())
+        self.assertEqual(comment_content, bytes.fromhex("BAADF00D"))
+
+        debug_info = self.getBuildArtifact("a.out.debug")
+        self.yaml2obj("main.yaml", debug_info)
+
+        ci = self.dbg.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(f"target symbols add {debug_info}", res)
+        self.assertTrue(res.Succeeded())
+
+        # Verify we didn't replace the sections after merge.s
+        main_exe_module_after_merge = target.GetModuleAtIndex(0)
+        text_after_merge = main_exe_module_after_merge.FindSection(".text")
+        self.assertTrue(text_after_merge.IsValid())
+        self.assertEqual(text_after_merge.data.size, text_before_merge.data.size)
+        section_content_after_merge = text_after_merge.data.ReadRawData(
+            error, 0, text_after_merge.data.size
+        )
+        self.assertTrue(error.Success())
+        self.assertEqual(section_content_after_merge, bytes.fromhex("BEC0FFEEEEFF0CEB"))
+
+        comment_after_merge = main_exe_module_after_merge.FindSection(".comment")
+        self.assertTrue(comment_after_merge.IsValid())
+        comment_content_after_merge = comment_after_merge.data.ReadRawData(
+            error, 0, comment_after_merge.data.size
+        )
+
+        self.assertTrue(error.Success())
+        self.assertEqual(comment_content_after_merge, bytes.fromhex("BAADF00D"))
+
+    def test_unified_section_list_overwrite_mixed_merge(self):
+        """
+        Test the merging of an ELF file with another ELF File where the lhs has a larger .comment section
+        and the RHS has a larger .text section.
+        """
+        exe = self.getBuildArtifact("a.out")
+        self.yaml2obj("main.largercomment.yaml", exe)
+
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        main_exe_module = target.GetModuleAtIndex(0)
+
+        # Verify we have the expected smaller BEC0FFEE
+        text_before_merge = main_exe_module.FindSection(".text")
+        self.assertTrue(text_before_merge.IsValid())
+        error = lldb.SBError()
+        section_content = text_before_merge.data.ReadRawData(
+            error, 0, text_before_merge.data.size
+        )
+        self.assertTrue(error.Success())
+        self.assertEqual(section_content, bytes.fromhex("BEC0FFEE"))
+
+        # Verify we have the larger palindromic comment
+        comment_before_merge = main_exe_module.FindSection(".comment")
+        self.assertTrue(comment_before_merge.IsValid())
+        comment_content = comment_before_merge.data.ReadRawData(
+            error, 0, comment_before_merge.data.size
+        )
+
+        self.assertTrue(error.Success())
+        self.assertEqual(comment_content, bytes.fromhex("BAADF00DF00DBAAD"))
+
+        debug_info = self.getBuildArtifact("a.out.debug")
+        self.yaml2obj("main.largertext.yaml", debug_info)
+
+        ci = self.dbg.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(f"target symbols add {debug_info}", res)
+        self.assertTrue(res.Succeeded())
+
+        # Verify we replaced .text
+        main_exe_module_after_merge = target.GetModuleAtIndex(0)
+        text_after_merge = main_exe_module_after_merge.FindSection(".text")
+        self.assertTrue(text_after_merge.IsValid())
+        section_content_after_merge = text_after_merge.data.ReadRawData(
+            error, 0, text_after_merge.data.size
+        )
+        self.assertTrue(error.Success())
+        self.assertEqual(section_content_after_merge, bytes.fromhex("BEC0FFEEEEFF0CEB"))
+
+        # Verify .comment is still the same.
+        comment_after_merge = main_exe_module_after_merge.FindSection(".comment")
+        self.assertTrue(comment_after_merge.IsValid())
+        comment_content_after_merge = comment_after_merge.data.ReadRawData(
+            error, 0, comment_after_merge.data.size
+        )
+
+        self.assertTrue(error.Success())
+        self.assertEqual(comment_content_after_merge, bytes.fromhex("BAADF00DF00DBAAD"))

--- a/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
+++ b/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
@@ -12,7 +12,6 @@ from lldbsuite.test.lldbutil import symbol_type_to_str
 
 
 class ModuleUnifiedSectionList(TestBase):
-
     @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     def test_unified_section_list(self):
         self.build()

--- a/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
+++ b/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
@@ -1,0 +1,50 @@
+"""
+Test Unified Section List merging.
+"""
+
+import os
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+from lldbsuite.test.lldbutil import symbol_type_to_str
+
+
+class ModuleUnifiedSectionList(TestBase):
+    def test_unified_section_list(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        debug_info = self.getBuildArtifact("a.out.debug")
+        new_dir = os.path.join(os.path.dirname(debug_info), "new_dir")
+        os.mkdir(new_dir)
+        renamed_debug_info = os.path.join(new_dir, "renamed.debug")
+        os.rename(debug_info, renamed_debug_info)
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        self.assertGreater(target.GetNumModules(), 0)
+
+        main_exe_module = target.GetModuleAtIndex(0)
+        eh_frame = main_exe_module.FindSection(".eh_frame")
+        self.assertTrue(eh_frame.IsValid())
+        self.assertGreater(eh_frame.size, 0)
+
+        # Should be stripped in main executable.
+        debug_info_section = main_exe_module.FindSection(".debug_info")
+        self.assertFalse(debug_info_section.IsValid())
+
+        ci = self.dbg.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(f"target symbols add {renamed_debug_info}", res)
+        self.assertTrue(res.Succeeded())
+
+        # Should be stripped in .debuginfo but be present in main executable.
+        main_exe_module = target.GetModuleAtIndex(0)
+        eh_frame = main_exe_module.FindSection(".eh_frame")
+        self.assertTrue(eh_frame.IsValid())
+        self.assertGreater(eh_frame.size, 0)
+
+        # Should be unified and both sections should have contents.
+        debug_info_section = main_exe_module.FindSection(".debug_info")
+        self.assertTrue(debug_info_section.IsValid())
+        self.assertGreater(debug_info_section.file_size, 0)

--- a/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
+++ b/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
@@ -12,6 +12,8 @@ from lldbsuite.test.lldbutil import symbol_type_to_str
 
 
 class ModuleUnifiedSectionList(TestBase):
+
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     def test_unified_section_list(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/python_api/unified_section_list/main.cpp
+++ b/lldb/test/API/python_api/unified_section_list/main.cpp
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello World\n");
+}

--- a/lldb/test/API/python_api/unified_section_list/main.cpp
+++ b/lldb/test/API/python_api/unified_section_list/main.cpp
@@ -1,5 +1,3 @@
 #include <stdio.h>
 
-int main() {
-  printf("Hello World\n");
-}
+int main() { printf("Hello World\n"); }

--- a/lldb/test/API/python_api/unified_section_list/main.largercomment.yaml
+++ b/lldb/test/API/python_api/unified_section_list/main.largercomment.yaml
@@ -1,0 +1,46 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1040
+ProgramHeaders:
+  - Type:            PT_PHDR
+    Flags:           [ PF_R ]
+    VAddr:           0x40
+    Align:           0x8
+    Offset:          0x40
+  - Type:            PT_LOAD
+    Flags:           [ PF_R ]
+    FirstSec:        .text
+    LastSec:         .fini
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1040
+    AddressAlign:    0x10
+    Content:         BEC0FFEE
+  - Name:            .fini
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1140
+    AddressAlign:    0x4
+    Content:         DEADBEEF
+  - Name:            .comment
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x3140
+    AddressAlign:    0x4
+    Content:         BAADF00DF00DBAAD
+Symbols:
+  - Name:            main
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x1130
+    Size:            0xF
+...

--- a/lldb/test/API/python_api/unified_section_list/main.largertext.yaml
+++ b/lldb/test/API/python_api/unified_section_list/main.largertext.yaml
@@ -1,0 +1,46 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1040
+ProgramHeaders:
+  - Type:            PT_PHDR
+    Flags:           [ PF_R ]
+    VAddr:           0x40
+    Align:           0x8
+    Offset:          0x40
+  - Type:            PT_LOAD
+    Flags:           [ PF_R ]
+    FirstSec:        .text
+    LastSec:         .fini
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1040
+    AddressAlign:    0x10
+    Content:         BEC0FFEEEEFF0CEB
+  - Name:            .fini
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1140
+    AddressAlign:    0x4
+    Content:         DEADBEEF
+  - Name:            .comment
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x3140
+    AddressAlign:    0x4
+    Content:         BAADF00D
+Symbols:
+  - Name:            main
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x1130
+    Size:            0xF
+...

--- a/lldb/test/API/python_api/unified_section_list/main.reversedtext.yaml
+++ b/lldb/test/API/python_api/unified_section_list/main.reversedtext.yaml
@@ -1,0 +1,45 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1040
+ProgramHeaders:
+  - Type:            PT_PHDR
+    Flags:           [ PF_R ]
+    VAddr:           0x40
+    Align:           0x8
+    Offset:          0x40
+  - Type:            PT_LOAD
+    Flags:           [ PF_R ]
+    FirstSec:        .text
+    LastSec:         .fini
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1040
+    AddressAlign:    0x10
+    Content:         BEC0FFEE
+  - Name:            .fini
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1140
+    AddressAlign:    0x4
+    Content:         DEADBEEF
+  - Name:            .comment
+    Type:            SHT_NOBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x3140
+    AddressAlign:    0x4
+Symbols:
+  - Name:            main
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x1130
+    Size:            0xF
+...

--- a/lldb/test/API/python_api/unified_section_list/main.yaml
+++ b/lldb/test/API/python_api/unified_section_list/main.yaml
@@ -1,0 +1,45 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1040
+ProgramHeaders:
+  - Type:            PT_PHDR
+    Flags:           [ PF_R ]
+    VAddr:           0x40
+    Align:           0x8
+    Offset:          0x40
+  - Type:            PT_LOAD
+    Flags:           [ PF_R ]
+    FirstSec:        .text
+    LastSec:         .fini
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1040
+    AddressAlign:    0x10
+    Content:         BEC0FFEE
+  - Name:            .fini
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1140
+    AddressAlign:    0x4
+    Content:         DEADBEEF
+  - Name:            .comment
+    Type:            SHT_NOBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x3140
+    AddressAlign:    0x4
+Symbols:
+  - Name:            main
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x1130
+    Size:            0xF
+...


### PR DESCRIPTION
Recently I've been deep diving ELF cores in LLDB, aspiring to move LLDB closer to GDB in capability. One issue I encountered was a system lib losing it's unwind plan when loading the debuginfo. The reason for this was the debuginfo has the eh_frame section stripped and the main executable did not.

The root cause of this was this line in [ObjectFileElf](https://github.com/llvm/llvm-project/blob/163933e9e7099f352ff8df1973f9a9c3d7def6c5/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp#L1972)
```
  // For eTypeDebugInfo files, the Symbol Vendor will take care of updating the
  // unified section list.
  if (GetType() != eTypeDebugInfo)
    unified_section_list = *m_sections_up;
```

This would always be executed because CalculateType can never return an eTypeDebugInfo
```
ObjectFile::Type ObjectFileELF::CalculateType() {
  switch (m_header.e_type) {
  case llvm::ELF::ET_NONE:
    // 0 - No file type
    return eTypeUnknown;

  case llvm::ELF::ET_REL:
    // 1 - Relocatable file
    return eTypeObjectFile;

  case llvm::ELF::ET_EXEC:
    // 2 - Executable file
    return eTypeExecutable;

  case llvm::ELF::ET_DYN:
    // 3 - Shared object file
    return eTypeSharedLibrary;

  case ET_CORE:
    // 4 - Core file
    return eTypeCoreFile;

  default:
    break;
  }
  return eTypeUnknown;
}
```

This makes sense as there isn't a explicit sh_type to denote that this file is a debuginfo. After some discussion with @clayborg and @GeorgeHuyubo we settled on joining the exciting unified section list with whatever new sections were being added. Adding each new unique section, or taking the section with the maximum file size. We picked this strategy to pick the section with the most information. In most scenarios, LHS should be SHT_NOBITS and RHS would be SHT_PROGBITS.

Here is a diagram documenting the existing vs proposed new way.
<img width="1666" height="1093" alt="image" src="https://github.com/user-attachments/assets/73ba9620-c737-439e-9934-ac350d88a3b5" />
