### PR TITLE
[clang] Unify -mspeculative-load-hardening as a benign compiler option

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -454,7 +454,7 @@ LANGOPT(BranchTargetEnforcement, 1, 0, NotCompatible, "Branch-target enforcement
 LANGOPT(BranchProtectionPAuthLR, 1, 0, NotCompatible, "Use PC as a diversifier using PAuthLR NOP instructions.")
 LANGOPT(GuardedControlStack, 1, 0, NotCompatible, "Guarded control stack enabled")
 
-LANGOPT(SpeculativeLoadHardening, 1, 0, NotCompatible, "Speculative load hardening enabled")
+LANGOPT(SpeculativeLoadHardening, 1, 0, Benign, "Speculative load hardening enabled")
 
 LANGOPT(RelativeCXXABIVTables, 1, 0, NotCompatible,
         "Use an ABI-incompatible v-table layout that uses relative references")

--- a/clang/test/ClangScanDeps/strip-codegen-args.m
+++ b/clang/test/ClangScanDeps/strip-codegen-args.m
@@ -16,6 +16,7 @@
 // CHECK-NOT:          "-flto"
 // CHECK-NOT:          "-fno-autolink"
 // CHECK-NOT:          "-mrelax-relocations=no"
+// CHECK-NOT:          "-mspeculative-load-hardening"
 // CHECK:            ]
 // CHECK:            "name": "A"
 // CHECK:          }
@@ -38,6 +39,11 @@
     "directory": "DIR",
     "command": "clang -Imodules/A -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -O2 -flto=full -fsyntax-only DIR/t3.m",
     "file": "DIR/t2.m"
+  }
+  {
+    "directory": "DIR",
+    "command": "clang -Imodules/A -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -O2 -mspeculative-load-hardening -fsyntax-only DIR/t3.m",
+    "file": "DIR/t3.m"
   }
 ]
 


### PR DESCRIPTION
Before this patch, compilations using modules &
`-mspeculative-load-hardening` failed because it was not consistent whether this option impacts module compatibility.

This repairs it by always treating it as benign. This was determined by checking if the option enables any kind of preprocessor checks and comparing how the compiler handles a similar option that impacts codegen (-fvisibility=hidden) but is more widely used.

resolves: rdar://163985667