### PR TITLE
[AIX] Enable libc++ bots on AIX

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -103,7 +103,6 @@ steps:
       queue: libcxx-builders
       os: aix
     <<: *common
-    skip: "https://github.com/llvm/llvm-project/issues/162516"
 
   - label: AIX (64-bit)
     command: libcxx/utils/ci/run-buildbot aix
@@ -115,7 +114,6 @@ steps:
       queue: libcxx-builders
       os: aix
     <<: *common
-    skip: "https://github.com/llvm/llvm-project/issues/162516"
 
 - group: ':freebsd: FreeBSD'
   steps:


### PR DESCRIPTION
Removing skip after confirming builds pass locally.  Upgraded workers to clang 20

Fixes #162516
