### PR TITLE
Revert "[libc] Return errno from OFD failure paths in fcntl."

### DIFF
--- a/libc/src/__support/OSUtil/linux/fcntl.cpp
+++ b/libc/src/__support/OSUtil/linux/fcntl.cpp
@@ -66,7 +66,7 @@ ErrorOr<int> fcntl(int fd, int cmd, void *arg) {
         LIBC_NAMESPACE::syscall_impl<int>(FCNTL_SYSCALL_ID, fd, cmd, &flk64);
     // On failure, return
     if (ret < 0)
-      return Error(-ret);
+      return Error(-1);
     // Check for overflow, i.e. the offsets are not the same when cast
     // to off_t from off64_t.
     if (static_cast<off_t>(flk64.l_len) != flk64.l_len ||

--- a/libc/test/src/fcntl/fcntl_test.cpp
+++ b/libc/test/src/fcntl/fcntl_test.cpp
@@ -94,99 +94,78 @@ TEST_F(LlvmLibcFcntlTest, FcntlSetFl) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 }
 
-/* Tests that are common between OFD and traditional variants of fcntl locks. */
-template <int GETLK_CMD, int SETLK_CMD>
-class LibcFcntlCommonLockTests : public LlvmLibcFcntlTest {
-public:
-  void GetLkRead() {
-    using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-    constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getlkread.test";
-    const auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
+TEST_F(LlvmLibcFcntlTest, FcntlGetLkRead) {
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+  constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getlkread.test";
+  auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
 
-    struct flock flk = {};
-    struct flock svflk = {};
-    int retVal;
-    int fd =
-        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDONLY, S_IRWXU);
-    ASSERT_ERRNO_SUCCESS();
-    ASSERT_GT(fd, 0);
+  struct flock flk, svflk;
+  int retVal;
+  int fd =
+      LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDONLY, S_IRWXU);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(fd, 0);
 
-    flk.l_type = F_RDLCK;
-    flk.l_start = 0;
-    flk.l_whence = SEEK_SET;
-    flk.l_len = 50;
+  flk.l_type = F_RDLCK;
+  flk.l_start = 0;
+  flk.l_whence = SEEK_SET;
+  flk.l_len = 50;
 
-    // copy flk into svflk
-    svflk = flk;
+  // copy flk into svflk
+  svflk = flk;
 
-    retVal = LIBC_NAMESPACE::fcntl(fd, GETLK_CMD, &svflk);
-    ASSERT_ERRNO_SUCCESS();
-    ASSERT_GT(retVal, -1);
-    ASSERT_NE((int)svflk.l_type, F_WRLCK); // File should not be write locked.
+  retVal = LIBC_NAMESPACE::fcntl(fd, F_GETLK, &svflk);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(retVal, -1);
+  ASSERT_NE((int)flk.l_type, F_WRLCK); // File should not be write locked.
 
-    retVal = LIBC_NAMESPACE::fcntl(fd, SETLK_CMD, &svflk);
-    ASSERT_ERRNO_SUCCESS();
-    ASSERT_GT(retVal, -1);
+  retVal = LIBC_NAMESPACE::fcntl(fd, F_SETLK, &svflk);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(retVal, -1);
 
-    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
-  }
+  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+}
 
-  void GetLkWrite() {
-    using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-    constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getlkwrite.test";
-    const auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
+TEST_F(LlvmLibcFcntlTest, FcntlGetLkWrite) {
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+  constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getlkwrite.test";
+  auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
 
-    struct flock flk = {};
-    struct flock svflk = {};
-    int retVal;
-    int fd =
-        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, S_IRWXU);
-    ASSERT_ERRNO_SUCCESS();
-    ASSERT_GT(fd, 0);
+  struct flock flk, svflk;
+  int retVal;
+  int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, S_IRWXU);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(fd, 0);
 
-    flk.l_type = F_WRLCK;
-    flk.l_start = 0;
-    flk.l_whence = SEEK_SET;
-    flk.l_len = 0;
+  flk.l_type = F_WRLCK;
+  flk.l_start = 0;
+  flk.l_whence = SEEK_SET;
+  flk.l_len = 0;
 
-    // copy flk into svflk
-    svflk = flk;
+  // copy flk into svflk
+  svflk = flk;
 
-    retVal = LIBC_NAMESPACE::fcntl(fd, GETLK_CMD, &svflk);
-    ASSERT_ERRNO_SUCCESS();
-    ASSERT_GT(retVal, -1);
-    ASSERT_NE((int)svflk.l_type, F_RDLCK); // File should not be read locked.
+  retVal = LIBC_NAMESPACE::fcntl(fd, F_GETLK, &svflk);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(retVal, -1);
+  ASSERT_NE((int)flk.l_type, F_RDLCK); // File should not be read locked.
 
-    retVal = LIBC_NAMESPACE::fcntl(fd, SETLK_CMD, &svflk);
-    ASSERT_ERRNO_SUCCESS();
-    ASSERT_GT(retVal, -1);
+  retVal = LIBC_NAMESPACE::fcntl(fd, F_SETLK, &svflk);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(retVal, -1);
 
-    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
-  }
+  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+}
 
-  void UseAfterClose() {
-    using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-    constexpr const char *TEST_FILE_NAME =
-        "testdata/fcntl_use_after_close.test";
-    const auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
-    int fd =
-        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, S_IRWXU);
-    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
-    ASSERT_EQ(-1, LIBC_NAMESPACE::fcntl(fd, GETLK_CMD));
-    ASSERT_ERRNO_EQ(EBADF);
-  }
-};
-
-#define COMMON_LOCK_TESTS(NAME, GETLK, SETLK)                                  \
-  using NAME = LibcFcntlCommonLockTests<GETLK, SETLK>;                         \
-  TEST_F(NAME, GetLkRead) { GetLkRead(); }                                     \
-  TEST_F(NAME, GetLkWrite) { GetLkWrite(); }                                   \
-  TEST_F(NAME, UseAfterClose) { UseAfterClose(); }                             \
-  static_assert(true, "Require semicolon.")
-
-COMMON_LOCK_TESTS(LlvmLibcFcntlProcessAssociatedLockTest, F_GETLK, F_SETLK);
-COMMON_LOCK_TESTS(LlvmLibcFcntlOpenFileDescriptionLockTest, F_OFD_GETLK,
-                  F_OFD_SETLK);
+TEST_F(LlvmLibcFcntlTest, UseAfterClose) {
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+  constexpr const char *TEST_FILE_NAME = "testdata/fcntl_use_after_close.test";
+  auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
+  int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, S_IRWXU);
+  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+  ASSERT_EQ(-1, LIBC_NAMESPACE::fcntl(fd, F_GETFL));
+  ASSERT_ERRNO_EQ(EBADF);
+}
 
 TEST_F(LlvmLibcFcntlTest, SetGetOwnerTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;


### PR DESCRIPTION
Reverts llvm/llvm-project#166252

Causing buildbot failures on `libc-x86_64-debian-dbg-asan`.