### PR TITLE
[clang-doc] remove indentation for preformatted text

### DIFF
--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -141,9 +141,7 @@
                 <div>
                     {{#PublicMembers}}
                     <div id="{{Name}}" class="delimiter-container">
-                        <pre>
-                            <code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code>
-                        </pre>
+                        <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
                         {{#MemberComments}}
                         <div>
                             {{>Comments}}
@@ -160,9 +158,7 @@
                 <div>
                     {{#Obj}}
                     <div id="{{Name}}" class="delimiter-container">
-                        <pre>
-<code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code>
-                        </pre>
+                        <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
                         {{#MemberComments}}
                         <div>
                             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -92,9 +92,7 @@
                         {{#Records}}
                             <li id="{{USR}}" style="max-height: 40px;">
                                 <a href="{{DocumentationFileName}}.html">
-                                    <pre>
-                                        <code class="language-cpp code-clang-doc">class {{Name}}</code>
-                                    </pre>
+                                    <pre><code class="language-cpp code-clang-doc">class {{Name}}</code></pre>
                                 </a>
                             </li>
                         {{/Records}}

--- a/clang-tools-extra/test/clang-doc/mustache-index.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-index.cpp
@@ -70,9 +70,7 @@ class Foo;
 // CHECK-NEXT:      <ul class="class-container">
 // CHECK-NEXT:          <li id="{{[0-9A-F]*}}" style="max-height: 40px;">
 // CHECK-NEXT:              <a href="_ZTV3Foo.html">
-// CHECK-NEXT:                  <pre>
-// CHECK-NEXT:                      <code class="language-cpp code-clang-doc">class Foo</code>
-// CHECK-NEXT:                  </pre>
+// CHECK-NEXT:                  <pre><code class="language-cpp code-clang-doc">class Foo</code></pre>
 // CHECK-NEXT:              </a>
 // CHECK-NEXT:          </li>
 // CHECK-NEXT:      </ul>

--- a/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
@@ -9,9 +9,7 @@ namespace MyNamespace {
 // CHECK:       <ul class="class-container">
 // CHECK-NEXT:    <li id="{{[0-9A-F]*}}" style="max-height: 40px;">
 // CHECK-NEXT:        <a href="_ZTVN11MyNamespace3FooE.html">
-// CHECK-NEXT:            <pre>
-// CHECK-NEXT:                <code class="language-cpp code-clang-doc">class Foo</code>
-// CHECK-NEXT:            </pre>
+// CHECK-NEXT:            <pre><code class="language-cpp code-clang-doc">class Foo</code></pre>
 // CHECK-NEXT:        </a>
 // CHECK-NEXT:    </li>
 // CHECK-NEXT: </ul>


### PR DESCRIPTION
Text that is in between `<pre>` tags is formatted verbatim. Thus, the
text that was correctly indented in relation to its depth in HTML was
being indented incorrectly when rendered. That resulted in bad looking pages.