### PR TITLE
Add binop-select test to profcheck-xfail.txt

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -358,6 +358,7 @@ Transforms/InstCombine/apint-div2.ll
 Transforms/InstCombine/ashr-demand.ll
 Transforms/InstCombine/atomic.ll
 Transforms/InstCombine/binop-cast.ll
+Transforms/InstCombine/binop-select.ll
 Transforms/InstCombine/binop-select-cast-of-select-cond.ll
 Transforms/InstCombine/bit-checks.ll
 Transforms/InstCombine/bitreverse.ll


### PR DESCRIPTION
Revealed in PR #166102, which itself doesn't _cause_ the profile being dropped. Referencing if it makes debugging easier.