### PR TITLE
[utils] support both files originating from split-file in DiffUpdater

### DIFF
--- a/llvm/utils/lit/lit/DiffUpdater.py
+++ b/llvm/utils/lit/lit/DiffUpdater.py
@@ -117,27 +117,32 @@ def get_source_and_target(a, b, test_path, commands):
     Try to figure out which file is the test output and which is the reference.
     """
     split_target_dir = SplitFileTarget.get_target_dir(commands, test_path)
+    a_target = None
+    b_target = None
     if split_target_dir:
         a_target = SplitFileTarget.create(a, commands, test_path, split_target_dir)
         b_target = SplitFileTarget.create(b, commands, test_path, split_target_dir)
-        if a_target and b_target:
-            return None
-        if a_target:
+        if a_target and not b_target:
             return b, a_target
-        if b_target:
+        if b_target and not a_target:
             return a, b_target
+
+    if not a_target:
+        a_target = NormalFileTarget(a)
+    if not b_target:
+        b_target = NormalFileTarget(b)
 
     expected_suffix = ".expected"
     if a.endswith(expected_suffix) and not b.endswith(expected_suffix):
-        return b, NormalFileTarget(a)
+        return b, a_target
     if b.endswith(expected_suffix) and not a.endswith(expected_suffix):
-        return a, NormalFileTarget(b)
+        return a, b_target
 
     tmp_substr = ".tmp"
     if tmp_substr in a and not tmp_substr in b:
-        return a, NormalFileTarget(b)
+        return a, b_target
     if tmp_substr in b and not tmp_substr in a:
-        return b, NormalFileTarget(a)
+        return b, a_target
 
     return None
 

--- a/llvm/utils/lit/tests/Inputs/diff-test-update/.gitignore
+++ b/llvm/utils/lit/tests/Inputs/diff-test-update/.gitignore
@@ -8,3 +8,4 @@ multiple-split-file-populated.test
 single-split-file-no-expected.test
 split-c-comments.test
 split whitespace.test
+split-both.test

--- a/llvm/utils/lit/tests/Inputs/diff-test-update/split-both.in
+++ b/llvm/utils/lit/tests/Inputs/diff-test-update/split-both.in
@@ -1,0 +1,9 @@
+# RUN: split-file %s %t
+# RUN: echo baz > %t/split-both.out
+# RUN: diff %t/split-both.expected %t/split-both.out
+
+#--- split-both.expected
+FOO
+#--- split-both.out
+BAR
+

--- a/llvm/utils/lit/tests/Inputs/diff-test-update/split-both.out
+++ b/llvm/utils/lit/tests/Inputs/diff-test-update/split-both.out
@@ -1,11 +1,9 @@
 # RUN: split-file %s %t
+# RUN: echo baz > %t/split-both.out
 # RUN: diff %t/split-both.expected %t/split-both.out
 
-# ignore the fact that it's called ".expected"
-# when comparing two files originating in split-file
-
 #--- split-both.expected
-FOO
+baz
 #--- split-both.out
 BAR
 

--- a/llvm/utils/lit/tests/diff-test-update.py
+++ b/llvm/utils/lit/tests/diff-test-update.py
@@ -5,6 +5,7 @@
 # RUN: cp %S/Inputs/diff-test-update/single-split-file-no-expected.in %S/Inputs/diff-test-update/single-split-file-no-expected.test
 # RUN: cp %S/Inputs/diff-test-update/split-c-comments.in %S/Inputs/diff-test-update/split-c-comments.test
 # RUN: cp %S/Inputs/diff-test-update/split-whitespace.in "%S/Inputs/diff-test-update/split whitespace.test"
+# RUN: cp %S/Inputs/diff-test-update/split-both.in %S/Inputs/diff-test-update/split-both.test
 
 # RUN: not %{lit} --update-tests -v %S/Inputs/diff-test-update | FileCheck %s
 
@@ -15,6 +16,7 @@
 # RUN: diff --strip-trailing-cr %S/Inputs/diff-test-update/single-split-file-no-expected.out %S/Inputs/diff-test-update/single-split-file-no-expected.test
 # RUN: diff --strip-trailing-cr %S/Inputs/diff-test-update/split-c-comments.out %S/Inputs/diff-test-update/split-c-comments.test
 # RUN: diff --strip-trailing-cr %S/Inputs/diff-test-update/split-whitespace.out "%S/Inputs/diff-test-update/split whitespace.test"
+# RUN: diff --strip-trailing-cr %S/Inputs/diff-test-update/split-both.out %S/Inputs/diff-test-update/split-both.test
 
 
 # CHECK: # update-diff-test: could not deduce source and target from {{.*}}1.in and {{.*}}2.in
@@ -22,7 +24,6 @@
 # CHECK: # update-diff-test: copied {{.*}}my-file.txt to {{.*}}my-file.expected
 # CHECK: # update-diff-test: copied {{.*}}1.txt to {{.*}}empty.txt
 # CHECK: # update-diff-test: copied {{.*}}diff-tmp.test.tmp.txt to {{.*}}diff-t-out.txt
-# CHECK: # update-diff-test: could not deduce source and target from {{.*}}split-both.expected and {{.*}}split-both.out
 # CHECK: # update-diff-test: copied {{.*}}unrelated-split.txt to {{.*}}unrelated-split.expected
 
 


### PR DESCRIPTION
With this change DiffUpdater can update expected files even if both files are created by split-files, if one of them ends with ".expected". This is useful when a file is created and then modified during the test.