### PR TITLE
[flang] Disallow passing array actual arguments to ignore_tkr(r) scalars with VALUE attribute

### DIFF
--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -32,6 +32,22 @@ A list of non-standard directives supported by Flang
     end
   end interface
 ```
+  Note that it's not allowed to pass array actual argument to `ignore_trk(R)`
+  dummy argument that is a scalar with `VALUE` attribute, for example:
+```
+  interface
+    subroutine s(b)
+      !dir$ ignore_tkr(r) b
+      integer, value :: b
+    end
+  end interface
+  integer :: a(5)
+  call s(a)
+```
+  The reason for this limitation is that scalars with `VALUE` attribute can
+  be passed in registers, so it's not clear how lowering should handle this
+  case. (Passing scalar actual argument to `ignore_tkr(R)` dummy argument
+  that is a scalar with `VALUE` attribute is allowed.)
 * `!dir$ assume_aligned desginator:alignment`, where designator is a variable,
   maybe with array indices, and alignment is what the compiler should assume the
   alignment to be. E.g A:64 or B(1,1,1):128. The alignment should be a power of 2,

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -548,7 +548,12 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     actualLastSymbol = &ResolveAssociations(*actualLastSymbol);
   }
   int actualRank{actualType.Rank()};
-  if (dummy.type.attrs().test(
+  if (dummyIsValue && dummyRank == 0 &&
+      dummy.ignoreTKR.test(common::IgnoreTKR::Rank) && actualRank > 0) {
+    messages.Say(
+      "Array actual argument may not be associated with IGNORE_TKR(R) scalar %s with VALUE attribute"_err_en_US,
+      dummyName);
+  } else if (dummy.type.attrs().test(
           characteristics::TypeAndShape::Attr::AssumedShape)) {
     // 15.5.2.4(16)
     if (actualIsAssumedRank) {

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -551,10 +551,10 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
   if (dummyIsValue && dummyRank == 0 &&
       dummy.ignoreTKR.test(common::IgnoreTKR::Rank) && actualRank > 0) {
     messages.Say(
-      "Array actual argument may not be associated with IGNORE_TKR(R) scalar %s with VALUE attribute"_err_en_US,
-      dummyName);
+        "Array actual argument may not be associated with IGNORE_TKR(R) scalar %s with VALUE attribute"_err_en_US,
+        dummyName);
   } else if (dummy.type.attrs().test(
-          characteristics::TypeAndShape::Attr::AssumedShape)) {
+                 characteristics::TypeAndShape::Attr::AssumedShape)) {
     // 15.5.2.4(16)
     if (actualIsAssumedRank) {
       messages.Say(

--- a/flang/test/Semantics/val-tkr.f90
+++ b/flang/test/Semantics/val-tkr.f90
@@ -1,0 +1,22 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+implicit none
+interface
+  subroutine s(b)
+    !dir$ ignore_tkr(tr) b
+    real, value :: b
+  end
+  subroutine s1(b)
+    !dir$ ignore_tkr(r) b
+    integer, value :: b
+  end
+end interface
+integer :: a(5), a1
+! forbid array to scalar with VALUE and ignore_tkr(r)
+!ERROR: Array actual argument may not be associated with IGNORE_TKR(R) scalar dummy argument 'b=' with VALUE attribute
+call s(a)
+!ERROR: Array actual argument may not be associated with IGNORE_TKR(R) scalar dummy argument 'b=' with VALUE attribute
+call s1(a)
+! allow scalar to scalar with VALUE
+call s(a1)
+call s1(a(1))
+end


### PR DESCRIPTION
Scalars with VALUE attribute are likely passed in registers, so it's now clear what lowering should do with the array actual argument in this case. Fail this case with an error before getting to lowering.