### PR TITLE
[mlir][NVVM] Add nvvm.membar operation

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -1249,7 +1249,7 @@ def NVVM_MembarOp : NVVM_Op<"memory_barrier">,
 
   let assemblyFormat = "$scope attr-dict";
   let llvmBuilder = [{
-    createIntrinsicCall(builder, getMemoryBarrierLevelID($scope), {});
+    createIntrinsicCall(builder, getMembarIntrinsicID($scope), {});
   }];
 }
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -1241,7 +1241,7 @@ def NVVM_MembarOp : NVVM_Op<"memory.barrier">,
   let summary = "Memory barrier operation";
   let description = [{
     `membar` operation guarantees that prior memory accesses requested by this
-    thread are performed at the specified `level`, before later memory
+    thread are performed at the specified `scope`, before later memory
     operations requested by this thread following the membar instruction.
 
     [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar)

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -1236,7 +1236,7 @@ def NVVM_FenceProxyAcquireOp : NVVM_Op<"fence.proxy.acquire">,
   let hasVerifier = 1;
 }
 
-def NVVM_MembarOp : NVVM_Op<"memory_barrier">,
+def NVVM_MembarOp : NVVM_Op<"memory.barrier">,
                     Arguments<(ins MemScopeKindAttr:$scope)> {
   let summary = "Memory barrier operation";
   let description = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -1236,6 +1236,39 @@ def NVVM_FenceProxyAcquireOp : NVVM_Op<"fence.proxy.acquire">,
   let hasVerifier = 1;
 }
 
+// Attrs describing the level of the Memory Operation
+def MemLevelCTA : I32EnumAttrCase<"CTA", 0, "cta">;
+def MemLevelGL : I32EnumAttrCase<"GL", 1, "gl">;
+def MemLevelSys : I32EnumAttrCase<"SYS", 2, "sys">;
+
+def MemLevelKind
+    : I32EnumAttr<
+          "MemLevelKind",
+          "NVVM Memory Level kind", [MemLevelCTA, MemLevelGL, MemLevelSys]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::NVVM";
+}
+def MemLevelKindAttr : EnumAttr<NVVM_Dialect, MemLevelKind, "mem_level"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+def NVVM_MembarOp : NVVM_Op<"membar">,
+                    Arguments<(ins MemLevelKindAttr:$level)> {
+  let summary = "Memory barrier operation";
+  let description = [{
+    `member` operation guarantees that prior memory accesses requested by this
+    thread are performed at the specified `level`, before later memory
+    operations requested by this thread following the membar instruction.
+
+    [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar)
+  }];
+
+  let assemblyFormat = "$level attr-dict";
+  let llvmBuilder = [{
+    createIntrinsicCall(builder, getMembarLevelID($level), {});
+  }];
+}
+
 def NVVM_FenceProxyReleaseOp : NVVM_Op<"fence.proxy.release">,
       Arguments<(ins MemScopeKindAttr:$scope,
                      DefaultValuedAttr<ProxyKindAttr,

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -1256,7 +1256,7 @@ def NVVM_MembarOp : NVVM_Op<"membar">,
                     Arguments<(ins MemLevelKindAttr:$level)> {
   let summary = "Memory barrier operation";
   let description = [{
-    `member` operation guarantees that prior memory accesses requested by this
+    `membar` operation guarantees that prior memory accesses requested by this
     thread are performed at the specified `level`, before later memory
     operations requested by this thread following the membar instruction.
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -1236,24 +1236,8 @@ def NVVM_FenceProxyAcquireOp : NVVM_Op<"fence.proxy.acquire">,
   let hasVerifier = 1;
 }
 
-// Attrs describing the level of the Memory Operation
-def MemLevelCTA : I32EnumAttrCase<"CTA", 0, "cta">;
-def MemLevelGL : I32EnumAttrCase<"GL", 1, "gl">;
-def MemLevelSys : I32EnumAttrCase<"SYS", 2, "sys">;
-
-def MemLevelKind
-    : I32EnumAttr<
-          "MemLevelKind",
-          "NVVM Memory Level kind", [MemLevelCTA, MemLevelGL, MemLevelSys]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::NVVM";
-}
-def MemLevelKindAttr : EnumAttr<NVVM_Dialect, MemLevelKind, "mem_level"> {
-  let assemblyFormat = "`<` $value `>`";
-}
-
-def NVVM_MembarOp : NVVM_Op<"membar">,
-                    Arguments<(ins MemLevelKindAttr:$level)> {
+def NVVM_MembarOp : NVVM_Op<"memory_barrier">,
+                    Arguments<(ins MemScopeKindAttr:$scope)> {
   let summary = "Memory barrier operation";
   let description = [{
     `membar` operation guarantees that prior memory accesses requested by this
@@ -1263,9 +1247,9 @@ def NVVM_MembarOp : NVVM_Op<"membar">,
     [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar)
   }];
 
-  let assemblyFormat = "$level attr-dict";
+  let assemblyFormat = "$scope attr-dict";
   let llvmBuilder = [{
-    createIntrinsicCall(builder, getMembarLevelID($level), {});
+    createIntrinsicCall(builder, getMemoryBarrierLevelID($scope), {});
   }];
 }
 

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -291,7 +291,7 @@ static unsigned getUnidirectionalFenceProxyID(NVVM::ProxyKind fromProxy,
   llvm_unreachable("Unsupported proxy kinds");
 }
 
-static unsigned getMemoryBarrierLevelID(NVVM::MemScopeKind scope) {
+static unsigned getMembarIntrinsicID(NVVM::MemScopeKind scope) {
   switch (scope) {
   case NVVM::MemScopeKind::CTA: {
     return llvm::Intrinsic::nvvm_membar_cta;

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -293,20 +293,16 @@ static unsigned getUnidirectionalFenceProxyID(NVVM::ProxyKind fromProxy,
 
 static unsigned getMembarIntrinsicID(NVVM::MemScopeKind scope) {
   switch (scope) {
-  case NVVM::MemScopeKind::CTA: {
+  case NVVM::MemScopeKind::CTA:
     return llvm::Intrinsic::nvvm_membar_cta;
-  }
-  case NVVM::MemScopeKind::CLUSTER: {
+  case NVVM::MemScopeKind::CLUSTER:
     return llvm::Intrinsic::nvvm_fence_sc_cluster;
-  }
-  case NVVM::MemScopeKind::GPU: {
+  case NVVM::MemScopeKind::GPU:
     return llvm::Intrinsic::nvvm_membar_gl;
-  }
-  case NVVM::MemScopeKind::SYS: {
+  case NVVM::MemScopeKind::SYS:
     return llvm::Intrinsic::nvvm_membar_sys;
   }
-  }
-  llvm_unreachable("Unknown level for memory barrier");
+  llvm_unreachable("Unknown scope for memory barrier");
 }
 
 #define TCGEN05LD(SHAPE, NUM) llvm::Intrinsic::nvvm_tcgen05_ld_##SHAPE##_##NUM

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -291,6 +291,21 @@ static unsigned getUnidirectionalFenceProxyID(NVVM::ProxyKind fromProxy,
   llvm_unreachable("Unsupported proxy kinds");
 }
 
+static unsigned getMembarLevelID(NVVM::MemLevelKind level) {
+  switch (level) {
+  case NVVM::MemLevelKind::CTA: {
+    return llvm::Intrinsic::nvvm_membar_cta;
+  }
+  case NVVM::MemLevelKind::GL: {
+    return llvm::Intrinsic::nvvm_membar_gl;
+  }
+  case NVVM::MemLevelKind::SYS: {
+    return llvm::Intrinsic::nvvm_membar_sys;
+  }
+  }
+  llvm_unreachable("Unknown level for memory barrier");
+}
+
 #define TCGEN05LD(SHAPE, NUM) llvm::Intrinsic::nvvm_tcgen05_ld_##SHAPE##_##NUM
 
 static llvm::Intrinsic::ID

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -291,15 +291,18 @@ static unsigned getUnidirectionalFenceProxyID(NVVM::ProxyKind fromProxy,
   llvm_unreachable("Unsupported proxy kinds");
 }
 
-static unsigned getMembarLevelID(NVVM::MemLevelKind level) {
-  switch (level) {
-  case NVVM::MemLevelKind::CTA: {
+static unsigned getMemoryBarrierLevelID(NVVM::MemScopeKind scope) {
+  switch (scope) {
+  case NVVM::MemScopeKind::CTA: {
     return llvm::Intrinsic::nvvm_membar_cta;
   }
-  case NVVM::MemLevelKind::GL: {
+  case NVVM::MemScopeKind::CLUSTER: {
+    return llvm::Intrinsic::nvvm_fence_sc_cluster;
+  }
+  case NVVM::MemScopeKind::GPU: {
     return llvm::Intrinsic::nvvm_membar_gl;
   }
-  case NVVM::MemLevelKind::SYS: {
+  case NVVM::MemScopeKind::SYS: {
     return llvm::Intrinsic::nvvm_membar_sys;
   }
   }

--- a/mlir/test/Target/LLVMIR/nvvm/membar.mlir
+++ b/mlir/test/Target/LLVMIR/nvvm/membar.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-translate -mlir-to-llvmir %s  -split-input-file --verify-diagnostics | FileCheck %s
+
+// CHECK-lABEL: @memorybarrier()
+llvm.func @memorybarrier() {
+  // CHECK: call void @llvm.nvvm.membar.cta()
+  nvvm.memory_barrier #nvvm.mem_scope<cta>
+  // CHECK: call void @llvm.nvvm.fence.sc.cluster()
+  nvvm.memory_barrier #nvvm.mem_scope<cluster>
+  // CHECK: call void @llvm.nvvm.membar.gl()
+  nvvm.memory_barrier #nvvm.mem_scope<gpu>
+  // CHECK: call void @llvm.nvvm.membar.sys()
+  nvvm.memory_barrier #nvvm.mem_scope<sys>
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/nvvm/membar.mlir
+++ b/mlir/test/Target/LLVMIR/nvvm/membar.mlir
@@ -3,12 +3,12 @@
 // CHECK-lABEL: @memorybarrier()
 llvm.func @memorybarrier() {
   // CHECK: call void @llvm.nvvm.membar.cta()
-  nvvm.memory_barrier #nvvm.mem_scope<cta>
+  nvvm.memory.barrier #nvvm.mem_scope<cta>
   // CHECK: call void @llvm.nvvm.fence.sc.cluster()
-  nvvm.memory_barrier #nvvm.mem_scope<cluster>
+  nvvm.memory.barrier #nvvm.mem_scope<cluster>
   // CHECK: call void @llvm.nvvm.membar.gl()
-  nvvm.memory_barrier #nvvm.mem_scope<gpu>
+  nvvm.memory.barrier #nvvm.mem_scope<gpu>
   // CHECK: call void @llvm.nvvm.membar.sys()
-  nvvm.memory_barrier #nvvm.mem_scope<sys>
+  nvvm.memory.barrier #nvvm.mem_scope<sys>
   llvm.return
 }

--- a/mlir/test/Target/LLVMIR/nvvmir.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir.mlir
@@ -975,3 +975,16 @@ llvm.func @nanosleep() {
   nvvm.nanosleep 4000
   llvm.return
 }
+
+// -----
+
+// CHECK-lABEL: @memorybarrier()
+llvm.func @memorybarrier() {
+  // CHECK: call void @llvm.nvvm.membar.cta()
+  nvvm.membar #nvvm.mem_level<cta>
+  // CHECK: call void @llvm.nvvm.membar.gl()
+  nvvm.membar #nvvm.mem_level<gl>
+  // CHECK: call void @llvm.nvvm.membar.sys()
+  nvvm.membar #nvvm.mem_level<sys>
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/nvvmir.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir.mlir
@@ -975,16 +975,3 @@ llvm.func @nanosleep() {
   nvvm.nanosleep 4000
   llvm.return
 }
-
-// -----
-
-// CHECK-lABEL: @memorybarrier()
-llvm.func @memorybarrier() {
-  // CHECK: call void @llvm.nvvm.membar.cta()
-  nvvm.membar #nvvm.mem_level<cta>
-  // CHECK: call void @llvm.nvvm.membar.gl()
-  nvvm.membar #nvvm.mem_level<gl>
-  // CHECK: call void @llvm.nvvm.membar.sys()
-  nvvm.membar #nvvm.mem_level<sys>
-  llvm.return
-}


### PR DESCRIPTION
Add nvvm.membar operation with level as defined in https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar

This will be used to replace direct intrinsic call in CUDA Fortran for `threadfence()`, `threadfence_block` and `thread fence_system()` currently lowered here: https://github.com/llvm/llvm-project/blob/e700f157026bf8b4d58f936c5db8f152e269d77f/flang/lib/Optimizer/Builder/CUDAIntrinsicCall.cpp#L1310

The nvvm membar intrsinsic are also used in CUDA C/C++ (https://github.com/llvm/llvm-project/blob/49f55f4991227f3c7a2b8161bbf45c74b7023944/clang/lib/Headers/__clang_cuda_device_functions.h#L528)