### PR TITLE
[libc++] Make `std::numeric_limits<NonPromoted>::traps` `false`

### DIFF
--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -107,6 +107,7 @@ template<> class numeric_limits<cv long double>;
 #else
 #  include <__config>
 #  include <__type_traits/is_arithmetic.h>
+#  include <__type_traits/is_same.h>
 #  include <__type_traits/is_signed.h>
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -220,7 +221,7 @@ protected:
   static _LIBCPP_CONSTEXPR const bool is_modulo  = !std::is_signed<_Tp>::value;
 
 #  if defined(__i386__) || defined(__x86_64__) || defined(__wasm__)
-  static _LIBCPP_CONSTEXPR const bool traps = true;
+  static _LIBCPP_CONSTEXPR const bool traps = is_same<decltype(+_Tp(0)), _Tp>::value;
 #  else
   static _LIBCPP_CONSTEXPR const bool traps = false;
 #  endif

--- a/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
@@ -10,6 +10,8 @@
 
 // traps
 
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
 #include <limits>
 
 #include "test_macros.h"
@@ -33,17 +35,17 @@ test()
 int main(int, char**)
 {
     test<bool, false>();
-    test<char, integral_types_trap>();
-    test<signed char, integral_types_trap>();
-    test<unsigned char, integral_types_trap>();
-    test<wchar_t, integral_types_trap>();
+    test<char, false>();
+    test<signed char, false>();
+    test<unsigned char, false>();
+    test<wchar_t, false>();
 #if TEST_STD_VER > 17 && defined(__cpp_char8_t)
-    test<char8_t, integral_types_trap>();
+    test<char8_t, false>();
 #endif
-    test<char16_t, integral_types_trap>();
-    test<char32_t, integral_types_trap>();
-    test<short, integral_types_trap>();
-    test<unsigned short, integral_types_trap>();
+    test<char16_t, false>();
+    test<char32_t, false>();
+    test<short, false>();
+    test<unsigned short, false>();
     test<int, integral_types_trap>();
     test<unsigned int, integral_types_trap>();
     test<long, integral_types_trap>();


### PR DESCRIPTION
Per [LWG554](https://cplusplus.github.io/LWG/issue554), the rationale is that even if `true / false` traps, the values causing trap are the converted `int` values produced by usual arithmetic conversion, but not the original `bool` values.

This is also true for all other non-promoted integer types. As a result, `std::numeric_limits<I>` should be `false` if `I` is a non non-promoted integer type.

Fixes #166053.