### PR TITLE
clang-format: Add IndentGotoLabelsToCurrentScope option

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst.bak
+++ b/clang/docs/ClangFormatStyleOptions.rst.bak
@@ -4544,23 +4544,21 @@ the configuration (without a prefix: ``Auto``).
 
 .. _IndentGotoLabelsToCurrentScope:
 
-**IndentGotoLabelsToCurrentScope** (``Boolean``) :versionbadge:`clang-format 19` :ref:`¶ <IndentGotoLabelsToCurrentScope>`
-  If true, aligns labels according to the current indentation level
-  instead of flushing them to the left margin.
-
-
-  .. code-block:: c++
-
-    true:                              false:
-    int main() {                       int main() {
-      for (int i = 0; i < 5; i++)       for (int i = 0; i < 5; i++)
-        for (int j = 0; j < 5; j++) {      for (int j = 0; j < 5; j++) {
-          // some code                       // some code
-          goto end_double_loop;              goto end_double_loop;
-        }                                   }
-      }                                    }
-      end_double_loop: {}                end_double_loop: {}
-    }                                  }
+  **IndentGotoLabelsToCurrentScope** (``Boolean``) :versionbadge:`clang-format 19` :ref:`¶ <IndentGotoLabelsToCurrentScope>`
+    If true, aligns labels according to the current indentation level
+    instead of flushing them to the left margin.
+  
+    .. code-block:: c++
+       
+      true:                                  false:
+      int main() {                           int main() {
+        for (int i = 0; i < 5; i++)            for (int i = 0; i < 5; i++)
+          for (int j = 0; j < 5; j++) {           for (int j = 0; j < 5; j++) {
+            // some code                            // some code
+            goto end_double_loop;                   goto end_double_loop;
+          }                                        }
+        end_double_loop: {}                     end_double_loop: {}
+      }                               }
 
 .. _IndentPPDirectives:
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3067,7 +3067,7 @@ struct FormatStyle {
   /// IndentExternBlockStyle is the type of indenting of extern blocks.
   /// \version 11
   IndentExternBlockStyle IndentExternBlock;
-
+  
   /// Indent goto labels.
   ///
   /// When ``false``, goto labels are flushed left.
@@ -3084,6 +3084,24 @@ struct FormatStyle {
   /// \endcode
   /// \version 10
   bool IndentGotoLabels;
+  
+  /// If true, aligns labels according to the current indentation level
+  /// instead of flushing them to the left margin.
+  ///
+  /// \code
+  ///   true:                              false:
+  ///   int main() {                       int main() {
+  ///     for (int i = 0; i < 5; i++)       for (int i = 0; i < 5; i++)
+  ///       for (int j = 0; j < 5; j++) {      for (int j = 0; j < 5; j++) {
+  ///         // some code                       // some code
+  ///         goto end_double_loop;              goto end_double_loop;
+  ///       }                                   }
+  ///     }                                    }
+  ///     end_double_loop: {}                end_double_loop: {}
+  ///   }                                  }
+  /// \endcode
+  /// \version 19
+  bool IndentGotoLabelsToCurrentScope;
 
   /// Options for indenting preprocessor directives.
   enum PPDirectiveIndentStyle : int8_t {

--- a/clang/lib/Format/.clang-format
+++ b/clang/lib/Format/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: clang-format
+

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1204,6 +1204,7 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("IndentExportBlock", Style.IndentExportBlock);
     IO.mapOptional("IndentExternBlock", Style.IndentExternBlock);
     IO.mapOptional("IndentGotoLabels", Style.IndentGotoLabels);
+    IO.mapOptional("IndentGotoLabelsToCurrentScope", Style.IndentGotoLabelsToCurrentScope);
     IO.mapOptional("IndentPPDirectives", Style.IndentPPDirectives);
     IO.mapOptional("IndentRequiresClause", Style.IndentRequiresClause);
     IO.mapOptional("IndentWidth", Style.IndentWidth);
@@ -1748,6 +1749,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.IndentExportBlock = true;
   LLVMStyle.IndentExternBlock = FormatStyle::IEBS_AfterExternBlock;
   LLVMStyle.IndentGotoLabels = true;
+  LLVMStyle.IndentGotoLabelsToCurrentScope = false;
   LLVMStyle.IndentPPDirectives = FormatStyle::PPDIS_None;
   LLVMStyle.IndentRequiresClause = true;
   LLVMStyle.IndentWidth = 2;
@@ -1987,6 +1989,7 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
     // TODO: enable once decided, in particular re disabling bin packing.
     // https://google.github.io/styleguide/jsguide.html#features-arrays-trailing-comma
     // GoogleStyle.InsertTrailingCommas = FormatStyle::TCS_Wrapped;
+    GoogleStyle.IndentGotoLabelsToCurrentScope = false;
     GoogleStyle.JavaScriptQuotes = FormatStyle::JSQS_Single;
     GoogleStyle.JavaScriptWrapImports = false;
     GoogleStyle.MaxEmptyLinesToKeep = 3;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -12,7 +12,6 @@
 #include "WhitespaceManager.h"
 #include "llvm/Support/Debug.h"
 #include <queue>
-#include <iostream>
 
 #define DEBUG_TYPE "format-formatter"
 
@@ -136,9 +135,6 @@ private:
 
     if(Line.First->is(tok::identifier) && Line.First->Next && Line.First->Next->is(TT_GotoLabelColon)){
       if(Style.IndentGotoLabelsToCurrentScope){
-        std::cout << Line.First->TokenText.str() << ": indented to current scope" << std::endl;
-        std::cout << "IndentGotoLabelsToCurrentScope is true" << std::endl;
-        std::cout << Line.Level << " " << Style.IndentWidth << std::endl;
         return Style.IndentWidth;
       }
     }

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -12,6 +12,7 @@
 #include "WhitespaceManager.h"
 #include "llvm/Support/Debug.h"
 #include <queue>
+#include <iostream>
 
 #define DEBUG_TYPE "format-formatter"
 
@@ -132,9 +133,18 @@ private:
       return Style.IndentAccessModifiers ? -Style.IndentWidth
                                          : Style.AccessModifierOffset;
     }
+
+    if(Line.First->is(tok::identifier) && Line.First->Next && Line.First->Next->is(TT_GotoLabelColon)){
+      if(Style.IndentGotoLabelsToCurrentScope){
+        std::cout << Line.First->TokenText.str() << ": indented to current scope" << std::endl;
+        std::cout << "IndentGotoLabelsToCurrentScope is true" << std::endl;
+        std::cout << Line.Level << " " << Style.IndentWidth << std::endl;
+        return Style.IndentWidth;
+      }
+    }
     return 0;
   }
-
+  
   /// Get the indent of \p Level from \p IndentForLevel.
   ///
   /// \p IndentForLevel must contain the indent for the level \c l


### PR DESCRIPTION
This adds a new style option to control indentation of goto labels. Includes documentation.