### PR TITLE
[libc][math] Enable math acos for baremetal Arm and AArch64

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -321,6 +321,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints
+    libc.src.math.acos
     libc.src.math.acosf
     libc.src.math.acoshf
     libc.src.math.asinf

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -321,6 +321,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints
+    libc.src.math.acos
     libc.src.math.acosf
     libc.src.math.acoshf
     libc.src.math.asinf


### PR DESCRIPTION
This patch adds `acos` to the entrypoints of baremetal Arm and AArch64.

Tests have been run with Arm Toolchain for Embedded, a downstream toolchain, in conjunction with qemu, across several configurations of FPUs and architecture versions. All tests run are passing.