### PR TITLE
[NFCI][lldb][test] Enable GNU POSIX extensions where necessary

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -294,6 +294,11 @@ ifeq "$(MAKE_DEBUG_NAMES)" "YES"
 	CFLAGS += -gpubnames
 endif
 
+# Enable GNU POSIX extensions (e.g. kill(), usleep(), getpgid(), ...)
+ifeq "$(OS)" "Linux"
+	CFLAGS += -D_DEFAULT_SOURCE
+endif
+
 ifeq "$(USE_PRIVATE_MODULE_CACHE)" "YES"
 THE_CLANG_MODULE_CACHE_DIR := $(BUILDDIR)/private-module-cache
 else

--- a/lldb/test/Shell/Commands/Inputs/sigchld.c
+++ b/lldb/test/Shell/Commands/Inputs/sigchld.c
@@ -1,3 +1,7 @@
+#if defined(__linux__)
+#define _XOPEN_SOURCE 500 /* for CLD_EXITED */
+#endif
+
 #include <assert.h>
 #include <signal.h>
 #include <stdio.h>

--- a/lldb/test/Shell/Commands/command-list-reach-beginning-of-file.test
+++ b/lldb/test/Shell/Commands/command-list-reach-beginning-of-file.test
@@ -4,7 +4,7 @@
 # RUN: %lldb %t.out -b -s %s 2>&1 | FileCheck %s
 
 list
-# CHECK: note: No source available 
+# CHECK: note: No source available
 
 b main
 # CHECK: Breakpoint 1:
@@ -18,7 +18,7 @@ list
 list -
 # CHECK: int main()
 
-list -10
+list -13
 # CHECK: #include <assert.h>
 
 list -


### PR DESCRIPTION
Otherwise these tests are reliant on the compiler defaulting to having the extensions on. Rest of LLVM's codebase doesn't seem to make such assumptions.

Tested by building with `-std=c2y` in Clang's C frotend's config file.