### PR TITLE
[NFCI][lldb][test] Avoid unnecessary GNU extension for assembly call

### DIFF
--- a/lldb/test/Shell/Unwind/Inputs/call-asm.c
+++ b/lldb/test/Shell/Unwind/Inputs/call-asm.c
@@ -1,3 +1,2 @@
-int asm_main() asm("asm_main");
-
+int asm_main();
 int main() { return asm_main(); }


### PR DESCRIPTION
`asm()` on function declarations is used for specifying the mangling. But it's a GNU extension and very much unnecessary here since the name matches.

Fixes compiling if the compiler defaults to non-extensions mode.