### PR TITLE
[NFCI][lldb][test][asm] Enable AT&T syntax explicitly

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -315,6 +315,13 @@ ifeq "$(MAKE_GMODULES)" "YES"
 	CXXFLAGS += $(MANDATORY_MODULE_BUILD_CFLAGS)
 endif
 
+# Our files use x86 AT&T assembly throughout.
+# Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
+ifeq ($(CC_TYPE), clang)
+	CFLAGS += -mllvm -x86-asm-syntax=att
+	CXXFLAGS += -mllvm -x86-asm-syntax=att
+endif
+
 CFLAGS += $(CFLAGS_EXTRAS)
 CXXFLAGS += -std=c++11 $(CFLAGS) $(ARCH_CXXFLAGS)
 # Copy common options to the linker flags (dwarf, arch. & etc).

--- a/lldb/test/API/functionalities/disassembler-variables/Makefile
+++ b/lldb/test/API/functionalities/disassembler-variables/Makefile
@@ -19,7 +19,7 @@ dummy_main.c:
 
 # Assemble .s → .o using the configured compiler.
 %.o: %.s
-	$(CC) -c -x assembler $< -o $@
+	$(CC) $(CFLAGS) -c -x assembler $< -o $@
 
 # Default target: build all .o fixtures and the dummy exe.
 .PHONY: all

--- a/lldb/test/API/functionalities/disassembler-variables/d_original_example.s
+++ b/lldb/test/API/functionalities/disassembler-variables/d_original_example.s
@@ -1,6 +1,6 @@
 /* Original C (for context):
 * #include <stdio.h>
-* 
+*
 * int main(int argc, char **argv) {
 *   for (int i = 1; i < argc; ++i)
 *     puts(argv[i]);
@@ -8,6 +8,7 @@
 * }
 */
 	.file	"d_original_example.c"
+	.att_syntax
 	.text
 	.globl	main                            # -- Begin function main
 	.p2align	4

--- a/lldb/test/API/functionalities/disassembler-variables/live_across_call.s
+++ b/lldb/test/API/functionalities/disassembler-variables/live_across_call.s
@@ -1,7 +1,7 @@
 /* Original C (for context):
 * // Declare a real external call so the compiler must respect ABI clobbers.
 * extern int leaf(int) __attribute__((noinline));
-* 
+*
 * __attribute__((noinline))
 * int live_across_call(int x) {
 *   volatile int a = x;                // a starts in a GPR (from arg)
@@ -12,6 +12,7 @@
 * }
 */
 	.file	"live_across_call.c"
+	.att_syntax
 	.text
 	.globl	live_across_call                # -- Begin function live_across_call
 	.p2align	4

--- a/lldb/test/API/functionalities/disassembler-variables/loop_reg_rotate.s
+++ b/lldb/test/API/functionalities/disassembler-variables/loop_reg_rotate.s
@@ -3,7 +3,7 @@
 * int loop_reg_rotate(int n, int seed) {
 *   volatile int acc = seed;    // keep as a named local
 *   int i = 0, j = 1, k = 2;    // extra pressure but not enough to spill
-* 
+*
 *   for (int t = 0; t < n; ++t) {
 *     // Mix uses so the allocator may reshuffle regs for 'acc'
 *     acc = acc + i;
@@ -13,12 +13,13 @@
 *     acc = acc + k;
 *     i ^= acc; j += acc; k ^= j;
 *   }
-* 
+*
 *   asm volatile("" :: "r"(acc));
 *   return acc + i + j + k;
 * }
 */
 	.file	"loop_reg_rotate.c"
+	.att_syntax
 	.text
 	.globl	loop_reg_rotate                 # -- Begin function loop_reg_rotate
 	.p2align	4

--- a/lldb/test/API/functionalities/disassembler-variables/regs_fp_params.s
+++ b/lldb/test/API/functionalities/disassembler-variables/regs_fp_params.s
@@ -5,6 +5,7 @@
 *   return a + b + c + d + e + f;
 * }*/
 	.file	"regs_fp_params.c"
+	.att_syntax
 	.text
 	.globl	regs_fp_params                  # -- Begin function regs_fp_params
 	.p2align	4

--- a/lldb/test/API/functionalities/disassembler-variables/regs_int_params.s
+++ b/lldb/test/API/functionalities/disassembler-variables/regs_int_params.s
@@ -8,6 +8,7 @@
 * }
 */
 	.file	"regs_int_params.c"
+	.att_syntax
 	.text
 	.globl	regs_int_params                 # -- Begin function regs_int_params
 	.p2align	4

--- a/lldb/test/API/functionalities/disassembler-variables/regs_mixed_params.s
+++ b/lldb/test/API/functionalities/disassembler-variables/regs_mixed_params.s
@@ -11,6 +11,7 @@
 */
 	.file	"regs_mixed_params.c"
 	.file	0 "." "regs_mixed_params.c" md5 0x73c4bda40238ae460aaecb3a6a2603cf
+	.att_syntax
 	.text
 	.globl	regs_mixed_params               # -- Begin function regs_mixed_params
 	.p2align	4

--- a/lldb/test/API/functionalities/disassembler-variables/seed_reg_const_undef.s
+++ b/lldb/test/API/functionalities/disassembler-variables/seed_reg_const_undef.s
@@ -10,6 +10,7 @@
 */
 
 	.file	"seed_reg_const_undef.c"
+	.att_syntax
 	.text
 	.globl	main                            # -- Begin function main
 	.p2align	4

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_GNU_call_site-DW_AT_low_pc.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_GNU_call_site-DW_AT_low_pc.s
@@ -27,6 +27,7 @@
 #   return 0;
 # }
 
+	.att_syntax
 	.text
 .Ltext0:
 	.type	b, @function

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_variable-DW_AT_decl_file-DW_AT_abstract_origin-crosscu1.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_variable-DW_AT_decl_file-DW_AT_abstract_origin-crosscu1.s
@@ -24,6 +24,7 @@
 # CHECK: inlinevar.h:2: (int) var = {{.*}}
 # Unfixed LLDB did show only: (int) var = {{.*}}
 
+	.att_syntax
 	.text
 	.file	"inlinevar1.c"
 	.file	1 "" "./inlinevarother.h"

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/Inputs/DW_TAG_variable-DW_AT_decl_file-DW_AT_abstract_origin-crosscu2.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/Inputs/DW_TAG_variable-DW_AT_decl_file-DW_AT_abstract_origin-crosscu2.s
@@ -1,3 +1,4 @@
+	.att_syntax
 	.text
 	.file	"inlinevar2.c"
 	.globl	other                       # -- Begin function other

--- a/lldb/test/Shell/Unwind/Inputs/basic-block-sections-with-dwarf.s
+++ b/lldb/test/Shell/Unwind/Inputs/basic-block-sections-with-dwarf.s
@@ -8,6 +8,7 @@
 # using the frame pointer register and the are deliberately adjusting the stack
 # pointer to test that we're using the correct unwind row.
 
+        .att_syntax
         .text
 
         .type   baz,@function

--- a/lldb/test/Shell/Unwind/Inputs/eh-frame-augment-noop.s
+++ b/lldb/test/Shell/Unwind/Inputs/eh-frame-augment-noop.s
@@ -2,6 +2,7 @@
 # augmentation machinery should detect that no augmentation is needed and use
 # eh_frame directly.
 
+        .att_syntax
         .text
         .globl  foo
 foo:

--- a/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind-abort.s
+++ b/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind-abort.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
         .globl  asm_main
 asm_main:

--- a/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind-val-offset.s
+++ b/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind-val-offset.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
         .globl  bar
 bar:

--- a/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind.s
+++ b/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
         .globl  bar
 bar:

--- a/lldb/test/Shell/Unwind/Inputs/eh-frame-small-fde.s
+++ b/lldb/test/Shell/Unwind/Inputs/eh-frame-small-fde.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
 
         .type   bar, @function

--- a/lldb/test/Shell/Unwind/Inputs/prefer-debug-over-eh-frame.s
+++ b/lldb/test/Shell/Unwind/Inputs/prefer-debug-over-eh-frame.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .cfi_sections .eh_frame, .debug_frame
         .text
         .globl  bar

--- a/lldb/test/Shell/Unwind/Inputs/thread-step-out-ret-addr-check.s
+++ b/lldb/test/Shell/Unwind/Inputs/thread-step-out-ret-addr-check.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
         .globl  asm_main
 asm_main:

--- a/lldb/test/Shell/Unwind/Inputs/trap_frame_sym_ctx.s
+++ b/lldb/test/Shell/Unwind/Inputs/trap_frame_sym_ctx.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
         .globl  bar
 bar:

--- a/lldb/test/Shell/Unwind/Inputs/unwind-plan-dwarf-dump.s
+++ b/lldb/test/Shell/Unwind/Inputs/unwind-plan-dwarf-dump.s
@@ -1,3 +1,4 @@
+        .att_syntax
         .text
         .globl  main
         .type   main, @function

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -242,6 +242,10 @@ def use_support_substitutions(config):
     # The clang module cache is used for building inferiors.
     host_flags += ["-fmodules-cache-path={}".format(config.clang_module_cache)]
 
+    # Our files use x86 AT&T assembly throughout.
+    # Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
+    host_flags += ["-mllvm", "-x86-asm-syntax=att"]
+
     if config.cmake_sysroot:
         host_flags += ["--sysroot={}".format(config.cmake_sysroot)]
 


### PR DESCRIPTION
Implementation files using the Intel syntax typically explicitly specify it. Do the same for the few files using AT&T syntax.

This enables building LLVM with `-mllvm -x86-asm-syntax=intel` in one's Clang config files (i.e. a global preference for Intel syntax).