### PR TITLE
RuntimeLibcalls: Remove LLVM_ABI from private member variable declarations

### DIFF
--- a/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
+++ b/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
@@ -12,9 +12,9 @@ namespace llvm {
 
 class LibcallLoweringInfo {
 private:
-  LLVM_ABI const RTLIB::RuntimeLibcallsInfo &RTLCI;
+  const RTLIB::RuntimeLibcallsInfo &RTLCI;
   /// Stores the implementation choice for each each libcall.
-  LLVM_ABI RTLIB::LibcallImpl LibcallImpls[RTLIB::UNKNOWN_LIBCALL + 1] = {
+  RTLIB::LibcallImpl LibcallImpls[RTLIB::UNKNOWN_LIBCALL + 1] = {
       RTLIB::Unsupported};
 
 public:


### PR DESCRIPTION
Seeing warnings:

llvm/include/llvm/CodeGen/LibcallLoweringInfo.h:15:46: error: 'visibility' attribute ignored [-Werror=attributes]
15 |   LLVM_ABI const RTLIB::RuntimeLibcallsInfo &RTLCI;
llvm/include/llvm/CodeGen/LibcallLoweringInfo.h:18:25: error: 'visibility' attribute ignored [-Werror=attributes]
18 |       RTLIB::Unsupported};
