### PR TITLE
[flang] Fixing macro variable expansion at compile time

### DIFF
--- a/flang/test/Preprocessing/macro-expansion.F90
+++ b/flang/test/Preprocessing/macro-expansion.F90
@@ -1,0 +1,12 @@
+! RUN: %flang -fc1 -emit-fir -cpp -DNVAR=2+1+0+0 -o - %s | FileCheck %s
+
+! CHECK: fir.string_lit "YES"(3) : !fir.char<1,3>
+! CHECK-NOT: fir.string_lit "NO"(2) : !fir.char<1,2>
+
+program test
+#if NVAR > 2
+  print *, "YES"
+#else
+  print *, "NO"
+#endif
+end program

--- a/flang/test/Preprocessing/macro-expansion2.F90
+++ b/flang/test/Preprocessing/macro-expansion2.F90
@@ -1,0 +1,13 @@
+! RUN: %flang -fc1 -emit-fir -cpp -DNVAR=2+1+0+0 -o - %s | FileCheck %s
+
+! CHECK: fir.string_lit "NO"(2) : !fir.char<1,2>
+! CHECK-NOT: fir.string_lit "YES"(3) : !fir.char<1,3>
+
+program test
+#if NVAR < 2
+  print *, "YES"
+#else
+  print *, "NO"
+#endif
+end program
+


### PR DESCRIPTION
Hello, 
I encountered a problem in the [Ramses](https://github.com/ramses-organisation/ramses/) project that used the macro as follows:

```
program test
#if NVAR > 2
  print *, "YES"
#else
  print *, "NO"
#endif
end program
```
When I compile with `gfortran` with `-cpp -DNVAR=2+1+0+0`, it doesn't raise an error and the mathematical expression was expand and evaluated correctly. 
However, with Flang, this was not the case and the macro was expanded as a string, which is not valid normally.

I'm proposing a patch to fix this (I don't know if this is the right way to do it, so any feedback is welcome).
