### PR TITLE
[CodeGen] Add missing header guard to LibcallLoweringInfo.h

### DIFF
--- a/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
+++ b/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef LLVM_CODEGEN_LIBCALLLOWERINGINFO_H
+#define LLVM_CODEGEN_LIBCALLLOWERINGINFO_H
+
 #include "llvm/IR/RuntimeLibcalls.h"
 
 namespace llvm {
@@ -64,3 +67,5 @@ public:
 };
 
 } // end namespace llvm
+
+#endif // LLVM_CODEGEN_LIBCALLLOWERINGINFO_H


### PR DESCRIPTION
Introduced by https://github.com/llvm/llvm-project/pull/164987