### PR TITLE
Add name for `ObjCInterface` in vTable

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -983,7 +983,11 @@ const char *vTableClassNameForType(const CIRGenModule &cgm, const Type *ty) {
     break;
 
   case Type::ObjCInterface:
-    cgm.errorNYI("VTableClassNameForType: ObjCInterface");
+    if (cast<ObjCInterfaceType>(Ty)->getDecl()->getSuperClass()) {
+      return siClassTypeInfo;
+    } else {
+      return classTypeInfo;
+    }
     break;
 
   case Type::ObjCObjectPointer:


### PR DESCRIPTION
Related: #163601

This PR adds RTTI support for `ObjCInterface` in the vtable.