### PR TITLE
[NFCI][test][asm] Enable AT&T syntax explicitly

### DIFF
--- a/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
+++ b/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
@@ -23,6 +23,7 @@
 ## The exception table is modified to use udata4 encoding for LPStart and
 ## sdata4 encoding for call sites.
 
+	.att_syntax
 	.text
 	.globl	main                            # -- Begin function main
 	.p2align	4, 0x90

--- a/libunwind/test/remember_state_leak.pass.sh.s
+++ b/libunwind/test/remember_state_leak.pass.sh.s
@@ -38,6 +38,7 @@
 
     SIZEOF_UNWIND_EXCEPTION = 32
 
+    .att_syntax
     .text
 callback:
     xorl    %eax, %eax


### PR DESCRIPTION
Implementation files using the Intel syntax typically explicitly specify it. Do the same for the few files where applicable for AT&T.

This enables building LLVM with `-mllvm -x86-asm-syntax=intel` in one's Clang config files (i.e. a global preference for Intel syntax).