### PR TITLE
[LLVM] Check if LLVM_ON_UNIX is Defined

### DIFF
--- a/llvm/include/llvm/Support/thread.h
+++ b/llvm/include/llvm/Support/thread.h
@@ -34,7 +34,7 @@ typedef PVOID HANDLE;
 
 namespace llvm {
 
-#if LLVM_ON_UNIX || _WIN32
+#if defined(LLVM_ON_UNIX) || defined(_WIN32)
 
 /// LLVM thread following std::thread interface with added constructor to
 /// specify stack size.
@@ -49,7 +49,7 @@ class thread {
   }
 
 public:
-#if LLVM_ON_UNIX
+#ifdef LLVM_ON_UNIX
   using native_handle_type = pthread_t;
   using id = pthread_t;
   using start_routine_type = void *(*)(void *);


### PR DESCRIPTION
This is canonical in the rest of the repository and otherwise we can end
up with warnings when compiling with clang-cl on Windows that look like
the following:

```
2025-11-06T17:55:25.2412502Z C:\_work\llvm-project\llvm-project\llvm\include\llvm/Support/thread.h(37,5): warning: 'LLVM_ON_UNIX' is not defined, evaluates to 0 [-Wundef]
2025-11-06T17:55:25.2413436Z    37 | #if LLVM_ON_UNIX || _WIN32
2025-11-06T17:55:25.2413791Z       |     ^
2025-11-06T17:55:25.2414625Z C:\_work\llvm-project\llvm-project\llvm\include\llvm/Support/thread.h(52,5): warning: 'LLVM_ON_UNIX' is not defined, evaluates to 0 [-Wundef]
2025-11-06T17:55:25.2415585Z    52 | #if LLVM_ON_UNIX
2025-11-06T17:55:25.2415901Z       |     ^
2025-11-06T17:55:25.2416169Z 2 warnings generated.
```
