### PR TITLE
[CI] Remove Disabled Warning Set on Windows

### DIFF
--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -47,7 +47,6 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D CMAKE_EXE_LINKER_FLAGS="/MANIFEST:NO" \
       -D CMAKE_MODULE_LINKER_FLAGS="/MANIFEST:NO" \
       -D CMAKE_SHARED_LINKER_FLAGS="/MANIFEST:NO" \
-      -D CMAKE_CXX_FLAGS="-Wno-c++98-compat -Wno-c++14-compat -Wno-unsafe-buffer-usage -Wno-old-style-cast" \
       -D LLVM_ENABLE_RUNTIMES="${runtimes}"
 
 start-group "ninja"


### PR DESCRIPTION
The low hanging fruit that was causing the vast majority of these warnings has been fixed, so reenable them now. There are still a couple more warnings that could probably do with some cleanup, but those can be fixed in the future.