### PR TITLE
[[gnu::weak]] disables constant evaluation of constexpr variables in C++14

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -3611,7 +3611,7 @@ static bool evaluateVarDeclInit(EvalInfo &Info, const Expr *E,
 
   // Never use the initializer of a weak variable, not even for constant
   // folding. We can't be sure that this is the definition that will be used.
-  if (VD->isWeak()) {
+  if (VD->isWeak()&& (Info.EvalMode != EvaluationMode::ConstantExpression)) {
     Info.FFDiag(E, diag::note_constexpr_var_init_weak) << VD;
     NoteLValueLocation(Info, Base);
     return false;


### PR DESCRIPTION
Clang's constant evaluator would unconditionally reject the initializer of any [[gnu::weak]] variable. This was intended to prevent unsafe constant folding but also incorrectly blocked valid constant evaluation in C++14 (e.g., static constexpr initialization).

This patch refines the logic to only apply the check when the evaluation mode is not EvaluationMode::ConstantExpression. This fixes the bug by allowing required constexpr evaluation to proceed while still preventing unsafe folding in other contexts.