### PR TITLE
[Option] Fix simple subcommand with positional arguments

### DIFF
--- a/llvm/lib/Option/ArgList.cpp
+++ b/llvm/lib/Option/ArgList.cpp
@@ -230,10 +230,8 @@ StringRef ArgList::getSubCommand(
     HandleMultipleSubcommands(SubCommands);
     return {};
   }
-  if (!OtherPositionals.empty()) {
+  if (!OtherPositionals.empty())
     HandleOtherPositionals(OtherPositionals);
-    return {};
-  }
 
   if (SubCommands.size() == 1)
     return SubCommands.front();

--- a/llvm/unittests/Option/OptionSubCommandsTest.cpp
+++ b/llvm/unittests/Option/OptionSubCommandsTest.cpp
@@ -200,7 +200,7 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
     StringRef SC = AL.getSubCommand(
         T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
-    EXPECT_EQ(SC, "bar");                  // valid subcommand
+    EXPECT_EQ(SC, "bar"); // valid subcommand
     EXPECT_NE(std::string::npos,
               ErrMsg.find("Unregistered positionals passed"));
     EXPECT_NE(std::string::npos, ErrMsg.find("input"));

--- a/llvm/unittests/Option/OptionSubCommandsTest.cpp
+++ b/llvm/unittests/Option/OptionSubCommandsTest.cpp
@@ -192,6 +192,19 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
         std::string::npos,
         ErrMsg.find("Option [lowercase] is not valid for SubCommand [bar]"));
   }
+
+  {
+    // Test case 7: Check valid use of a valid subcommand following more
+    // positional arguments.
+    const char *Args[] = {"bar", "input"};
+    InputArgList AL = T.ParseArgs(Args, MAI, MAC);
+    StringRef SC = AL.getSubCommand(
+        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    EXPECT_EQ(SC, "bar");                  // valid subcommand
+    EXPECT_NE(std::string::npos,
+              ErrMsg.find("Unregistered positionals passed"));
+    EXPECT_NE(std::string::npos, ErrMsg.find("input"));
+  }
 }
 
 TYPED_TEST(OptSubCommandTableTest, SubCommandHelp) {


### PR DESCRIPTION
Fix subcommand detection when subcommand used with positional arguments.
When there is only one valid subcommand passed,
`ArgList::getSubCommand()` should return the correct subcommand even
there are other positionals passed.
