### PR TITLE
[Github] Use zstd to compress CI container images

### DIFF
--- a/.github/actions/push-container/action.yml
+++ b/.github/actions/push-container/action.yml
@@ -24,9 +24,9 @@ runs:
           latest_name=$(echo $image_name | sed 's/:[a-f0-9]\+$/:latest/g')
           podman tag $image_name $latest_name
           echo "Pushing $image_name ..."
-          podman push $image_name
+          podman push --compression-format=zstd $image_name
           echo "Pushing $latest_name ..."
-          podman push $latest_name
+          podman push --compression-format=zstd $latest_name
         }
 
         podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io


### PR DESCRIPTION
zstd usually offers better compression ratios, but also offers much higher decompression speeds, which can tangibly impact image unpack times. Enable this by default given it is a two line change that is transparent at image pull time given most container runtimes these days supported zstd compressed images.