### PR TITLE
Add a workaround for people that use *args instead of listing

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -188,8 +188,13 @@ public:
       // This addresses the cases where the embedded interpreter session
       // dictionary is passed to the extension initializer which is not used
       // most of the time.
+      // Note, though none of our API's suggest defining the interfaces with
+      // varargs, we have some extant clients that were doing that.  To keep 
+      // from breaking them, we just say putting a varargs in these signatures
+      // turns off argument checking.
       size_t num_args = sizeof...(Args);
-      if (num_args != arg_info->max_positional_args) {
+      if (arg_info->max_positional_args != PythonCallable::ArgInfo::UNBOUNDED 
+          && num_args != arg_info->max_positional_args) {
         if (num_args != arg_info->max_positional_args - 1)
           return create_error("Passed arguments ({0}) doesn't match the number "
                               "of expected arguments ({1}).",

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -189,12 +189,12 @@ public:
       // dictionary is passed to the extension initializer which is not used
       // most of the time.
       // Note, though none of our API's suggest defining the interfaces with
-      // varargs, we have some extant clients that were doing that.  To keep 
+      // varargs, we have some extant clients that were doing that.  To keep
       // from breaking them, we just say putting a varargs in these signatures
       // turns off argument checking.
       size_t num_args = sizeof...(Args);
-      if (arg_info->max_positional_args != PythonCallable::ArgInfo::UNBOUNDED 
-          && num_args != arg_info->max_positional_args) {
+      if (arg_info->max_positional_args != PythonCallable::ArgInfo::UNBOUNDED &&
+          num_args != arg_info->max_positional_args) {
         if (num_args != arg_info->max_positional_args - 1)
           return create_error("Passed arguments ({0}) doesn't match the number "
                               "of expected arguments ({1}).",


### PR DESCRIPTION
parameters when defining the scripting interfaces.

We try to count the parameters to make sure the user has defined them correctly, but this throws the counting off.

I'm not adding a test for this because then it would seem like we thought this was a good idea.  I'd actually rather not support it altogether, but we added the parameter checking pretty recently so there are extant implementations that we broke.  I only want to support them, not suggest anyone else do this going forward.