### PR TITLE
[bazel] Add missing deps for AlignmentAttrInterface.h

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -4905,6 +4905,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":AffineDialect",
+        ":AlignmentAttrInterface",
         ":Analysis",
         ":ArithDialect",
         ":ArithUtils",
@@ -6979,6 +6980,7 @@ cc_library(
     ]),
     includes = ["include"],
     deps = [
+        ":AlignmentAttrInterface",
         ":BytecodeOpInterface",
         ":CallOpInterfaces",
         ":CommonFolders",


### PR DESCRIPTION
Commit 4a7d3df added `#include "AlignmentAttrInterface.h"` in three places: MemRef.h, SPIRVOps.h, and VectorOps.h; my previous bazel fix 7e9db96 only covered MemRef.h, but not the other two.