### PR TITLE
[Clang/test] Add required targets to gpu-libc.c

### DIFF
--- a/clang/test/Driver/gpu-libc.c
+++ b/clang/test/Driver/gpu-libc.c
@@ -1,3 +1,5 @@
+// REQUIRES: x86-registered-target, amdgpu-registered-target, nvptx-registered-target
+
 // RUN:   %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a --sysroot=%S/Inputs/basic_gpu_tree \
 // RUN:     -ccc-install-dir %S/Inputs/basic_gpu_tree/bin -nogpulib %s 2>&1 | FileCheck %s --check-prefix=CHECK-HEADERS-AMDGPU
 // RUN:   %clang -### --target=nvptx64-nvidia-cuda -march=sm_89 --sysroot=%S/Inputs/basic_gpu_tree \


### PR DESCRIPTION
The test clang/test/Driver/gpu-libc.c is run unconditionally. This should be run only if LLVM is built with X86, AMDGPU and NVPTX target, thus use *-registered-target.