### PR TITLE
[flang] remove bogus header include from #164988

### DIFF
--- a/flang/lib/Optimizer/Builder/HLFIRTools.cpp
+++ b/flang/lib/Optimizer/Builder/HLFIRTools.cpp
@@ -18,7 +18,6 @@
 #include "flang/Optimizer/Builder/Todo.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
-#include "flang/Optimizer/OpenMP/Passes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/TypeSwitch.h"


### PR DESCRIPTION
I mistakenly added this header in #164988 while I ended-up not using it.
It is causing build failures on some buildbot because of MLIR .inc dependencies not reflected in cmake.
https://lab.llvm.org/buildbot/#/builders/124/builds/1604
Remove it.