### PR TITLE
[SPIRV] Fix failing assertion in SPIRVAsmPrinter

### DIFF
--- a/llvm/test/CodeGen/SPIRV/non_int_constant_null.ll
+++ b/llvm/test/CodeGen/SPIRV/non_int_constant_null.ll
@@ -1,0 +1,10 @@
+; RUN: not llc -mtriple spirv64-unknown-unknown %s --spirv-ext=+SPV_KHR_float_controls2 -o -
+; Assertion `isImm() && "Wrong MachineOperand accessor"' failed
+; On TypeMI->getOperand(1).getImm() then TypeMI is OpTypeArray %8, %17
+
+@A = addrspace(1) constant [1 x i8] zeroinitializer
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/non_int_constant_null.ll
+++ b/llvm/test/CodeGen/SPIRV/non_int_constant_null.ll
@@ -1,8 +1,23 @@
-; RUN: not llc -mtriple spirv64-unknown-unknown %s --spirv-ext=+SPV_KHR_float_controls2 -o -
-; Assertion `isImm() && "Wrong MachineOperand accessor"' failed
-; On TypeMI->getOperand(1).getImm() then TypeMI is OpTypeArray %8, %17
+; RUN: llc -mtriple spirv64-unknown-unknown %s --spirv-ext=+SPV_KHR_float_controls2 -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple spirv64-unknown-unknown %s --spirv-ext=+SPV_KHR_float_controls2 -o - -filetype=obj | spirv-val %}
 
 @A = addrspace(1) constant [1 x i8] zeroinitializer
+
+; CHECK: OpName %[[#FOO:]] "foo"
+; CHECK: OpName %[[#A:]] "A"
+; CHECK: OpDecorate %[[#A]] Constant
+; CHECK: OpDecorate %[[#A]] LinkageAttributes "A" Export
+; CHECK: %[[#INT8:]] = OpTypeInt 8 0
+; CHECK: %[[#INT32:]] = OpTypeInt 32 0
+; CHECK: %[[#ONE:]] = OpConstant %[[#INT32]] 1
+; CHECK: %[[#ARR_INT8:]] = OpTypeArray %[[#INT8]] %7
+; CHECK: %[[#ARR_INT8_PTR:]] = OpTypePointer CrossWorkgroup %[[#ARR_INT8]]
+; CHECK: %[[#ARR_INT8_ZERO:]] = OpConstantNull %[[#ARR_INT8]]
+; CHECK: %13 = OpVariable %[[#ARR_INT8_PTR]] CrossWorkgroup %[[#ARR_INT8_ZERO]]
+; CHECK: %[[#FOO]] = OpFunction
+; CHECK: = OpLabel
+; CHECK: OpReturn
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @foo() {
 entry:


### PR DESCRIPTION
With `+SPV_KHR_float_controls2` and when there is a non-int `OpConstantNull` we
would call `MI.getOperand(1).getImm()` when `MI` was not an `OpTypeInt` (the
associated test has an `OpTypeArray` zeroinitialized).
Under this conditions an assertion is triggered.

This patch adds the missing condition.