### PR TITLE
[LLDB] Run MSVC STL (forward-)list test with PDB

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
@@ -203,6 +203,16 @@ private:
   ValueObject *m_tail = nullptr;
 };
 
+/// Gets the (forward-)list element type from the head node instead of the
+/// template arguments. This is needed with PDB as it doesn't have info about
+/// the template arguments.
+CompilerType GetMsvcStlElementTypeFromHead(ValueObject &head) {
+  auto val_sp = head.GetChildMemberWithName("_Myval");
+  if (val_sp)
+    return val_sp->GetCompilerType();
+  return CompilerType();
+}
+
 } // end anonymous namespace
 
 template <StlType Stl>
@@ -530,11 +540,9 @@ lldb::ChildCacheState MsvcStlForwardListFrontEnd::Update() {
           m_backend.GetChildAtNamePath({"_Mypair", "_Myval2", "_Myhead"}))
     m_head = head_sp.get();
 
-  if (!m_element_type && m_head) {
-    auto val_sp = m_head->GetChildMemberWithName("_Myval");
-    if (val_sp)
-      m_element_type = val_sp->GetCompilerType();
-  }
+  // With PDB, we can't get the element type from the template arguments
+  if (!m_element_type && m_head)
+    m_element_type = GetMsvcStlElementTypeFromHead(*m_head);
 
   return ChildCacheState::eRefetch;
 }
@@ -612,11 +620,9 @@ lldb::ChildCacheState MsvcStlListFrontEnd::Update() {
   m_head = first.get();
   m_tail = last.get();
 
-  if (!m_element_type && m_head) {
-    auto val_sp = m_head->GetChildMemberWithName("_Myval");
-    if (val_sp)
-      m_element_type = val_sp->GetCompilerType();
-  }
+  // With PDB, we can't get the element type from the template arguments
+  if (!m_element_type && m_head)
+    m_element_type = GetMsvcStlElementTypeFromHead(*m_head);
 
   return lldb::ChildCacheState::eRefetch;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
@@ -530,6 +530,12 @@ lldb::ChildCacheState MsvcStlForwardListFrontEnd::Update() {
           m_backend.GetChildAtNamePath({"_Mypair", "_Myval2", "_Myhead"}))
     m_head = head_sp.get();
 
+  if (!m_element_type && m_head) {
+    auto val_sp = m_head->GetChildMemberWithName("_Myval");
+    if (val_sp)
+      m_element_type = val_sp->GetCompilerType();
+  }
+
   return ChildCacheState::eRefetch;
 }
 
@@ -605,6 +611,12 @@ lldb::ChildCacheState MsvcStlListFrontEnd::Update() {
 
   m_head = first.get();
   m_tail = last.get();
+
+  if (!m_element_type && m_head) {
+    auto val_sp = m_head->GetChildMemberWithName("_Myval");
+    if (val_sp)
+      m_element_type = val_sp->GetCompilerType();
+  }
 
   return lldb::ChildCacheState::eRefetch;
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestDataFormatterGenericForwardList(TestBase):
+    TEST_WITH_PDB_DEBUG_INFO = True
+
     def setUp(self):
         TestBase.setUp(self)
         self.line = line_number("main.cpp", "// break here")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class GenericListDataFormatterTestCase(TestBase):
+    TEST_WITH_PDB_DEBUG_INFO = True
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/loop/TestDataFormatterGenericListLoop.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/loop/TestDataFormatterGenericListLoop.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericListDataFormatterTestCase(TestBase):
+    TEST_WITH_PDB_DEBUG_INFO = True
     NO_DEBUG_INFO_TESTCASE = True
 
     def do_test_with_run_command(self):


### PR DESCRIPTION
Since PDB doesn't have template information, we need to get the element type from somewhere else. I'm using the type of `_Myval` in a list node, which holds the element type.