### PR TITLE
[CAS] Fix wrong usage of `llvm::sort()` in UnifiedOnDiskCache

### DIFF
--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -174,7 +174,7 @@ getAllDBDirs(StringRef Path, bool IncludeCorrupt = false) {
     return createFileError(Path, EC);
 
   llvm::sort(FoundDBDirs, [](const DBDir &LHS, const DBDir &RHS) -> bool {
-    return LHS.Order <= RHS.Order;
+    return LHS.Order < RHS.Order;
   });
 
   SmallVector<std::string, 4> DBDirs;


### PR DESCRIPTION
Fix compare function in getAllDBDirs(). The compare function in sort
should be strictly less than operator.
