### PR TITLE
Revert "[NFCI][lldb][test] Avoid unnecessary GNU extension for assembly call"

### DIFF
--- a/lldb/test/Shell/Unwind/Inputs/call-asm.c
+++ b/lldb/test/Shell/Unwind/Inputs/call-asm.c
@@ -1,2 +1,3 @@
-int asm_main();
+int asm_main() asm("asm_main");
+
 int main() { return asm_main(); }


### PR DESCRIPTION
Reverts llvm/llvm-project#166769

Darwin platforms prefix symbols with `_`, other platforms don't necessarily.