### PR TITLE
[MLIR][CODEOWNERS] Add XeGPU and XeVM codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,8 @@
 /mlir/include/mlir/Dialect/XeGPU @charithaintc @Jianhui-Li
 /mlir/lib/Dialect/XeGPU @charithaintc @Jianhui-Li
 /mlir/lib/Conversion/*XeGPU* @charithaintc @Jianhui-Li
+/mlir/include/mlir/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li @tkarna
+/mlir/lib/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li @tkarna
 /mlir/include/mlir/Dialect/LLVMIR/XeVM* @silee2
 /mlir/lib/Dialect/LLVMIR/IR/XeVM @silee2
 /mlir/lib/Conversion/*XeVM* @silee2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,8 +64,8 @@
 /mlir/include/mlir/Dialect/XeGPU @charithaintc @Jianhui-Li
 /mlir/lib/Dialect/XeGPU @charithaintc @Jianhui-Li
 /mlir/lib/Conversion/*XeGPU* @charithaintc @Jianhui-Li
-/mlir/include/mlir/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li @tkarna
-/mlir/lib/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li @tkarna
+/mlir/include/mlir/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li
+/mlir/lib/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li
 /mlir/include/mlir/Dialect/LLVMIR/XeVM* @silee2
 /mlir/lib/Dialect/LLVMIR/IR/XeVM @silee2
 /mlir/lib/Conversion/*XeVM* @silee2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,6 +60,14 @@
 /mlir/lib/Conversion/*ToROCDL @krzysz00 @kuhar
 /mlir/include/mlir/Dialect/LLVMIR/ROCDL* @krzysz00 @kuhar
 
+# XeGPU and XeVM dialects in MLIR.
+/mlir/include/mlir/Dialect/XeGPU @charithaintc @Jianhui-Li
+/mlir/lib/Dialect/XeGPU @charithaintc @Jianhui-Li
+/mlir/lib/Conversion/*XeGPU* @charithaintc @Jianhui-Li
+/mlir/include/mlir/Dialect/LLVMIR/XeVM* @silee2
+/mlir/lib/Dialect/LLVMIR/IR/XeVM @silee2
+/mlir/lib/Conversion/*XeVM* @silee2
+
 # Bufferization Dialect in MLIR.
 /mlir/include/mlir/Dialect/Bufferization @matthias-springer
 /mlir/lib/Dialect/Bufferization @matthias-springer


### PR DESCRIPTION
XeGPU and XeVM dialect has assigned maintainers, but related folders currently lack code owners.
Add charithaintc and Jianhui-Li as code owner for XeGPU related folders.
Add silee2 as code owner for XeVM related folders.
Note:
charithaintc is current maintainer of XeGPU dialect.
silee2 is current maintainer of XeVM dialect.