### PR TITLE
[sanitizer_common] [Darwin] Fix strncmp => internal_strncmp in NextSegmentLoad

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -305,7 +305,8 @@ static bool NextSegmentLoad(MemoryMappedSegment *segment,
   layout_data->current_load_cmd_count--;
   if (((const load_command *)lc)->cmd == kLCSegment) {
     const SegmentCommand* sc = (const SegmentCommand *)lc;
-    if (internal_strncmp(sc->segname, "__LINKEDIT", sizeof("__LINKEDIT")) == 0) {
+    if (internal_strncmp(sc->segname, "__LINKEDIT", sizeof("__LINKEDIT")) ==
+        0) {
       // The LINKEDIT sections are for internal linker use, and may alias
       // with the LINKEDIT section for other modules. (If we included them,
       // our memory map would contain overlappping sections.)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -305,7 +305,7 @@ static bool NextSegmentLoad(MemoryMappedSegment *segment,
   layout_data->current_load_cmd_count--;
   if (((const load_command *)lc)->cmd == kLCSegment) {
     const SegmentCommand* sc = (const SegmentCommand *)lc;
-    if (strncmp(sc->segname, "__LINKEDIT", sizeof("__LINKEDIT")) == 0) {
+    if (internal_strncmp(sc->segname, "__LINKEDIT", sizeof("__LINKEDIT")) == 0) {
       // The LINKEDIT sections are for internal linker use, and may alias
       // with the LINKEDIT section for other modules. (If we included them,
       // our memory map would contain overlappping sections.)


### PR DESCRIPTION
#166005 introduced a call to strncmp, but we interpose that on macOS. We should use internal_strncmp instead.