### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (2 of N)

### DIFF
--- a/flang/test/Analysis/AliasAnalysis/modref-call-globals.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-globals.f90
@@ -75,7 +75,7 @@ end subroutine
 subroutine test_common
   implicit none
   real :: test_var_x_common
-  common /comm/ test_var_x_common 
+  common /comm/ test_var_x_common
   call test_effect_external()
 end subroutine
 ! CHECK-LABEL: Testing : "_QPtest_common"

--- a/flang/test/Evaluate/folding12.f90
+++ b/flang/test/Evaluate/folding12.f90
@@ -5,7 +5,7 @@ module m1
     integer :: parent_field
   end type parent_type
   type, extends(parent_type) :: child_type
-    integer :: child_field 
+    integer :: child_field
   end type child_type
   type parent_array_type
     integer, dimension(2) :: parent_field
@@ -21,7 +21,7 @@ module m1
   type(child_type), parameter :: child_const2 = child_type(12, 13)
   type(child_type), parameter :: array_var(2) = &
     [child_type(14, 15), child_type(16, 17)]
-  logical, parameter :: test_array_child = array_var(2)%child_field == 17 
+  logical, parameter :: test_array_child = array_var(2)%child_field == 17
   logical, parameter :: test_array_parent = array_var(2)%parent_field == 16
 
   type array_type
@@ -40,7 +40,7 @@ module m1
   type(child_array_type), parameter, dimension(2) :: child_const5 = &
     [child_array_type([22, 23], 24), child_array_type([25, 26], 27)]
   integer, dimension(2), parameter :: int_const6 = child_const5(:)%parent_field(2)
-  logical, parameter :: test_child3 = int_const6(1) == 23 
+  logical, parameter :: test_child3 = int_const6(1) == 23
 
   type(child_type), parameter :: child_const7 =  child_type(28, 29)
   type(parent_type), parameter :: parent_const8 = child_const7%parent_type
@@ -114,7 +114,7 @@ module m3
   logical, parameter :: test_parent1 = child_const1%parent_field1 == 12
   logical, parameter :: test_parent2 = child_const1%parent_field2 == 10.0
   logical, parameter :: test_parent3 = child_const1%parent_field3 .eqv. .false.
-  logical, parameter :: test_parent4 = & 
+  logical, parameter :: test_parent4 = &
     child_const1%parent_type%parent_field1 == 12
   logical, parameter :: test_parent5 = &
     child_const1%parent_type%parent_field2 == 10.0

--- a/flang/test/Examples/omp-in-reduction-clause.f90
+++ b/flang/test/Examples/omp-in-reduction-clause.f90
@@ -15,7 +15,7 @@ subroutine omp_in_reduction_taskgroup()
         do i=1,10
             z = z * 5
         end do
-    !$omp end taskloop 
+    !$omp end taskloop
     !$omp end taskgroup
 end subroutine omp_in_reduction_taskgroup
 

--- a/flang/test/Fir/CUDA/cuda-constructor-2.f90
+++ b/flang/test/Fir/CUDA/cuda-constructor-2.f90
@@ -28,10 +28,10 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 // CHECK-DAG: fir.call @_FortranACUFRegisterVariable(%[[MODULE2]], %[[VAR_ADDR2]], %[[VAR_NAME2]], %[[CST2]]) : (!fir.ref<!fir.llvm_ptr<i8>>, !fir.ref<i8>, !fir.ref<i8>, i64) -> ()
 // CHECK-DAG: %[[BOX:.*]] = fir.address_of(@_QMmtestsEndev) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 // CHECK-DAG: %[[BOXREF:.*]] = fir.convert %[[BOX]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<i8>
-// CHECK-DAG: fir.call @_FortranACUFRegisterVariable(%[[MODULE:.*]], %[[BOXREF]], %{{.*}}, %{{.*}}) 
+// CHECK-DAG: fir.call @_FortranACUFRegisterVariable(%[[MODULE:.*]], %[[BOXREF]], %{{.*}}, %{{.*}})
 //
 
-// ----- 
+// -----
 
 // Checking that constant global variables are not registered
 
@@ -40,7 +40,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i1 = dense<8> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, f80 = dense<128> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, i64 = dense<64> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">, fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.ident = "flang version 20.0.0 (https://github.com/llvm/llvm-project.git 3372303188df0f7f8ac26e7ab610cf8b0f716d42)", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
   fir.global @_QMiso_c_bindingECc_int constant : i32
-  
+
 
   fir.type_info @_QM__fortran_builtinsT__builtin_c_ptr noinit nodestroy nofinal : !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
   gpu.module @cuda_device_mod {
@@ -63,7 +63,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<i8 = dense<8> : vector<2xi64>, i
 
 // -----
 
-module attributes {dlti.dl_spec = #dlti.dl_spec<i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i1 = dense<8> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, f80 = dense<128> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, i64 = dense<64> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">, fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.ident = "flang version 20.0.0 (https://github.com/llvm/llvm-project.git 3372303188df0f7f8ac26e7ab610cf8b0f716d42)", llvm.target_triple = "x86_64-unknown-linux-gnu"} {  
+module attributes {dlti.dl_spec = #dlti.dl_spec<i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i1 = dense<8> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, f80 = dense<128> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, i64 = dense<64> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">, fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.ident = "flang version 20.0.0 (https://github.com/llvm/llvm-project.git 3372303188df0f7f8ac26e7ab610cf8b0f716d42)", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
   fir.global @_QMmEa00 {data_attr = #cuf.cuda<managed>} : !fir.box<!fir.heap<!fir.array<?x?x?x?x?xf64>>> {
     %c0 = arith.constant 0 : index
     %0 = fir.zero_bits !fir.heap<!fir.array<?x?x?x?x?xf64>>

--- a/flang/test/Fir/CUDA/cuda-implicit-device-global.f90
+++ b/flang/test/Fir/CUDA/cuda-implicit-device-global.f90
@@ -144,7 +144,7 @@ func.func private @_FortranAioEndIoStatement(!fir.ref<i8>) -> i32 attributes {fi
 // Checking that a constant fir.global that is used in device code is copied over to the device
 // CHECK: fir.global linkonce @_QQclX5465737420504153534544 constant : !fir.char<1,11>
 
-// CHECK-LABEL: gpu.module @cuda_device_mod 
+// CHECK-LABEL: gpu.module @cuda_device_mod
 // CHECK: fir.global linkonce @_QQclX5465737420504153534544 constant
 
 // -----
@@ -312,10 +312,10 @@ fir.global linkonce_odr @_QM__mod1E.n.cptr constant : !fir.char<1,4> {
 // -----
 
 // Variables with initialization are promoted to non constant global.
-// 
+//
 // attributes(global) subroutine kernel4()
 //   integer :: a = 4
-// end subroutine 
+// end subroutine
 
 func.func @_QPkernel4() attributes {cuf.proc_attr = #cuf.cuda_proc<global>} {
   %0 = fir.address_of(@_QFkernel4Ea) : !fir.ref<i32>

--- a/flang/test/Fir/dispatch.f90
+++ b/flang/test/Fir/dispatch.f90
@@ -296,7 +296,7 @@ end
 ! CHECK-LABEL: _QMdispatch1Pno_pass_array_pointer
 ! CHECK-LABEL: _QMdispatch1Pcall_a1_proc
 
-! Check the layout of the binding table. This is easier to do in FIR than in 
+! Check the layout of the binding table. This is easier to do in FIR than in
 ! LLVM IR.
 
 ! BT-LABEL: fir.type_info @_QMdispatch1Tty_kindK10K20

--- a/flang/test/Fir/non-trivial-procedure-binding-description.f90
+++ b/flang/test/Fir/non-trivial-procedure-binding-description.f90
@@ -25,6 +25,6 @@ end module a
 program main
   use a
 
-  type(f) :: obj 
+  type(f) :: obj
   print *, obj%foo(obj)
 end program

--- a/flang/test/HLFIR/assumed_shape_with_value_keyword.f90
+++ b/flang/test/HLFIR/assumed_shape_with_value_keyword.f90
@@ -31,7 +31,7 @@ end
 ! CHECK:          return
 ! CHECK:        }
 
-subroutine test_real_value1(x) 
+subroutine test_real_value1(x)
   real, value :: x(:)
   call internal_call3(x)
 end
@@ -45,7 +45,7 @@ end
 ! CHECK:          return
 ! CHECK:        }
 
-subroutine test_real_value2(x) 
+subroutine test_real_value2(x)
   real, value :: x(:,:)
   call internal_call4(x)
 end

--- a/flang/test/HLFIR/order_assignments/forall-proc-pointer-assignment-scheduling-character.f90
+++ b/flang/test/HLFIR/order_assignments/forall-proc-pointer-assignment-scheduling-character.f90
@@ -44,7 +44,7 @@ contains
 
   integer pure function decode(c)
     character(2), intent(in) :: c
-    decode = modulo(iachar(c(2:2))-49,10)+1 
+    decode = modulo(iachar(c(2:2))-49,10)+1
   end function
 
   subroutine test_no_conflict(x)

--- a/flang/test/Integration/unroll.f90
+++ b/flang/test/Integration/unroll.f90
@@ -3,7 +3,7 @@
 ! CHECK-LABEL: unroll_dir
 subroutine unroll_dir
   integer :: a(10)
-  !dir$ unroll 
+  !dir$ unroll
   ! CHECK:   br i1 {{.*}}, label {{.*}}, label {{.*}}
   ! CHECK-NOT: !llvm.loop
   ! CHECK:   br label {{.*}}, !llvm.loop ![[UNROLL_ENABLE_FULL_ANNO:.*]]

--- a/flang/test/Integration/unroll_and_jam.f90
+++ b/flang/test/Integration/unroll_and_jam.f90
@@ -27,7 +27,7 @@ end subroutine unroll_and_jam_dir_0
 ! CHECK-LABEL: unroll_and_jam_dir_1
 subroutine unroll_and_jam_dir_1
   integer :: a(10)
-  !dir$ unroll_and_jam 1 
+  !dir$ unroll_and_jam 1
   ! CHECK:   br i1 {{.*}}, label {{.*}}, label {{.*}}
   ! CHECK-NOT: !llvm.loop
   ! CHECK:   br label {{.*}}, !llvm.loop ![[ANNOTATION_DISABLE]]

--- a/flang/test/Transforms/DoConcurrent/basic_host.f90
+++ b/flang/test/Transforms/DoConcurrent/basic_host.f90
@@ -4,7 +4,7 @@
 ! RUN:   | FileCheck %s
 ! RUN: bbc -emit-hlfir -fopenmp -fdo-concurrent-to-openmp=host %s -o - \
 ! RUN:   | FileCheck %s
- 
+
 ! CHECK-LABEL: DO_CONCURRENT_BASIC
 program do_concurrent_basic
     ! CHECK: %[[ARR:.*]]:2 = hlfir.declare %{{.*}}(%{{.*}}) {uniq_name = "_QFEa"} : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xi32>>, !fir.ref<!fir.array<10xi32>>)

--- a/flang/test/Transforms/DoConcurrent/map_shape_info.f90
+++ b/flang/test/Transforms/DoConcurrent/map_shape_info.f90
@@ -28,7 +28,7 @@ end program do_concurrent_shape
 ! CHECK: omp.map.info
 ! CHECK: omp.map.info
 
-! CHECK: %[[DIM0_EXT_MAP:.*]] = omp.map.info 
+! CHECK: %[[DIM0_EXT_MAP:.*]] = omp.map.info
 ! CHECK-SAME:   var_ptr(%[[DIM0_EXT]] : !fir.ref<index>, index)
 ! CHECK-SAME:   map_clauses(implicit)
 ! CHECK-SAME:   capture(ByCopy) -> !fir.ref<index> {name = "_QFEa.extent.dim0"}
@@ -77,9 +77,9 @@ end subroutine do_concurrent_shape_shift
 ! CHECK: omp.map.info
 ! CHECK: omp.map.info
 
-! CHECK: %[[DIM0_STRT_MAP:.*]] = omp.map.info 
+! CHECK: %[[DIM0_STRT_MAP:.*]] = omp.map.info
 ! CHECK-SAME:   var_ptr(%[[DIM0_STRT]] : !fir.ref<index>, index)
-! CHECK-SAME:   map_clauses(implicit) 
+! CHECK-SAME:   map_clauses(implicit)
 ! CHECK-SAME:   capture(ByCopy) -> !fir.ref<index> {name = "_QF{{.*}}Ea.start_idx.dim0"}
 
 ! CHECK: %[[DIM0_EXT_MAP:.*]] = omp.map.info

--- a/flang/test/Transforms/DoConcurrent/use_loop_bounds_in_body.f90
+++ b/flang/test/Transforms/DoConcurrent/use_loop_bounds_in_body.f90
@@ -14,7 +14,7 @@ subroutine foo(a, n)
   do concurrent (i=1:n)
     a(i) = n
   end do
-end subroutine 
+end subroutine
 
 ! CHECK-LABEL: func.func @_QPfoo
 ! CHECK: omp.target


### PR DESCRIPTION
Only the fortran source files in flang/test have been modified. The other files in the directory will be cleaned up in subsequent commits