### PR TITLE
TargetLibraryInfo: Split off VectorLibrary enum and flag

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -23,6 +23,7 @@
 namespace llvm {
 
 template <typename T> class ArrayRef;
+enum class VectorLibrary;
 
 /// Provides info so a possible vectorization of a function can be
 /// computed. Function 'VectorFnName' is equivalent to 'ScalarFnName'
@@ -117,25 +118,6 @@ class TargetLibraryInfoImpl {
                                        const Module &M) const;
 
 public:
-  /// List of known vector-functions libraries.
-  ///
-  /// The vector-functions library defines, which functions are vectorizable
-  /// and with which factor. The library can be specified by either frontend,
-  /// or a commandline option, and then used by
-  /// addVectorizableFunctionsFromVecLib for filling up the tables of
-  /// vectorizable functions.
-  enum VectorLibrary {
-    NoLibrary,        // Don't use any vector library.
-    Accelerate,       // Use Accelerate framework.
-    DarwinLibSystemM, // Use Darwin's libsystem_m.
-    LIBMVEC,          // GLIBC Vector Math library.
-    MASSV,            // IBM MASS vector library.
-    SVML,             // Intel short vector math library.
-    SLEEFGNUABI, // SLEEF - SIMD Library for Evaluating Elementary Functions.
-    ArmPL,       // Arm Performance Libraries.
-    AMDLIBM      // AMD Math Vector library.
-  };
-
   TargetLibraryInfoImpl() = delete;
   LLVM_ABI explicit TargetLibraryInfoImpl(const Triple &T);
 

--- a/llvm/include/llvm/IR/SystemLibraries.h
+++ b/llvm/include/llvm/IR/SystemLibraries.h
@@ -1,0 +1,39 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_IR_SYSTEMLIBRARIES_H
+#define LLVM_IR_SYSTEMLIBRARIES_H
+
+namespace llvm {
+/// List of known vector-functions libraries.
+///
+/// The vector-functions library defines, which functions are vectorizable
+/// and with which factor. The library can be specified by either frontend,
+/// or a commandline option, and then used by
+/// addVectorizableFunctionsFromVecLib for filling up the tables of
+/// vectorizable functions.
+enum class VectorLibrary {
+  NoLibrary,        // Don't use any vector library.
+  Accelerate,       // Use Accelerate framework.
+  DarwinLibSystemM, // Use Darwin's libsystem_m.
+  LIBMVEC,          // GLIBC Vector Math library.
+  MASSV,            // IBM MASS vector library.
+  SVML,             // Intel short vector math library.
+  SLEEFGNUABI,      // SLEEF - SIMD Library for Evaluating Elementary Functions.
+  ArmPL,            // Arm Performance Libraries.
+  AMDLIBM           // AMD Math Vector library.
+};
+
+/// Command line flag value for the vector math library to use
+///
+/// FIXME: This should come from a module flag, and not be mutually exclusive
+extern VectorLibrary ClVectorLibrary;
+
+} // namespace llvm
+
+#endif // LLVM_IR_SYSTEMLIBRARIES_H

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -15,32 +15,10 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/SystemLibraries.h"
 #include "llvm/InitializePasses.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/TargetParser/Triple.h"
 using namespace llvm;
-
-static cl::opt<TargetLibraryInfoImpl::VectorLibrary> ClVectorLibrary(
-    "vector-library", cl::Hidden, cl::desc("Vector functions library"),
-    cl::init(TargetLibraryInfoImpl::NoLibrary),
-    cl::values(clEnumValN(TargetLibraryInfoImpl::NoLibrary, "none",
-                          "No vector functions library"),
-               clEnumValN(TargetLibraryInfoImpl::Accelerate, "Accelerate",
-                          "Accelerate framework"),
-               clEnumValN(TargetLibraryInfoImpl::DarwinLibSystemM,
-                          "Darwin_libsystem_m", "Darwin libsystem_m"),
-               clEnumValN(TargetLibraryInfoImpl::LIBMVEC, "LIBMVEC",
-                          "GLIBC Vector Math library"),
-               clEnumValN(TargetLibraryInfoImpl::MASSV, "MASSV",
-                          "IBM MASS vector library"),
-               clEnumValN(TargetLibraryInfoImpl::SVML, "SVML",
-                          "Intel SVML library"),
-               clEnumValN(TargetLibraryInfoImpl::SLEEFGNUABI, "sleefgnuabi",
-                          "SIMD Library for Evaluating Elementary Functions"),
-               clEnumValN(TargetLibraryInfoImpl::ArmPL, "ArmPL",
-                          "Arm Performance Libraries"),
-               clEnumValN(TargetLibraryInfoImpl::AMDLIBM, "AMDLIBM",
-                          "AMD vector math library")));
 
 StringLiteral const TargetLibraryInfoImpl::StandardNames[LibFunc::NumLibFuncs] =
     {
@@ -1392,15 +1370,15 @@ const VecDesc VecFuncs_AMDLIBM[] = {
 void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
     enum VectorLibrary VecLib, const llvm::Triple &TargetTriple) {
   switch (VecLib) {
-  case Accelerate: {
+  case VectorLibrary::Accelerate: {
     addVectorizableFunctions(VecFuncs_Accelerate);
     break;
   }
-  case DarwinLibSystemM: {
+  case VectorLibrary::DarwinLibSystemM: {
     addVectorizableFunctions(VecFuncs_DarwinLibSystemM);
     break;
   }
-  case LIBMVEC: {
+  case VectorLibrary::LIBMVEC: {
     switch (TargetTriple.getArch()) {
     default:
       break;
@@ -1415,15 +1393,15 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
     }
     break;
   }
-  case MASSV: {
+  case VectorLibrary::MASSV: {
     addVectorizableFunctions(VecFuncs_MASSV);
     break;
   }
-  case SVML: {
+  case VectorLibrary::SVML: {
     addVectorizableFunctions(VecFuncs_SVML);
     break;
   }
-  case SLEEFGNUABI: {
+  case VectorLibrary::SLEEFGNUABI: {
     switch (TargetTriple.getArch()) {
     default:
       break;
@@ -1439,7 +1417,7 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
     }
     break;
   }
-  case ArmPL: {
+  case VectorLibrary::ArmPL: {
     switch (TargetTriple.getArch()) {
     default:
       break;
@@ -1450,11 +1428,11 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
     }
     break;
   }
-  case AMDLIBM: {
+  case VectorLibrary::AMDLIBM: {
     addVectorizableFunctions(VecFuncs_AMDLIBM);
     break;
   }
-  case NoLibrary:
+  case VectorLibrary::NoLibrary:
     break;
   }
 }

--- a/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
+++ b/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Frontend/Driver/CodeGenOptions.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/IR/SystemLibraries.h"
 #include "llvm/ProfileData/InstrProfCorrelator.h"
 #include "llvm/TargetParser/Triple.h"
 
@@ -25,35 +26,35 @@ TargetLibraryInfoImpl *createTLII(const llvm::Triple &TargetTriple,
   using VectorLibrary = llvm::driver::VectorLibrary;
   switch (Veclib) {
   case VectorLibrary::Accelerate:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::Accelerate,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::Accelerate,
                                              TargetTriple);
     break;
   case VectorLibrary::LIBMVEC:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::LIBMVEC,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::LIBMVEC,
                                              TargetTriple);
     break;
   case VectorLibrary::MASSV:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::MASSV,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::MASSV,
                                              TargetTriple);
     break;
   case VectorLibrary::SVML:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::SVML,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::SVML,
                                              TargetTriple);
     break;
   case VectorLibrary::SLEEF:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::SLEEFGNUABI,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::SLEEFGNUABI,
                                              TargetTriple);
     break;
   case VectorLibrary::Darwin_libsystem_m:
     TLII->addVectorizableFunctionsFromVecLib(
-        TargetLibraryInfoImpl::DarwinLibSystemM, TargetTriple);
+        llvm::VectorLibrary::DarwinLibSystemM, TargetTriple);
     break;
   case VectorLibrary::ArmPL:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::ArmPL,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::ArmPL,
                                              TargetTriple);
     break;
   case VectorLibrary::AMDLIBM:
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::AMDLIBM,
+    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::AMDLIBM,
                                              TargetTriple);
     break;
   default:

--- a/llvm/lib/IR/CMakeLists.txt
+++ b/llvm/lib/IR/CMakeLists.txt
@@ -67,6 +67,7 @@ add_llvm_component_library(LLVMCore
   ReplaceConstant.cpp
   Statepoint.cpp
   StructuralHash.cpp
+  SystemLibraries.cpp
   Type.cpp
   TypedPointerType.cpp
   TypeFinder.cpp

--- a/llvm/lib/IR/SystemLibraries.cpp
+++ b/llvm/lib/IR/SystemLibraries.cpp
@@ -1,0 +1,34 @@
+//===-----------------------------------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/SystemLibraries.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace llvm;
+
+VectorLibrary llvm::ClVectorLibrary;
+
+static cl::opt<VectorLibrary, true> ClVectorLibraryOpt(
+    "vector-library", cl::Hidden, cl::desc("Vector functions library"),
+    cl::location(llvm::ClVectorLibrary), cl::init(VectorLibrary::NoLibrary),
+    cl::values(
+        clEnumValN(VectorLibrary::NoLibrary, "none",
+                   "No vector functions library"),
+        clEnumValN(VectorLibrary::Accelerate, "Accelerate",
+                   "Accelerate framework"),
+        clEnumValN(VectorLibrary::DarwinLibSystemM, "Darwin_libsystem_m",
+                   "Darwin libsystem_m"),
+        clEnumValN(VectorLibrary::LIBMVEC, "LIBMVEC",
+                   "GLIBC Vector Math library"),
+        clEnumValN(VectorLibrary::MASSV, "MASSV", "IBM MASS vector library"),
+        clEnumValN(VectorLibrary::SVML, "SVML", "Intel SVML library"),
+        clEnumValN(VectorLibrary::SLEEFGNUABI, "sleefgnuabi",
+                   "SIMD Library for Evaluating Elementary Functions"),
+        clEnumValN(VectorLibrary::ArmPL, "ArmPL", "Arm Performance Libraries"),
+        clEnumValN(VectorLibrary::AMDLIBM, "AMDLIBM",
+                   "AMD vector math library")));


### PR DESCRIPTION
Move this to a new shared header to facilitate the eventual
merger of RuntimeLibcallsInfo and TargetLibraryInfo. Ideally
this would be replaced with a module flag. For now put it into
a common header both can use.