### PR TITLE
[Hexagon] Add missing build attributes

### DIFF
--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -311,8 +311,6 @@ static std::optional<std::string> hexagonAttrToFeatureString(unsigned Attr) {
     return "v73";
   case 75:
     return "v75";
-  case 77:
-    return "v77";
   case 79:
     return "v79";
   case 81:

--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -311,6 +311,12 @@ static std::optional<std::string> hexagonAttrToFeatureString(unsigned Attr) {
     return "v73";
   case 75:
     return "v75";
+  case 77:
+    return "v77";
+  case 79:
+    return "v79";
+  case 81:
+    return "v81";
   default:
     return {};
   }


### PR DESCRIPTION
Attributes for v79 and 81 were recorded but ignored.