### PR TITLE
[llvm][RISCV] Do not assume V extension on seeing vector type.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -2140,9 +2140,9 @@ InstructionCost RISCVTTIImpl::getMemoryOpCost(unsigned Opcode, Type *Src,
   // Assume memory ops cost scale with the number of vector registers
   // possible accessed by the instruction.  Note that BasicTTI already
   // handles the LT.first term for us.
-  if (TLI->getSubtarget().hasVInstructions())
-    if (LT.second.isVector() && CostKind != TTI::TCK_CodeSize)
-      BaseCost *= TLI->getLMULCost(LT.second);
+  if (ST->hasVInstructions() && LT.second.isVector() &&
+      CostKind != TTI::TCK_CodeSize)
+    BaseCost *= TLI->getLMULCost(LT.second);
   return Cost + BaseCost;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -2140,8 +2140,9 @@ InstructionCost RISCVTTIImpl::getMemoryOpCost(unsigned Opcode, Type *Src,
   // Assume memory ops cost scale with the number of vector registers
   // possible accessed by the instruction.  Note that BasicTTI already
   // handles the LT.first term for us.
-  if (LT.second.isVector() && CostKind != TTI::TCK_CodeSize)
-    BaseCost *= TLI->getLMULCost(LT.second);
+  if (TLI->getSubtarget().hasVInstructions())
+    if (LT.second.isVector() && CostKind != TTI::TCK_CodeSize)
+      BaseCost *= TLI->getLMULCost(LT.second);
   return Cost + BaseCost;
 }
 


### PR DESCRIPTION
We have a private extension which also uses the vector type in the frontend. Our platform does not have the V extension, so it triggered assertion failures from within getLMULCost().

I am not sure what is the best way to handle this, or if there are more such assertions within the codebase. But it feels reasonable to check for V extension before assuming LMUL exists.