### PR TITLE
[CIR] Fix failing lit test (statement-exprs.c)

### DIFF
--- a/clang/test/CIR/CodeGen/statement-exprs.c
+++ b/clang/test/CIR/CodeGen/statement-exprs.c
@@ -6,7 +6,7 @@
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
 
 int f19(void) {
-  return ({ 3;;4;; });
+  return ({ 3;;4; });
 }
 
 // CIR: cir.func dso_local @f19() -> !s32i


### PR DESCRIPTION
This fixes a test case in the clang/CIR/CodeGen/statement-exprs.c test. The test case was copied from a similar test in clang/CodeGen/exprs.c and was recently broken by https://github.com/llvm/llvm-project/pull/166036 which corrects Clang's behavior with trailing NullStmts. This change updates the CIR test in the same way that the classic codegen test was updated, removing the trailing null part of the expression.