### PR TITLE
[Clang] Introduce malloc_span attribute

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -353,6 +353,10 @@ Attribute Changes in Clang
 - New format attributes ``gnu_printf``, ``gnu_scanf``, ``gnu_strftime`` and ``gnu_strfmon`` are added
   as aliases for ``printf``, ``scanf``, ``strftime`` and ``strfmon``. (#GH16219)
 
+- New function attribute `malloc_span` is added. Its semantics is similar to that of the `malloc`
+  attribute, but `malloc_span` applies not to functions returning pointers, but to functions returning
+  span-like structures (i.e. those that contain a pointer field and a size integer field).
+
 Improvements to Clang's diagnostics
 -----------------------------------
 - Diagnostics messages now refer to ``structured binding`` instead of ``decomposition``,

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -355,7 +355,7 @@ Attribute Changes in Clang
 
 - New function attribute `malloc_span` is added. It has semantics similar to that of the `malloc`
   attribute, but `malloc_span` applies not to functions returning pointers, but to functions returning
-  span-like structures (i.e. those that contain a pointer field and a size integer field).
+  span-like structures (i.e. those that contain a pointer field and a size integer field or two pointers).
 
 Improvements to Clang's diagnostics
 -----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -353,7 +353,7 @@ Attribute Changes in Clang
 - New format attributes ``gnu_printf``, ``gnu_scanf``, ``gnu_strftime`` and ``gnu_strfmon`` are added
   as aliases for ``printf``, ``scanf``, ``strftime`` and ``strfmon``. (#GH16219)
 
-- New function attribute `malloc_span` is added. Its semantics is similar to that of the `malloc`
+- New function attribute `malloc_span` is added. It has semantics similar to that of the `malloc`
   attribute, but `malloc_span` applies not to functions returning pointers, but to functions returning
   span-like structures (i.e. those that contain a pointer field and a size integer field).
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2072,6 +2072,12 @@ def Restrict : InheritableAttr {
   let Documentation = [RestrictDocs];
 }
 
+def MallocSpan : InheritableAttr {
+  let Spellings = [Clang<"malloc_span">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [MallocSpanDocs];
+}
+
 def LayoutVersion : InheritableAttr, TargetSpecificAttr<TargetMicrosoftRecordLayout> {
   let Spellings = [Declspec<"layout_version">];
   let Args = [UnsignedArgument<"Version">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5256,10 +5256,11 @@ like a system memory allocation function and returns a span-like structure,
 where the returned memory range does not alias storage from any other object
 accessible to the caller.
 
-In this context, a span-like structure is assumed to have two fields, one of
-which is a pointer to the start of the allocated memory and another one is
-either an integer type containing the size of the actually allocated memory
-or a pointer the end of the allocated region.
+In this context, a span-like structure is assumed to have two non-static data
+members, one of which is a pointer to the start of the allocated memory and
+the other one is either an integer type containing the size of the actually
+allocated memory or a pointer to the end of the allocated region. Note, static
+data members do not impact whether a type is span-like or not.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5257,7 +5257,7 @@ where the returned memory range does not alias storage from any other object
 accessible to the caller.
 
 In this context, a span-like structure is assumed to have two fields, one of
-which is a pointer to the start of theallocated memory and another one is
+which is a pointer to the start of the allocated memory and another one is
 either an integer type containing the size of the actually allocated memory
 or a pointer the end of the allocated region.
   }];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5247,6 +5247,21 @@ yet implemented in clang.
   }];
 }
 
+def MallocSpanDocs : Documentation {
+  let Category = DocCatFunction;
+  let Heading = "malloc_span";
+  let Content = [{
+The ``malloc_span`` attribute can be used to mark that a function which acts
+like a system memory allocation function and returns a span-like structure,
+where the returned memory range does not alias storage from any other object
+accessible to the caller.
+
+In this context, a span-like structure is assumed to have a pointer to the
+allocated memory as its first field and any integer type containing the size
+of the actually allocated memory as the second field.
+  }];
+}
+
 def ReturnsNonNullDocs : Documentation {
   let Category = NullabilityDocs;
   let Content = [{

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5257,8 +5257,9 @@ where the returned memory range does not alias storage from any other object
 accessible to the caller.
 
 In this context, a span-like structure is assumed to have two fields, one of
-which is a pointer to the allocated memory and another one is an integer type
-containing the size of the actually allocated memory.
+which is a pointer to the start of theallocated memory and another one is
+either an integer type containing the size of the actually allocated memory
+or a pointer the end of the allocated region.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5256,9 +5256,9 @@ like a system memory allocation function and returns a span-like structure,
 where the returned memory range does not alias storage from any other object
 accessible to the caller.
 
-In this context, a span-like structure is assumed to have a pointer to the
-allocated memory as its first field and any integer type containing the size
-of the actually allocated memory as the second field.
+In this context, a span-like structure is assumed to have two fields, one of
+which is a pointer to the allocated memory and another one is an integer type
+containing the size of the actually allocated memory.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3465,8 +3465,8 @@ def note_returned_not_integer_field
 def note_returned_not_wide_enough_field
     : Note<"%ordinal0 field of span-like type is not a wide enough integer "
            "(minimum width: %1)">;
-def note_inherits_not_empty_base
-    : Note<"returned class inherits from a non-empty base">;
+def note_type_inherits_from_base
+    : Note<"returned type inherits from a base class">;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3465,6 +3465,8 @@ def note_returned_not_integer_field
 def note_returned_not_wide_enough_field
     : Note<"integer field #%0 of span-like type is not wide enough (minimum "
            "width: %1)">;
+def note_inherits_not_empty_base
+    : Note<"returned struct/class inherits from a non-empty base">;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3453,20 +3453,20 @@ def warn_attribute_return_span_only
     : Warning<"%0 attribute only applies to functions that return span-like "
               "structures">,
       InGroup<IgnoredAttributes>;
-def note_returned_not_struct : Note<"returned type is not a struct/class type">;
+def note_returned_not_struct : Note<"returned type is not a struct type">;
 def note_returned_incomplete_type : Note<"returned type is incomplete">;
 def note_returned_not_two_field_struct
-    : Note<"returned struct/class has %0 fields, expected 2">;
+    : Note<"returned struct has %0 fields, expected 2">;
 def note_returned_not_span_struct
-    : Note<"returned struct/class fields are not a supported combination for a "
+    : Note<"returned struct fields are not a supported combination for a "
            "span-like type (expected pointer/integer or pointer/pointer)">;
 def note_returned_not_integer_field
-    : Note<"field #%0 expected to be an integer">;
+    : Note<"%ordinal0 field is expected to be an integer">;
 def note_returned_not_wide_enough_field
-    : Note<"integer field #%0 of span-like type is not wide enough (minimum "
-           "width: %1)">;
+    : Note<"%ordinal0 field of span-like type is not a wide enough integer "
+           "(minimum width: %1)">;
 def note_inherits_not_empty_base
-    : Note<"returned struct/class inherits from a non-empty base">;
+    : Note<"returned class inherits from a non-empty base">;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3453,14 +3453,18 @@ def warn_attribute_return_span_only
     : Warning<"%0 attribute only applies to functions that return span-like "
               "structures">,
       InGroup<IgnoredAttributes>;
-def note_span_must_be_struct : Note<"span-like type must be a struct">;
-def note_span_must_be_complete : Note<"span-like type must be complete">;
-def note_wrong_span_field_count : Note<"span-like type must have 2 fields">;
-def note_wrong_span_field_types
-    : Note<"span-like type must have a pointer and an integer field or two "
-           "pointer fields">;
-def note_span_invalid_integer : Note<"the integer field must be an actual "
-                                     "integer that is at least as big as int">;
+def note_returned_not_struct : Note<"returned type is not a struct/class type">;
+def note_returned_incomlete_type : Note<"returned type is incomplete">;
+def note_returned_not_two_field_struct
+    : Note<"returned struct/class has %0 fields, expected 2">;
+def note_returned_not_span_struct
+    : Note<"returned struct/class fields are not a supported combination for a "
+           "span-like type (expected pointer/integer or pointer/pointer)">;
+def note_returned_not_integer_field
+    : Note<"field #%0 expected to be an integer">;
+def note_returned_not_wide_enough_field
+    : Note<"integer field #%0 of span-like type is not wide enough (minimum "
+           "width: %1)">;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3454,7 +3454,7 @@ def warn_attribute_return_span_only
               "structures">,
       InGroup<IgnoredAttributes>;
 def note_returned_not_struct : Note<"returned type is not a struct/class type">;
-def note_returned_incomlete_type : Note<"returned type is incomplete">;
+def note_returned_incomplete_type : Note<"returned type is incomplete">;
 def note_returned_not_two_field_struct
     : Note<"returned struct/class has %0 fields, expected 2">;
 def note_returned_not_span_struct

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3449,6 +3449,10 @@ def err_attribute_integers_only : Error<
 def warn_attribute_return_pointers_only : Warning<
   "%0 attribute only applies to return values that are pointers">,
   InGroup<IgnoredAttributes>;
+def warn_attribute_return_span_only
+    : Warning<"%0 attribute only applies to return values that are span-like "
+              "structures">,
+      InGroup<IgnoredAttributes>;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3450,8 +3450,9 @@ def warn_attribute_return_pointers_only : Warning<
   "%0 attribute only applies to return values that are pointers">,
   InGroup<IgnoredAttributes>;
 def warn_attribute_return_span_only
-    : Warning<"%0 attribute only applies to return values that are span-like "
-              "structures">,
+    : Warning<"%0 attribute only applies to functions that return span-like structures: "
+    "one field is a pointer to the allocated memory and another field is an integer with "
+    "the size of the allocated memory">,
       InGroup<IgnoredAttributes>;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3450,10 +3450,17 @@ def warn_attribute_return_pointers_only : Warning<
   "%0 attribute only applies to return values that are pointers">,
   InGroup<IgnoredAttributes>;
 def warn_attribute_return_span_only
-    : Warning<"%0 attribute only applies to functions that return span-like structures: "
-    "one field is a pointer to the allocated memory and another field is an integer with "
-    "the size of the allocated memory">,
+    : Warning<"%0 attribute only applies to functions that return span-like "
+              "structures">,
       InGroup<IgnoredAttributes>;
+def note_span_must_be_struct : Note<"span-like type must be a struct">;
+def note_span_must_be_complete : Note<"span-like type must be complete">;
+def note_wrong_span_field_count : Note<"span-like type must have 2 fields">;
+def note_wrong_span_field_types
+    : Note<"span-like type must have a pointer and an integer field or two "
+           "pointer fields">;
+def note_span_invalid_integer : Note<"the integer field must be an actual "
+                                     "integer that is at least as big as int">;
 def warn_attribute_return_pointers_refs_only : Warning<
   "%0 attribute only applies to return values that are pointers or references">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5111,6 +5111,11 @@ public:
   /// Essentially, this just moves them to the current pool.
   void redelayDiagnostics(sema::DelayedDiagnosticPool &pool);
 
+  /// Check that the type is a plain record with one field being a pointer
+  /// type and the other field being an integer. This matches the common
+  /// implementation of std::span or sized_allocation_t in P0901R11.
+  bool CheckSpanLikeType(const AttributeCommonInfo &CI, const QualType &Ty);
+
   /// Check if IdxExpr is a valid parameter index for a function or
   /// instance method D.  May output an error.
   ///

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1858,11 +1858,8 @@ bool Sema::CheckSpanLikeType(const AttributeCommonInfo &CI,
   if (!RD || RD->isUnion())
     return emitWarning(diag::note_returned_not_struct);
   if (const auto *CXXRD = dyn_cast<CXXRecordDecl>(RD)) {
-    for (const auto &Base : CXXRD->bases()) {
-      const CXXRecordDecl *BaseDecl = Base.getType()->getAsCXXRecordDecl();
-      if (!BaseDecl || !BaseDecl->isEmpty()) {
-        return emitWarning(diag::note_inherits_not_empty_base);
-      }
+    if (CXXRD->getNumBases() > 0) {
+      return emitWarning(diag::note_type_inherits_from_base);
     }
   }
   auto FieldsBegin = RD->field_begin();

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1858,11 +1858,11 @@ bool Sema::CheckSpanLikeType(const AttributeCommonInfo &CI,
   if (!RD || RD->isUnion())
     return emitWarning(diag::note_returned_not_struct);
   auto FieldsBegin = RD->field_begin();
-  const auto FieldsCount = std::distance(FieldsBegin, RD->field_end());
+  auto FieldsCount = std::distance(FieldsBegin, RD->field_end());
   if (FieldsCount != 2)
     return emitWarning(diag::note_returned_not_two_field_struct) << FieldsCount;
-  const QualType FirstFieldType = FieldsBegin->getType();
-  const QualType SecondFieldType = std::next(FieldsBegin)->getType();
+  QualType FirstFieldType = FieldsBegin->getType();
+  QualType SecondFieldType = std::next(FieldsBegin)->getType();
   auto validatePointerType = [](const QualType &T) {
     // It must not point to functions.
     return T->isPointerType() && !T->isFunctionPointerType();
@@ -1872,7 +1872,7 @@ bool Sema::CheckSpanLikeType(const AttributeCommonInfo &CI,
     const auto *BT = dyn_cast<BuiltinType>(T.getCanonicalType());
     if (!BT || !BT->isInteger())
       return emitWarning(diag::note_returned_not_integer_field) << FieldNo;
-    const auto IntSize = Context.getTypeSize(Context.IntTy);
+    auto IntSize = Context.getTypeSize(Context.IntTy);
     if (Context.getTypeSize(BT) < IntSize)
       return emitWarning(diag::note_returned_not_wide_enough_field)
              << FieldNo << IntSize;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1857,6 +1857,14 @@ bool Sema::CheckSpanLikeType(const AttributeCommonInfo &CI,
   const RecordDecl *RD = Ty->getAsRecordDecl();
   if (!RD || RD->isUnion())
     return emitWarning(diag::note_returned_not_struct);
+  if (const auto *CXXRD = dyn_cast<CXXRecordDecl>(RD)) {
+    for (const auto &Base : CXXRD->bases()) {
+      const CXXRecordDecl *BaseDecl = Base.getType()->getAsCXXRecordDecl();
+      if (!BaseDecl || !BaseDecl->isEmpty()) {
+        return emitWarning(diag::note_inherits_not_empty_base);
+      }
+    }
+  }
   auto FieldsBegin = RD->field_begin();
   auto FieldsCount = std::distance(FieldsBegin, RD->field_end());
   if (FieldsCount != 2)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1857,11 +1857,15 @@ static bool checkSpanLikeType(const QualType &Ty) {
     return false;
   const QualType FirstFieldType = FieldsBegin->getType();
   const QualType SecondFieldType = std::next(FieldsBegin)->getType();
+  auto validatePointerType = [](const QualType &T) {
+    // It must not point to functions.
+    return T->isPointerType() && !T->isFunctionPointerType();
+  };
   // Verify two possible orderings.
-  return (FirstFieldType->isAnyPointerType() &&
+  return (validatePointerType(FirstFieldType) &&
           SecondFieldType->isIntegerType()) ||
          (FirstFieldType->isIntegerType() &&
-          SecondFieldType->isAnyPointerType());
+          validatePointerType(SecondFieldType));
 }
 
 static void handleMallocSpanAttr(Sema &S, Decl *D, const ParsedAttr &AL) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1853,7 +1853,7 @@ static bool checkSpanLikeType(Sema &S, const ParsedAttr &AL,
     return S.Diag(AL.getLoc(), NoteDiagID);
   };
   if (Ty->isIncompleteType())
-    return emitWarning(diag::note_returned_incomlete_type);
+    return emitWarning(diag::note_returned_incomplete_type);
   const RecordDecl *RD = Ty->getAsRecordDecl();
   if (!RD || RD->isUnion())
     return emitWarning(diag::note_returned_not_struct);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1839,7 +1839,7 @@ static void handleRestrictAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
                  RestrictAttr(S.Context, AL, DeallocE, DeallocPtrIdx));
 }
 
-static bool isSpanLikeType(const QualType &Ty) {
+static bool checkSpanLikeType(const QualType &Ty) {
   // Check that the type is a plain record with one field being a pointer
   // type and the other field being an integer. This matches the common
   // implementation of std::span or sized_allocation_t in P0901R11.
@@ -1866,7 +1866,7 @@ static bool isSpanLikeType(const QualType &Ty) {
 
 static void handleMallocSpanAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   QualType ResultType = getFunctionOrMethodResultType(D);
-  if (!isSpanLikeType(ResultType)) {
+  if (!checkSpanLikeType(ResultType)) {
     S.Diag(AL.getLoc(), diag::warn_attribute_return_span_only)
         << AL << getFunctionOrMethodResultSourceRange(D);
     return;

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -800,14 +800,8 @@ static void instantiateDependentMallocSpanAttr(Sema &S,
                                                const MallocSpanAttr *Attr,
                                                Decl *New) {
   QualType RT = getFunctionOrMethodResultType(New);
-  if (RT->isDependentType()) {
-    // The type is still dependent.
-    // Clone the attribute, it will be checked later.
+  if (!S.CheckSpanLikeType(*Attr, RT))
     New->addAttr(Attr->clone(S.getASTContext()));
-  } else if (!S.CheckSpanLikeType(*Attr, RT)) {
-    // The conditions have been successfully validated.
-    New->addAttr(Attr->clone(S.getASTContext()));
-  }
 }
 
 void Sema::InstantiateAttrsForDecl(

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -102,6 +102,7 @@
 // CHECK-NEXT: MIGServerRoutine (SubjectMatchRule_function, SubjectMatchRule_objc_method, SubjectMatchRule_block)
 // CHECK-NEXT: MSConstexpr (SubjectMatchRule_function)
 // CHECK-NEXT: MSStruct (SubjectMatchRule_record)
+// CHECK-NEXT: MallocSpan (SubjectMatchRule_function)
 // CHECK-NEXT: MaybeUndef (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: MicroMips (SubjectMatchRule_function)
 // CHECK-NEXT: MinSize (SubjectMatchRule_function, SubjectMatchRule_objc_method)

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -32,7 +32,7 @@ typedef struct incomplete_span incomplete_span;
 incomplete_span returns_incomplete_span (void) __attribute((malloc_span));
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned type is not a struct/class type}}
+// expected-note@+1 {{returned type is not a struct type}}
 int *returns_int_ptr  (void) __attribute((malloc_span));
 
 typedef struct {
@@ -41,7 +41,7 @@ typedef struct {
   size_t n2;
 } too_long_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class has 3 fields, expected 2}}
+// expected-note@+1 {{returned struct has 3 fields, expected 2}}
 too_long_span  returns_too_long_span  (void) __attribute((malloc_span));
 
 // Function pointers are not allowed.
@@ -50,7 +50,7 @@ typedef struct {
   size_t n;
 } func_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class fields are not a supported combination}}
+// expected-note@+1 {{returned struct fields are not a supported combination}}
 func_span  returns_func_span  (void) __attribute((malloc_span));
 
 // Integer should not be an enum.
@@ -60,7 +60,7 @@ typedef struct {
   enum some_enum field;
 } enum_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{field #2 expected to be an integer}}
+// expected-note@+1 {{2nd field is expected to be an integer}}
 enum_span  returns_enum_span  (void) __attribute((malloc_span));
 
 // Bit integers are also not supported.
@@ -69,7 +69,7 @@ typedef struct {
   _BitInt(16) n;
 } bit_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{field #2 expected to be an integer}}
+// expected-note@+1 {{2nd field is expected to be an integer}}
 bit_span  returns_bit_span  (void) __attribute((malloc_span));
 
 // Integer must be at least as big as int.
@@ -78,5 +78,5 @@ typedef struct {
   short n;
 } short_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{integer field #2 of span-like type is not wide enough (minimum width: 32)}}
+// expected-note@+1 {{2nd field of span-like type is not a wide enough integer (minimum width: 32)}}
 short_span  returns_short_span  (void) __attribute((malloc_span));

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -6,26 +6,26 @@
 typedef struct {
   void *ptr;
   size_t n;
-} sized_ptr;
-sized_ptr  returns_sized_ptr  (void) __attribute((malloc_span)); // no-warning
+} span;
+span  returns_span  (void) __attribute((malloc_span)); // no-warning
 
-// The first struct field must be pointer and the second must be an integer.
-// Check the possible ways to violate it.
+// Try out a different field ordering.
 typedef struct {
   size_t n;
   void *ptr;
+} span2;
+span2  returns_span2  (void) __attribute((malloc_span)); // no-warning
+
+// Ensure that a warning is produced on malloc_span precondition violation.
+typedef struct {
+  void *ptr;
+  void *ptr2;
 } invalid_span1;
 invalid_span1  returns_non_std_span1  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
 
 typedef struct {
   void *ptr;
-  void *ptr2;
-} invalid_span2;
-invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
-
-typedef struct {
-  void *ptr;
   size_t n;
   size_t n2;
-} invalid_span3;
-invalid_span3  returns_non_std_span3  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
+} invalid_span2;
+invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -16,23 +16,57 @@ typedef struct {
 } span2;
 span2  returns_span2  (void) __attribute((malloc_span)); // no-warning
 
-// Ensure that a warning is produced on malloc_span precondition violation.
 typedef struct {
   void *ptr;
   void *ptr2;
-} invalid_span1;
-invalid_span1  returns_non_std_span1  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}
+} span3;
+span3  returns_span3  (void) __attribute((malloc_span)); // no-warning
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{span-like type must be a struct}}
+int *returns_int_ptr  (void) __attribute((malloc_span));
 
 typedef struct {
   void *ptr;
   size_t n;
   size_t n2;
-} invalid_span2;
-invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}
+} too_long_span;
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{span-like type must have 2 fields}}
+too_long_span  returns_too_long_span  (void) __attribute((malloc_span));
 
 // Function pointers are not allowed.
 typedef struct {
   int (*func_ptr)(void);
   size_t n;
 } func_span;
-func_span  returns_func_span  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{span-like type must have a pointer and an integer field or two pointer fields}}
+func_span  returns_func_span  (void) __attribute((malloc_span));
+
+// Integer should not be an enum.
+enum some_enum { some_value, other_value };
+typedef struct {
+  void *ptr;
+  enum some_enum field;
+} enum_span;
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{the integer field must be an actual integer}}
+enum_span  returns_enum_span  (void) __attribute((malloc_span));
+
+// Bit integers are also not supported.
+typedef struct {
+  void *ptr;
+  _BitInt(16) n;
+} bit_span;
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{the integer field must be an actual integer}}
+bit_span  returns_bit_span  (void) __attribute((malloc_span));
+
+// Integer must be at least as big as int.
+typedef struct {
+  void *ptr;
+  short n;
+} short_span;
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{the integer field must be an actual integer}}
+short_span  returns_short_span  (void) __attribute((malloc_span));

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -verify -fsyntax-only %s
 // RUN: %clang_cc1 -emit-llvm -o %t %s
 
-#include <stddef.h>
+typedef __SIZE_TYPE__ size_t;
 
 typedef struct {
   void *ptr;
@@ -21,11 +21,11 @@ typedef struct {
   void *ptr;
   void *ptr2;
 } invalid_span1;
-invalid_span1  returns_non_std_span1  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
+invalid_span1  returns_non_std_span1  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}
 
 typedef struct {
   void *ptr;
   size_t n;
   size_t n2;
 } invalid_span2;
-invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
+invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -9,7 +9,6 @@ typedef struct {
 } span;
 span  returns_span  (void) __attribute((malloc_span)); // no-warning
 
-// Try out a different field ordering.
 typedef struct {
   size_t n;
   void *ptr;
@@ -21,8 +20,20 @@ typedef struct {
   void *ptr2;
 } span3;
 span3  returns_span3  (void) __attribute((malloc_span)); // no-warning
+
+typedef struct {
+  void *ptr;
+  int n;
+} span4;
+span4  returns_span4  (void) __attribute((malloc_span)); // no-warning
+
+typedef struct incomplete_span incomplete_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{span-like type must be a struct}}
+// expected-note@+1 {{returned type is incomplete}}
+incomplete_span returns_incomplete_span (void) __attribute((malloc_span));
+
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{returned type is not a struct/class type}}
 int *returns_int_ptr  (void) __attribute((malloc_span));
 
 typedef struct {
@@ -31,7 +42,7 @@ typedef struct {
   size_t n2;
 } too_long_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{span-like type must have 2 fields}}
+// expected-note@+1 {{returned struct/class has 3 fields, expected 2}}
 too_long_span  returns_too_long_span  (void) __attribute((malloc_span));
 
 // Function pointers are not allowed.
@@ -40,7 +51,7 @@ typedef struct {
   size_t n;
 } func_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{span-like type must have a pointer and an integer field or two pointer fields}}
+// expected-note@+1 {{returned struct/class fields are not a supported combination}}
 func_span  returns_func_span  (void) __attribute((malloc_span));
 
 // Integer should not be an enum.
@@ -50,7 +61,7 @@ typedef struct {
   enum some_enum field;
 } enum_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{the integer field must be an actual integer}}
+// expected-note@+1 {{field #2 expected to be an integer}}
 enum_span  returns_enum_span  (void) __attribute((malloc_span));
 
 // Bit integers are also not supported.
@@ -59,7 +70,7 @@ typedef struct {
   _BitInt(16) n;
 } bit_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{the integer field must be an actual integer}}
+// expected-note@+1 {{field #2 expected to be an integer}}
 bit_span  returns_bit_span  (void) __attribute((malloc_span));
 
 // Integer must be at least as big as int.
@@ -68,5 +79,5 @@ typedef struct {
   short n;
 } short_span;
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{the integer field must be an actual integer}}
+// expected-note@+1 {{integer field #2 of span-like type is not wide enough (minimum width: 32)}}
 short_span  returns_short_span  (void) __attribute((malloc_span));

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -29,3 +29,10 @@ typedef struct {
   size_t n2;
 } invalid_span2;
 invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}
+
+// Function pointers are not allowed.
+typedef struct {
+  int (*func_ptr)(void);
+  size_t n;
+} func_span;
+func_span  returns_func_span  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to functions that return span-like structures}}

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -verify -fsyntax-only %s
-// RUN: %clang_cc1 -emit-llvm -o %t %s
 
 typedef __SIZE_TYPE__ size_t;
 

--- a/clang/test/Sema/attr-malloc_span.c
+++ b/clang/test/Sema/attr-malloc_span.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -emit-llvm -o %t %s
+
+#include <stddef.h>
+
+typedef struct {
+  void *ptr;
+  size_t n;
+} sized_ptr;
+sized_ptr  returns_sized_ptr  (void) __attribute((malloc_span)); // no-warning
+
+// The first struct field must be pointer and the second must be an integer.
+// Check the possible ways to violate it.
+typedef struct {
+  size_t n;
+  void *ptr;
+} invalid_span1;
+invalid_span1  returns_non_std_span1  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
+
+typedef struct {
+  void *ptr;
+  void *ptr2;
+} invalid_span2;
+invalid_span2  returns_non_std_span2  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}
+
+typedef struct {
+  void *ptr;
+  size_t n;
+  size_t n2;
+} invalid_span3;
+invalid_span3  returns_non_std_span3  (void) __attribute((malloc_span)); // expected-warning {{attribute only applies to return values that are span-like structures}}

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -108,3 +108,26 @@ __attribute((malloc_span)) auto trailing_return_temmplate_good(void) -> Pair<int
 __attribute((malloc_span)) auto trailing_return_temmplate_bad(void) -> Pair<int, int> {
   return Pair<int, int>{};
 }
+
+struct EmptyBase {
+};
+
+struct GoodChildSpan : EmptyBase {
+  void *p;
+  int n;
+};
+
+__attribute((malloc_span)) GoodChildSpan return_span_with_good_base(void); // no-warning
+
+struct NonEmptyBase {
+  void *other_p;
+};
+
+struct BadChildSpan : EmptyBase, NonEmptyBase {
+  void *p;
+  int n;
+};
+
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{returned struct/class inherits from a non-empty base}}
+__attribute((malloc_span)) BadChildSpan return_span_with_bad_base(void);

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -1,5 +1,13 @@
 // RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
 
+struct span_with_static {
+  void *ptr;
+  int n;
+  static int static_field;
+};
+
+span_with_static  returns_span_with_static  (void) __attribute((malloc_span)); // no-warning
+
 class SomeClass {
 public:
   int Data;

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -74,29 +74,29 @@ void TestGoodBadSpan() {
 }
 
 // Ensure that trailing return types are also supported.
-__attribute__((malloc_span)) auto trailling_return_type(int size)  -> GoodSpan { // no-warning
+__attribute__((malloc_span)) auto trailing_return_type(int size)  -> GoodSpan { // no-warning
   return GoodSpan{};
 }
 
 template<typename T>
 // expected-warning@+2 {{'malloc_span' attribute only applies to functions that return span-like structures}}
 // expected-note@+1 {{returned struct/class has 1 fields, expected 2}}
-__attribute__((malloc_span)) auto templated_trailling_return_type()  -> T { // no-warning
+__attribute__((malloc_span)) auto templated_trailing_return_type()  -> T {
   return T{};
 }
 
 void TestGoodBadTrailingReturnType() {
-  templated_trailling_return_type<GoodSpan>(); // no-warnings
-  // expected-note@+1 {{in instantiation of function template specialization 'templated_trailling_return_type<BadSpan>' requested here}}
-  templated_trailling_return_type<BadSpan>();
+  templated_trailing_return_type<GoodSpan>(); // no-warnings
+  // expected-note@+1 {{in instantiation of function template specialization 'templated_trailing_return_type<BadSpan>' requested here}}
+  templated_trailing_return_type<BadSpan>();
 }
 
-__attribute((malloc_span)) auto trailling_return_temmplate_good(void) -> Pair<int*, int> { // no-warning
+__attribute((malloc_span)) auto trailing_return_temmplate_good(void) -> Pair<int*, int> { // no-warning
   return Pair<int*, int>{};
 }
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
 // expected-note@+1 {{returned struct/class fields are not a supported combination for a span-like type}}
-__attribute((malloc_span)) auto trailling_return_temmplate_bad(void) -> Pair<int, int> {
+__attribute((malloc_span)) auto trailing_return_temmplate_bad(void) -> Pair<int, int> {
   return Pair<int, int>{};
 }

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -72,3 +72,31 @@ void TestGoodBadSpan() {
   // expected-note@+1 {{in instantiation of function template specialization 'produce_span<BadSpan>' requested here}}
   produce_span<BadSpan>();
 }
+
+// Ensure that trailing return types are also supported.
+__attribute__((malloc_span)) auto trailling_return_type(int size)  -> GoodSpan { // no-warning
+  return GoodSpan{};
+}
+
+template<typename T>
+// expected-warning@+2 {{'malloc_span' attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{returned struct/class has 1 fields, expected 2}}
+__attribute__((malloc_span)) auto templated_trailling_return_type()  -> T { // no-warning
+  return T{};
+}
+
+void TestGoodBadTrailingReturnType() {
+  templated_trailling_return_type<GoodSpan>(); // no-warnings
+  // expected-note@+1 {{in instantiation of function template specialization 'templated_trailling_return_type<BadSpan>' requested here}}
+  templated_trailling_return_type<BadSpan>();
+}
+
+__attribute((malloc_span)) auto trailling_return_temmplate_good(void) -> Pair<int*, int> { // no-warning
+  return Pair<int*, int>{};
+}
+
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{returned struct/class fields are not a supported combination for a span-like type}}
+__attribute((malloc_span)) auto trailling_return_temmplate_bad(void) -> Pair<int, int> {
+  return Pair<int, int>{};
+}

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -121,3 +121,12 @@ struct ChildSpan : Base {
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
 // expected-note@+1 {{returned type inherits from a base class}}
 __attribute((malloc_span)) ChildSpan return_child_span(void);
+
+class VirtualBaseSpan : public virtual Base {
+  void *p;
+  int n;
+};
+
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{returned type inherits from a base class}}
+__attribute((malloc_span)) VirtualBaseSpan return_virtual_base_span(void);

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -20,7 +20,7 @@ struct DataMemberSpan {
 };
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class fields are not a supported combination}}
+// expected-note@+1 {{returned struct fields are not a supported combination}}
 DataMemberSpan returns_data_member_span(void) __attribute((malloc_span)) {
   return DataMemberSpan{};
 }
@@ -32,7 +32,7 @@ struct MemberFuncSpan {
 };
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class fields are not a supported combination}}
+// expected-note@+1 {{returned struct fields are not a supported combination}}
 MemberFuncSpan returns_member_func_span(void) __attribute((malloc_span)) {
   return MemberFuncSpan{};
 }
@@ -52,7 +52,7 @@ Pair<int*, int*> returns_templated_span2(void) __attribute((malloc_span)) { // n
 }
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class fields are not a supported combination for a span-like type}}
+// expected-note@+1 {{returned struct fields are not a supported combination for a span-like type}}
 Pair<int, int> returns_templated_span3(void) __attribute((malloc_span)) {
   return Pair<int, int>{};
 }
@@ -70,7 +70,7 @@ struct BadSpan {
 
 template <typename T>
 // expected-warning@+2 {{'malloc_span' attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class has 1 fields, expected 2}}
+// expected-note@+1 {{returned struct has 1 fields, expected 2}}
 T produce_span() __attribute((malloc_span)) {
   return T{};
 }
@@ -88,7 +88,7 @@ __attribute__((malloc_span)) auto trailing_return_type(int size)  -> GoodSpan { 
 
 template<typename T>
 // expected-warning@+2 {{'malloc_span' attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class has 1 fields, expected 2}}
+// expected-note@+1 {{returned struct has 1 fields, expected 2}}
 __attribute__((malloc_span)) auto templated_trailing_return_type()  -> T {
   return T{};
 }
@@ -104,7 +104,7 @@ __attribute((malloc_span)) auto trailing_return_temmplate_good(void) -> Pair<int
 }
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class fields are not a supported combination for a span-like type}}
+// expected-note@+1 {{returned struct fields are not a supported combination for a span-like type}}
 __attribute((malloc_span)) auto trailing_return_temmplate_bad(void) -> Pair<int, int> {
   return Pair<int, int>{};
 }
@@ -129,5 +129,5 @@ struct BadChildSpan : EmptyBase, NonEmptyBase {
 };
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned struct/class inherits from a non-empty base}}
+// expected-note@+1 {{returned class inherits from a non-empty base}}
 __attribute((malloc_span)) BadChildSpan return_span_with_bad_base(void);

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -109,25 +109,15 @@ __attribute((malloc_span)) auto trailing_return_temmplate_bad(void) -> Pair<int,
   return Pair<int, int>{};
 }
 
-struct EmptyBase {
-};
-
-struct GoodChildSpan : EmptyBase {
-  void *p;
-  int n;
-};
-
-__attribute((malloc_span)) GoodChildSpan return_span_with_good_base(void); // no-warning
-
-struct NonEmptyBase {
+struct Base {
   void *other_p;
 };
 
-struct BadChildSpan : EmptyBase, NonEmptyBase {
+struct ChildSpan : Base {
   void *p;
   int n;
 };
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{returned class inherits from a non-empty base}}
-__attribute((malloc_span)) BadChildSpan return_span_with_bad_base(void);
+// expected-note@+1 {{returned type inherits from a base class}}
+__attribute((malloc_span)) ChildSpan return_child_span(void);

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+class SomeClass {
+public:
+  int Data;
+};
+
+// Returning pointers to data members is not allowed.
+struct DataMemberSpan {
+  int SomeClass::* member_ptr;
+  int n;
+};
+
+DataMemberSpan returns_data_member_span(void) __attribute((malloc_span)) { // expected-warning {{attribute only applies to functions that return span-like structures}}
+  return DataMemberSpan{};
+}
+
+// Returning pointers to member functions is not allowed.
+struct MemberFuncSpan {
+  void (SomeClass::*member_func_ptr)();
+  int n;
+};
+
+MemberFuncSpan returns_member_func_span(void) __attribute((malloc_span)) { // expected-warning {{attribute only applies to functions that return span-like structures}}
+  return MemberFuncSpan{};
+}
+

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -11,7 +11,9 @@ struct DataMemberSpan {
   int n;
 };
 
-DataMemberSpan returns_data_member_span(void) __attribute((malloc_span)) { // expected-warning {{attribute only applies to functions that return span-like structures}}
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{span-like type must have a pointer and an integer field or two pointer fields}}
+DataMemberSpan returns_data_member_span(void) __attribute((malloc_span)) {
   return DataMemberSpan{};
 }
 
@@ -21,7 +23,9 @@ struct MemberFuncSpan {
   int n;
 };
 
-MemberFuncSpan returns_member_func_span(void) __attribute((malloc_span)) { // expected-warning {{attribute only applies to functions that return span-like structures}}
+// expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
+// expected-note@+1 {{span-like type must have a pointer and an integer field or two pointer fields}}
+MemberFuncSpan returns_member_func_span(void) __attribute((malloc_span)) {
   return MemberFuncSpan{};
 }
 

--- a/clang/test/SemaCXX/attr-malloc_span.cpp
+++ b/clang/test/SemaCXX/attr-malloc_span.cpp
@@ -12,7 +12,7 @@ struct DataMemberSpan {
 };
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{span-like type must have a pointer and an integer field or two pointer fields}}
+// expected-note@+1 {{returned struct/class fields are not a supported combination}}
 DataMemberSpan returns_data_member_span(void) __attribute((malloc_span)) {
   return DataMemberSpan{};
 }
@@ -24,7 +24,7 @@ struct MemberFuncSpan {
 };
 
 // expected-warning@+2 {{attribute only applies to functions that return span-like structures}}
-// expected-note@+1 {{span-like type must have a pointer and an integer field or two pointer fields}}
+// expected-note@+1 {{returned struct/class fields are not a supported combination}}
 MemberFuncSpan returns_member_func_span(void) __attribute((malloc_span)) {
   return MemberFuncSpan{};
 }


### PR DESCRIPTION
The "malloc" attribute restricts the possible function signatures to the ones returning a pointer, which is not the case for some non-standard allocation function variants. For example, P0901R11 proposed ::operator new overloads that return a return_size_t result - a struct that contains a pointer to the allocated memory as well as the actual size of the allocated memory. Another example is __size_returning_new.

Introduce a new "malloc_span" attribute that exhibits similar semantics, but applies to functions returning records where one member is a pointer (assumed to point to the allocated memory) and another is an integer (assumed to be the size of the allocated memory). This is the case for return_size_t as well as std::span, should it be returned from such an annotated function.

An alternative approach would be to relax the restrictions of the existing "malloc" attribute to be applied to both functions returning pointers and functions returning span-like structs. However, it would complicate the user-space code by requiring specific Clang version checks. In contrast, the presence of a new attribute can be straightforwardly verified via the __has_attribute macro. Introducing a new attribute also avoids concerns about the potential incompatibility with GCC's "malloc" semantics.

In future commits, codegen can be improved to recognize the noalias-ness of the pointer returned inside a span-like struct.

This change helps unlock the alloc token instrumentation for such non-standard allocation functions:
https://clang.llvm.org/docs/AllocToken.html#instrumenting-non-standard-allocation-functions