### PR TITLE
[lldb][docs] Use section_iter() to iterate over sections

### DIFF
--- a/lldb/bindings/interface/SBSectionDocstrings.i
+++ b/lldb/bindings/interface/SBSectionDocstrings.i
@@ -4,7 +4,7 @@
 SBSection supports iteration through its subsection, represented as SBSection
 as well.  For example, ::
 
-    for sec in exe_module:
+    for sec in exe_module.section_iter():
         if sec.GetName() == '__TEXT':
             print sec
             break


### PR DESCRIPTION
Iterating over an `SBModule` directly will give you symbols, not sections. According to the docs, we can use `section_iter()` to iterate over sections.

https://lldb.llvm.org/python_api/lldb.SBModule.html#lldb.SBModule