### PR TITLE
[.gitignore] Ignore .claude and .gemini in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,9 @@ autoconf/autom4te.cache
 /cmake-build*
 # Coding assistants' stuff
 /CLAUDE.md
-/.claude/
+.claude/
 /GEMINI.md
-/.gemini/
+.gemini/
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).


### PR DESCRIPTION
Currently `.claude/` and `.gemini/` are only ignored in the root of the repo. Developers might conceivable run these tools in project subdirectories, in which case these should be ignored as well.