### PR TITLE
[X86] Use an FP-based expansion for v4i32 ctlz on SSE2-only targets

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -5543,6 +5543,11 @@ public:
   /// \returns The expansion result or SDValue() if it fails.
   SDValue expandVPCTLZ(SDNode *N, SelectionDAG &DAG) const;
 
+  /// Expands a CTLZ node into a sequence of floating point operations.
+  /// \param N Node to expand
+  /// \returns The expansion result or SDValue() if it fails.
+  SDValue expandCTLZWithFP(SDNode *N, SelectionDAG &DAG) const;
+
   /// Expand CTTZ via Table Lookup.
   /// \param N Node to expand
   /// \returns The expansion result or SDValue() if it fails.

--- a/llvm/test/CodeGen/X86/ctlz-v4i32-fp-1.ll
+++ b/llvm/test/CodeGen/X86/ctlz-v4i32-fp-1.ll
@@ -1,0 +1,26 @@
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu -mattr=+sse2,-ssse3 -o - | FileCheck %s
+
+define <4 x i32> @test_v4i32_sse2(<4 x i32> %a) #0 {
+; CHECK-LABEL: test_v4i32_sse2:
+; CHECK:       # %bb.0:
+
+; Zero test (strict CTLZ needs select)
+; CHECK-DAG:   pcmpeqd %xmm{{[0-9]+}}, %xmm{{[0-9]+}}
+
+; Exponent extraction + bias arithmetic (order-free)
+; CHECK-DAG:   psrld {{\$}}23, %xmm{{[0-9]+}}
+; CHECK-DAG:   psubd %xmm{{[0-9]+}}, %xmm{{[0-9]+}}
+
+; Select/merge (could be por/pandn etc.)
+; CHECK:       por %xmm{{[0-9]+}}, %xmm{{[0-9]+}}
+
+; Must NOT use SSSE3 LUT path
+; CHECK-NOT:   pshufb
+
+; CHECK:       retq
+  %res = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %a, i1 false)
+  ret <4 x i32> %res
+}
+
+declare <4 x i32> @llvm.ctlz.v4i32(<4 x i32>, i1)
+attributes #0 = { "optnone" }

--- a/llvm/test/CodeGen/X86/ctlz-v4i32-fp-2.ll
+++ b/llvm/test/CodeGen/X86/ctlz-v4i32-fp-2.ll
@@ -1,0 +1,28 @@
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu -mattr=+sse2,-ssse3 -o - | FileCheck %s
+
+define <4 x i32> @test_v4i32_sse2_zero_undef(<4 x i32> %a) #0 {
+; CHECK-LABEL: test_v4i32_sse2_zero_undef:
+
+; zero check
+; CHECK-DAG:   pcmpeqd
+
+; FP-based mantissa/exponent steps (order may vary)
+; CHECK-DAG:   psrld     $16
+; CHECK-DAG:   subps
+; CHECK-DAG:   psrld     $23
+; CHECK-DAG:   psubd
+
+; merge/select
+; CHECK:       pandn
+; CHECK:       por
+
+; CHECK-NOT:   pshufb
+
+; CHECK: retq
+
+  %res = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %a, i1 true)
+  ret <4 x i32> %res
+}
+
+declare <4 x i32> @llvm.ctlz.v4i32(<4 x i32>, i1)
+attributes #0 = { "optnone" }

--- a/llvm/test/CodeGen/X86/ctlz-v4i32-fp-3.ll
+++ b/llvm/test/CodeGen/X86/ctlz-v4i32-fp-3.ll
@@ -1,0 +1,23 @@
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu -mattr=+ssse3 -o - | FileCheck %s
+
+; This verifies that **with SSSE3 enabled**, we use the LUT-based `pshufb`
+; implementation and *not* the floating-point exponent trick.
+
+define <4 x i32> @test_v4i32_ssse3(<4 x i32> %a) {
+; CHECK-LABEL: test_v4i32_ssse3:
+; CHECK:       # %bb.0:
+
+; Must use SSSE3 table LUT:
+; CHECK:       pshufb
+
+; Must NOT use FP exponent trick:
+; CHECK-NOT:   cvtdq2ps
+; CHECK-NOT:   psrld $23
+; CHECK-NOT:   psubd
+
+; CHECK:       retq
+  %res = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %a, i1 false)
+  ret <4 x i32> %res
+}
+
+declare <4 x i32> @llvm.ctlz.v4i32(<4 x i32>, i1)


### PR DESCRIPTION
Fixes #161746

This pull request implements a new optimization for the `ISD::CTLZ` operation, as suggested in the issue. It uses a floating-point-based algorithm for `v4i32` vectors on x86 targets that have `SSE2` but do not have `SSSE3`.

1. A new generic function, `TargetLowering::expandCTLZWithFP`, was added. This function implements the `clz(x) = 31 - (bitcast<int>((float)x) >> 23) - 127` algorithm, complete with a `VSELECT` to handle the `clz(0) == 32` edge case.
2. The `X86TargetLowering::LowerVectorCTLZ` function was updated. It now checks for the `+sse2,-ssse3` feature combination and calls `expandCTLZWithFP` for `v4i32` vectors. 
3. The new implementation was benchmarked against the existing fallback for `v4i32`: the generic integer `Expand` logic (for `SSE2`).

#### Benchmark Results (`llvm-mca` on `core2`)

The `llvm-mca` analysis from the testcases (`ctlz-v4i32-fp-1.ll`, `ctlz-v4i32-fp-2.ll`) confirms the benefit of this change.

| Implementation | Instructions <br/> (Per Iteration) | Total Cycles <br/> (Per Iteration) | IPC <br/> (Average) | Block RThroughput <br/> (Average) |
| :--- | :---: | :---: | :---: | :---: |
| Old `SSE2` (Integer Fallback) | **39** <br/> (3900 / 100) | **45.01** <br/> (4501 / 100) | 0.87 | 7.3 |
| **New `SSE2` (FP Fallback)** | **18** <br/> (1800 / 100) | **21.04** <br/> (2104 / 100) | 0.86 | 4.0 |

The llvm-mca result files:
[ctlz-v4i32-fp-1-after-mca.txt](https://github.com/user-attachments/files/23426769/ctlz-v4i32-fp-1-after-mca.txt)
[ctlz-v4i32-fp-1-before-mca.txt](https://github.com/user-attachments/files/23426770/ctlz-v4i32-fp-1-before-mca.txt)
[ctlz-v4i32-fp-2-after-mca.txt](https://github.com/user-attachments/files/23426771/ctlz-v4i32-fp-2-after-mca.txt)
[ctlz-v4i32-fp-2-before-mca.txt](https://github.com/user-attachments/files/23426772/ctlz-v4i32-fp-2-before-mca.txt)
