### PR TITLE
Reapply "[compiler-rt][HWAsan] Remove CHECK lines from test"

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/Linux/fixed-shadow.c
+++ b/compiler-rt/test/hwasan/TestCases/Linux/fixed-shadow.c
@@ -3,17 +3,17 @@
 // Default compiler instrumentation works with any shadow base (dynamic or fixed).
 // RUN: %clang_hwasan %s -o %t
 // RUN: %run %t
-// RUN: env HWASAN_OPTIONS=fixed_shadow_base=263878495698944 %run %t 2>%t.out || (cat %t.out | FileCheck %s)
+// RUN: env HWASAN_OPTIONS=fixed_shadow_base=17592186044416 %run %t
 // RUN: env HWASAN_OPTIONS=fixed_shadow_base=4398046511104 %run %t
 //
 // If -hwasan-mapping-offset is set, then the fixed_shadow_base needs to match.
-// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=263878495698944 -o %t
-// RUN: env HWASAN_OPTIONS=fixed_shadow_base=263878495698944 %run %t 2>%t.out || (cat %t.out | FileCheck %s)
+// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=17592186044416 -o %t
+// RUN: env HWASAN_OPTIONS=fixed_shadow_base=17592186044416 %run %t
 // RUN: env HWASAN_OPTIONS=fixed_shadow_base=4398046511104 not %run %t
 
 // RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=4398046511104 -o %t
 // RUN: env HWASAN_OPTIONS=fixed_shadow_base=4398046511104 %run %t
-// RUN: env HWASAN_OPTIONS=fixed_shadow_base=263878495698944 not %run %t
+// RUN: env HWASAN_OPTIONS=fixed_shadow_base=17592186044416 not %run %t
 //
 // Note: if fixed_shadow_base is not set, compiler-rt will dynamically choose a
 // shadow base, which has a tiny but non-zero probability of matching the
@@ -25,8 +25,6 @@
 // REQUIRES: Clang
 //
 // UNSUPPORTED: android
-
-// CHECK: FATAL: HWAddressSanitizer: Shadow range {{.*}} is not available
 
 #include <assert.h>
 #include <sanitizer/allocator_interface.h>


### PR DESCRIPTION
This reverts commit cc8478b38d9dc72f4f3b38bbaa55718663523277.

This was exposing existing failures due to the removal of the || clause in the run lines due to address space conflicts. Move the fixed base lower than the libraries will ever end up being to resolve the issue.