### PR TITLE
[CAS] Fix msan error in ObjectStore::importObject()

### DIFF
--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -213,10 +213,13 @@ Expected<ObjectRef> ObjectStore::importObject(ObjectStore &Upstream,
 
       // Remove the current node and its IDs from the stack.
       PrimaryRefStack.truncate(PrimaryRefStack.size() - Cur.RefsCount);
-      CursorStack.pop_back();
 
+      // Push new node into created objects.
       PrimaryRefStack.push_back(*NewNode);
       CreatedObjects.try_emplace(Cur.Ref, *NewNode);
+
+      // Pop the cursor in the end after all uses.
+      CursorStack.pop_back();
       continue;
     }
 


### PR DESCRIPTION
Fix msan error that reference to ObjectRef is used after the storage is
deleted. Make sure all usages is finished before deleting the container.
