### PR TITLE
RuntimeLibcalls: Add __memcpy_chk, __memmove_chk, __memset_chk

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -149,6 +149,8 @@ foreach FPTy = ["F32", "F64", "F80", "F128", "PPCF128"] in {
   def ATAN_#FPTy : RuntimeLibcall;
   def ATAN2_#FPTy : RuntimeLibcall;
   def SINCOS_#FPTy : RuntimeLibcall;
+  def REMQUO_#FPTy : RuntimeLibcall;
+  def FDIM_#FPTy : RuntimeLibcall;
 }
 
 foreach FPTy = [ "F32", "F64" ] in {
@@ -180,6 +182,12 @@ foreach FPTy = ["F32", "F64", "F80", "F128", "PPCF128"] in {
   def FREXP_#FPTy : RuntimeLibcall;
   def SINCOSPI_#FPTy : RuntimeLibcall;
   def MODF_#FPTy : RuntimeLibcall;
+  def NAN_#FPTy : RuntimeLibcall;
+  def NEXTTOWARD_#FPTy : RuntimeLibcall;
+  def REMAINDER_#FPTy : RuntimeLibcall;
+  def SCALBLN_#FPTy : RuntimeLibcall;
+  def SCALBN_#FPTy : RuntimeLibcall;
+  def TGAMMA_#FPTy : RuntimeLibcall;
 }
 
 defvar F32VectorSuffixes = ["V2F32", "V4F32", "V8F32", "V16F32", "NXV4F32"];
@@ -1033,6 +1041,38 @@ defm frexpl : LibmLongDoubleLibCall;
 def modff : RuntimeLibcallImpl<MODF_F32>;
 def modf : RuntimeLibcallImpl<MODF_F64>;
 defm modfl : LibmLongDoubleLibCall;
+
+def nanf : RuntimeLibcallImpl<NAN_F32>;
+def nan : RuntimeLibcallImpl<NAN_F64>;
+defm nanl : LibmLongDoubleLibCall;
+
+def nexttowardf : RuntimeLibcallImpl<NEXTTOWARD_F32>;
+def nexttoward : RuntimeLibcallImpl<NEXTTOWARD_F64>;
+defm nexttowardl : LibmLongDoubleLibCall;
+
+def remainderf : RuntimeLibcallImpl<REMAINDER_F32>;
+def remainder : RuntimeLibcallImpl<REMAINDER_F64>;
+defm remainderl : LibmLongDoubleLibCall;
+
+def remquof : RuntimeLibcallImpl<REMQUO_F32>;
+def remquo : RuntimeLibcallImpl<REMQUO_F64>;
+defm remquol : LibmLongDoubleLibCall;
+
+def fdimf : RuntimeLibcallImpl<FDIM_F32>;
+def fdim : RuntimeLibcallImpl<FDIM_F64>;
+defm fdiml : LibmLongDoubleLibCall;
+
+def scalbnf : RuntimeLibcallImpl<SCALBN_F32>;
+def scalbn : RuntimeLibcallImpl<SCALBN_F64>;
+defm scalbnl : LibmLongDoubleLibCall;
+
+def scalblnf : RuntimeLibcallImpl<SCALBLN_F32>;
+def scalbln : RuntimeLibcallImpl<SCALBLN_F64>;
+defm scalblnl : LibmLongDoubleLibCall;
+
+def tgammaf : RuntimeLibcallImpl<TGAMMA_F32>;
+def tgamma : RuntimeLibcallImpl<TGAMMA_F64>;
+defm tgammal : LibmLongDoubleLibCall;
 
 // Floating point environment
 def fegetenv : RuntimeLibcallImpl<FEGETENV>;

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -35,6 +35,9 @@ def isNotOSLinuxAndNotOSOpenBSD : RuntimeLibcallPredicate<
 def isNotOSAIXAndNotOSOpenBSD : RuntimeLibcallPredicate<
   [{!TT.isOSAIX() && !TT.isOSOpenBSD()}]>;
 
+def isNotPS : RuntimeLibcallPredicate<
+  [{!TT.isPS()}]>;
+
 // OpenBSD uses __guard_local. AIX uses __ssp_canary_word, MSVC/Windows
 // Itanium uses __security_cookie
 def hasStackChkFail : RuntimeLibcallPredicate<
@@ -374,8 +377,11 @@ foreach FPTy = ["F32", "F64", "F128", "PPCF128"] in {
 // Memory
 def MEMCMP : RuntimeLibcall;
 def MEMCPY : RuntimeLibcall;
+def MEMCPY_CHK : RuntimeLibcall;
 def MEMMOVE : RuntimeLibcall;
+def MEMMOVE_CHK : RuntimeLibcall;
 def MEMSET : RuntimeLibcall;
+def MEMSET_CHK : RuntimeLibcall;
 def CALLOC : RuntimeLibcall;
 def BZERO : RuntimeLibcall;
 def STRLEN : RuntimeLibcall;
@@ -1090,6 +1096,10 @@ def fesetmode : RuntimeLibcallImpl<FESETMODE>;
 def memcpy : RuntimeLibcallImpl<MEMCPY>;
 def memmove : RuntimeLibcallImpl<MEMMOVE>;
 def memset : RuntimeLibcallImpl<MEMSET>;
+
+def __memcpy_chk : RuntimeLibcallImpl<MEMCPY_CHK>;
+def __memmove_chk : RuntimeLibcallImpl<MEMMOVE_CHK>;
+def __memset_chk : RuntimeLibcallImpl<MEMSET_CHK>;
 
 // DSEPass can emit calloc if it finds a pair of malloc/memset
 def calloc : RuntimeLibcallImpl<CALLOC>;
@@ -2624,8 +2634,10 @@ defvar X86_F128_Libcalls = LibcallImpls<(add LibmF128Libcalls, LibmF128FiniteLib
 
 defvar SinCosF32F64Libcalls = LibcallImpls<(add sincosf, sincos), hasSinCos_f32_f64>;
 
+defvar MemChkLibcalls = [__memcpy_chk, __memset_chk, __memmove_chk];
+
 defvar X86CommonLibcalls =
-  (add (sub WinDefaultLibcallImpls, WindowsDivRemMulLibcallOverrides),
+  (add (sub WinDefaultLibcallImpls, WindowsDivRemMulLibcallOverrides, MemChkLibcalls),
        DarwinSinCosStret, DarwinExp10,
        X86_F128_Libcalls,
        LibmHasSinCosF80, // FIXME: Depends on long double
@@ -2641,7 +2653,8 @@ defvar X86CommonLibcalls =
        // FIXME: MSVCRT doesn't have powi. The f128 case is added as a
        // hack for one test relying on it.
        __powitf2_f128,
-       DefaultStackProtector
+       DefaultStackProtector,
+       LibcallImpls<(add MemChkLibcalls), isNotPS>
      );
 
 defvar Windows32DivRemMulCalls =

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
@@ -12,6 +12,10 @@ define float @sinf(float %x) {
 
 ; CHECK: declare void @_Unwind_Resume(...)
 
+; CHECK: declare void @__memcpy_chk(...)
+; CHECK: declare void @__memmove_chk(...)
+; CHECK: declare void @__memset_chk(...)
+
 ; CHECK: declare void @__umodti3(...)
 
 ; CHECK: declare void @acosf(...)

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
@@ -16,9 +16,41 @@ define float @sinf(float %x) {
 
 ; CHECK: declare void @acosf(...)
 
+; CHECK: declare void @fdim(...)
+; CHECK: declare void @fdimf(...)
+; CHECK: declare void @fdiml(...)
+
+; CHECK: declare void @nan(...)
+; CHECK: declare void @nanf(...)
+; CHECK: declare void @nanl(...)
+
+; CHECK: declare void @nexttoward(...)
+; CHECK: declare void @nexttowardf(...)
+; CHECK: declare void @nexttowardl(...)
+
+; CHECK: declare void @remainder(...)
+; CHECK: declare void @remainderf(...)
+; CHECK: declare void @remainderl(...)
+
+; CHECK: declare void @remquo(...)
+; CHECK: declare void @remquof(...)
+; CHECK: declare void @remquol(...)
+
+; CHECK: declare void @scalbln(...)
+; CHECK: declare void @scalblnf(...)
+; CHECK: declare void @scalblnl(...)
+
+; CHECK: declare void @scalbn(...)
+; CHECK: declare void @scalbnf(...)
+; CHECK: declare void @scalbnl(...)
+
 ; CHECK: declare nofpclass(ninf nsub nnorm) double @sqrt(double) [[SQRT_ATTRS:#[0-9]+]]
 
 ; CHECK: declare nofpclass(ninf nsub nnorm) float @sqrtf(float) [[SQRT_ATTRS:#[0-9]+]]
+
+; CHECK: declare void @tgamma(...)
+; CHECK: declare void @tgammaf(...)
+; CHECK: declare void @tgammal(...)
 
 ; CHECK: declare void @truncl(...)
 

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/ps.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/ps.ll
@@ -1,0 +1,6 @@
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=x86_64-scei-ps4 < %s | FileCheck %s
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=x86_64-scei-ps5 < %s | FileCheck %s
+
+; CHECK-NOT: __memcpy_chk
+; CHECK-NOT: __memset_chk
+; CHECK-NOT: __memmove_chk


### PR DESCRIPTION
These were in TargetLibraryInfo, but missing from RuntimeLibcalls.
This only adds the cases that already have the non-chk variants
already. Copies the enabled-by-default logic from TargetLibraryInfo,
which is probably overly permissive. Only isPS opts-out.