### PR TITLE
[lldb-dap] Refactoring IO handling for the SBDebugger.

### DIFF
--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -57,6 +57,7 @@ enum class LLDBLog : Log::MaskType {
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
 void InitializeLldbChannel();
+void TerminateLldbChannel();
 
 template <> Log::Channel &LogChannelFor<LLDBLog>();
 } // namespace lldb_private

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -995,15 +995,15 @@ class DebugCommunication(object):
 
     def request_evaluate(
         self,
-        expression,
+        expression: str,
         frameIndex=0,
-        threadId=None,
-        context=None,
+        threadId: Optional[int] = None,
+        context: Optional[
+            Literal["watch", "repl", "hover", "clipboard", "variables"]
+        ] = None,
         is_hex: Optional[bool] = None,
-    ):
+    ) -> Optional[Response]:
         stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=threadId)
-        if stackFrame is None:
-            return []
         args_dict = {
             "expression": expression,
             "frameId": stackFrame["id"],
@@ -1012,7 +1012,7 @@ class DebugCommunication(object):
             args_dict["context"] = context
         if is_hex is not None:
             args_dict["format"] = {"hex": is_hex}
-        command_dict = {
+        command_dict: Request = {
             "command": "evaluate",
             "type": "request",
             "arguments": args_dict,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -743,6 +743,11 @@ void Debugger::Terminate() {
         debugger->Clear();
       g_debugger_list_ptr->clear();
     }
+
+    delete g_debugger_list_ptr;
+    delete g_debugger_list_mutex_ptr;
+    g_debugger_list_ptr = nullptr;
+    g_debugger_list_mutex_ptr = nullptr;
   }
 }
 

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -101,4 +101,5 @@ void SystemInitializerCommon::Terminate() {
   Log::DisableAllLogChannels();
   FileSystem::Terminate();
   Diagnostics::Terminate();
+  TerminateLldbChannel();
 }

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -87,3 +87,5 @@ template <> Log::Channel &lldb_private::LogChannelFor<LLDBLog>() {
 void lldb_private::InitializeLldbChannel() {
   Log::Register("lldb", g_log_channel);
 }
+
+void lldb_private::TerminateLldbChannel() { Log::Unregister("lldb"); }

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -2,8 +2,6 @@
 Test lldb-dap cancel request
 """
 
-import time
-
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbdap_testcase

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -128,6 +128,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         self.assertEvaluate("var1", "20", want_type="int")
         # Empty expression should equate to the previous expression.
         if context == "repl":
+            self.assertEvaluate("p var1", "20")
             self.assertEvaluate("", "20")
         else:
             self.assertEvaluateFailure("")

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -17,27 +17,26 @@
 #include "OutputRedirector.h"
 #include "ProgressEvent.h"
 #include "Protocol/ProtocolBase.h"
+#include "Protocol/ProtocolEvents.h"
 #include "Protocol/ProtocolRequests.h"
 #include "Protocol/ProtocolTypes.h"
 #include "SourceBreakpoint.h"
 #include "Transport.h"
 #include "Variables.h"
 #include "lldb/API/SBBroadcaster.h"
-#include "lldb/API/SBCommandInterpreter.h"
+#include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBDebugger.h"
 #include "lldb/API/SBError.h"
-#include "lldb/API/SBFile.h"
 #include "lldb/API/SBFormat.h"
 #include "lldb/API/SBFrame.h"
 #include "lldb/API/SBMutex.h"
+#include "lldb/API/SBProgress.h"
 #include "lldb/API/SBTarget.h"
 #include "lldb/API/SBThread.h"
 #include "lldb/Host/MainLoop.h"
-#include "lldb/Utility/Status.h"
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -45,6 +44,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/Threading.h"
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
@@ -52,6 +52,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -67,8 +68,7 @@ typedef llvm::DenseMap<lldb::addr_t, InstructionBreakpoint>
 
 using AdapterFeature = protocol::AdapterFeature;
 using ClientFeature = protocol::ClientFeature;
-
-enum class OutputType { Console, Important, Stdout, Stderr, Telemetry };
+using OutputCategory = protocol::OutputCategory;
 
 /// Buffer size for handling output events.
 constexpr uint64_t OutputBufferSize = (1u << 12);
@@ -79,6 +79,34 @@ enum DAPBroadcasterBits {
 };
 
 enum class ReplMode { Variable = 0, Command, Auto };
+struct ReplContext {
+  llvm::StringRef line_ref;
+  bool succeeded = true;
+  bool did_timeout = false;
+  bool stop_on_next_write = false;
+  static constexpr std::chrono::milliseconds kRawInputTimeout =
+      std::chrono::milliseconds(250);
+  DAP &dap;
+  lldb_private::MainLoop loop;
+  llvm::SmallString<256> output;
+  lldb::SBValueList values;
+
+  // FIXME: It would be nice to be able to cancel this operation, at the
+  // moment we do not support progress cancellation.
+  lldb::SBProgress progress;
+
+  explicit ReplContext(DAP &dap, llvm::StringRef line);
+  ~ReplContext();
+
+  bool WantsRawInput();
+
+  void UpdateWantsMore();
+
+  void Write(llvm::StringRef str);
+  void Write(lldb::SBCommandReturnObject &result);
+
+  llvm::Error Run();
+};
 
 using DAPTransport = lldb_private::transport::JSONTransport<ProtocolDescriptor>;
 
@@ -88,9 +116,9 @@ struct DAP final : public DAPTransport::MessageHandler {
   /// Path to the lldb-dap binary itself.
   static llvm::StringRef debug_adapter_path;
 
-  Log *log;
+  Log &log;
   DAPTransport &transport;
-  lldb::SBFile in;
+  lldb::FileSP pty_primary;
   OutputRedirector out;
   OutputRedirector err;
 
@@ -145,6 +173,7 @@ struct DAP final : public DAPTransport::MessageHandler {
   llvm::SmallDenseMap<int64_t, std::unique_ptr<ResponseHandler>>
       inflight_reverse_requests;
   ReplMode repl_mode;
+  ReplContext *repl_context = nullptr;
   lldb::SBFormat frame_format;
   lldb::SBFormat thread_format;
 
@@ -156,15 +185,12 @@ struct DAP final : public DAPTransport::MessageHandler {
   std::string last_nonempty_var_expression;
 
   /// The set of features supported by the connected client.
-  llvm::DenseSet<ClientFeature> clientFeatures;
-
-  /// Whether to disable sourcing .lldbinit files.
-  bool no_lldbinit;
+  llvm::DenseSet<ClientFeature> client_features;
 
   /// Stores whether the initialize request specified a value for
   /// lldbExtSourceInitFile. Used by the test suite to prevent sourcing
   /// `.lldbinit` and changing its behavior.
-  bool sourceInitFile = true;
+  bool source_init_files = true;
 
   /// The initial thread list upon attaching.
   std::vector<protocol::Thread> initial_thread_list;
@@ -181,22 +207,22 @@ struct DAP final : public DAPTransport::MessageHandler {
 
   /// Creates a new DAP sessions.
   ///
-  /// \param[in] log
-  ///     Log stream, if configured.
   /// \param[in] default_repl_mode
   ///     Default repl mode behavior, as configured by the binary.
   /// \param[in] pre_init_commands
   ///     LLDB commands to execute as soon as the debugger instance is
   ///     allocated.
-  /// \param[in] no_lldbinit
-  ///     Whether to disable sourcing .lldbinit files.
+  /// \param[in] client_name
+  ///     The name of this client, for example 'stdio' or 'client_1'.
+  /// \param[in] log
+  ///     Log stream.
   /// \param[in] transport
   ///     Transport for this debug session.
   /// \param[in] loop
   ///     Main loop associated with this instance.
-  DAP(Log *log, const ReplMode default_repl_mode,
-      std::vector<std::string> pre_init_commands, bool no_lldbinit,
-      llvm::StringRef client_name, DAPTransport &transport,
+  DAP(const ReplMode default_repl_mode,
+      const std::vector<std::string> &pre_init_commands,
+      llvm::StringRef client_name, Log &log, DAPTransport &transport,
       lldb_private::MainLoop &loop);
 
   ~DAP();
@@ -232,13 +258,12 @@ struct DAP final : public DAPTransport::MessageHandler {
   /// Send the given message to the client.
   protocol::Id Send(const protocol::Message &message);
 
-  void SendOutput(OutputType o, const llvm::StringRef output);
+  /// Send output to the client.
+  void SendOutput(OutputCategory o, const llvm::StringRef output);
+  void SendOutput(const protocol::OutputEventBody &);
 
   void SendProgressEvent(uint64_t progress_id, const char *message,
                          uint64_t completed, uint64_t total);
-
-  void __attribute__((format(printf, 3, 4)))
-  SendFormattedOutput(OutputType o, const char *format, ...);
 
   int32_t CreateSourceReference(lldb::addr_t address);
 
@@ -509,6 +534,7 @@ private:
 
   // Loop for managing reading from the client.
   lldb_private::MainLoop &m_loop;
+  lldb_private::MainLoop::ReadHandleUP m_pty_handle;
 
   std::mutex m_cancelled_requests_mutex;
   llvm::SmallSet<int64_t, 4> m_cancelled_requests;

--- a/lldb/tools/lldb-dap/DAPError.cpp
+++ b/lldb/tools/lldb-dap/DAPError.cpp
@@ -15,9 +15,19 @@ namespace lldb_dap {
 
 char DAPError::ID;
 
+DAPError::DAPError(std::string message) : DAPError(std::move(message), true) {}
+
+DAPError::DAPError(std::string message, std::error_code EC)
+    : DAPError(std::move(message), std::move(EC), true) {}
+
+DAPError::DAPError(std::string message, bool show_user)
+    : DAPError(std::move(message), llvm::inconvertibleErrorCode(), show_user) {}
+
+DAPError::DAPError(std::string message, std::error_code EC, bool show_user)
+    : DAPError(std::move(message), std::move(EC), show_user, "", "") {}
+
 DAPError::DAPError(std::string message, std::error_code EC, bool show_user,
-                   std::optional<std::string> url,
-                   std::optional<std::string> url_label)
+                   std::string url, std::string url_label)
     : m_message(std::move(message)), m_ec(EC), m_show_user(show_user),
       m_url(std::move(url)), m_url_label(std::move(url_label)) {}
 

--- a/lldb/tools/lldb-dap/DAPError.h
+++ b/lldb/tools/lldb-dap/DAPError.h
@@ -22,25 +22,31 @@ class DAPError : public llvm::ErrorInfo<DAPError> {
 public:
   static char ID;
 
-  DAPError(std::string message,
-           std::error_code EC = llvm::inconvertibleErrorCode(),
-           bool show_user = true, std::optional<std::string> url = std::nullopt,
-           std::optional<std::string> url_label = std::nullopt);
+  explicit DAPError(std::string message);
+
+  DAPError(std::string message, std::error_code EC);
+
+  DAPError(std::string message, bool show_user);
+
+  DAPError(std::string message, std::error_code EC, bool show_user);
+
+  DAPError(std::string message, std::error_code EC, bool show_user,
+           std::string url, std::string url_label);
 
   void log(llvm::raw_ostream &OS) const override;
   std::error_code convertToErrorCode() const override;
 
   const std::string &getMessage() const { return m_message; }
   bool getShowUser() const { return m_show_user; }
-  const std::optional<std::string> &getURL() const { return m_url; }
-  const std::optional<std::string> &getURLLabel() const { return m_url_label; }
+  const std::string &getURL() const { return m_url; }
+  const std::string &getURLLabel() const { return m_url_label; }
 
 private:
   std::string m_message;
   std::error_code m_ec;
   bool m_show_user;
-  std::optional<std::string> m_url;
-  std::optional<std::string> m_url_label;
+  std::string m_url;
+  std::string m_url_label;
 };
 
 /// An error that indicates the current request handler cannot execute because

--- a/lldb/tools/lldb-dap/DAPForward.h
+++ b/lldb/tools/lldb-dap/DAPForward.h
@@ -9,6 +9,9 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_DAPFORWARD_H
 #define LLDB_TOOLS_LLDB_DAP_DAPFORWARD_H
 
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+
 // IWYU pragma: begin_exports
 
 namespace lldb_dap {
@@ -22,6 +25,8 @@ class ResponseHandler;
 class SourceBreakpoint;
 class Watchpoint;
 struct DAP;
+using LogSP = std::shared_ptr<Log>;
+using StreamSP = std::shared_ptr<llvm::raw_ostream>;
 } // namespace lldb_dap
 
 namespace lldb {

--- a/lldb/tools/lldb-dap/DAPLog.cpp
+++ b/lldb/tools/lldb-dap/DAPLog.cpp
@@ -8,22 +8,32 @@
 
 #include "DAPLog.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include <chrono>
 #include <mutex>
-#include <system_error>
 
 using namespace llvm;
 
 namespace lldb_dap {
 
-Log::Log(StringRef filename, std::error_code &EC) : m_stream(filename, EC) {}
-
-void Log::WriteMessage(StringRef message) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+void Log::Emit(StringRef message) {
+  std::lock_guard<Log::Mutex> lock(m_mutex);
   std::chrono::duration<double> now{
       std::chrono::system_clock::now().time_since_epoch()};
-  m_stream << formatv("{0:f9} ", now.count()).str() << message << "\n";
+  m_stream << formatv("{0:f9} ", now.count()).str() << m_prefix << message
+           << "\n";
+  m_stream.flush();
+}
+
+void Log::Emit(StringRef file, size_t line, StringRef message) {
+  std::lock_guard<Log::Mutex> lock(m_mutex);
+  std::chrono::duration<double> now{
+      std::chrono::system_clock::now().time_since_epoch()};
+  m_stream << formatv("{0:f9} {1}:{2} ", now.count(), sys::path::filename(file),
+                      line)
+                  .str()
+           << m_prefix << message << "\n";
   m_stream.flush();
 }
 

--- a/lldb/tools/lldb-dap/DAPLog.h
+++ b/lldb/tools/lldb-dap/DAPLog.h
@@ -9,35 +9,32 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_DAPLOG_H
 #define LLDB_TOOLS_LLDB_DAP_DAPLOG_H
 
+#include "DAPForward.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <mutex>
 #include <string>
-#include <system_error>
 
 // Write a message to log, if logging is enabled.
 #define DAP_LOG(log, ...)                                                      \
   do {                                                                         \
-    ::lldb_dap::Log *log_private = (log);                                      \
-    if (log_private) {                                                         \
-      log_private->WriteMessage(::llvm::formatv(__VA_ARGS__).str());           \
-    }                                                                          \
+    ::lldb_dap::Log &log_private = (log);                                      \
+    log_private.Emit(__FILE__, __LINE__, ::llvm::formatv(__VA_ARGS__).str());  \
   } while (0)
 
 // Write message to log, if error is set. In the log message refer to the error
 // with {0}. Error is cleared regardless of whether logging is enabled.
 #define DAP_LOG_ERROR(log, error, ...)                                         \
   do {                                                                         \
-    ::lldb_dap::Log *log_private = (log);                                      \
+    ::lldb_dap::Log &log_private = (log);                                      \
     ::llvm::Error error_private = (error);                                     \
-    if (log_private && error_private) {                                        \
-      log_private->WriteMessage(                                               \
+    if (error_private) {                                                       \
+      log_private.Emit(                                                        \
+          __FILE__, __LINE__,                                                  \
           ::lldb_dap::FormatError(::std::move(error_private), __VA_ARGS__));   \
-    } else                                                                     \
-      ::llvm::consumeError(::std::move(error_private));                        \
+    }                                                                          \
   } while (0)
 
 namespace lldb_dap {
@@ -46,14 +43,31 @@ namespace lldb_dap {
 /// `DAP_LOG_ERROR` helpers.
 class Log final {
 public:
-  /// Creates a log file with the given filename.
-  Log(llvm::StringRef filename, std::error_code &EC);
+  using Mutex = std::recursive_mutex;
 
-  void WriteMessage(llvm::StringRef message);
+  Log(llvm::raw_ostream &stream, Mutex &mutex)
+      : m_stream(stream), m_mutex(mutex) {}
+  Log(llvm::StringRef prefix, const Log &log)
+      : m_prefix(prefix), m_stream(log.m_stream), m_mutex(log.m_mutex) {}
+
+  /// Retuns a new Log instance with the associated prefix for all messages.
+  inline Log WithPrefix(llvm::StringRef prefix) const {
+    std::string full_prefix =
+        m_prefix.empty() ? prefix.str() : m_prefix + " " + prefix.str();
+    return Log(full_prefix, *this);
+  }
+
+  /// Emit writes a message to the underlying stream.
+  void Emit(llvm::StringRef message);
+
+  /// Emit writes a message to the underlying stream, including the file and
+  /// line the message originated from.
+  void Emit(llvm::StringRef file, size_t line, llvm::StringRef message);
 
 private:
-  std::mutex m_mutex;
-  llvm::raw_fd_ostream m_stream;
+  std::string m_prefix;
+  llvm::raw_ostream &m_stream;
+  Mutex &m_mutex;
 };
 
 template <typename... Args>

--- a/lldb/tools/lldb-dap/EventHelper.h
+++ b/lldb/tools/lldb-dap/EventHelper.h
@@ -51,16 +51,7 @@ void SendMemoryEvent(DAP &dap, lldb::SBValue variable);
 /// \param client_name The client name for thread naming/logging purposes.
 /// \param log The log instance for logging.
 void EventThread(lldb::SBDebugger debugger, lldb::SBBroadcaster broadcaster,
-                 llvm::StringRef client_name, Log *log);
-
-/// Event handler functions called by EventThread.
-/// These handlers extract the necessary objects from events and find the
-/// appropriate DAP instance to handle them.
-void HandleProcessEvent(const lldb::SBEvent &event, bool &done, Log *log);
-void HandleTargetEvent(const lldb::SBEvent &event, Log *log);
-void HandleBreakpointEvent(const lldb::SBEvent &event, Log *log);
-void HandleThreadEvent(const lldb::SBEvent &event, Log *log);
-void HandleDiagnosticEvent(const lldb::SBEvent &event, Log *log);
+                 llvm::StringRef client_name, Log &log);
 
 } // namespace lldb_dap
 

--- a/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
@@ -7,10 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "DAP.h"
-#include "JSONUtils.h"
 #include "Protocol/ProtocolRequests.h"
 #include "Protocol/ProtocolTypes.h"
 #include "RequestHandler.h"
+#include "lldb/API/SBCommandInterpreter.h"
+#include "lldb/API/SBDebugger.h"
 #include "lldb/API/SBStringList.h"
 
 using namespace llvm;

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CommandPlugins.h"
 #include "DAP.h"
 #include "EventHelper.h"
-#include "JSONUtils.h"
-#include "LLDBUtils.h"
 #include "Protocol/ProtocolRequests.h"
 #include "RequestHandler.h"
-#include "lldb/API/SBTarget.h"
 
 using namespace lldb_dap;
 using namespace lldb_dap::protocol;
@@ -22,8 +18,6 @@ using namespace lldb_dap::protocol;
 llvm::Expected<InitializeResponse> InitializeRequestHandler::Run(
     const InitializeRequestArguments &arguments) const {
   // Store initialization arguments for later use in Launch/Attach.
-  dap.clientFeatures = arguments.supportedFeatures;
-  dap.sourceInitFile = arguments.lldbExtSourceInitFile;
-
+  dap.client_features = arguments.supportedFeatures;
   return dap.GetCapabilities();
 }

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -22,6 +22,8 @@ namespace lldb_dap {
 
 /// Launch request; value of command field is 'launch'.
 Error LaunchRequestHandler::Run(const LaunchRequestArguments &arguments) const {
+  dap.source_init_files = arguments.configuration.sourceInitFiles;
+
   // Initialize DAP debugger.
   if (Error err = dap.InitializeDebugger())
     return err;

--- a/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
@@ -61,8 +61,7 @@ SetVariableRequestHandler::Run(const SetVariableArguments &args) const {
   // so always insert a new one to get its variablesReference.
   // is_permanent is false because debug console does not support
   // setVariable request.
-  const int64_t new_var_ref =
-      dap.variables.InsertVariable(variable, /*is_permanent=*/false);
+  const int64_t new_var_ref = dap.variables.InsertVariable(variable);
   if (variable.MightHaveChildren()) {
     body.variablesReference = new_var_ref;
     if (desc.type_obj.IsArrayType())

--- a/lldb/tools/lldb-dap/Handler/VariablesRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/VariablesRequestHandler.cpp
@@ -106,8 +106,7 @@ VariablesRequestHandler::Run(const VariablesArguments &arguments) const {
 
         if (stop_return_value.MightHaveChildren() ||
             stop_return_value.IsSynthetic()) {
-          return_var_ref = dap.variables.InsertVariable(stop_return_value,
-                                                        /*is_permanent=*/false);
+          return_var_ref = dap.variables.InsertVariable(stop_return_value);
         }
         variables.emplace_back(CreateVariable(
             renamed_return_value, return_var_ref, hex,
@@ -123,8 +122,7 @@ VariablesRequestHandler::Run(const VariablesArguments &arguments) const {
       if (!variable.IsValid())
         break;
 
-      const int64_t frame_var_ref =
-          dap.variables.InsertVariable(variable, /*is_permanent=*/false);
+      const int64_t frame_var_ref = dap.variables.InsertVariable(variable);
       variables.emplace_back(CreateVariable(
           variable, frame_var_ref, hex,
           dap.configuration.enableAutoVariableSummaries,
@@ -135,35 +133,36 @@ VariablesRequestHandler::Run(const VariablesArguments &arguments) const {
     // We are expanding a variable that has children, so we will return its
     // children.
     lldb::SBValue variable = dap.variables.GetVariable(var_ref);
-    if (variable.IsValid()) {
-      const bool is_permanent =
-          dap.variables.IsPermanentVariableReference(var_ref);
-      auto addChild = [&](lldb::SBValue child,
-                          std::optional<std::string> custom_name = {}) {
-        if (!child.IsValid())
-          return;
-        const int64_t child_var_ref =
-            dap.variables.InsertVariable(child, is_permanent);
-        variables.emplace_back(
-            CreateVariable(child, child_var_ref, hex,
-                           dap.configuration.enableAutoVariableSummaries,
-                           dap.configuration.enableSyntheticChildDebugging,
-                           /*is_name_duplicated=*/false, custom_name));
-      };
-      const int64_t num_children = variable.GetNumChildren();
-      const int64_t end_idx = start + ((count == 0) ? num_children : count);
-      int64_t i = start;
-      for (; i < end_idx && i < num_children; ++i)
-        addChild(variable.GetChildAtIndex(i));
-
-      // If we haven't filled the count quota from the request, we insert a new
-      // "[raw]" child that can be used to inspect the raw version of a
-      // synthetic member. That eliminates the need for the user to go to the
-      // debug console and type `frame var <variable> to get these values.
-      if (dap.configuration.enableSyntheticChildDebugging &&
-          variable.IsSynthetic() && i == num_children)
-        addChild(variable.GetNonSyntheticValue(), "[raw]");
+    if (!variable.IsValid()) {
+      return llvm::make_error<DAPError>(llvm::formatv("").str(),
+                                        llvm::inconvertibleErrorCode(),
+                                        /*show_user=*/false);
     }
+
+    auto addChild = [&](lldb::SBValue child,
+                        std::optional<std::string> custom_name = {}) {
+      if (!child.IsValid())
+        return;
+      const int64_t child_var_ref = dap.variables.InsertVariable(child);
+      variables.emplace_back(
+          CreateVariable(child, child_var_ref, hex,
+                         dap.configuration.enableAutoVariableSummaries,
+                         dap.configuration.enableSyntheticChildDebugging,
+                         /*is_name_duplicated=*/false, custom_name));
+    };
+    const int64_t num_children = variable.GetNumChildren();
+    const int64_t end_idx = start + ((count == 0) ? num_children : count);
+    int64_t i = start;
+    for (; i < end_idx && i < num_children; ++i)
+      addChild(variable.GetChildAtIndex(i));
+
+    // If we haven't filled the count quota from the request, we insert a new
+    // "[raw]" child that can be used to inspect the raw version of a
+    // synthetic member. That eliminates the need for the user to go to the
+    // debug console and type `frame var <variable> to get these values.
+    if (dap.configuration.enableSyntheticChildDebugging &&
+        variable.IsSynthetic() && i == num_children)
+      addChild(variable.GetNonSyntheticValue(), "[raw]");
   }
 
   return VariablesResponseBody{variables};

--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp
@@ -188,9 +188,9 @@ bool operator==(const Response &a, const Response &b) {
 json::Value toJSON(const ErrorMessage &EM) {
   json::Object Result{{"id", EM.id}, {"format", EM.format}};
 
-  if (EM.variables) {
+  if (!EM.variables.empty()) {
     json::Object variables;
-    for (auto &var : *EM.variables)
+    for (auto &var : EM.variables)
       variables[var.first] = var.second;
     Result.insert({"variables", std::move(variables)});
   }
@@ -198,9 +198,9 @@ json::Value toJSON(const ErrorMessage &EM) {
     Result.insert({"sendTelemetry", EM.sendTelemetry});
   if (EM.showUser)
     Result.insert({"showUser", EM.showUser});
-  if (EM.url)
+  if (!EM.url.empty())
     Result.insert({"url", EM.url});
-  if (EM.urlLabel)
+  if (!EM.urlLabel.empty())
     Result.insert({"urlLabel", EM.urlLabel});
 
   return std::move(Result);
@@ -209,10 +209,10 @@ json::Value toJSON(const ErrorMessage &EM) {
 bool fromJSON(json::Value const &Params, ErrorMessage &EM, json::Path P) {
   json::ObjectMapper O(Params, P);
   return O && O.map("id", EM.id) && O.map("format", EM.format) &&
-         O.map("variables", EM.variables) &&
-         O.map("sendTelemetry", EM.sendTelemetry) &&
-         O.map("showUser", EM.showUser) && O.map("url", EM.url) &&
-         O.map("urlLabel", EM.urlLabel);
+         O.mapOptional("variables", EM.variables) &&
+         O.mapOptional("sendTelemetry", EM.sendTelemetry) &&
+         O.mapOptional("showUser", EM.showUser) &&
+         O.mapOptional("url", EM.url) && O.mapOptional("urlLabel", EM.urlLabel);
 }
 
 json::Value toJSON(const Event &E) {

--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
@@ -148,7 +148,7 @@ struct ErrorMessage {
 
   /// An object used as a dictionary for looking up the variables in the format
   /// string.
-  std::optional<std::map<std::string, std::string>> variables;
+  std::map<std::string, std::string> variables;
 
   /// If true send to telemetry.
   bool sendTelemetry = false;
@@ -157,10 +157,10 @@ struct ErrorMessage {
   bool showUser = false;
 
   /// A url where additional information about this message can be found.
-  std::optional<std::string> url;
+  std::string url;
 
   /// A label that is presented to the user as the UI for opening the url.
-  std::optional<std::string> urlLabel;
+  std::string urlLabel;
 };
 bool fromJSON(const llvm::json::Value &, ErrorMessage &, llvm::json::Path);
 llvm::json::Value toJSON(const ErrorMessage &);

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
@@ -64,4 +64,55 @@ llvm::json::Value toJSON(const MemoryEventBody &MEB) {
       {"count", MEB.count}};
 }
 
+static llvm::json::Value toJSON(const OutputCategory &OC) {
+  switch (OC) {
+  case eOutputCategoryConsole:
+    return "console";
+  case eOutputCategoryImportant:
+    return "important";
+  case eOutputCategoryStdout:
+    return "stdout";
+  case eOutputCategoryStderr:
+    return "stderr";
+  case eOutputCategoryTelemetry:
+    return "telemetry";
+  }
+  llvm_unreachable("unhandled output category!.");
+}
+
+static llvm::json::Value toJSON(const OutputGroup &OG) {
+  switch (OG) {
+  case eOutputGroupStart:
+    return "start";
+  case eOutputGroupStartCollapsed:
+    return "startCollapsed";
+  case eOutputGroupEnd:
+    return "end";
+  case eOutputGroupNone:
+    break;
+  }
+  llvm_unreachable("unhandled output category!.");
+}
+
+llvm::json::Value toJSON(const OutputEventBody &OEB) {
+  json::Object Result{{"output", OEB.output}, {"category", OEB.category}};
+
+  if (OEB.group != eOutputGroupNone)
+    Result.insert({"group", OEB.group});
+  if (OEB.variablesReference)
+    Result.insert({"variablesReference", OEB.variablesReference});
+  if (OEB.source)
+    Result.insert({"source", OEB.source});
+  if (OEB.line != LLDB_INVALID_LINE_NUMBER)
+    Result.insert({"line", OEB.line});
+  if (OEB.column != LLDB_INVALID_COLUMN_NUMBER)
+    Result.insert({"column", OEB.column});
+  if (OEB.data)
+    Result.insert({"data", OEB.data});
+  if (OEB.locationReference)
+    Result.insert({"locationReference", OEB.locationReference});
+
+  return Result;
+}
+
 } // namespace lldb_dap::protocol

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.h
@@ -117,6 +117,99 @@ struct MemoryEventBody {
 };
 llvm::json::Value toJSON(const MemoryEventBody &);
 
+/// The output category.
+enum OutputCategory : unsigned {
+  /// Show the output in the client's default message UI, e.g. a 'debug
+  /// console'. This category should only be used for informational output from
+  /// the debugger (as opposed to the debuggee).
+  eOutputCategoryConsole,
+  /// A hint for the client to show the output in the client's UI for important
+  /// and highly visible information, e.g. as a popup notification. This
+  /// category should only be used for important messages from the debugger (as
+  /// opposed to the debuggee). Since this category value is a hint, clients
+  /// might ignore the hint and assume the `console` category.
+  eOutputCategoryImportant,
+  /// Show the output as normal program output from the debuggee.
+  eOutputCategoryStdout,
+  /// Show the output as error program output from the debuggee.
+  eOutputCategoryStderr,
+  /// Send the output to telemetry instead of showing it to the user
+  eOutputCategoryTelemetry,
+};
+
+enum OutputGroup : unsigned {
+  /// No grouping of output.
+  eOutputGroupNone,
+  /// Start a new group in expanded mode. Subsequent output events are members
+  /// of the group and should be shown indented.
+  /// The `output` attribute becomes the name of the group and is not indented.
+  eOutputGroupStart,
+  /// Start a new group in collapsed mode. Subsequent output events are members
+  /// of the group and should be shown indented (as soon as the group is
+  /// expanded).
+  /// The `output` attribute becomes the name of the group and is not indented.
+  eOutputGroupStartCollapsed,
+  /// End the current group and decrease the indentation of subsequent output
+  /// events.
+  /// A non-empty `output` attribute is shown as the unindented end of the
+  /// group.
+  eOutputGroupEnd,
+};
+
+/// The event indicates that the target has produced some output.
+struct OutputEventBody {
+  /// The output category. If not specified or if the category is not understood
+  /// by the client, `console` is assumed.
+  OutputCategory category = eOutputCategoryConsole;
+
+  /// The output to report.
+  ///
+  /// ANSI escape sequences may be used to influence text color and styling if
+  /// `supportsANSIStyling` is present in both the adapter's `Capabilities` and
+  /// the client's `InitializeRequestArguments`. A client may strip any
+  /// unrecognized ANSI sequences.
+  ///
+  /// If the `supportsANSIStyling` capabilities are not both true, then the
+  /// client should display the output literally.
+  std::string output;
+
+  /// Support for keeping an output log organized by grouping related messages.
+  OutputGroup group = eOutputGroupNone;
+
+  /// If an attribute `variablesReference` exists and its value is > 0, the
+  /// output contains objects which can be retrieved by passing
+  /// `variablesReference` to the `variables` request as long as execution
+  /// remains suspended. See 'Lifetime of Object References' in the Overview
+  /// section for details.
+  uint64_t variablesReference = 0;
+
+  /// The source location where the output was produced.
+  std::optional<Source> source;
+
+  /// The source location's line where the output was produced.
+  uint32_t line = LLDB_INVALID_LINE_NUMBER;
+
+  /// The position in `line` where the output was produced. It is measured in
+  /// UTF-16 code units and the client capability `columnsStartAt1` determines
+  /// whether it is 0- or 1-based.
+  uint32_t column = LLDB_INVALID_COLUMN_NUMBER;
+
+  /// Additional data to report. For the `telemetry` category the data is sent
+  /// to telemetry, for the other categories the data is shown in JSON format.
+  std::optional<llvm::json::Value> data;
+
+  /// A reference that allows the client to request the location where the new
+  /// value is declared. For example, if the logged value is function pointer,
+  /// the adapter may be able to look up the function's location. This should
+  /// be present only if the adapter is likely to be able to resolve the
+  /// location.
+  ///
+  /// This reference shares the same lifetime as the `variablesReference`. See
+  /// 'Lifetime of Object References' in the Overview section for details.
+  int64_t locationReference = 0;
+};
+llvm::json::Value toJSON(const OutputEventBody &);
+
 } // end namespace lldb_dap::protocol
 
 #endif

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -128,14 +128,6 @@ struct InitializeRequestArguments {
 
   /// The set of supported features reported by the client.
   llvm::DenseSet<ClientFeature> supportedFeatures;
-
-  /// lldb-dap Extensions
-  /// @{
-
-  /// Source init files when initializing lldb::SBDebugger.
-  bool lldbExtSourceInitFile = true;
-
-  /// @}
 };
 bool fromJSON(const llvm::json::Value &, InitializeRequestArguments &,
               llvm::json::Path);
@@ -170,6 +162,9 @@ struct Configuration {
 
   /// Stop at the entry point of the program when launching or attaching.
   bool stopOnEntry = false;
+
+  /// Source init files (e.g. '~/.lldbinit') on launch or attach.
+  bool sourceInitFiles = true;
 
   /// Optional timeout when waiting for the program to `runInTerminal` or
   /// attach.
@@ -315,6 +310,8 @@ using LaunchResponse = VoidResponse;
 #define LLDB_DAP_INVALID_PORT -1
 /// An invalid 'frameId' default value.
 #define LLDB_DAP_INVALID_FRAME_ID UINT64_MAX
+#define LLDB_DAP_INVALID_DEBUGGER_ID -1
+#define LLDB_DAP_INVALID_TARGET_ID UINT64_MAX
 
 /// lldb-dap specific attach arguments.
 struct AttachRequestArguments {
@@ -351,10 +348,10 @@ struct AttachRequestArguments {
   std::string coreFile;
 
   /// Unique ID of an existing target to attach to.
-  std::optional<lldb::user_id_t> targetId;
+  lldb::user_id_t targetId = LLDB_DAP_INVALID_TARGET_ID;
 
   /// ID of an existing debugger instance to use.
-  std::optional<int> debuggerId;
+  int debuggerId = LLDB_DAP_INVALID_DEBUGGER_ID;
 
   /// @}
 };

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -10,6 +10,7 @@
 #include "BreakpointBase.h"
 #include "DAP.h"
 #include "JSONUtils.h"
+#include "Protocol/ProtocolEvents.h"
 #include "ProtocolUtils.h"
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/API/SBFileSpec.h"
@@ -377,7 +378,7 @@ void SourceBreakpoint::SetLogMessage() {
 void SourceBreakpoint::NotifyLogMessageError(llvm::StringRef error) {
   std::string message = "Log message has error: ";
   message += error;
-  m_dap.SendOutput(OutputType::Console, message);
+  m_dap.SendOutput(protocol::eOutputCategoryConsole, message);
 }
 
 /*static*/
@@ -411,7 +412,7 @@ bool SourceBreakpoint::BreakpointHitCallback(
   }
   if (!output.empty() && output.back() != '\n')
     output.push_back('\n'); // Ensure log message has line break.
-  bp->m_dap.SendOutput(OutputType::Console, output.c_str());
+  bp->m_dap.SendOutput(protocol::eOutputCategoryConsole, output.c_str());
 
   // Do not stop.
   return false;

--- a/lldb/tools/lldb-dap/Transport.cpp
+++ b/lldb/tools/lldb-dap/Transport.cpp
@@ -17,13 +17,10 @@ using namespace lldb_private;
 
 namespace lldb_dap {
 
-Transport::Transport(llvm::StringRef client_name, lldb_dap::Log *log,
-                     lldb::IOObjectSP input, lldb::IOObjectSP output)
-    : HTTPDelimitedJSONTransport(input, output), m_client_name(client_name),
-      m_log(log) {}
+Transport::Transport(lldb_dap::Log &log, lldb::IOObjectSP input,
+                     lldb::IOObjectSP output)
+    : HTTPDelimitedJSONTransport(input, output), m_log(log) {}
 
-void Transport::Log(llvm::StringRef message) {
-  DAP_LOG(m_log, "({0}) {1}", m_client_name, message);
-}
+void Transport::Log(llvm::StringRef message) { m_log.Emit(message); }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Transport.h
+++ b/lldb/tools/lldb-dap/Transport.h
@@ -35,15 +35,14 @@ class Transport final
     : public lldb_private::transport::HTTPDelimitedJSONTransport<
           ProtocolDescriptor> {
 public:
-  Transport(llvm::StringRef client_name, lldb_dap::Log *log,
-            lldb::IOObjectSP input, lldb::IOObjectSP output);
+  Transport(lldb_dap::Log &log, lldb::IOObjectSP input,
+            lldb::IOObjectSP output);
   virtual ~Transport() = default;
 
   void Log(llvm::StringRef message) override;
 
 private:
-  llvm::StringRef m_client_name;
-  lldb_dap::Log *m_log;
+  lldb_dap::Log &m_log;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Variables.h
+++ b/lldb/tools/lldb-dap/Variables.h
@@ -20,6 +20,8 @@
 
 namespace lldb_dap {
 
+bool IsPersistent(lldb::SBValue &);
+
 struct Variables {
   lldb::SBValueList locals;
   lldb::SBValueList globals;
@@ -41,7 +43,8 @@ struct Variables {
 
   /// Insert a new \p variable.
   /// \return variableReference assigned to this expandable variable.
-  int64_t InsertVariable(lldb::SBValue variable, bool is_permanent);
+  int64_t InsertVariable(lldb::SBValue variable);
+  int64_t InsertVariables(lldb::SBValueList variables);
 
   lldb::SBValueList *GetTopLevelScope(int64_t variablesReference);
 
@@ -61,6 +64,8 @@ private:
   /// Variables that persist across entire debug session.
   /// These are the variables evaluated from debug console REPL.
   llvm::DenseMap<int64_t, lldb::SBValue> m_referencedpermanent_variables;
+
+  llvm::DenseMap<int64_t, lldb::SBValueList> m_referencedlists;
 
   int64_t m_next_temporary_var_ref{VARREF_FIRST_VAR_IDX};
   int64_t m_next_permanent_var_ref{PermanentVariableStartIndex};

--- a/lldb/tools/lldb-dap/tool/Options.td
+++ b/lldb/tools/lldb-dap/tool/Options.td
@@ -68,12 +68,6 @@ def: Separate<["-"], "c">,
   Alias<pre_init_command>,
   HelpText<"Alias for --pre-init-command">;
 
-def no_lldbinit: F<"no-lldbinit">,
-  HelpText<"Do not automatically parse any '.lldbinit' files.">;
-def: Flag<["-"], "x">,
-  Alias<no_lldbinit>,
-  HelpText<"Alias for --no-lldbinit">;
-
 def connection_timeout: S<"connection-timeout">,
   MetaVarName<"<timeout>">,
   HelpText<"When using --connection, the number of seconds to wait for new "

--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -13,6 +13,7 @@ add_lldb_unittest(DAPTests
   ProtocolTypesTest.cpp
   ProtocolUtilsTest.cpp
   TestBase.cpp
+  TestFixtures.cpp
   VariablesTest.cpp
 
   SBAPITEST

--- a/lldb/unittests/DAP/DAPErrorTest.cpp
+++ b/lldb/unittests/DAP/DAPErrorTest.cpp
@@ -21,8 +21,8 @@ TEST(DAPErrorTest, DefaultConstructor) {
   EXPECT_EQ(error.getMessage(), "Invalid thread");
   EXPECT_EQ(error.convertToErrorCode(), llvm::inconvertibleErrorCode());
   EXPECT_TRUE(error.getShowUser());
-  EXPECT_EQ(error.getURL(), std::nullopt);
-  EXPECT_EQ(error.getURLLabel(), std::nullopt);
+  EXPECT_TRUE(error.getURL().empty());
+  EXPECT_TRUE(error.getURLLabel().empty());
 }
 
 TEST(DAPErrorTest, FullConstructor) {
@@ -32,6 +32,6 @@ TEST(DAPErrorTest, FullConstructor) {
   EXPECT_EQ(error.getMessage(), "Timed out");
   EXPECT_EQ(error.convertToErrorCode(), timed_out);
   EXPECT_FALSE(error.getShowUser());
-  EXPECT_THAT(error.getURL(), testing::Optional<std::string>("URL"));
-  EXPECT_THAT(error.getURLLabel(), testing::Optional<std::string>("URLLabel"));
+  EXPECT_EQ(error.getURL(), "URL");
+  EXPECT_EQ(error.getURLLabel(), "URLLabel");
 }

--- a/lldb/unittests/DAP/DAPSessionManagerTest.cpp
+++ b/lldb/unittests/DAP/DAPSessionManagerTest.cpp
@@ -1,4 +1,4 @@
-//===-- DAPSessionManagerTest.cpp ----------------------------------------===//
+//===-- SessionManagerTest.cpp ----------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,41 +11,39 @@
 #include "lldb/API/SBDebugger.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <future>
 
 using namespace lldb_dap;
 using namespace lldb;
 using namespace lldb_dap_tests;
 
-class DAPSessionManagerTest : public DAPTestBase {};
+class SessionManagerTest : public DAPTestBase {};
 
-TEST_F(DAPSessionManagerTest, GetInstanceReturnsSameSingleton) {
-  DAPSessionManager &instance1 = DAPSessionManager::GetInstance();
-  DAPSessionManager &instance2 = DAPSessionManager::GetInstance();
+TEST_F(SessionManagerTest, GetInstanceReturnsSameSingleton) {
+  SessionManager &instance1 = SessionManager::GetInstance();
+  SessionManager &instance2 = SessionManager::GetInstance();
 
   EXPECT_EQ(&instance1, &instance2);
 }
 
 // UnregisterSession uses std::notify_all_at_thread_exit, so it must be called
 // from a separate thread to properly release the mutex on thread exit.
-TEST_F(DAPSessionManagerTest, RegisterAndUnregisterSession) {
-  DAPSessionManager &manager = DAPSessionManager::GetInstance();
+TEST_F(SessionManagerTest, RegisterAndUnregisterSession) {
+  SessionManager &manager = SessionManager::GetInstance();
 
   // Initially not registered.
   std::vector<DAP *> sessions_before = manager.GetActiveSessions();
   EXPECT_EQ(
       std::count(sessions_before.begin(), sessions_before.end(), dap.get()), 0);
 
-  manager.RegisterSession(&loop, dap.get());
+  {
+    auto handle = manager.Register(*dap.get());
 
-  // Should be in active sessions after registration.
-  std::vector<DAP *> sessions_after = manager.GetActiveSessions();
-  EXPECT_EQ(std::count(sessions_after.begin(), sessions_after.end(), dap.get()),
-            1);
-
-  // Unregister.
-  std::thread unregister_thread([&]() { manager.UnregisterSession(&loop); });
-
-  unregister_thread.join();
+    // Should be in active sessions after registration.
+    std::vector<DAP *> sessions_after = manager.GetActiveSessions();
+    EXPECT_EQ(
+        std::count(sessions_after.begin(), sessions_after.end(), dap.get()), 1);
+  }
 
   // There should no longer be active sessions.
   std::vector<DAP *> sessions_final = manager.GetActiveSessions();
@@ -53,10 +51,10 @@ TEST_F(DAPSessionManagerTest, RegisterAndUnregisterSession) {
             0);
 }
 
-TEST_F(DAPSessionManagerTest, DisconnectAllSessions) {
-  DAPSessionManager &manager = DAPSessionManager::GetInstance();
+TEST_F(SessionManagerTest, DisconnectAllSessions) {
+  SessionManager &manager = SessionManager::GetInstance();
 
-  manager.RegisterSession(&loop, dap.get());
+  auto handle = manager.Register(*dap.get());
 
   std::vector<DAP *> sessions = manager.GetActiveSessions();
   EXPECT_EQ(std::count(sessions.begin(), sessions.end(), dap.get()), 1);
@@ -67,37 +65,35 @@ TEST_F(DAPSessionManagerTest, DisconnectAllSessions) {
   // sessions to complete or remove them from the active sessions map.
   sessions = manager.GetActiveSessions();
   EXPECT_EQ(std::count(sessions.begin(), sessions.end(), dap.get()), 1);
-
-  std::thread unregister_thread([&]() { manager.UnregisterSession(&loop); });
-  unregister_thread.join();
 }
 
-TEST_F(DAPSessionManagerTest, WaitForAllSessionsToDisconnect) {
-  DAPSessionManager &manager = DAPSessionManager::GetInstance();
+TEST_F(SessionManagerTest, WaitForAllSessionsToDisconnect) {
+  SessionManager &manager = SessionManager::GetInstance();
 
-  manager.RegisterSession(&loop, dap.get());
+  std::promise<void> registered_promise;
+  std::promise<void> unregistered_promise;
+
+  // Register the session after a delay to test blocking behavior.
+  std::thread session_thread([&]() {
+    auto handle = manager.Register(*dap.get());
+    registered_promise.set_value();
+    unregistered_promise.get_future().wait();
+  });
+
+  registered_promise.get_future().wait();
 
   std::vector<DAP *> sessions = manager.GetActiveSessions();
   EXPECT_EQ(std::count(sessions.begin(), sessions.end(), dap.get()), 1);
 
-  // Unregister after a delay to test blocking behavior.
-  std::thread unregister_thread([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    manager.UnregisterSession(&loop);
-  });
-
+  // Trigger the session_thread to return, which should unregister the session.
+  unregistered_promise.set_value();
   // WaitForAllSessionsToDisconnect should block until unregistered.
-  auto start = std::chrono::steady_clock::now();
   llvm::Error err = manager.WaitForAllSessionsToDisconnect();
   EXPECT_FALSE(err);
-  auto duration = std::chrono::steady_clock::now() - start;
-
-  // Verify it waited at least 100ms.
-  EXPECT_GE(duration, std::chrono::milliseconds(100));
 
   // Session should be unregistered now.
   sessions = manager.GetActiveSessions();
   EXPECT_EQ(std::count(sessions.begin(), sessions.end(), dap.get()), 0);
 
-  unregister_thread.join();
+  session_thread.join();
 }

--- a/lldb/unittests/DAP/Handler/DisconnectTest.cpp
+++ b/lldb/unittests/DAP/Handler/DisconnectTest.cpp
@@ -38,20 +38,14 @@ TEST_F(DisconnectRequestHandlerTest, DisconnectTriggersTerminated) {
 #ifndef __linux__
 TEST_F(DisconnectRequestHandlerTest, DisconnectTriggersTerminateCommands) {
   CreateDebugger();
-
-  if (!GetDebuggerSupportsTarget("X86"))
-    GTEST_SKIP() << "Unsupported platform";
-
   LoadCore();
 
   DisconnectRequestHandler handler(*dap);
 
-  dap->configuration.terminateCommands = {"?script print(1)",
-                                          "script print(2)"};
+  dap->configuration.terminateCommands = {"?help", "script print(2)"};
   EXPECT_EQ(dap->target.GetProcess().GetState(), lldb::eStateStopped);
   ASSERT_THAT_ERROR(handler.Run(std::nullopt), Succeeded());
-  EXPECT_CALL(client, Received(Output("1\n")));
-  EXPECT_CALL(client, Received(Output("2\n"))).Times(2);
+  EXPECT_CALL(client, Received(Output("2\n")));
   EXPECT_CALL(client, Received(Output("(lldb) script print(2)\n")));
   EXPECT_CALL(client, Received(Output("Running terminateCommands:\n")));
   EXPECT_CALL(client, Received(IsEvent("terminated", _)));

--- a/lldb/unittests/DAP/TestBase.h
+++ b/lldb/unittests/DAP/TestBase.h
@@ -9,6 +9,7 @@
 #include "DAP.h"
 #include "DAPLog.h"
 #include "Protocol/ProtocolBase.h"
+#include "TestFixtures.h"
 #include "TestingSupport/Host/JSONTransportTestUtilities.h"
 #include "TestingSupport/SubsystemRAII.h"
 #include "Transport.h"
@@ -54,11 +55,11 @@ using TestDAPTransport = TestTransport<lldb_dap::ProtocolDescriptor>;
 /// messages.
 class TransportBase : public testing::Test {
 protected:
-  lldb_private::SubsystemRAII<lldb_private::FileSystem, lldb_private::HostInfo>
-      subsystems;
+  lldb_private::SubsystemRAII<lldb::SBDebugger> subsystems;
   lldb_private::MainLoop loop;
   lldb_private::MainLoop::ReadHandleUP handles[2];
 
+  lldb_dap::Log::Mutex log_mutex;
   std::unique_ptr<lldb_dap::Log> log;
 
   std::unique_ptr<TestDAPTransport> to_client;
@@ -99,18 +100,8 @@ inline auto Output(llvm::StringRef o, llvm::StringRef cat = "console") {
 /// A base class for tests that interact with a `lldb_dap::DAP` instance.
 class DAPTestBase : public TransportBase {
 protected:
-  std::optional<llvm::sys::fs::TempFile> core;
-  std::optional<llvm::sys::fs::TempFile> binary;
+  TestFixtures fixtures;
 
-  static constexpr llvm::StringLiteral k_linux_binary = "linux-x86_64.out.yaml";
-  static constexpr llvm::StringLiteral k_linux_core = "linux-x86_64.core.yaml";
-
-  static void SetUpTestSuite();
-  static void TeatUpTestSuite();
-  void SetUp() override;
-  void TearDown() override;
-
-  bool GetDebuggerSupportsTarget(llvm::StringRef platform);
   void CreateDebugger();
   void LoadCore();
 };

--- a/lldb/unittests/DAP/TestFixtures.cpp
+++ b/lldb/unittests/DAP/TestFixtures.cpp
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestFixtures.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBStream.h"
+#include "lldb/lldb-enumerations.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace lldb;
+using namespace lldb_dap_tests;
+
+TestFixtures::~TestFixtures() {
+  if (m_binary)
+    EXPECT_THAT_ERROR(m_binary->discard(), Succeeded());
+  if (m_core)
+    EXPECT_THAT_ERROR(m_core->discard(), Succeeded());
+}
+
+bool TestFixtures::IsPlatformSupported(StringRef platform) {
+  if (!debugger)
+    LoadDebugger();
+
+  SBStructuredData data =
+      debugger.GetBuildConfiguration().GetValueForKey("targets").GetValueForKey(
+          "value");
+  for (size_t i = 0; i < data.GetSize(); i++) {
+    char buf[100] = {0};
+    size_t size = data.GetItemAtIndex(i).GetStringValue(buf, sizeof(buf));
+    if (StringRef(buf, size) == platform)
+      return true;
+  }
+
+  return false;
+}
+
+void TestFixtures::LoadDebugger() {
+  ASSERT_FALSE(debugger) << "Debugger already loaded";
+  debugger = SBDebugger::Create(false);
+  ASSERT_TRUE(debugger);
+}
+
+void TestFixtures::LoadTarget(llvm::StringRef path) {
+  ASSERT_FALSE(target) << "Target already loaded";
+  ASSERT_TRUE(debugger) << "Debugger not loaded";
+
+  Expected<lldb_private::TestFile> binary_yaml =
+      lldb_private::TestFile::fromYamlFile(path);
+  ASSERT_THAT_EXPECTED(binary_yaml, Succeeded());
+  Expected<sys::fs::TempFile> binary_file = binary_yaml->writeToTemporaryFile();
+  ASSERT_THAT_EXPECTED(binary_file, Succeeded());
+  m_binary = std::move(*binary_file);
+  target = debugger.CreateTarget(m_binary->TmpName.data());
+  ASSERT_TRUE(target);
+}
+
+void TestFixtures::LoadProcess(llvm::StringRef path) {
+  llvm::errs() << "LoadProcess(" << path << ")\n";
+  ASSERT_FALSE(process) << "Process already loaded";
+  ASSERT_TRUE(target) << "Target not loaded";
+  ASSERT_TRUE(debugger) << "Debugger not loaded";
+  ASSERT_EQ(debugger.GetID(), target.GetDebugger().GetID())
+      << "Debugger mismatch";
+
+  Expected<lldb_private::TestFile> core_yaml =
+      lldb_private::TestFile::fromYamlFile(path);
+  ASSERT_THAT_EXPECTED(core_yaml, Succeeded());
+  Expected<sys::fs::TempFile> core_file = core_yaml->writeToTemporaryFile();
+  ASSERT_THAT_EXPECTED(core_file, Succeeded());
+  m_core = std::move(*core_file);
+  lldb::SBError error;
+  process = target.LoadCore(m_core->TmpName.data(), error);
+  lldb::SBStream str;
+  target.GetDescription(str, lldb::eDescriptionLevelFull);
+  ASSERT_TRUE(process) << "Failed to load " << m_core->TmpName.data() << " "
+                       << error.GetCString() << " and " << str.GetData();
+}

--- a/lldb/unittests/DAP/TestFixtures.h
+++ b/lldb/unittests/DAP/TestFixtures.h
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UNITTESTS_DAP_TESTFIXTURES_H
+#define LLDB_UNITTESTS_DAP_TESTFIXTURES_H
+
+#include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBProcess.h"
+#include "lldb/API/SBTarget.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include <optional>
+
+namespace lldb_dap_tests {
+
+class DAPTestBase;
+
+struct TestFixtures {
+  TestFixtures() = default;
+  ~TestFixtures();
+  TestFixtures(const TestFixtures &) = delete;
+  TestFixtures &operator=(const TestFixtures &) = delete;
+
+  static constexpr llvm::StringLiteral k_linux_binary = "linux-x86_64.out.yaml";
+  static constexpr llvm::StringLiteral k_linux_core = "linux-x86_64.core.yaml";
+
+  bool IsPlatformSupported(llvm::StringRef platform);
+
+  lldb::SBDebugger debugger;
+  lldb::SBTarget target;
+  lldb::SBProcess process;
+
+  void LoadDebugger();
+  void LoadTarget(llvm::StringRef path = k_linux_binary);
+  void LoadProcess(llvm::StringRef path = k_linux_core);
+
+private:
+  friend DAPTestBase;
+
+  std::optional<llvm::sys::fs::TempFile> m_binary;
+  std::optional<llvm::sys::fs::TempFile> m_core;
+};
+
+} // namespace lldb_dap_tests
+
+#endif


### PR DESCRIPTION
This refactors the IO handling of lldb-dap and its SBDebugger. This adjusts the SBDebugger instance to have a pty associated with in/out/err. Using a pty allows us to handle commands with raw input modes, such as `script` or `breakpoint command add`.

Additionally, to better handle output produced by the debugger and evaluate command I added a print helper. This new print helper will inspect the SBCommandReturnObject and store any associated variables in the variable store. This lets users more easily inspect variables directly in the Debug Console in VSCode.

See the associated screenshot for more info comparing `v <var>`, `p <var>` and `e <var>` as an example.
<img width="1825" height="1090" alt="Screenshot 2025-11-07 at 4 57 07 PM" src="https://github.com/user-attachments/assets/83c35131-2549-4569-bab8-b0388982fa28" />