### PR TITLE
[libc++] Drop -Wno-user-defined-literals when running the test suite

### DIFF
--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -481,6 +481,10 @@ operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 inline namespace literals {
 inline namespace chrono_literals {
 
+_LIBCPP_DIAGNOSTIC_PUSH
+_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wuser-defined-literals")
+_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wliteral-suffix")
+
 _LIBCPP_HIDE_FROM_ABI constexpr chrono::hours operator""h(unsigned long long __h) {
   return chrono::hours(static_cast<chrono::hours::rep>(__h));
 }
@@ -528,6 +532,8 @@ _LIBCPP_HIDE_FROM_ABI constexpr chrono::nanoseconds operator""ns(unsigned long l
 _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double, nano> operator""ns(long double __ns) {
   return chrono::duration<long double, nano>(__ns);
 }
+
+_LIBCPP_DIAGNOSTIC_POP
 
 } // namespace chrono_literals
 } // namespace literals

--- a/libcxx/include/__chrono/literals.h
+++ b/libcxx/include/__chrono/literals.h
@@ -24,6 +24,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 inline namespace literals {
 inline namespace chrono_literals {
+
+_LIBCPP_DIAGNOSTIC_PUSH
+_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wuser-defined-literals")
+_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wliteral-suffix")
+
 _LIBCPP_HIDE_FROM_ABI constexpr chrono::day operator""d(unsigned long long __d) noexcept {
   return chrono::day(static_cast<unsigned>(__d));
 }
@@ -31,6 +36,9 @@ _LIBCPP_HIDE_FROM_ABI constexpr chrono::day operator""d(unsigned long long __d) 
 _LIBCPP_HIDE_FROM_ABI constexpr chrono::year operator""y(unsigned long long __y) noexcept {
   return chrono::year(static_cast<int>(__y));
 }
+
+_LIBCPP_DIAGNOSTIC_POP
+
 } // namespace chrono_literals
 } // namespace literals
 

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -1443,6 +1443,11 @@ _LIBCPP_HIDE_FROM_ABI constexpr const _Xp&& get(const complex<_Xp>&& __z) noexce
 // Literal suffix for complex number literals [complex.literals]
 inline namespace literals {
 inline namespace complex_literals {
+
+_LIBCPP_DIAGNOSTIC_PUSH
+_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wuser-defined-literals")
+_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wliteral-suffix")
+
 _LIBCPP_HIDE_FROM_ABI inline constexpr complex<long double> operator""il(long double __im) { return {0.0l, __im}; }
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr complex<long double> operator""il(unsigned long long __im) {
@@ -1464,6 +1469,9 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr complex<float> operator""if(long double _
 _LIBCPP_HIDE_FROM_ABI inline constexpr complex<float> operator""if(unsigned long long __im) {
   return {0.0f, static_cast<float>(__im)};
 }
+
+_LIBCPP_DIAGNOSTIC_POP
+
 } // namespace complex_literals
 } // namespace literals
 #  endif

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -3946,6 +3946,11 @@ erase_if(basic_string<_CharT, _Traits, _Allocator>& __str, _Predicate __pred) {
 // Literal suffixes for basic_string [basic.string.literals]
 inline namespace literals {
 inline namespace string_literals {
+
+_LIBCPP_DIAGNOSTIC_PUSH
+_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wuser-defined-literals")
+_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wliteral-suffix")
+
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<char>
 operator""s(const char* __str, size_t __len) {
   return basic_string<char>(__str, __len);
@@ -3973,6 +3978,9 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<char32_t
 operator""s(const char32_t* __str, size_t __len) {
   return basic_string<char32_t>(__str, __len);
 }
+
+_LIBCPP_DIAGNOSTIC_POP
+
 } // namespace string_literals
 } // namespace literals
 

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -924,6 +924,11 @@ struct hash<basic_string_view<wchar_t, char_traits<wchar_t> > > : __string_view_
 #  if _LIBCPP_STD_VER >= 14
 inline namespace literals {
 inline namespace string_view_literals {
+
+_LIBCPP_DIAGNOSTIC_PUSH
+_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wuser-defined-literals")
+_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wliteral-suffix")
+
 inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char> operator""sv(const char* __str, size_t __len) noexcept {
   return basic_string_view<char>(__str, __len);
 }
@@ -951,6 +956,9 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char32_t>
 operator""sv(const char32_t* __str, size_t __len) noexcept {
   return basic_string_view<char32_t>(__str, __len);
 }
+
+_LIBCPP_DIAGNOSTIC_POP
+
 } // namespace string_view_literals
 } // namespace literals
 #  endif

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -35,10 +35,6 @@ _warningFlags = [
     # GCC warns about places where we might want to add sized allocation/deallocation
     # functions, but we know better what we're doing/testing in the test suite.
     "-Wno-sized-deallocation",
-    # Turn off warnings about user-defined literals with reserved suffixes. Those are
-    # just noise since we are testing the Standard Library itself.
-    "-Wno-literal-suffix",  # GCC
-    "-Wno-user-defined-literals",  # Clang
     # GCC warns about this when TEST_IS_CONSTANT_EVALUATED is used on a non-constexpr
     # function. (This mostly happens in C++11 mode.)
     # TODO(mordante) investigate a solution for this issue.


### PR DESCRIPTION
I'd like to reduce the number of warnings we disable when running the test suite, and these two seem like obvious targets for removal since it's really easy to just guard the "offending" code with pragmas.