### PR TITLE
benchmarks: Fix sample_symbol_list.txt generation again

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -22,23 +22,25 @@ if(NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
   get_host_tool_path(llvm-nm LLVM_NM llvm_nm_exe llvm_nm_target)
   get_host_tool_path(llc LLC llc_exe llc_target)
 
-  if(${llc_exe} AND ${llvm_nm_exe})
-    # Extract the list of symbols in a random utility as sample data.
-    set(SYMBOL_TEST_DATA_FILE "sample_symbol_list.txt")
-    set(SYMBOL_TEST_DATA_SOURCE_BINARY ${llc_exe})
+  if(TARGET ${llc_target})
+    if(TARGET ${llvm_nm_target})
+      # Extract the list of symbols in a random utility as sample data.
+      set(SYMBOL_TEST_DATA_FILE "sample_symbol_list.txt")
+      set(SYMBOL_TEST_DATA_SOURCE_BINARY ${llc_exe})
 
-    add_custom_command(OUTPUT ${SYMBOL_TEST_DATA_FILE}
-      COMMAND ${llvm_nm_exe} --no-demangle --no-sort
-      --format=just-symbols
-      ${SYMBOL_TEST_DATA_SOURCE_BINARY} > ${SYMBOL_TEST_DATA_FILE}
-     DEPENDS ${llvm_nm_target} ${llc_target})
+      add_custom_command(OUTPUT ${SYMBOL_TEST_DATA_FILE}
+        COMMAND ${llvm_nm_exe} --no-demangle --no-sort
+        --format=just-symbols
+        ${SYMBOL_TEST_DATA_SOURCE_BINARY} > ${SYMBOL_TEST_DATA_FILE}
+       DEPENDS ${llvm_nm_target} ${llc_target})
 
-    add_custom_target(generate-runtime-libcalls-sample-symbol-list
-                      DEPENDS ${SYMBOL_TEST_DATA_FILE})
+      add_custom_target(generate-runtime-libcalls-sample-symbol-list
+                        DEPENDS ${SYMBOL_TEST_DATA_FILE})
 
-    add_dependencies(RuntimeLibcallsBench
-                     generate-runtime-libcalls-sample-symbol-list)
-    target_compile_definitions(RuntimeLibcallsBench PRIVATE
-      -DSYMBOL_TEST_DATA_FILE="${CMAKE_CURRENT_BINARY_DIR}/${SYMBOL_TEST_DATA_FILE}")
+      add_dependencies(RuntimeLibcallsBench
+                       generate-runtime-libcalls-sample-symbol-list)
+      target_compile_definitions(RuntimeLibcallsBench PRIVATE
+        -DSYMBOL_TEST_DATA_FILE="${CMAKE_CURRENT_BINARY_DIR}/${SYMBOL_TEST_DATA_FILE}")
+    endif()
   endif()
 endif()

--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -22,25 +22,23 @@ if(NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
   get_host_tool_path(llvm-nm LLVM_NM llvm_nm_exe llvm_nm_target)
   get_host_tool_path(llc LLC llc_exe llc_target)
 
-  if(TARGET ${llc_target})
-    if(TARGET ${llvm_nm_target})
-      # Extract the list of symbols in a random utility as sample data.
-      set(SYMBOL_TEST_DATA_FILE "sample_symbol_list.txt")
-      set(SYMBOL_TEST_DATA_SOURCE_BINARY ${llc_exe})
+  if(llc_exe AND llvm_nm_exe)
+    # Extract the list of symbols in a random utility as sample data.
+    set(SYMBOL_TEST_DATA_FILE "sample_symbol_list.txt")
+    set(SYMBOL_TEST_DATA_SOURCE_BINARY ${llc_exe})
 
-      add_custom_command(OUTPUT ${SYMBOL_TEST_DATA_FILE}
-        COMMAND ${llvm_nm_exe} --no-demangle --no-sort
-        --format=just-symbols
-        ${SYMBOL_TEST_DATA_SOURCE_BINARY} > ${SYMBOL_TEST_DATA_FILE}
-       DEPENDS ${llvm_nm_target} ${llc_target})
+    add_custom_command(OUTPUT ${SYMBOL_TEST_DATA_FILE}
+      COMMAND ${llvm_nm_exe} --no-demangle --no-sort
+      --format=just-symbols
+      ${SYMBOL_TEST_DATA_SOURCE_BINARY} > ${SYMBOL_TEST_DATA_FILE}
+     DEPENDS ${llvm_nm_target} ${llc_target})
 
-      add_custom_target(generate-runtime-libcalls-sample-symbol-list
-                        DEPENDS ${SYMBOL_TEST_DATA_FILE})
+    add_custom_target(generate-runtime-libcalls-sample-symbol-list
+                      DEPENDS ${SYMBOL_TEST_DATA_FILE})
 
-      add_dependencies(RuntimeLibcallsBench
-                       generate-runtime-libcalls-sample-symbol-list)
-      target_compile_definitions(RuntimeLibcallsBench PRIVATE
-        -DSYMBOL_TEST_DATA_FILE="${CMAKE_CURRENT_BINARY_DIR}/${SYMBOL_TEST_DATA_FILE}")
-    endif()
+    add_dependencies(RuntimeLibcallsBench
+                     generate-runtime-libcalls-sample-symbol-list)
+    target_compile_definitions(RuntimeLibcallsBench PRIVATE
+      -DSYMBOL_TEST_DATA_FILE="${CMAKE_CURRENT_BINARY_DIR}/${SYMBOL_TEST_DATA_FILE}")
   endif()
 endif()


### PR DESCRIPTION
This wasn't triggering on a basic build. The various target checks
seem to not work as I expect with AND, so split this into separate
if TARGET checks.