### PR TITLE
RuntimeLibcalls: Add macos unlocked IO functions to systems

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -24,6 +24,7 @@ def isNotOSWindows : RuntimeLibcallPredicate<"!TT.isOSWindows()">;
 def isNotOSLinux : RuntimeLibcallPredicate<[{!TT.isOSLinux()}]>;
 def isNotOSMSVCRT : RuntimeLibcallPredicate<"!TT.isOSMSVCRT()">;
 def isPS : RuntimeLibcallPredicate<"TT.isPS()">;
+def isMacOSX : RuntimeLibcallPredicate<[{TT.isMacOSX()}]>;
 def isNotOSWindowsOrIsCygwinMinGW
   : RuntimeLibcallPredicate<"!TT.isOSWindows() || TT.isOSCygMing()">;
 def isWindowsMSVCEnvironment : RuntimeLibcallPredicate<
@@ -1982,6 +1983,10 @@ defvar DarwinMemsetPattern = LibcallImpls<(add memset_pattern4,
                                                memset_pattern16),
                                                darwinHasMemsetPattern>;
 
+defvar MacOSUnlockedIO = LibcallImpls<(add
+  getc_unlocked, getchar_unlocked, putc_unlocked, putchar_unlocked),
+  isMacOSX>;
+
 defvar SecurityCheckCookieIfWinMSVC =
     LibcallImpls<(add __security_check_cookie, __security_cookie),
                  isWindowsMSVCOrItaniumEnvironment>;
@@ -2140,6 +2145,7 @@ def AArch64SystemLibrary : SystemRuntimeLibrary<
        LibcallImpls<(add Int128RTLibcalls), isAArch64_ILP64>,
        LibcallImpls<(add bzero), isOSDarwin>,
        DarwinExp10, DarwinSinCosStret, DarwinMemsetPattern,
+       MacOSUnlockedIO,
        LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
        DefaultLibmExp10,
        DefaultStackProtector,
@@ -3294,7 +3300,7 @@ defvar MemChkLibcalls = [__memcpy_chk, __memset_chk, __memmove_chk];
 
 defvar X86CommonLibcalls =
   (add (sub WinDefaultLibcallImpls, WindowsDivRemMulLibcallOverrides, MemChkLibcalls),
-       DarwinSinCosStret, DarwinExp10, DarwinMemsetPattern,
+       DarwinSinCosStret, DarwinExp10, DarwinMemsetPattern, MacOSUnlockedIO,
        X86_F128_Libcalls,
        LibmHasSinCosF80, // FIXME: Depends on long double
        SinCosF32F64Libcalls,

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/darwin.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/darwin.ll
@@ -1,11 +1,12 @@
 ; REQUIRES: aarch64-registered-target, arm-registered-target, x86-registered-target
 
-; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=i386-apple-macosx10.5 < %s | FileCheck -check-prefix=HAS-MEMSET-PATTERN %s
-; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=i386-apple-macosx10.4 < %s | FileCheck -check-prefix=NO-MEMSET-PATTERN %s
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=i386-apple-macosx10.5 < %s | FileCheck -check-prefixes=HAS-MEMSET-PATTERN,MACOS %s
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=i386-apple-macosx10.4 < %s | FileCheck -check-prefixes=NO-MEMSET-PATTERN,MACOS %s
 
 ; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=x86_64-apple-macosx10.5 < %s | FileCheck -check-prefix=HAS-MEMSET-PATTERN %s
 ; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=x86_64-apple-macosx10.4 < %s | FileCheck -check-prefix=NO-MEMSET-PATTERN %s
 
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=arm64-apple-macos10.5 < %s | FileCheck -check-prefixes=HAS-MEMSET-PATTERN,MACOS %s
 ; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=arm64-apple-ios3 < %s | FileCheck -check-prefix=HAS-MEMSET-PATTERN %s
 ; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=arm64-apple-ios2 < %s | FileCheck -check-prefix=NO-MEMSET-PATTERN %s
 
@@ -15,8 +16,14 @@
 ; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=arm64_32-apple-watchos < %s | FileCheck -check-prefix=HAS-MEMSET-PATTERN %s
 ; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=armv7k-apple-watchos < %s | FileCheck -check-prefix=HAS-MEMSET-PATTERN %s
 
+; MACOS: declare void @getc_unlocked(...)
+; MACOS: declare void @getchar_unlocked(...)
+
 ; HAS-MEMSET-PATTERN: declare void @memset_pattern16(...)
 ; HAS-MEMSET-PATTERN: declare void @memset_pattern4(...)
 ; HAS-MEMSET-PATTERN: declare void @memset_pattern8(...)
+
+; MACOS: declare void @putc_unlocked(...)
+; MACOS: declare void @putchar_unlocked(...)
 
 ; NO-MEMSET-PATTERN-NOT: memset_pattern


### PR DESCRIPTION
This is another of the easier to understand conditions from
TargetLibraryInfo