### PR TITLE
[clang-tidy][NFC] Remove trailing whitespaces in documentation

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
@@ -146,7 +146,7 @@ If calls are made using reverse iterators on containers, The code will be
 fixed using the ``boost::adaptors::reverse`` adaptor.
 
 .. code-block:: c++
-  
+
   auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
                             std::crbegin(Items2), std::crend(Items2));
 
@@ -166,7 +166,7 @@ Options
    is `llvm`.
 
 .. option:: IncludeBoostSystem
-   
+
    If `true` (default value) the boost headers are included as system headers
    with angle brackets (`#include <boost.hpp>`), otherwise quotes are used
    (`#include "boost.hpp"`).

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-if-condition.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-if-condition.rst
@@ -8,7 +8,7 @@ Such assignments are bug-prone because they may have been intended as equality t
 
 This check finds all assignments within `if` conditions, including ones that are not flagged
 by `-Wparentheses` due to an extra set of parentheses, and including assignments that call
-an overloaded `operator=()`. The identified assignments violate 
+an overloaded `operator=()`. The identified assignments violate
 `BARR group "Rule 8.2.c" <https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements>`_.
 
 .. code-block:: c++

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/capturing-this-in-member-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/capturing-this-in-member-variable.rst
@@ -30,7 +30,7 @@ Possible fixes:
   - marking copy and move constructors and assignment operators deleted.
   - using class member method instead of class member variable with function
     object types.
-  - passing ``this`` pointer as parameter 
+  - passing ``this`` pointer as parameter.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/crtp-constructor-accessibility.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/crtp-constructor-accessibility.rst
@@ -6,7 +6,7 @@ bugprone-crtp-constructor-accessibility
 Detects error-prone Curiously Recurring Template Pattern usage, when the CRTP
 can be constructed outside itself and the derived class.
 
-The CRTP is an idiom, in which a class derives from a template class, where 
+The CRTP is an idiom, in which a class derives from a template class, where
 itself is the template argument. It should be ensured that if a class is
 intended to be a base class in this idiom, it can only be instantiated if
 the derived class is its template argument.
@@ -23,7 +23,7 @@ Example:
 
   class Derived : CRTP<Derived> {};
 
-Below can be seen some common mistakes that will allow the breaking of the 
+Below can be seen some common mistakes that will allow the breaking of the
 idiom.
 
 If the constructor of a class intended to be used in a CRTP is public, then
@@ -62,7 +62,7 @@ Example:
   class Bad : CRTP<Good> {};
   Bad BadInstance;
 
-To ensure that no accidental instantiation happens, the best practice is to 
+To ensure that no accidental instantiation happens, the best practice is to
 make the constructor private and declare the derived class as friend. Note
 that as a tradeoff, this also gives the derived class access to every other
 private members of the CRTP. However, constructors can still be public or

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/derived-method-shadowing-base-method.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/derived-method-shadowing-base-method.rst
@@ -7,7 +7,7 @@ Finds derived class methods that shadow a (non-virtual) base class method.
 
 In order to be considered "shadowing", methods must have the same signature
 (i.e. the same name, same number of parameters, same parameter types, etc).
-Only checks public, non-templated methods. 
+Only checks public, non-templated methods.
 
 The below example is bugprone because consumers of the ``Derived`` class will
 expect the ``reset`` method to do the work of ``Base::reset()`` in addition to extra

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/incorrect-enable-shared-from-this.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/incorrect-enable-shared-from-this.rst
@@ -3,8 +3,8 @@
 bugprone-incorrect-enable-shared-from-this
 ==========================================
 
-Detect classes or structs that do not publicly inherit from 
-``std::enable_shared_from_this``, because unintended behavior will 
+Detect classes or structs that do not publicly inherit from
+``std::enable_shared_from_this``, because unintended behavior will
 otherwise occur when calling ``shared_from_this``.
 
 Consider the following code:
@@ -15,7 +15,7 @@ Consider the following code:
 
     // private inheritance
     class BadExample : std::enable_shared_from_this<BadExample> {
-    
+
     // ``shared_from_this``` unintended behaviour
     // `libstdc++` implementation returns uninitialized ``weak_ptr``
         public:
@@ -29,6 +29,6 @@ Consider the following code:
         b_ex->bar();
     }
 
-Using `libstdc++` implementation, ``shared_from_this`` will throw 
-``std::bad_weak_ptr``. When ``using_not_public()`` is called, this code will 
+Using `libstdc++` implementation, ``shared_from_this`` will throw
+``std::bad_weak_ptr``. When ``using_not_public()`` is called, this code will
 crash without exception handling.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.rst
@@ -54,7 +54,7 @@ Options
   Default: `false`.
 
   .. code-block:: c++
-  
+
     void bar(Base b[], Derived d[]) {
       b += 1; // warning, as Base declares a virtual destructor
       d += 1; // warning only if IgnoreVirtualDeclarationsOnly is set to false

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/raw-memory-call-on-non-trivial-type.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/raw-memory-call-on-non-trivial-type.rst
@@ -16,17 +16,17 @@ Options
 
 .. option:: MemSetNames
 
-   Specify extra functions to flag that act similarly to ``memset``. Specify 
+   Specify extra functions to flag that act similarly to ``memset``. Specify
    names in a semicolon-delimited list. Default is an empty string.
 
 .. option:: MemCpyNames
 
-   Specify extra functions to flag that act similarly to ``memcpy``. Specify 
+   Specify extra functions to flag that act similarly to ``memcpy``. Specify
    names in a semicolon-delimited list. Default is an empty string.
 
 .. option:: MemCmpNames
 
-   Specify extra functions to flag that act similarly to ``memcmp``. Specify 
+   Specify extra functions to flag that act similarly to ``memcmp``. Specify
    names in a semicolon-delimited list. Default is an empty string.
 
 This check corresponds to the CERT C++ Coding Standard rule

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/return-const-ref-from-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/return-const-ref-from-parameter.rst
@@ -22,7 +22,7 @@ Example
     S(int);
     ~S();
   };
-  
+
   const S &fn(const S &a) {
     return a;
   }
@@ -35,7 +35,7 @@ This issue can be resolved by declaring an overload of the problematic function
 where the ``const &`` parameter is instead declared as ``&&``. The developer has
 to ensure that the implementation of that function does not produce a
 use-after-free, the exact error that this check is warning against.
-Marking such an ``&&`` overload as ``deleted``, will silence the warning as 
+Marking such an ``&&`` overload as ``deleted``, will silence the warning as
 well. In the case of different ``const &`` parameters being returned depending
 on the control flow of the function, an overload where all problematic
 ``const &`` parameters have been declared as ``&&`` will resolve the issue.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
@@ -44,7 +44,7 @@ Options
 
   Selects which set of functions is considered as asynchronous-safe
   (and therefore allowed in signal handlers). It can be set to the following values:
-  
+
   ``minimal``
      Selects a minimal set that is defined in the CERT SIG30-C rule.
      and includes functions ``abort()``, ``_Exit()``, ``quick_exit()`` and

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/string-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/string-constructor.rst
@@ -36,7 +36,7 @@ Examples:
   std::string_view("test", 0);
 
 Passing an invalid first character position parameter to constructor will
-cause ``std::out_of_range`` exception at runtime. 
+cause ``std::out_of_range`` exception at runtime.
 
 Examples:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-realloc-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-realloc-usage.rst
@@ -10,7 +10,7 @@ The problem with this construct is that if ``realloc`` fails it returns a
 null pointer but does not deallocate the original memory. If no other variable
 is pointing to it, the original memory block is not available any more for the
 program to use or free. In either case ``p = realloc(p, size);`` indicates bad
-coding style and can be replaced by ``q = realloc(p, size);``. 
+coding style and can be replaced by ``q = realloc(p, size);``.
 
 The pointer expression (used at ``realloc``) can be a variable or a field member
 of a data structure, but can not contain function calls or unresolved types.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/tagged-union-member-count.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/tagged-union-member-count.rst
@@ -9,7 +9,7 @@ different from the number of data members inside the union.
 A struct or a class is considered to be a tagged union if it has
 exactly one union data member and exactly one enum data member and
 any number of other data members that are neither unions or enums.
-Furthermore, the types of the union and the enum members must 
+Furthermore, the types of the union and the enum members must
 not come from system header files nor the ``std`` namespace.
 
 Example:

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unsafe-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unsafe-functions.rst
@@ -86,7 +86,7 @@ checked. The format is the following, without newlines:
 .. code::
 
    bugprone-unsafe-functions.CustomFunctions="
-     functionRegex1[, replacement1[, reason1]]; 
+     functionRegex1[, replacement1[, reason1]];
      functionRegex2[, replacement2[, reason2]];
      ...
    "
@@ -104,7 +104,7 @@ As an example, the configuration `^original$, replacement, is deprecated;`
 will produce the following diagnostic message.
 
 .. code:: c
-  
+
    original(); // warning: function 'original' is deprecated; 'replacement' should be used instead.
    ::std::original(); // no-warning
    original_function(); // no-warning

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
@@ -42,11 +42,11 @@ Options
     Semicolon-separated list of regular expressions matching class names that
     overwrites the default exclusion list. The default is:
     `::std::map;::std::unordered_map;::std::flat_map`.
-    
+
 .. option:: FixMode
 
-    Determines what fixes are suggested. Either `none`, `at` (use 
-    ``a.at(index)`` if a fitting function exists) or `function` (use a 
+    Determines what fixes are suggested. Either `none`, `at` (use
+    ``a.at(index)`` if a fitting function exists) or `function` (use a
     function ``f(a, index)``). The default is `none`.
 
 .. option:: FixFunction
@@ -54,7 +54,7 @@ Options
     The function to use in the `function` mode. For C++23 and beyond, the
     passed function must support the empty subscript operator, i.e., the case
     where ``a[]`` becomes ``f(a)``. :option:`FixFunctionEmptyArgs` can be
-    used to override the suggested function in that case. The default is `gsl::at`. 
+    used to override the suggested function in that case. The default is `gsl::at`.
 
 .. option:: FixFunctionEmptyArgs
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-static-over-anonymous-namespace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-static-over-anonymous-namespace.rst
@@ -37,7 +37,7 @@ For example non-compliant code:
 Should become:
 
 .. code-block:: c++
-  
+
   // Small anonymous namespace for class declaration
   namespace {
 
@@ -48,7 +48,7 @@ Should become:
   };
 
   }
-  
+
   // placed method definition outside of the anonymous namespace
   bool StringSort::operator<(const char *RHS) const {}
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/use-ranges.rst
@@ -12,7 +12,7 @@ Example
 .. code-block:: c++
 
   auto it = std::find(vec.begin(), vec.end(), value);
-  bool all = std::all_of(vec.begin(), vec.end(), 
+  bool all = std::all_of(vec.begin(), vec.end(),
                          [](int x) { return x > 0; });
 
 Transforms to:

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
@@ -99,7 +99,7 @@ Options
 .. option:: AnalyzePointers
 
   Enable or disable the analysis of pointers variables, like
-  ``int *ptr = &i;``. For specific checks, see 
+  ``int *ptr = &i;``. For specific checks, see
   :option:`WarnPointersAsValues` and :option:`WarnPointersAsPointers`.
   Default is `true`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
@@ -10,7 +10,7 @@ Findings correspond to https://clangd.llvm.org/design/include-cleaner.
 Example:
 
 .. code-block:: c++
-   
+
    // foo.h
    class Foo{};
    // bar.h

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/override-with-different-visibility.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/override-with-different-visibility.rst
@@ -20,7 +20,7 @@ the ``using`` keyword is not considered as visibility change by this check.
   private:
     virtual void f_priv();
   };
-  
+
   class B: public A {
   public:
     void f_priv(); // warning: changed visibility from private to public

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/min-max-use-initializer-list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/min-max-use-initializer-list.rst
@@ -3,7 +3,7 @@
 modernize-min-max-use-initializer-list
 ======================================
 
-Replaces nested ``std::min`` and ``std::max`` calls with an initializer list 
+Replaces nested ``std::min`` and ``std::max`` calls with an initializer list
 where applicable.
 
 For instance, consider the following code:
@@ -21,8 +21,8 @@ The check will transform the above code to:
 Performance Considerations
 ==========================
 
-While this check simplifies the code and makes it more readable, it may cause 
-performance degradation for non-trivial types due to the need to copy objects 
+While this check simplifies the code and makes it more readable, it may cause
+performance degradation for non-trivial types due to the need to copy objects
 into the initializer list.
 
 To avoid this, it is recommended to use `std::ref` or `std::cref` for

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/type-traits.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/type-traits.rst
@@ -37,7 +37,7 @@ Options
 
     #define IS_SIGNED(T) std::is_signed<T>::value
 
-  Defaults to `false`. 
+  Defaults to `false`.
 
 
 Limitations

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
@@ -114,7 +114,7 @@ If calls are made using reverse iterators on containers, The code will be
 fixed using the ``std::views::reverse`` adaptor.
 
 .. code-block:: c++
-  
+
   auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
                             std::crbegin(Items2), std::crend(Items2));
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-scoped-lock.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-scoped-lock.rst
@@ -93,9 +93,9 @@ Options
 
     template <typename T>
     using Lock = std::lock_guard<T>; // warning: use 'std::scoped_lock' instead of 'std::lock_guard'
-    
+
     using LockMutex = std::lock_guard<std::mutex>; // warning: use 'std::scoped_lock' instead of 'std::lock_guard'
-    
+
     typedef std::lock_guard<std::mutex> LockDef; // warning: use 'std::scoped_lock' instead of 'std::lock_guard'
 
     using std::lock_guard; // warning: use 'std::scoped_lock' instead of 'std::lock_guard'

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.rst
@@ -4,7 +4,7 @@ modernize-use-starts-ends-with
 ==============================
 
 Checks for common roundabout ways to express ``starts_with`` and ``ends_with``
-and suggests replacing with the simpler method when it is available. Notably, 
+and suggests replacing with the simpler method when it is available. Notably,
 this will work with ``std::string`` and ``std::string_view``.
 
 Covered scenarios:

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
@@ -62,7 +62,7 @@ Options
 
 .. option:: StrFormatLikeFunctions
 
-   A semicolon-separated list of regular expressions matching the 
+   A semicolon-separated list of regular expressions matching the
    (fully qualified) names of functions to replace, with the requirement that
    the first parameter contains the printf-style format string and the
    arguments to be formatted follow immediately afterwards. Qualified member

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -122,7 +122,7 @@ Options
 
 .. option:: PrintfLikeFunctions
 
-   A semicolon-separated list of regular expressions matching the 
+   A semicolon-separated list of regular expressions matching the
    (fully qualified) names of functions to replace, with the requirement
    that the first parameter contains the printf-style format string and the
    arguments to be formatted follow immediately afterwards. Qualified member
@@ -134,13 +134,13 @@ Options
 
 .. option:: FprintfLikeFunctions
 
-   A semicolon-separated list of regular expressions matching the 
+   A semicolon-separated list of regular expressions matching the
    (fully qualified) names of functions to replace, with the requirement
    that the first parameter is retained, the second parameter contains the
    printf-style format string and the arguments to be formatted follow
    immediately afterwards. Qualified member function names are supported,
    but the replacement function name must be unqualified. If neither this
-   option nor `PrintfLikeFunctions` are set then the default value is 
+   option nor `PrintfLikeFunctions` are set then the default value is
    `fprintf;absl::FPrintF`, otherwise it is the empty string.
 
 

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/nsdate-formatter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/nsdate-formatter.rst
@@ -10,64 +10,64 @@ despite being legal. See http://www.unicode.org/reports/tr35/tr35-dates.html#Dat
 This checker reports as warnings the following string patterns in a date format specifier:
 
 #. yyyy + ww : Calendar year specified with week of a week year (unless YYYY is also specified).
-  
-   * | **Example 1:** Input Date: `29 December 2014` ; Format String: `yyyy-ww`; 
+
+   * | **Example 1:** Input Date: `29 December 2014` ; Format String: `yyyy-ww`;
      | Output string: `2014-01` (Wrong because it’s not the first week of 2014)
-    
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `dd-MM-yyyy (ww-YYYY)`; 
+
+   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `dd-MM-yyyy (ww-YYYY)`;
      | Output string: `29-12-2014 (01-2015)` (This is correct)
-    
+
 #. F without ee/EE : Numeric day of week in a month without actual day.
-    
-   * | **Example:** Input Date: `29 December 2014` ; Format String: `F-MM`; 
+
+   * | **Example:** Input Date: `29 December 2014` ; Format String: `F-MM`;
      | Output string: `5-12` (Wrong because it reads as *5th ___ of Dec* in English)
-    
+
 #. F without MM : Numeric day of week in a month without month.
-   
+
    * | **Example:** Input Date: `29 December 2014` ; Format String: `F-EE`
      | Output string: `5-Mon` (Wrong because it reads as *5th Mon of ___* in English)
-    
+
 #. WW without MM : Week of the month without the month.
-   
+
    * | **Example:** Input Date: `29 December 2014` ; Format String: `WW-yyyy`
      | Output string: `05-2014` (Wrong because it reads as *5th Week of ___* in English)
-    
+
 #. YYYY + QQ : Week year specified with quarter of normal year (unless yyyy is also specified).
-   
+
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-QQ`
      | Output string: `2015-04` (Wrong because it’s not the 4th quarter of 2015)
-    
+
    * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (QQ-yyyy)`
      | Output string: `01-2015 (04-2014)` (This is correct)
-    
+
 #. YYYY + MM :  Week year specified with Month of a calendar year (unless yyyy is also specified).
-    
+
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-MM`
      | Output string: `2015-12` (Wrong because it’s not the 12th month of 2015)
-    
+
    * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (MM-yyyy)`
      | Output string: `01-2015 (12-2014)` (This is correct)
-    
+
 #. YYYY + DD : Week year with day of a calendar year (unless yyyy is also specified).
-    
+
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-DD`
      | Output string: `2015-363` (Wrong because it’s not the 363rd day of 2015)
-    
+
    * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (DD-yyyy)`
      | Output string: `01-2015 (363-2014)` (This is correct)
-    
+
 #. YYYY + WW : Week year with week of a calendar year (unless yyyy is also specified).
-    
+
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-WW`
      | Output string: `2015-05` (Wrong because it’s not the 5th week of 2015)
-    
+
    * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (WW-MM-yyyy)`
      | Output string: `01-2015 (05-12-2014)` (This is correct)
-    
+
 #. YYYY + F : Week year with day of week in a calendar month (unless yyyy is also specified).
-    
+
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-ww-F-EE`
      | Output string: `2015-01-5-Mon` (Wrong because it’s not the 5th Monday of January in 2015)
-    
+
    * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (F-EE-MM-yyyy)`
      | Output string: `01-2015 (5-Mon-12-2014)` (This is correct)

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/template-virtual-member-function.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/template-virtual-member-function.rst
@@ -3,11 +3,11 @@
 portability-template-virtual-member-function
 ============================================
 
-Finds cases when an uninstantiated virtual member function in a template class causes 
+Finds cases when an uninstantiated virtual member function in a template class causes
 cross-compiler incompatibility.
 
-Upon instantiating a template class, non-virtual member functions don't have to be 
-instantiated unless they are used. Virtual member function instantiation on the other hand 
+Upon instantiating a template class, non-virtual member functions don't have to be
+instantiated unless they are used. Virtual member function instantiation on the other hand
 is unspecified and depends on the implementation of the compiler.
 
 In the following snippets the virtual member function is not instantiated by GCC and Clang,
@@ -19,7 +19,7 @@ it is rejected by the latter.
     template<typename T>
     struct CrossPlatformError {
         virtual ~CrossPlatformError() = default;
-        
+
         static void used() {}
 
         virtual void unused() {
@@ -33,5 +33,5 @@ it is rejected by the latter.
     }
 
 Cross-platform projects that need to support MSVC on Windows might see compiler errors
-because certain virtual member functions are instantiated, which are not instantiated 
+because certain virtual member functions are instantiated, which are not instantiated
 by other compilers on other platforms. This check highlights such virtual member functions.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/ambiguous-smartptr-reset-call.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/ambiguous-smartptr-reset-call.rst
@@ -40,14 +40,14 @@ other smart pointers or other classes use the :option:`SmartPointers` option.
 
 
 .. note::
-    
+
   The check may emit invalid fix-its and misleading warning messages when
   specifying custom smart pointers or other classes in the
   :option:`SmartPointers` option. For example, ``boost::scoped_ptr`` does not
   have an ``operator=`` which makes fix-its invalid.
 
 .. note::
-    
+
   Automatic fix-its are enabled only if :program:`clang-tidy` is invoked with
   the `--fix-notes` option.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.rst
@@ -9,7 +9,7 @@ of different priorities.
 Parentheses in mathematical expressions clarify the order
 of operations, especially with different-priority operators. Lengthy or multiline
 expressions can obscure this order, leading to coding errors. IDEs can aid clarity
-by highlighting parentheses. Explicitly using parentheses also clarifies what the 
+by highlighting parentheses. Explicitly using parentheses also clarifies what the
 developer had in mind when writing the expression. Ensuring their presence reduces
 ambiguity and errors, promoting clearer and more maintainable code.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.rst
@@ -15,7 +15,7 @@ In the example above the keyword ``inline`` is redundant since constexpr
 functions are implicitly inlined
 
 .. code-block:: c++
-   
+
    class MyClass {
        inline void myMethod() {}
    };

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-parentheses.rst
@@ -36,7 +36,7 @@ Options
   Semicolon-separated list of regular expressions matching names of declarations
   to ignore when the parentheses are around. Declarations can include variables
   or functions. The default is an `std::max;std::min`.
-  
+
   Some STL library functions may have the same name as widely used function-like
   macro. For example, ``std::max`` and ``max`` macro. A workaround to distinguish
   them is adding parentheses around functions to prevent function-like macro.


### PR DESCRIPTION
This is part of the codebase cleanup described in [#167098](https://github.com/llvm/llvm-project/issues/167098)