### PR TITLE
[clang-doc] Remove an unused local variable (NFC)

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
@@ -156,7 +156,6 @@ Error MustacheHTMLGenerator::generateDocs(
   SmallString<128> JSONPath;
   sys::path::native(RootDir.str() + "/json", JSONPath);
 
-  StringMap<json::Value> JSONFileMap;
   {
     llvm::TimeTraceScope TS("Iterate JSON files");
     std::error_code EC;


### PR DESCRIPTION
Identified with bugprone-unused-local-non-trivial-variable.
