### PR TITLE
[clang-include-cleaner] Export public headers as part of the CMake target

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -7,8 +7,6 @@ setup_host_tool(clang-tidy-confusable-chars-gen CLANG_TIDY_CONFUSABLE_CHARS_GEN 
 
 add_subdirectory(ConfusableTable)
 
-include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/../../include-cleaner/include")
-
 add_custom_command(
     OUTPUT Confusables.inc
     COMMAND ${clang_tidy_confusable_chars_gen} ${CMAKE_CURRENT_SOURCE_DIR}/ConfusableTable/confusables.txt ${CMAKE_CURRENT_BINARY_DIR}/Confusables.inc

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -59,7 +59,6 @@ if(MSVC AND NOT CLANG_CL)
 endif()
 
 include_directories(BEFORE "${CMAKE_CURRENT_BINARY_DIR}/../clang-tidy")
-include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/../include-cleaner/include")
 
 add_clang_library(clangDaemon STATIC
   AST.cpp

--- a/clang-tools-extra/clangd/indexer/CMakeLists.txt
+++ b/clang-tools-extra/clangd/indexer/CMakeLists.txt
@@ -17,6 +17,7 @@ clang_target_link_libraries(clangd-indexer
 )
 target_link_libraries(clangd-indexer
   PRIVATE
+  clangIncludeCleaner
   clangDaemon
   clangdSupport
 )

--- a/clang-tools-extra/clangd/refactor/tweaks/CMakeLists.txt
+++ b/clang-tools-extra/clangd/refactor/tweaks/CMakeLists.txt
@@ -34,6 +34,7 @@ add_clang_library(clangDaemonTweaks OBJECT
   SwapIfBranches.cpp
 
   LINK_LIBS
+  clangIncludeCleaner
   clangAST
   clangBasic
   clangDaemon

--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -32,6 +32,7 @@ clang_target_link_libraries(clangdMain
 
 target_link_libraries(clangdMain
   PRIVATE
+  clangIncludeCleaner
   clangTidy
   clangTidyUtils
 

--- a/clang-tools-extra/include-cleaner/CMakeLists.txt
+++ b/clang-tools-extra/include-cleaner/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(include)
 add_subdirectory(lib)
 add_subdirectory(tool)
 if(CLANG_INCLUDE_TESTS)

--- a/clang-tools-extra/include-cleaner/lib/CMakeLists.txt
+++ b/clang-tools-extra/include-cleaner/lib/CMakeLists.txt
@@ -14,6 +14,8 @@ add_clang_library(clangIncludeCleaner STATIC
   ClangDriverOptions
   )
 
+target_include_directories(clangIncludeCleaner PUBLIC ../include)
+
 clang_target_link_libraries(clangIncludeCleaner
   PRIVATE
   clangAST

--- a/clang-tools-extra/unittests/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/unittests/clang-tidy/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 get_filename_component(CLANG_LINT_SOURCE_DIR
   ${CMAKE_CURRENT_SOURCE_DIR}/../../clang-tidy REALPATH)
 include_directories(${CLANG_LINT_SOURCE_DIR})
-include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/../../include-cleaner/include")
 
 add_extra_unittest(ClangTidyTests
   AddConstTest.cpp


### PR DESCRIPTION
So that tools that use include-cleaner, like clangd and clang-tidy, don't need to do ugly manual header management.