### PR TITLE
[Flang] Add -ffast-real-mod back for further control of MOD optimizations

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2782,6 +2782,9 @@ def fno_unsafe_math_optimizations : Flag<["-"], "fno-unsafe-math-optimizations">
   Group<f_Group>;
 def fassociative_math : Flag<["-"], "fassociative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
 def fno_associative_math : Flag<["-"], "fno-associative-math">, Visibility<[ClangOption, FlangOption]>, Group<f_Group>;
+def ffast_real_mod : Flag<["-"], "ffast-real-mod">,
+  Group<f_Group>, Visibility<[FlangOption, FC1Option]>,
+  HelpText<"Enable optimization of MOD for REAL types">;
 def fno_fast_real_mod : Flag<["-"], "fno-fast-real-mod">,
   Group<f_Group>, Visibility<[FlangOption, FC1Option]>,
   HelpText<"Disable optimization of MOD for REAL types in presence of -ffast-math">;

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -822,6 +822,8 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
                                          complexRangeKindToStr(Range)));
   }
 
+  if (Args.hasArg(options::OPT_ffast_real_mod))
+    CmdArgs.push_back("-ffast-real-mod");
   if (Args.hasArg(options::OPT_fno_fast_real_mod))
     CmdArgs.push_back("-fno-fast-real-mod");
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -827,8 +827,7 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
                           clang::options::OPT_fno_fast_real_mod)) {
     if (A->getOption().matches(clang::options::OPT_ffast_real_mod))
       CmdArgs.push_back("-ffast-real-mod");
-    else if (A->getOption().matches(
-                 clang::options::OPT_fno_fast_real_mod))
+    else if (A->getOption().matches(clang::options::OPT_fno_fast_real_mod))
       CmdArgs.push_back("-fno-fast-real-mod");
   }
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -822,10 +822,15 @@ static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
                                          complexRangeKindToStr(Range)));
   }
 
-  if (Args.hasArg(options::OPT_ffast_real_mod))
-    CmdArgs.push_back("-ffast-real-mod");
-  if (Args.hasArg(options::OPT_fno_fast_real_mod))
-    CmdArgs.push_back("-fno-fast-real-mod");
+  if (llvm::opt::Arg *A =
+          Args.getLastArg(clang::options::OPT_ffast_real_mod,
+                          clang::options::OPT_fno_fast_real_mod)) {
+    if (A->getOption().matches(clang::options::OPT_ffast_real_mod))
+      CmdArgs.push_back("-ffast-real-mod");
+    else if (A->getOption().matches(
+                 clang::options::OPT_fno_fast_real_mod))
+      CmdArgs.push_back("-fno-fast-real-mod");
+  }
 
   if (!HonorINFs && !HonorNaNs && AssociativeMath && ReciprocalMath &&
       ApproxFunc && !SignedZeros &&

--- a/flang/include/flang/Support/LangOptions.def
+++ b/flang/include/flang/Support/LangOptions.def
@@ -61,7 +61,7 @@ LANGOPT(OpenMPNoNestedParallelism, 1, 0)
 /// Use SIMD only OpenMP support.
 LANGOPT(OpenMPSimd, 1, false)
 /// Enable fast MOD operations for REAL
-LANGOPT(NoFastRealMod, 1, false)
+LANGOPT(FastRealMod, 1, false)
 LANGOPT(VScaleMin, 32, 0)  ///< Minimum vscale range value
 LANGOPT(VScaleMax, 32, 0)  ///< Maximum vscale range value
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1403,11 +1403,14 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
     opts.ReciprocalMath = true;
     opts.ApproxFunc = true;
     opts.NoSignedZeros = true;
+    opts.FastRealMod = true;
     opts.setFPContractMode(Fortran::common::LangOptions::FPM_Fast);
   }
 
+  if (args.hasArg(clang::options::OPT_ffast_real_mod))
+    opts.FastRealMod = true;
   if (args.hasArg(clang::options::OPT_fno_fast_real_mod))
-    opts.NoFastRealMod = true;
+    opts.FastRealMod = false;
 
   return true;
 }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1407,10 +1407,14 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
     opts.setFPContractMode(Fortran::common::LangOptions::FPM_Fast);
   }
 
-  if (args.hasArg(clang::options::OPT_ffast_real_mod))
-    opts.FastRealMod = true;
-  if (args.hasArg(clang::options::OPT_fno_fast_real_mod))
-    opts.FastRealMod = false;
+  if (llvm::opt::Arg *arg =
+          args.getLastArg(clang::options::OPT_ffast_real_mod,
+                          clang::options::OPT_fno_fast_real_mod)) {
+    if (arg->getOption().matches(clang::options::OPT_ffast_real_mod))
+      opts.FastRealMod = true;
+    if (arg->getOption().matches(clang::options::OPT_fno_fast_real_mod))
+      opts.FastRealMod = false;
+  }
 
   return true;
 }

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -277,11 +277,11 @@ bool CodeGenAction::beginSourceFileAction() {
                               ci.getInvocation().getLangOpts().OpenMPVersion);
   }
 
-  if (ci.getInvocation().getLangOpts().NoFastRealMod) {
+  if (ci.getInvocation().getLangOpts().FastRealMod) {
     mlir::ModuleOp mod = lb.getModule();
     mod.getOperation()->setAttr(
         mlir::StringAttr::get(mod.getContext(),
-                              llvm::Twine{"fir.no_fast_real_mod"}),
+                              llvm::Twine{"fir.fast_real_mod"}),
         mlir::BoolAttr::get(mod.getContext(), true));
   }
 

--- a/flang/test/Driver/fast-real-mod.f90
+++ b/flang/test/Driver/fast-real-mod.f90
@@ -1,5 +1,7 @@
+! RUN: %flang -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
 ! RUN: %flang -fno-fast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-NO-FAST-REAL-MOD
 
+! CHECK-FAST-REAL-MOD: "-ffast-real-mod"
 ! CHECK-NO-FAST-REAL-MOD: "-fno-fast-real-mod"
 
 program test

--- a/flang/test/Driver/fast-real-mod.f90
+++ b/flang/test/Driver/fast-real-mod.f90
@@ -1,8 +1,12 @@
 ! RUN: %flang -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
 ! RUN: %flang -fno-fast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-NO-FAST-REAL-MOD
+! RUN: %flang -fno-fast-real-mod -ffast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-FAST-REAL-MOD
+! RUN: %flang -ffast-real-mod -fno-fast-real-mod -### -c %s 2>&1 | FileCheck %s -check-prefix CHECK-NO-FAST-REAL-MOD
 
 ! CHECK-FAST-REAL-MOD: "-ffast-real-mod"
+! CHECK-FAST-REAL-MOD-NOT: "-fno-fast-real-mod"
 ! CHECK-NO-FAST-REAL-MOD: "-fno-fast-real-mod"
+! CHECK-NO-FAST-REAL-MOD-NOT: "-fast-real-mod"
 
 program test
     ! nothing to be done in here

--- a/flang/test/Lower/Intrinsics/fast-real-mod.f90
+++ b/flang/test/Lower/Intrinsics/fast-real-mod.f90
@@ -1,24 +1,24 @@
-! RUN: %flang_fc1 -ffast-math -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
+! RUN: %flang_fc1 -ffast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK-FRM%if target=x86_64{{.*}} %{,CHECK-FRM-KIND10%}%if flang-supports-f128-math %{,CHECK-FRM-KIND16%}
+! RUN: %flang_fc1 -ffast-math -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK-FRM%if target=x86_64{{.*}} %{,CHECK-FRM-KIND10%}%if flang-supports-f128-math %{,CHECK-FRM-KIND16%}
 ! RUN: %flang_fc1 -ffast-math -fno-fast-real-mod -emit-mlir -o - %s | FileCheck %s --check-prefixes=CHECK-NFRM%if target=x86_64{{.*}} %{,CHECK-NFRM-KIND10%}%if flang-supports-f128-math %{,CHECK-NFRM-KIND16%}
 
-! TODO: check line that fir.fast_real_mod is not there
-! CHECK-NFRM: module attributes {{{.*}}fir.no_fast_real_mod = true{{.*}}}
+! CHECK,CHECK-FRM: module attributes {{{.*}}fir.fast_real_mod = true{{.*}}}
 
 ! CHECK-LABEL: @_QPmod_real4
 subroutine mod_real4(r, a, p)
     implicit none
     real(kind=4) :: r, a, p
-! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
-! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
-! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
-! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
-! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f32
-! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f32) -> si32
-! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si32) -> f32
-! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f32
-! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f32
-! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f32>
+! CHECK-FRM: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK-FRM: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK-FRM: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK-FRM: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK-FRM: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK-FRM: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<{{.*}}> : f32
+! CHECK-FRM: %[[CV1:.*]] = fir.convert %[[DIV]] : (f32) -> si32
+! CHECK-FRM: %[[CV2:.*]] = fir.convert %[[CV1]] : (si32) -> f32
+! CHECK-FRM: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<{{.*}}> : f32
+! CHECK-FRM: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<{{.*}}> : f32
+! CHECK-FRM: fir.store %[[SUB]] to %[[R]] : !fir.ref<f32>
 ! CHECK-NFRM: fir.call @_FortranAModReal4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f32, f32, !fir.ref<i8>, i32) -> f32
     r = mod(a, p)
 end subroutine mod_real4
@@ -27,17 +27,17 @@ end subroutine mod_real4
 subroutine mod_real8(r, a, p)
     implicit none
     real(kind=8) :: r, a, p
-! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
-! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
-! CHECK: %[[R:.*]] = fir.declare{{.*}}r"
-! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
-! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f64
-! CHECK: %[[CV1:.*]] = fir.convert %[[DIV]] : (f64) -> si64
-! CHECK: %[[CV2:.*]] = fir.convert %[[CV1]] : (si64) -> f64
-! CHECK: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f64
-! CHECK: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f64
-! CHECK: fir.store %[[SUB]] to %[[R]] : !fir.ref<f64>
+! CHECK-FRM: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK-FRM: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK-FRM: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK-FRM: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK-FRM: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK-FRM: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<{{.*}}> : f64
+! CHECK-FRM: %[[CV1:.*]] = fir.convert %[[DIV]] : (f64) -> si64
+! CHECK-FRM: %[[CV2:.*]] = fir.convert %[[CV1]] : (si64) -> f64
+! CHECK-FRM: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<{{.*}}> : f64
+! CHECK-FRM: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<{{.*}}> : f64
+! CHECK-FRM: fir.store %[[SUB]] to %[[R]] : !fir.ref<f64>
 ! CHECK-NFRM: fir.call @_FortranAModReal8(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f64, f64, !fir.ref<i8>, i32) -> f64
     r = mod(a, p)
 end subroutine mod_real8
@@ -47,17 +47,17 @@ subroutine mod_real10(r, a, p)
     implicit none
     integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
     real(kind=kind10) :: r, a, p
-! CHECK-KIND10: %[[A:.*]] = fir.declare{{.*}}a"
-! CHECK-KIND10: %[[P:.*]] = fir.declare{{.*}}p"
-! CHECK-KIND10: %[[R:.*]] = fir.declare{{.*}}r"
-! CHECK-KIND10: %[[A_LOAD:.*]] = fir.load %[[A]]
-! CHECK-KIND10: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK-KIND10: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f80
-! CHECK-KIND10: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
-! CHECK-KIND10: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
-! CHECK-KIND10: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f80
-! CHECK-KIND10: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f80
-! CHECK-KIND10: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
+! CHECK-FRM-KIND10: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK-FRM-KIND10: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK-FRM-KIND10: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK-FRM-KIND10: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK-FRM-KIND10: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK-FRM-KIND10: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<{{.*}}> : f80
+! CHECK-FRM-KIND10: %[[CV1:.*]] = fir.convert %[[DIV]] : (f80) -> si80
+! CHECK-FRM-KIND10: %[[CV2:.*]] = fir.convert %[[CV1]] : (si80) -> f80
+! CHECK-FRM-KIND10: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<{{.*}}> : f80
+! CHECK-FRM-KIND10: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<{{.*}}> : f80
+! CHECK-FRM-KIND10: fir.store %[[SUB]] to %[[R]] : !fir.ref<f80>
 ! CHECK-NFRM-KIND10: fir.call @_FortranAModReal10(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f80, f80, !fir.ref<i8>, i32) -> f80
     r = mod(a, p)
 end subroutine mod_real10
@@ -67,17 +67,17 @@ subroutine mod_real16(r, a, p)
     implicit none
     integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
     real(kind=kind16) :: r, a, p
-! CHECK-KIND16: %[[A:.*]] = fir.declare{{.*}}a"
-! CHECK-KIND16: %[[P:.*]] = fir.declare{{.*}}p"
-! CHECK-KIND16: %[[R:.*]] = fir.declare{{.*}}r"
-! CHECK-KIND16: %[[A_LOAD:.*]] = fir.load %[[A]]
-! CHECK-KIND16: %[[P_LOAD:.*]] = fir.load %[[P]]
-! CHECK-KIND16: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<fast> : f128
-! CHECK-KIND16: %[[CV1:.*]] = fir.convert %[[DIV]] : (f128) -> si128
-! CHECK-KIND16: %[[CV2:.*]] = fir.convert %[[CV1]] : (si128) -> f128
-! CHECK-KIND16: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<fast> : f128
-! CHECK-KIND16: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<fast> : f128
-! CHECK-KIND16: fir.store %[[SUB]] to %[[R]] : !fir.ref<f128>
+! CHECK-FRM-KIND16: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK-FRM-KIND16: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK-FRM-KIND16: %[[R:.*]] = fir.declare{{.*}}r"
+! CHECK-FRM-KIND16: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK-FRM-KIND16: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK-FRM-KIND16: %[[DIV:.*]] = arith.divf %[[A_LOAD]], %[[P_LOAD]] fastmath<{{.*}}> : f128
+! CHECK-FRM-KIND16: %[[CV1:.*]] = fir.convert %[[DIV]] : (f128) -> si128
+! CHECK-FRM-KIND16: %[[CV2:.*]] = fir.convert %[[CV1]] : (si128) -> f128
+! CHECK-FRM-KIND16: %[[MUL:.*]] = arith.mulf %[[CV2]], %[[P_LOAD]] fastmath<{{.*}}> : f128
+! CHECK-FRM-KIND16: %[[SUB:.*]] = arith.subf %[[A_LOAD]], %[[MUL]] fastmath<{{.*}}> : f128
+! CHECK-FRM-KIND16: fir.store %[[SUB]] to %[[R]] : !fir.ref<f128>
 ! CHECK-NFRM-KIND16: fir.call @_FortranAModReal16(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f128, f128, !fir.ref<i8>, i32) -> f128
     r = mod(a, p)
 end subroutine mod_real16


### PR DESCRIPTION
It turns out that having `-ffast-math` as the only option to control optimizations for MOD for REAL kinds (PR #160660) is too coarse-grained for some applications. Thus, this PR adds back `-ffast-real-mod` to have more control over the optimization. The `-ffast-math` flag will still enable the optimization, and `-fno-fast-real-mod` allows one to disable it.