### PR TITLE
clang-format: Add splitting for strings with user-defined suffixes

### DIFF
--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -279,8 +279,7 @@ void BreakableStringLiteral::insertBreak(unsigned LineIndex,
                                          WhitespaceManager &Whitespaces) const {
 
   const unsigned SplitEnd = TailOffset + Split.first + Split.second;
-  const bool IsLastFragment = SplitEnd >= Line.size() - UnbreakableTailLength;
-
+  const bool IsLastFragment = SplitEnd > Line.size() - UnbreakableTailLength;
   StringRef LocalPostfix = (IsLastFragment) ? Postfix : ContinuationPostfix;
 
   Whitespaces.replaceWhitespaceInToken(

--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -298,7 +298,7 @@ BreakableStringLiteralUsingOperators::BreakableStringLiteralUsingOperators(
                                                                   : "\"",
           /*Postfix=*/QuoteStyle == SingleQuotes ? "'" : "\"",
           /*ContinuationPrefix=*/QuoteStyle == SingleQuotes ? "'"
-                               : QuoteStyle == AtDoubleQuotes                    ? "@\""
+          : QuoteStyle == AtDoubleQuotes                    ? "@\""
                                                             : "\"",
           /*ContinuationPostfix=*/QuoteStyle == SingleQuotes ? "'" : "\"",
           UnbreakableTailLength, InPPDirective, Encoding, Style),

--- a/clang/lib/Format/BreakableToken.h
+++ b/clang/lib/Format/BreakableToken.h
@@ -252,6 +252,8 @@ public:
   /// after formatting.
   BreakableStringLiteral(const FormatToken &Tok, unsigned StartColumn,
                          StringRef Prefix, StringRef Postfix,
+                         StringRef ContinuationPrefix,
+                         StringRef ContinuationPostfix,
                          unsigned UnbreakableTailLength, bool InPPDirective,
                          encoding::Encoding Encoding, const FormatStyle &Style);
 
@@ -274,15 +276,21 @@ public:
 protected:
   // The column in which the token starts.
   unsigned StartColumn;
-  // The prefix a line needs after a break in the token.
+  // The prefix a line needs at the start
   StringRef Prefix;
-  // The postfix a line needs before introducing a break.
+  // The postfix a line needs at the end
   StringRef Postfix;
+  // The prefix every line except the first line needs
+  StringRef ContinuationPrefix;
+  // The postfix every line except the last line needs
+  StringRef ContinuationPostfix;
   // The token text excluding the prefix and postfix.
   StringRef Line;
   // Length of the sequence of tokens after this string literal that cannot
   // contain line breaks.
   unsigned UnbreakableTailLength;
+  // Whether the string prefix and postfix should be repeated on each line
+  // when breaking the string.
 };
 
 class BreakableStringLiteralUsingOperators : public BreakableStringLiteral {

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -2570,8 +2570,8 @@ ContinuationIndenter::createBreakableToken(const FormatToken &Current,
            Text.starts_with(Prefix = "u8\"") ||
            Text.starts_with(Prefix = "L\""))) {
 
-        // Use quotes when breaking the string
-        llvm::StringRef ContinuationPrefix = "\"";
+        // Repeat the prefix on every line but don't repeat the suffix
+        llvm::StringRef ContinuationPrefix = Prefix;
         llvm::StringRef ContinuationPostfix = "\"";
         return std::make_unique<BreakableStringLiteral>(
             Current, StartColumn, Prefix, Postfix, ContinuationPrefix,

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -15838,6 +15838,10 @@ TEST_F(FormatTest, BreaksWideAndNSStringLiterals) {
                "@\"NSString literal\";", getGoogleStyleWithColumns(19));
   verifyFormat(R"(NSString *s = @"那那那那";)", getLLVMStyleWithColumns(26));
 
+  EXPECT_EQ("L\"suffixed \"\n"
+            "L\"string\"_s;",
+            format("L\"suffixed string\"_s;", getLLVMStyleWithColumns(19)));
+
   // This input makes clang-format try to split the incomplete unicode escape
   // sequence, which used to lead to a crasher.
   verifyNoCrash(


### PR DESCRIPTION
String literals with user-defined suffixes can now be split between lines.
 - Uses regex to identify user-defined suffixes
 - We want the suffix to be placed only on the last line, so I added `ContinuationPrefix` and `ContinuationPostfix` attributes to `BreakableStringLiteral` to have different postfixes for the last line and all the other lines
 - `ContinuationPrefix` is currently unused - prefixes are still placed on every line when splitting. I've kept it for completeness.
 - Adds a new unit test for splitting strings with user-defined-suffixes.

Fixes #165617