### PR TITLE
[ADT] Add a missing std::move to StringSwitch::EndsWithLower

### DIFF
--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -158,7 +158,7 @@ public:
 
   StringSwitch &EndsWithLower(StringLiteral S, T Value) {
     if (!Result && Str.ends_with_insensitive(S))
-      Result = Value;
+      Result = std::move(Value);
 
     return *this;
   }


### PR DESCRIPTION
All others seem to use std::move in StringSwitch.
