### PR TITLE
[NVPTX] Remove redundant declarations (NFC)

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTX.h
+++ b/llvm/lib/Target/NVPTX/NVPTX.h
@@ -66,7 +66,6 @@ void initializeNVPTXCtorDtorLoweringLegacyPass(PassRegistry &);
 void initializeNVPTXLowerAggrCopiesPass(PassRegistry &);
 void initializeNVPTXLowerAllocaPass(PassRegistry &);
 void initializeNVPTXLowerUnreachablePass(PassRegistry &);
-void initializeNVPTXCtorDtorLoweringLegacyPass(PassRegistry &);
 void initializeNVPTXLowerArgsLegacyPassPass(PassRegistry &);
 void initializeNVPTXProxyRegErasurePass(PassRegistry &);
 void initializeNVPTXForwardParamsPassPass(PassRegistry &);

--- a/llvm/lib/Target/NVPTX/NVPTXGenericToNVVM.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXGenericToNVVM.cpp
@@ -28,10 +28,6 @@
 
 using namespace llvm;
 
-namespace llvm {
-void initializeGenericToNVVMLegacyPassPass(PassRegistry &);
-}
-
 namespace {
 class GenericToNVVM {
 public:


### PR DESCRIPTION
initializeNVPTXCtorDtorLoweringLegacyPass is declared twice in
NVPTX.h.

initializeGenericToNVVMLegacyPassPass is declared in NVPTX.h.

Identified with readability-redundant-declaration.
