### PR TITLE
[ObjectYAML] Remove redundant .str().c_str() (NFC)

### DIFF
--- a/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp
+++ b/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp
@@ -80,15 +80,14 @@ void ScalarEnumerationTraits<SymbolKind>::enumeration(IO &io,
                                                       SymbolKind &Value) {
   auto SymbolNames = getSymbolTypeNames();
   for (const auto &E : SymbolNames)
-    io.enumCase(Value, E.Name.str().c_str(), E.Value);
+    io.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarBitSetTraits<CompileSym2Flags>::bitset(IO &io,
                                                   CompileSym2Flags &Flags) {
   auto FlagNames = getCompileSym2FlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<CompileSym2Flags>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<CompileSym2Flags>(E.Value));
   }
 }
 
@@ -96,40 +95,35 @@ void ScalarBitSetTraits<CompileSym3Flags>::bitset(IO &io,
                                                   CompileSym3Flags &Flags) {
   auto FlagNames = getCompileSym3FlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<CompileSym3Flags>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<CompileSym3Flags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<ExportFlags>::bitset(IO &io, ExportFlags &Flags) {
   auto FlagNames = getExportSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<ExportFlags>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<ExportFlags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<PublicSymFlags>::bitset(IO &io, PublicSymFlags &Flags) {
   auto FlagNames = getPublicSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<PublicSymFlags>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<PublicSymFlags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<LocalSymFlags>::bitset(IO &io, LocalSymFlags &Flags) {
   auto FlagNames = getLocalFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<LocalSymFlags>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<LocalSymFlags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<ProcSymFlags>::bitset(IO &io, ProcSymFlags &Flags) {
   auto FlagNames = getProcSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<ProcSymFlags>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<ProcSymFlags>(E.Value));
   }
 }
 
@@ -137,15 +131,14 @@ void ScalarBitSetTraits<FrameProcedureOptions>::bitset(
     IO &io, FrameProcedureOptions &Flags) {
   auto FlagNames = getFrameProcSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name.str().c_str(),
-                  static_cast<FrameProcedureOptions>(E.Value));
+    io.bitSetCase(Flags, E.Name, static_cast<FrameProcedureOptions>(E.Value));
   }
 }
 
 void ScalarEnumerationTraits<CPUType>::enumeration(IO &io, CPUType &Cpu) {
   auto CpuNames = getCPUTypeNames();
   for (const auto &E : CpuNames) {
-    io.enumCase(Cpu, E.Name.str().c_str(), static_cast<CPUType>(E.Value));
+    io.enumCase(Cpu, E.Name, static_cast<CPUType>(E.Value));
   }
 }
 
@@ -177,7 +170,7 @@ void ScalarEnumerationTraits<RegisterId>::enumeration(IO &io, RegisterId &Reg) {
     RegNames = getRegisterNames(*CpuType);
 
   for (const auto &E : RegNames) {
-    io.enumCase(Reg, E.Name.str().c_str(), static_cast<RegisterId>(E.Value));
+    io.enumCase(Reg, E.Name, static_cast<RegisterId>(E.Value));
   }
   io.enumFallback<Hex16>(Reg);
 }
@@ -186,8 +179,7 @@ void ScalarEnumerationTraits<TrampolineType>::enumeration(
     IO &io, TrampolineType &Tramp) {
   auto TrampNames = getTrampolineNames();
   for (const auto &E : TrampNames) {
-    io.enumCase(Tramp, E.Name.str().c_str(),
-                static_cast<TrampolineType>(E.Value));
+    io.enumCase(Tramp, E.Name, static_cast<TrampolineType>(E.Value));
   }
 }
 
@@ -195,7 +187,7 @@ void ScalarEnumerationTraits<ThunkOrdinal>::enumeration(IO &io,
                                                         ThunkOrdinal &Ord) {
   auto ThunkNames = getThunkOrdinalNames();
   for (const auto &E : ThunkNames) {
-    io.enumCase(Ord, E.Name.str().c_str(), static_cast<ThunkOrdinal>(E.Value));
+    io.enumCase(Ord, E.Name, static_cast<ThunkOrdinal>(E.Value));
   }
 }
 
@@ -203,8 +195,7 @@ void ScalarEnumerationTraits<FrameCookieKind>::enumeration(
     IO &io, FrameCookieKind &FC) {
   auto ThunkNames = getFrameCookieKindNames();
   for (const auto &E : ThunkNames) {
-    io.enumCase(FC, E.Name.str().c_str(),
-                static_cast<FrameCookieKind>(E.Value));
+    io.enumCase(FC, E.Name, static_cast<FrameCookieKind>(E.Value));
   }
 }
 
@@ -212,8 +203,7 @@ void ScalarEnumerationTraits<JumpTableEntrySize>::enumeration(
     IO &io, JumpTableEntrySize &FC) {
   auto ThunkNames = getJumpTableEntrySizeNames();
   for (const auto &E : ThunkNames) {
-    io.enumCase(FC, E.Name.str().c_str(),
-                static_cast<JumpTableEntrySize>(E.Value));
+    io.enumCase(FC, E.Name, static_cast<JumpTableEntrySize>(E.Value));
   }
 }
 

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -589,55 +589,55 @@ void MappingTraits<DXContainerYAML::SignatureElement>::mapping(
 void ScalarEnumerationTraits<dxbc::PSV::SemanticKind>::enumeration(
     IO &IO, dxbc::PSV::SemanticKind &Value) {
   for (const auto &E : dxbc::PSV::getSemanticKinds())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::ComponentType>::enumeration(
     IO &IO, dxbc::PSV::ComponentType &Value) {
   for (const auto &E : dxbc::PSV::getComponentTypes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::InterpolationMode>::enumeration(
     IO &IO, dxbc::PSV::InterpolationMode &Value) {
   for (const auto &E : dxbc::PSV::getInterpolationModes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::ResourceType>::enumeration(
     IO &IO, dxbc::PSV::ResourceType &Value) {
   for (const auto &E : dxbc::PSV::getResourceTypes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::ResourceKind>::enumeration(
     IO &IO, dxbc::PSV::ResourceKind &Value) {
   for (const auto &E : dxbc::PSV::getResourceKinds())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::D3DSystemValue>::enumeration(
     IO &IO, dxbc::D3DSystemValue &Value) {
   for (const auto &E : dxbc::getD3DSystemValues())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::SigMinPrecision>::enumeration(
     IO &IO, dxbc::SigMinPrecision &Value) {
   for (const auto &E : dxbc::getSigMinPrecisions())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::SigComponentType>::enumeration(
     IO &IO, dxbc::SigComponentType &Value) {
   for (const auto &E : dxbc::getSigComponentTypes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::RootParameterType>::enumeration(
     IO &IO, dxbc::RootParameterType &Value) {
   for (const auto &E : dxbc::getRootParameterTypes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxil::ResourceClass>::enumeration(
@@ -650,37 +650,37 @@ void ScalarEnumerationTraits<dxil::ResourceClass>::enumeration(
   };
 
   for (const auto &E : ResourceClasses)
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::SamplerFilter>::enumeration(
     IO &IO, dxbc::SamplerFilter &Value) {
   for (const auto &E : dxbc::getSamplerFilters())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::StaticBorderColor>::enumeration(
     IO &IO, dxbc::StaticBorderColor &Value) {
   for (const auto &E : dxbc::getStaticBorderColors())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::TextureAddressMode>::enumeration(
     IO &IO, dxbc::TextureAddressMode &Value) {
   for (const auto &E : dxbc::getTextureAddressModes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::ShaderVisibility>::enumeration(
     IO &IO, dxbc::ShaderVisibility &Value) {
   for (const auto &E : dxbc::getShaderVisibility())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::ComparisonFunc>::enumeration(
     IO &IO, dxbc::ComparisonFunc &Value) {
   for (const auto &E : dxbc::getComparisonFuncs())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+    IO.enumCase(Value, E.Name, E.Value);
 }
 
 } // namespace yaml


### PR DESCRIPTION
We can drop .str().c_str() here because all of the following are of
type StringRef:

- E.Name
- the second parameter of llvm::yaml::IO::enumCase
- the second parameter of llvm::yaml::IO::bitSetCase

Identified with readability-redundant-string-cstr.
