### PR TITLE
[WebAssembly] Clean up CustomMappingTraits<BBNumberMap> (NFC)

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
@@ -211,8 +211,8 @@ template <> struct CustomMappingTraits<BBNumberMap> {
   }
 
   static void output(IO &YamlIO, BBNumberMap &SrcToUnwindDest) {
-    for (auto KV : SrcToUnwindDest)
-      YamlIO.mapRequired(std::to_string(KV.first).c_str(), KV.second);
+    for (auto [Src, Dest] : SrcToUnwindDest)
+      YamlIO.mapRequired(std::to_string(Src), Dest);
   }
 };
 


### PR DESCRIPTION
This patch does two things for readability:

- Use structured bindings.
- Remove extraneous .c_str().

Note that YamlIO.mapRequired takes StringRef as the key type.  As
such, we can implicitly construct StringRef from std::string.
