### PR TITLE
[clang][Sema] fix incorrect ambiguous function call which use designated-initializer as template argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -489,7 +489,7 @@ Bug Fixes in This Version
 - Accept empty enumerations in MSVC-compatible C mode. (#GH114402)
 - Fix a bug leading to incorrect code generation with complex number compound assignment and bitfield values, which also caused a crash with UBsan. (#GH166798)
 - Fixed false-positive shadow diagnostics for lambdas in explicit object member functions. (#GH163731)
-- Fixed an incorrect diagnostic for ambiguous function call that use a 
+- Fixed an incorrect diagnostic for ambiguous function call that uses a 
   designated-initializer as template argument. (#GH166784)
 
 Bug Fixes to Compiler Builtins

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -489,7 +489,7 @@ Bug Fixes in This Version
 - Accept empty enumerations in MSVC-compatible C mode. (#GH114402)
 - Fix a bug leading to incorrect code generation with complex number compound assignment and bitfield values, which also caused a crash with UBsan. (#GH166798)
 - Fixed false-positive shadow diagnostics for lambdas in explicit object member functions. (#GH163731)
-- Fixed a incorrect diagnostic for ambiguous function call that use a 
+- Fixed an incorrect diagnostic for ambiguous function call that use a 
   designated-initializer as template argument. (#GH166784)
 
 Bug Fixes to Compiler Builtins

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -489,6 +489,8 @@ Bug Fixes in This Version
 - Accept empty enumerations in MSVC-compatible C mode. (#GH114402)
 - Fix a bug leading to incorrect code generation with complex number compound assignment and bitfield values, which also caused a crash with UBsan. (#GH166798)
 - Fixed false-positive shadow diagnostics for lambdas in explicit object member functions. (#GH163731)
+- Fixed a incorrect diagnostic for ambiguous function call that use a 
+  designated-initializer as template argument. (#GH166784)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -5628,6 +5628,11 @@ public:
       FieldInfo.NameOrField = reinterpret_cast<uintptr_t>(FD);
     }
 
+    void clearFieldDecl() {
+      assert(isFieldDesignator() && "Only valid on a field designator");
+      FieldInfo.NameOrField = reinterpret_cast<uintptr_t>(getFieldName()) | 0x1;
+    }
+
     SourceLocation getDotLoc() const {
       assert(isFieldDesignator() && "Only valid on a field designator");
       return FieldInfo.DotLoc;

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -2937,6 +2937,8 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
     }
 
     FieldDecl *KnownField = D->getFieldDecl();
+    if (KnownField && KnownField->getParent() != RD)
+      KnownField = nullptr;
     if (!KnownField) {
       const IdentifierInfo *FieldName = D->getFieldName();
       ValueDecl *VD = SemaRef.tryLookupUnambiguousFieldDecl(RD, FieldName);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -2937,8 +2937,6 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
     }
 
     FieldDecl *KnownField = D->getFieldDecl();
-    if (KnownField && KnownField->getParent() != RD)
-      KnownField = nullptr;
     if (!KnownField) {
       const IdentifierInfo *FieldName = D->getFieldName();
       ValueDecl *VD = SemaRef.tryLookupUnambiguousFieldDecl(RD, FieldName);

--- a/clang/test/SemaTemplate/temp_arg_nontype_cxx2c.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype_cxx2c.cpp
@@ -134,3 +134,26 @@ namespace error_on_type_instantiation {
   template void g<int>();
   // expected-note@-1 {{in instantiation of function template specialization}}
 }
+
+namespace GH166784 {
+
+struct A {
+  int a;
+};
+struct B {
+  int b;
+};
+template <A a> void f() {
+  static_assert(a.a == 42);
+}
+template <B b> void f() {
+  static_assert(b.b == 42);
+}
+
+using T1 = decltype(f<{.a = 42}>());
+using T2 = decltype(f<A{.a = 42}>());
+
+using T3 = decltype(f<{.b = 42}>());
+using T4 = decltype(f<B{.b = 42}>());
+
+} // namespace GH166784


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/166784

After performing initialization of a `B` using `{.b = 42}` successfully, we will set FieldDecl of designator `b` to `B::b`, and then use the saved FieldDecl in later actions. When it comes to performing initialization of a `A` using `{.b = 42}`, we **do not clear the saved FieldDecl**, **use it without any check**, which is wrong as there is no `B::b` inside `A`. 

As a result, we perform the initialization successfully, this makes both `f<A>` and `f<B>` viable and finally makes the call to `f<{.b = 42}>` ambiguous.

This pr add a check to make sure we use correct FieldDecl of designators. I also tried some other methods, but all of them do not work:
- I tried clearing saved FieldDecl after we finish initialization, but I can not find a proper place.
- I tried looking up FieldDecl of designators each time, but anonymous structs/unions set FieldDecl in other place and require us to use the saved FieldDecl.

https://github.com/llvm/llvm-project/blob/545c3022d28164f5040036a7b515a85f74dbd5cc/clang/lib/Sema/SemaInit.cpp#L2939-L2957