### PR TITLE
clang: improve diagnostic for 'auto' used in disallowed local class contexts

### DIFF
--- a/clang/test/SemaCXX/abbrev-top-level-fn.cpp
+++ b/clang/test/SemaCXX/abbrev-top-level-fn.cpp
@@ -1,0 +1,5 @@
+// RUN: not %clang_cc1 -std=c++17 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK17
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s
+
+void top_fun(auto x) { }
+// CHECK17: {{.+}}:[[@LINE-1]]:14: error: 'auto' not allowed in function prototype

--- a/clang/test/SemaCXX/template-abbrev-local-class.cpp
+++ b/clang/test/SemaCXX/template-abbrev-local-class.cpp
@@ -1,0 +1,12 @@
+// RUN: not %clang_cc1 -std=c++20 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK20
+// RUN: not %clang_cc1 -std=c++23 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK23
+// RUN: not %clang_cc1 -std=c++17 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK17
+
+int main() {
+  struct A {
+    void foo(auto x) {}
+// CHECK20: {{.+}}:[[@LINE-2]]:3: error: templates cannot be declared inside of a local class
+// CHECK23: {{.+}}:[[@LINE-3]]:3: error: templates cannot be declared inside of a local class
+// CHECK17: {{.+}}:[[@LINE-3]]:14: error: 'auto' not allowed in function prototype
+  };
+}

--- a/clang/test/SemaCXX/template-local-class-fn.cpp
+++ b/clang/test/SemaCXX/template-local-class-fn.cpp
@@ -1,0 +1,12 @@
+// RUN: not %clang_cc1 -std=c++17 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK17
+// RUN: not %clang_cc1 -std=c++20 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK20
+// RUN: not %clang_cc1 -std=c++23 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK23
+
+int main() {
+  struct Local {
+// CHECK20: {{.+}}:[[@LINE-1]]:3: error: templates cannot be declared inside of a local class
+// CHECK23: {{.+}}:[[@LINE-2]]:3: error: templates cannot be declared inside of a local class
+    void mem(auto x) {}
+// CHECK17: {{.+}}:[[@LINE-1]]:14: error: 'auto' not allowed in function prototype
+  };
+}

--- a/clang/test/SemaCXX/template-local-class.cpp
+++ b/clang/test/SemaCXX/template-local-class.cpp
@@ -1,0 +1,11 @@
+// RUN: not %clang_cc1 -std=c++20 -fsyntax-only %s 2>&1 | FileCheck %s
+
+int main() {
+  struct S {
+    auto L = [](auto x) { return x; };
+// CHECK: {{.+}}:[[@LINE-1]]:5: error: 'auto' not allowed in non-static struct member
+    template<typename T> void memb(T);
+// CHECK: {{.+}}:[[@LINE-1]]:5: error: templates cannot be declared inside of a local class
+  };
+  return 0;
+}

--- a/clang/test/SemaCXX/template-nested-local-classes.cpp
+++ b/clang/test/SemaCXX/template-nested-local-classes.cpp
@@ -1,0 +1,17 @@
+// RUN: not %clang_cc1 -std=c++20 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK20
+// RUN: not %clang_cc1 -std=c++17 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK17
+
+int outer() {
+  struct Outer {
+    void f() {
+      struct Inner {
+        template<typename T> void m(T);
+// CHECK20: {{.+}}:[[@LINE-1]]:9: error: templates cannot be declared inside of a local class
+// CHECK20: {{.+}}:[[@LINE-3]]:7: error: templates cannot be declared inside of a local class
+        void bad(auto x) {}
+// CHECK17: {{.+}}:[[@LINE-1]]:18: error: 'auto' not allowed in function prototype
+      };
+    }
+  };
+  return 0;
+}


### PR DESCRIPTION
Fixes #147324

**Summary:**
Fixes missing source location (filename, line, column) in template diagnostics when templates or abbreviated function templates (auto parameters) are declared inside local classes.

**Changes:**

- Updated `CheckTemplateDeclScope` in `SemaTemplate.cpp` to correctly detect abbreviated function templates and compute accurate source locations.
- Improved diagnostic messages for templates inside local classes, `extern "C"`, and invalid scopes.
- Added new test cases for `C++17`, `C++20`, and `C++23`.

**Tests Added:**

- `template-local-class.cpp` – templates and `auto` members inside local class
- `template-abbrev-local-class.cpp` – abbreviated function templates across standards
- `template-nested-local-classes.cpp` – nested local class templates
- `abbrev-top-level-fn.cpp` – top-level functions with `auto` parameters


**Result:**
Diagnostics now show correct file, line, and column numbers, and handle auto parameter templates accurately.