### PR TITLE
[clang-tidy][NFC] Enable misc-const-correctness rule in clang-tidy codebase

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
   -bugprone-narrowing-conversions,
   -bugprone-unchecked-optional-access,
   -bugprone-unused-return-value,
+  misc-const-correctness,
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-pass-by-value,

--- a/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
@@ -601,13 +601,14 @@ ExceptionAnalyzer::throwsException(const Stmt *St,
     // whether the call itself throws.
     if (const auto *Call = dyn_cast<CallExpr>(St)) {
       if (const FunctionDecl *Func = Call->getDirectCallee()) {
-        ExceptionInfo Excs =
+        const ExceptionInfo Excs =
             throwsException(Func, Caught, CallStack, Call->getBeginLoc());
         Results.merge(Excs);
       }
     } else if (const auto *Construct = dyn_cast<CXXConstructExpr>(St)) {
-      ExceptionInfo Excs = throwsException(Construct->getConstructor(), Caught,
-                                           CallStack, Construct->getBeginLoc());
+      const ExceptionInfo Excs =
+          throwsException(Construct->getConstructor(), Caught, CallStack,
+                          Construct->getBeginLoc());
       Results.merge(Excs);
     }
   }


### PR DESCRIPTION
After successful `misc-const-correctness` cleanup (last patch https://github.com/llvm/llvm-project/pull/167131), we can enable `misc-const-correctness` rule for the whole project.

During cleanup, I didn't encounter any false positives so it's safe to assume that we will have minimal FP in the future.