### PR TITLE
[LifetimeSafety] Use StringMap::contains (NFC)

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -68,8 +68,7 @@ llvm::StringMap<ProgramPoint> FactManager::getTestPoints() const {
     for (const Fact *F : BlockFacts) {
       if (const auto *TPF = F->getAs<TestPointFact>()) {
         StringRef PointName = TPF->getAnnotation();
-        assert(AnnotationToPointMap.find(PointName) ==
-                   AnnotationToPointMap.end() &&
+        assert(!AnnotationToPointMap.contains(PointName) &&
                "more than one test points with the same name");
         AnnotationToPointMap[PointName] = F;
       }


### PR DESCRIPTION
Identified with readability-container-contains.
