### PR TITLE
[clang-format] Don't swap `(const override)` with QAS_Right

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -177,7 +177,7 @@ static bool isQualifier(const FormatToken *const Tok) {
 
 const FormatToken *LeftRightQualifierAlignmentFixer::analyzeRight(
     const SourceManager &SourceMgr, const AdditionalKeywords &Keywords,
-    tooling::Replacements &Fixes, const FormatToken *Tok,
+    tooling::Replacements &Fixes, const FormatToken *const Tok,
     const std::string &Qualifier, tok::TokenKind QualifierType) {
   // We only need to think about streams that begin with a qualifier.
   if (Tok->isNot(QualifierType))

--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -177,13 +177,16 @@ static bool isQualifier(const FormatToken *const Tok) {
 
 const FormatToken *LeftRightQualifierAlignmentFixer::analyzeRight(
     const SourceManager &SourceMgr, const AdditionalKeywords &Keywords,
-    tooling::Replacements &Fixes, const FormatToken *const Tok,
+    tooling::Replacements &Fixes, const FormatToken *Tok,
     const std::string &Qualifier, tok::TokenKind QualifierType) {
   // We only need to think about streams that begin with a qualifier.
   if (Tok->isNot(QualifierType))
     return Tok;
+
+  const auto *Next = Tok->getNextNonComment();
+
   // Don't concern yourself if nothing follows the qualifier.
-  if (!Tok->Next)
+  if (!Next)
     return Tok;
 
   // Skip qualifiers to the left to find what preceeds the qualifiers.
@@ -247,9 +250,15 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeRight(
   }();
 
   // Find the last qualifier to the right.
-  const FormatToken *LastQual = Tok;
-  while (isQualifier(LastQual->getNextNonComment()))
-    LastQual = LastQual->getNextNonComment();
+  const auto *LastQual = Tok;
+  for (; isQualifier(Next); Next = Next->getNextNonComment())
+    LastQual = Next;
+
+  if (!LastQual || !Next ||
+      (LastQual->isOneOf(tok::kw_const, tok::kw_volatile) &&
+       Next->isOneOf(Keywords.kw_override, Keywords.kw_final))) {
+    return Tok;
+  }
 
   // If this qualifier is to the right of a type or pointer do a partial sort
   // and return.

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -215,6 +215,8 @@ TEST_F(QualifierFixerTest, RightQualifier) {
                Style);
   verifyFormat("void foo() const override;", Style);
   verifyFormat("void foo() const override LLVM_READONLY;", Style);
+  verifyFormat("MOCK_METHOD(ReturnType, myMethod, (int), (const override));",
+               Style);
   verifyFormat("void foo() const final;", Style);
   verifyFormat("void foo() const final LLVM_READONLY;", Style);
   verifyFormat("void foo() const LLVM_READONLY;", Style);


### PR DESCRIPTION
Fixes #154846