### PR TITLE
[mlir] Consolidate two implementations of meet (NFC)

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -138,27 +138,24 @@ public:
 
   /// Meet (intersect) the information contained in the 'rhs' value with this
   /// lattice. Returns if the state of the current lattice changed.  If the
-  /// lattice elements don't have a `meet` method, this is a no-op (see below.)
-  template <typename VT,
-            std::enable_if_t<lattice_has_meet<VT>::value> * = nullptr>
+  /// lattice elements don't have a `meet` method, this is a no-op.
+  template <typename VT>
   ChangeResult meet(const VT &rhs) {
-    ValueT newValue = ValueT::meet(value, rhs);
-    assert(ValueT::meet(newValue, value) == newValue &&
-           "expected `meet` to be monotonic");
-    assert(ValueT::meet(newValue, rhs) == newValue &&
-           "expected `meet` to be monotonic");
+    if constexpr (lattice_has_meet<VT>::value) {
+      ValueT newValue = ValueT::meet(value, rhs);
+      assert(ValueT::meet(newValue, value) == newValue &&
+             "expected `meet` to be monotonic");
+      assert(ValueT::meet(newValue, rhs) == newValue &&
+             "expected `meet` to be monotonic");
 
-    // Update the current optimistic value if something changed.
-    if (newValue == value)
-      return ChangeResult::NoChange;
+      // Update the current optimistic value if something changed.
+      if (newValue == value)
+        return ChangeResult::NoChange;
 
-    value = newValue;
-    return ChangeResult::Change;
-  }
+      value = newValue;
+      return ChangeResult::Change;
+    }
 
-  template <typename VT,
-            std::enable_if_t<!lattice_has_meet<VT>::value> * = nullptr>
-  ChangeResult meet(const VT &rhs) {
     return ChangeResult::NoChange;
   }
 

--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -141,7 +141,9 @@ public:
   /// lattice elements don't have a `meet` method, this is a no-op.
   template <typename VT>
   ChangeResult meet(const VT &rhs) {
-    if constexpr (lattice_has_meet<VT>::value) {
+    if constexpr (!lattice_has_meet<VT>::value) {
+      return ChangeResult::NoChange;
+    } else {
       ValueT newValue = ValueT::meet(value, rhs);
       assert(ValueT::meet(newValue, value) == newValue &&
              "expected `meet` to be monotonic");
@@ -155,8 +157,6 @@ public:
       value = newValue;
       return ChangeResult::Change;
     }
-
-    return ChangeResult::NoChange;
   }
 
   /// Print the lattice element.


### PR DESCRIPTION
This patch consolidates two implementations of meet using
"if constexpr", migrating away from the SFINAE-based approach.
