### PR TITLE
[tools][llc] Fix save-stats.ll require aarch64 target

### DIFF
--- a/llvm/test/tools/llc/save-stats.ll
+++ b/llvm/test/tools/llc/save-stats.ll
@@ -1,4 +1,5 @@
 ; REQUIRES: asserts
+; REQUIRES: aarch64-registered-target
 
 ; RUN: llc -mtriple=arm64-apple-macosx --save-stats=obj -o %t.s %s && cat %t.stats | FileCheck %s
 ; RUN: llc -mtriple=arm64-apple-macosx --save-stats=cwd -o %t.s %s && cat %{t:stem}.tmp.stats | FileCheck %s


### PR DESCRIPTION
A quick fix for the CI failure introduced by https://github.com/llvm/llvm-project/pull/163967