### PR TITLE
[NFCI][lldb][test][Recognizer] Fix mismatched C/C++ frontend subtitutions

### DIFF
--- a/lldb/test/Shell/Recognizer/registration-unique.test
+++ b/lldb/test/Shell/Recognizer/registration-unique.test
@@ -5,16 +5,16 @@
 
 # RUN: split-file %s %t
 
-# RUN: %clang_host %t/main.cpp -g -o %t/cpp.out
+# RUN: %clangxx_host %t/main.cpp -g -o %t/cpp.out
 # RUN: %lldb -b -s %t/commands.input %t/cpp.out | FileCheck %s
 
-# RUN: %clang_host -x objective-c++ %t/main.mm -g -o %t/objcxx.out
+# RUN: %clangxx_host %t/main.mm -g -o %t/objcxx.out
 # RUN: %lldb -b -s %t/commands.input %t/objcxx.out | FileCheck %s
 
 # RUN: %clang_host %t/main.c -g -o %t/c.out
 # RUN: %lldb -b -s %t/commands.input %t/c.out | FileCheck %s
 
-# RUN: %clang_host -x objective-c %t/main.m -g -o %t/objc.out
+# RUN: %clang_host %t/main.m -g -o %t/objc.out
 # RUN: %lldb -b -s %t/commands.input %t/objc.out | FileCheck %s
 
 #--- main.m

--- a/lldb/test/Shell/Recognizer/verbose_trap-objc.test
+++ b/lldb/test/Shell/Recognizer/verbose_trap-objc.test
@@ -1,6 +1,6 @@
 # REQUIRES: system-darwin
 #
-# RUN: %clangxx_host -x objective-c -g %S/Inputs/verbose_trap.m -o %t.out
+# RUN: %clang_host -g %S/Inputs/verbose_trap.m -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 
 run


### PR DESCRIPTION
The explicit language specifications for Objective C/C++ don't seem necessary either so I've removed them too.

I found these by using Clang frontend configuration files containing language-specific options for both C and C++ (e.g. `-std=c2y` and `-std=c++26`).

Prior-art: 21041c92925faf529717d96279b6d8f20b17c70c