### PR TITLE
[NFCI][lldb][test] Avoid GNU extension for specifying mangling

### DIFF
--- a/lldb/test/Shell/Unwind/Inputs/call-asm.c
+++ b/lldb/test/Shell/Unwind/Inputs/call-asm.c
@@ -1,3 +1,3 @@
-int asm_main() asm("asm_main");
-
+// Explicit mangling is necessary as on Darwin an underscore is prepended to the symbol.
+int asm_main() __asm("asm_main");
 int main() { return asm_main(); }


### PR DESCRIPTION
`asm()` on function declarations is used for specifying the mangling. But that specific spelling is a GNU extension unlike `__asm()`.

Found by building with `-std=c2y` in Clang's C frontend's config file.