### PR TITLE
[WebAssembly] Truncate extra bits of large elements in BUILD_VECTOR

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -2603,18 +2603,13 @@ SDValue WebAssemblyTargetLowering::LowerBUILD_VECTOR(SDValue Op,
         // Values may need to be fixed so that they will sign extend to be
         // within the expected range during ISel. Check whether the value is in
         // bounds based on the lane bit width and if it is out of bounds, lop
-        // off the extra bits and subtract 2^n to reflect giving the high bit
-        // value -2^(n-1) rather than +2^(n-1). Skip the i64 case because it
-        // cannot possibly be out of range.
+        // off the extra bits.
         auto *Const = dyn_cast<ConstantSDNode>(Lane.getNode());
-        int64_t Val = Const ? Const->getSExtValue() : 0;
         uint64_t LaneBits = 128 / Lanes;
-        assert((LaneBits == 64 || Val >= -(1ll << (LaneBits - 1))) &&
-               "Unexpected out of bounds negative value");
-        if (Const && LaneBits != 64 && Val > (1ll << (LaneBits - 1)) - 1) {
-          uint64_t Mask = (1ll << LaneBits) - 1;
-          auto NewVal = (((uint64_t)Val & Mask) - (1ll << LaneBits)) & Mask;
-          ConstLanes.push_back(DAG.getConstant(NewVal, SDLoc(Lane), LaneT));
+        if (Const) {
+          ConstLanes.push_back(DAG.getConstant(
+              Const->getAPIntValue().trunc(LaneBits).getZExtValue(),
+              SDLoc(Lane), LaneT));
         } else {
           ConstLanes.push_back(Lane);
         }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -2604,9 +2604,8 @@ SDValue WebAssemblyTargetLowering::LowerBUILD_VECTOR(SDValue Op,
         // within the expected range during ISel. Check whether the value is in
         // bounds based on the lane bit width and if it is out of bounds, lop
         // off the extra bits.
-        auto *Const = dyn_cast<ConstantSDNode>(Lane.getNode());
         uint64_t LaneBits = 128 / Lanes;
-        if (Const) {
+        if (auto *Const = dyn_cast<ConstantSDNode>(Lane.getNode())) {
           ConstLanes.push_back(DAG.getConstant(
               Const->getAPIntValue().trunc(LaneBits).getZExtValue(),
               SDLoc(Lane), LaneT));

--- a/llvm/test/CodeGen/WebAssembly/simd-build-vector.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-build-vector.ll
@@ -25,7 +25,7 @@ define <8 x i16> @different_const_one_replaced_i16x8(i16 %x) {
 ; CHECK-LABEL: different_const_one_replaced_i16x8:
 ; CHECK:         .functype different_const_one_replaced_i16x8 (i32) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    v128.const $push0=, 1, -2, 3, -4, 5, 0, 7, -8
+; CHECK-NEXT:    v128.const $push0=, 1, 65534, 3, 65532, 5, 0, 7, 65528
 ; CHECK-NEXT:    i16x8.replace_lane $push1=, $pop0, 5, $0
 ; CHECK-NEXT:    return $pop1
   %v = insertelement
@@ -523,3 +523,14 @@ define <2 x double> @load_zero_lane_f64x2(ptr %addr.a, ptr %addr.b) {
   ret <2 x double> %v.1
 }
 
+define <2 x i8> @pr165713() {
+; CHECK-LABEL: pr165713:
+; CHECK:         .functype pr165713 () -> (v128)
+; CHECK-NEXT:  # %bb.0: # %entry
+; CHECK-NEXT:    v128.const $push0=, 0, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK-NEXT:    return $pop0
+entry:
+  %shuffle3.i = shufflevector <32 x i32> zeroinitializer, <32 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 -62880201, i32 poison, i32 poison, i32 poison>, <2 x i32> <i32 17, i32 60>
+  %conv.i = trunc <2 x i32> %shuffle3.i to <2 x i8>
+  ret <2 x i8> %conv.i
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/165713
This patch handles out-of-bound vector elements and truncates extra bits.