### PR TITLE
[NFCI][bolt][test] Enable AT&T syntax explicitly

### DIFF
--- a/bolt/test/lit.local.cfg
+++ b/bolt/test/lit.local.cfg
@@ -5,7 +5,7 @@ if not "linux" in host_triple:
   host_triple = host_triple.split("-")[0] + "-unknown-linux-gnu"
 
 common_linker_flags = "-fuse-ld=lld -Wl,--unresolved-symbols=ignore-all -Wl,--build-id=none -pie"
-flags = f"--target={host_triple} -fPIE {common_linker_flags}"
+flags = f"--target={host_triple} -fPIE {common_linker_flags} -mllvm -x86-asm-syntax=att"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))


### PR DESCRIPTION
Files using the Intel syntax typically explicitly specify it. Do the same for the few relevant files for AT&T.

This enables building LLVM with `-mllvm -x86-asm-syntax=intel` in one's Clang config files (i.e. a global preference for Intel syntax).

Prior art: https://github.com/llvm/llvm-project/pull/164453 https://github.com/llvm/llvm-project/pull/166818