### PR TITLE
[LoopBoundSplit] Check if latch is operand of PHI induction variable

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -72,7 +72,9 @@ static void analyzeICmp(ScalarEvolution &SE, ICmpInst *ICmp,
     // value from backedge.
     if (Cond.AddRecSCEV && isa<PHINode>(Cond.AddRecValue)) {
       PHINode *PN = cast<PHINode>(Cond.AddRecValue);
-      Cond.NonPHIAddRecValue = PN->getIncomingValueForBlock(L.getLoopLatch());
+      int Idx = PN->getBasicBlockIndex(L.getLoopLatch());
+      if (Idx >= 0)
+        Cond.NonPHIAddRecValue = PN->getIncomingValue(Idx);
     }
   }
 }


### PR DESCRIPTION
A problem occurs when conditionally comparing the PHI derived variable from the outer loop with ICmp in the inner loop of a nested loop. This is because the latch in the inner loop is not an operand of the outer loop PHI, causing an assert to occur when `getIncomingValueForBlock` is called.

The issue is resolved by verifying whether the latch is an operand of the current PHI.

Fixed: #156793, #61655