### PR TITLE
[mlir][Affine] Fix vector fusion legality and buffer sizing

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
@@ -547,10 +547,12 @@ struct MemRefRegion {
   /// use int64_t instead of uint64_t since index types can be at most
   /// int64_t. `lbs` are set to the lower bound maps for each of the rank
   /// dimensions where each of these maps is purely symbolic in the constraints
-  /// set's symbols.
+  /// set's symbols. If `minShape` is provided, each computed bound is at least
+  /// `minShape[d]` for dimension `d`.
   std::optional<int64_t> getConstantBoundingSizeAndShape(
       SmallVectorImpl<int64_t> *shape = nullptr,
-      SmallVectorImpl<AffineMap> *lbs = nullptr) const;
+      SmallVectorImpl<AffineMap> *lbs = nullptr,
+      ArrayRef<int64_t> minShape = {}) const;
 
   /// Gets the lower and upper bound map for the dimensional variable at
   /// `pos`.

--- a/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
@@ -549,10 +549,10 @@ struct MemRefRegion {
   /// dimensions where each of these maps is purely symbolic in the constraints
   /// set's symbols. If `minShape` is provided, each computed bound is at least
   /// `minShape[d]` for dimension `d`.
-  std::optional<int64_t> getConstantBoundingSizeAndShape(
-      SmallVectorImpl<int64_t> *shape = nullptr,
-      SmallVectorImpl<AffineMap> *lbs = nullptr,
-      ArrayRef<int64_t> minShape = {}) const;
+  std::optional<int64_t>
+  getConstantBoundingSizeAndShape(SmallVectorImpl<int64_t> *shape = nullptr,
+                                  SmallVectorImpl<AffineMap> *lbs = nullptr,
+                                  ArrayRef<int64_t> minShape = {}) const;
 
   /// Gets the lower and upper bound map for the dimensional variable at
   /// `pos`.

--- a/mlir/lib/Dialect/Affine/Utils/LoopFusionUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopFusionUtils.cpp
@@ -40,13 +40,6 @@ static std::optional<VectorType> getAffineVectorType(Operation *op) {
   return std::nullopt;
 }
 
-/// Returns the memref underlying an affine read/write op.
-static Value getAccessMemRef(Operation *op) {
-  if (auto loadOp = dyn_cast<AffineReadOpInterface>(op))
-    return loadOp.getMemRef();
-  return cast<AffineWriteOpInterface>(op).getMemRef();
-}
-
 // Gathers all load and store memref accesses in 'opA' into 'values', where
 // 'values[memref] == true' for each store operation.
 static void getLoadAndStoreMemRefAccesses(Operation *opA,

--- a/mlir/test/Dialect/Affine/loop-fusion-sibling.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-sibling.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(affine-loop-fusion{maximal mode=sibling}))' | FileCheck %s
+// RUN: mlir-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.module(func.func(affine-loop-fusion{maximal mode=sibling}))' -split-input-file | FileCheck %s
 
 // Test cases specifically for sibling fusion. Note that sibling fusion test
 // cases also exist in loop-fusion*.mlir.
@@ -19,5 +19,26 @@ func.func @disjoint_stores(%0: memref<8xf32>) {
   }
   // CHECK: affine.for
   // CHECK-NOT: affine.for
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @sibling_fusion_shape_mismatch
+// CHECK: affine.for %{{.*}} = 0 to 10 {
+// CHECK:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<4xf32>
+// CHECK:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<8xf32>
+// CHECK:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<4xf32>
+
+/// Read-After-Read dependence does not require vector shape alignment.
+func.func @sibling_fusion_shape_mismatch(%src: memref<10x16xf32>) {
+  affine.for %i = 0 to 10 {
+    %vec = affine.vector_load %src[%i, 0] : memref<10x16xf32>, vector<4xf32>
+  }
+
+  affine.for %i = 0 to 10 {
+    %wide = affine.vector_load %src[%i, 8] : memref<10x16xf32>, vector<8xf32>
+    %vec = affine.vector_load %src[%i, 0] : memref<10x16xf32>, vector<4xf32>
+  }
   return
 }

--- a/mlir/test/Dialect/Affine/loop-fusion-vector.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-vector.mlir
@@ -1,0 +1,97 @@
+// RUN: mlir-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.module(func.func(affine-loop-fusion))' -split-input-file | FileCheck %s
+// RUN: mlir-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.module(func.func(affine-loop-fusion{maximal mode=sibling}))' -split-input-file | FileCheck %s --check-prefix=SIBLING
+
+// CHECK-LABEL: func.func @skip_fusing_mismatched_vectors
+// CHECK: affine.for %{{.*}} = 0 to 8 {
+// CHECK:   affine.vector_store {{.*}} : memref<64x512xf32>, vector<64x64xf32>
+// CHECK: }
+// CHECK: affine.for %{{.*}} = 0 to 8 {
+// CHECK:   affine.vector_load {{.*}} : memref<64x512xf32>, vector<64x512xf32>
+// CHECK: }
+func.func @skip_fusing_mismatched_vectors(%a: memref<64x512xf32>, %b: memref<64x512xf32>, %c: memref<64x512xf32>, %d: memref<64x4096xf32>, %e: memref<64x4096xf32>) {
+  affine.for %j = 0 to 8 {
+    %lhs = affine.vector_load %a[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
+    %rhs = affine.vector_load %b[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
+    %res = arith.addf %lhs, %rhs : vector<64x64xf32>
+    affine.vector_store %res, %c[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
+  }
+
+  affine.for %j = 0 to 8 {
+    %lhs = affine.vector_load %c[0, 0] : memref<64x512xf32>, vector<64x512xf32>
+    %rhs = affine.vector_load %d[0, %j * 512] : memref<64x4096xf32>, vector<64x512xf32>
+    %res = arith.subf %lhs, %rhs : vector<64x512xf32>
+    affine.vector_store %res, %d[0, %j * 512] : memref<64x4096xf32>, vector<64x512xf32>
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @vector_private_memref
+// CHECK: memref.alloc() : memref<1x64xf32>
+// CHECK-NOT: memref<1x1xf32>
+// CHECK: affine.vector_store {{.*}} : memref<1x64xf32>, vector<64xf32>
+func.func @vector_private_memref(%src: memref<10x64xf32>, %dst: memref<10x64xf32>) {
+  %tmp = memref.alloc() : memref<10x64xf32>
+  affine.for %i = 0 to 10 {
+    %vec = affine.vector_load %src[%i, 0] : memref<10x64xf32>, vector<64xf32>
+    affine.vector_store %vec, %tmp[%i, 0] : memref<10x64xf32>, vector<64xf32>
+  }
+
+  affine.for %i = 0 to 10 {
+    %vec = affine.vector_load %tmp[%i, 0] : memref<10x64xf32>, vector<64xf32>
+    affine.vector_store %vec, %dst[%i, 0] : memref<10x64xf32>, vector<64xf32>
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @fuse_scalar_vector
+// CHECK: %[[TMP:.*]] = memref.alloc() : memref<64xf32>
+// CHECK: affine.for %[[I:.*]] = 0 to 16 {
+// CHECK:   %[[S0:.*]] = affine.load %[[SRC:.*]][%[[I]] * 4] : memref<64xf32>
+// CHECK:   affine.store %[[S0]], %[[TMP]][%[[I]] * 4] : memref<64xf32>
+// CHECK:   %[[V:.*]] = affine.vector_load %[[TMP]][%[[I]] * 4] : memref<64xf32>, vector<4xf32>
+// CHECK:   affine.vector_store %[[V]], %[[DST:.*]][%[[I]] * 4] : memref<64xf32>, vector<4xf32>
+// CHECK: }
+func.func @fuse_scalar_vector(%src: memref<64xf32>, %dst: memref<64xf32>) {
+  %tmp = memref.alloc() : memref<64xf32>
+  affine.for %i = 0 to 16 {
+    %s0 = affine.load %src[%i * 4] : memref<64xf32>
+    affine.store %s0, %tmp[%i * 4] : memref<64xf32>
+    %s1 = affine.load %src[%i * 4 + 1] : memref<64xf32>
+    affine.store %s1, %tmp[%i * 4 + 1] : memref<64xf32>
+    %s2 = affine.load %src[%i * 4 + 2] : memref<64xf32>
+    affine.store %s2, %tmp[%i * 4 + 2] : memref<64xf32>
+    %s3 = affine.load %src[%i * 4 + 3] : memref<64xf32>
+    affine.store %s3, %tmp[%i * 4 + 3] : memref<64xf32>
+  }
+
+  affine.for %i = 0 to 16 {
+    %vec = affine.vector_load %tmp[%i * 4] : memref<64xf32>, vector<4xf32>
+    affine.vector_store %vec, %dst[%i * 4] : memref<64xf32>, vector<4xf32>
+  }
+  memref.dealloc %tmp : memref<64xf32>
+  return
+}
+
+// -----
+
+// SIBLING-LABEL: func.func @sibling_vector_mismatch
+// SIBLING: affine.for %{{.*}} = 0 to 10 {
+// SIBLING:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<4xf32>
+// SIBLING:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<8xf32>
+// SIBLING:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<4xf32>
+// SIBLING: }
+func.func @sibling_vector_mismatch(%src: memref<10x16xf32>) {
+  affine.for %i = 0 to 10 {
+    %vec = affine.vector_load %src[%i, 0] : memref<10x16xf32>, vector<4xf32>
+  }
+
+  affine.for %i = 0 to 10 {
+    %wide = affine.vector_load %src[%i, 8] : memref<10x16xf32>, vector<8xf32>
+    %vec = affine.vector_load %src[%i, 0] : memref<10x16xf32>, vector<4xf32>
+  }
+  return
+}

--- a/mlir/test/Dialect/Affine/loop-fusion-vector.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-vector.mlir
@@ -1,37 +1,43 @@
 // RUN: mlir-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.module(func.func(affine-loop-fusion))' -split-input-file | FileCheck %s
-// RUN: mlir-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.module(func.func(affine-loop-fusion{maximal mode=sibling}))' -split-input-file | FileCheck %s --check-prefix=SIBLING
 
-// CHECK-LABEL: func.func @skip_fusing_mismatched_vectors
+// CHECK-LABEL: func.func @negative_fusion_producer_consumer_shape_mismatch
 // CHECK: affine.for %{{.*}} = 0 to 8 {
 // CHECK:   affine.vector_store {{.*}} : memref<64x512xf32>, vector<64x64xf32>
-// CHECK: }
 // CHECK: affine.for %{{.*}} = 0 to 8 {
 // CHECK:   affine.vector_load {{.*}} : memref<64x512xf32>, vector<64x512xf32>
-// CHECK: }
-func.func @skip_fusing_mismatched_vectors(%a: memref<64x512xf32>, %b: memref<64x512xf32>, %c: memref<64x512xf32>, %d: memref<64x4096xf32>, %e: memref<64x4096xf32>) {
+
+/// Mismatched vector shapes prevent valid fusion due to element misalignment.
+func.func @negative_fusion_producer_consumer_shape_mismatch(
+    %arg0: memref<64x512xf32>,
+    %arg1: memref<64x512xf32>,
+    %arg2: memref<64x512xf32>,
+    %arg3: memref<64x4096xf32>) {
   affine.for %j = 0 to 8 {
-    %lhs = affine.vector_load %a[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
-    %rhs = affine.vector_load %b[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
+    %lhs = affine.vector_load %arg0[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
+    %rhs = affine.vector_load %arg1[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
     %res = arith.addf %lhs, %rhs : vector<64x64xf32>
-    affine.vector_store %res, %c[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
+    affine.vector_store %res, %arg2[0, %j * 64] : memref<64x512xf32>, vector<64x64xf32>
   }
 
   affine.for %j = 0 to 8 {
-    %lhs = affine.vector_load %c[0, 0] : memref<64x512xf32>, vector<64x512xf32>
-    %rhs = affine.vector_load %d[0, %j * 512] : memref<64x4096xf32>, vector<64x512xf32>
+    %lhs = affine.vector_load %arg2[0, 0] : memref<64x512xf32>, vector<64x512xf32>
+    %rhs = affine.vector_load %arg3[0, %j * 512] : memref<64x4096xf32>, vector<64x512xf32>
     %res = arith.subf %lhs, %rhs : vector<64x512xf32>
-    affine.vector_store %res, %d[0, %j * 512] : memref<64x4096xf32>, vector<64x512xf32>
+    affine.vector_store %res, %arg3[0, %j * 512] : memref<64x4096xf32>, vector<64x512xf32>
   }
   return
 }
 
 // -----
 
-// CHECK-LABEL: func.func @vector_private_memref
+// CHECK-LABEL: func.func @fusion_private_memref_vector_size
 // CHECK: memref.alloc() : memref<1x64xf32>
 // CHECK-NOT: memref<1x1xf32>
 // CHECK: affine.vector_store {{.*}} : memref<1x64xf32>, vector<64xf32>
-func.func @vector_private_memref(%src: memref<10x64xf32>, %dst: memref<10x64xf32>) {
+
+/// Private buffer must accommodate vector shape (1x64), not just scalar shape
+/// (1x1).
+func.func @fusion_private_memref_vector_size(%src: memref<10x64xf32>, %dst: memref<10x64xf32>) {
   %tmp = memref.alloc() : memref<10x64xf32>
   affine.for %i = 0 to 10 {
     %vec = affine.vector_load %src[%i, 0] : memref<10x64xf32>, vector<64xf32>
@@ -47,15 +53,16 @@ func.func @vector_private_memref(%src: memref<10x64xf32>, %dst: memref<10x64xf32
 
 // -----
 
-// CHECK-LABEL: func.func @fuse_scalar_vector
+// CHECK-LABEL: func.func @fusion_scalar_producer_vector_consumer
 // CHECK: %[[TMP:.*]] = memref.alloc() : memref<64xf32>
 // CHECK: affine.for %[[I:.*]] = 0 to 16 {
 // CHECK:   %[[S0:.*]] = affine.load %[[SRC:.*]][%[[I]] * 4] : memref<64xf32>
 // CHECK:   affine.store %[[S0]], %[[TMP]][%[[I]] * 4] : memref<64xf32>
 // CHECK:   %[[V:.*]] = affine.vector_load %[[TMP]][%[[I]] * 4] : memref<64xf32>, vector<4xf32>
 // CHECK:   affine.vector_store %[[V]], %[[DST:.*]][%[[I]] * 4] : memref<64xf32>, vector<4xf32>
-// CHECK: }
-func.func @fuse_scalar_vector(%src: memref<64xf32>, %dst: memref<64xf32>) {
+
+/// Scalar-to-vector fusion requires correct intermediate buffer alloc.
+func.func @fusion_scalar_producer_vector_consumer(%src: memref<64xf32>, %dst: memref<64xf32>) {
   %tmp = memref.alloc() : memref<64xf32>
   affine.for %i = 0 to 16 {
     %s0 = affine.load %src[%i * 4] : memref<64xf32>
@@ -73,25 +80,5 @@ func.func @fuse_scalar_vector(%src: memref<64xf32>, %dst: memref<64xf32>) {
     affine.vector_store %vec, %dst[%i * 4] : memref<64xf32>, vector<4xf32>
   }
   memref.dealloc %tmp : memref<64xf32>
-  return
-}
-
-// -----
-
-// SIBLING-LABEL: func.func @sibling_vector_mismatch
-// SIBLING: affine.for %{{.*}} = 0 to 10 {
-// SIBLING:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<4xf32>
-// SIBLING:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<8xf32>
-// SIBLING:   affine.vector_load %{{.*}} : memref<10x16xf32>, vector<4xf32>
-// SIBLING: }
-func.func @sibling_vector_mismatch(%src: memref<10x16xf32>) {
-  affine.for %i = 0 to 10 {
-    %vec = affine.vector_load %src[%i, 0] : memref<10x16xf32>, vector<4xf32>
-  }
-
-  affine.for %i = 0 to 10 {
-    %wide = affine.vector_load %src[%i, 8] : memref<10x16xf32>, vector<8xf32>
-    %vec = affine.vector_load %src[%i, 0] : memref<10x16xf32>, vector<4xf32>
-  }
   return
 }


### PR DESCRIPTION
Guard producer/consumer fusion with explicit vector-shape checks, rejecting mismatched loads/stores so vectorized legality errors can’t slip through.
Size private fusion buffers conservatively for vector stores by threading a `minShape` through `MemRefRegion::getConstantBoundingSizeAndShape`, ensuring temporary memrefs are large enough to hold entire vector tiles.
Extend `loop-fusion-vector.mlir` to cover mismatched-vector rejection, correct vector buffer sizing, scalar <-> vector fusion, and sibling-mode mismatches.

Fixes #115849, Fixes #115989