### PR TITLE
[MC][X86/M68k] Emit syntax directive for AT&T

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -119,6 +119,10 @@ Changes to the Windows Target
 Changes to the X86 Backend
 --------------------------
 
+* `.att_syntax` directive is now emitted for assembly files when AT&T syntax is
+  in use. This matches the behaviour of Intel syntax and aids with
+  compatibility when changing the default Clang syntax to the Intel syntax.
+
 Changes to the OCaml bindings
 -----------------------------
 

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -1054,7 +1054,7 @@ public:
   /// Get the .xdata section used for the given section.
   MCSection *getAssociatedXDataSection(const MCSection *TextSec);
 
-  virtual void emitSyntaxDirective();
+  virtual void emitSyntaxDirective(StringRef Syntax, StringRef Options);
 
   /// Record a relocation described by the .reloc directive.
   virtual void emitRelocDirective(const MCExpr &Offset, StringRef Name,

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -123,7 +123,7 @@ public:
     EmitCommentsAndEOL();
   }
 
-  void emitSyntaxDirective() override;
+  void emitSyntaxDirective(StringRef Syntax, StringRef Options) override;
 
   void EmitCommentsAndEOL();
 
@@ -798,14 +798,11 @@ void MCAsmStreamer::emitSymbolDesc(MCSymbol *Symbol, unsigned DescValue) {
   EmitEOL();
 }
 
-void MCAsmStreamer::emitSyntaxDirective() {
-  if (MAI->getAssemblerDialect() == 1) {
-    OS << "\t.intel_syntax noprefix";
-    EmitEOL();
-  }
-  // FIXME: Currently emit unprefix'ed registers.
-  // The intel_syntax directive has one optional argument
-  // with may have a value of prefix or noprefix.
+void MCAsmStreamer::emitSyntaxDirective(StringRef Syntax, StringRef Options) {
+  OS << "\t." << Syntax << "_syntax";
+  if (!Options.empty())
+    OS << " " << Options;
+  EmitEOL();
 }
 
 void MCAsmStreamer::beginCOFFSymbolDef(const MCSymbol *Symbol) {

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -885,7 +885,7 @@ MCSection *MCStreamer::getAssociatedXDataSection(const MCSection *TextSec) {
                           TextSec);
 }
 
-void MCStreamer::emitSyntaxDirective() {}
+void MCStreamer::emitSyntaxDirective(StringRef Syntax, StringRef Options) {}
 
 static unsigned encodeSEHRegNum(MCContext &Ctx, MCRegister Reg) {
   return Ctx.getRegisterInfo()->getSEHRegNum(Reg);

--- a/llvm/lib/Target/M68k/M68kAsmPrinter.cpp
+++ b/llvm/lib/Target/M68k/M68kAsmPrinter.cpp
@@ -189,10 +189,6 @@ void M68kAsmPrinter::emitFunctionBodyStart() {}
 
 void M68kAsmPrinter::emitFunctionBodyEnd() {}
 
-void M68kAsmPrinter::emitStartOfAsmFile(Module &M) {
-  OutStreamer->emitSyntaxDirective();
-}
-
 void M68kAsmPrinter::emitEndOfAsmFile(Module &M) {}
 
 char M68kAsmPrinter::ID = 0;

--- a/llvm/lib/Target/M68k/M68kAsmPrinter.h
+++ b/llvm/lib/Target/M68k/M68kAsmPrinter.h
@@ -73,7 +73,6 @@ public:
   void emitInstruction(const MachineInstr *MI) override;
   void emitFunctionBodyStart() override;
   void emitFunctionBodyEnd() override;
-  void emitStartOfAsmFile(Module &M) override;
   void emitEndOfAsmFile(Module &M) override;
 };
 } // namespace llvm

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -932,7 +932,11 @@ void X86AsmPrinter::emitStartOfAsmFile(Module &M) {
     if (M.getModuleFlag("import-call-optimization"))
       EnableImportCallOptimization = true;
   }
-  OutStreamer->emitSyntaxDirective();
+
+  // TODO: Support prefixed registers for the Intel syntax.
+  const bool IntelSyntax = MAI->getAssemblerDialect() == InlineAsm::AD_Intel;
+  OutStreamer->emitSyntaxDirective(IntelSyntax ? "intel" : "att",
+                                   IntelSyntax ? "noprefix" : "");
 
   // If this is not inline asm and we're in 16-bit
   // mode prefix assembly with .code16.

--- a/llvm/test/CodeGen/X86/asm-dialect-directive.ll
+++ b/llvm/test/CodeGen/X86/asm-dialect-directive.ll
@@ -1,0 +1,7 @@
+;; Make sure that we always emit an assembly syntax directive for X86.
+; RUN: llc < %s -mtriple=x86_64 | FileCheck %s --check-prefix=ATT
+; RUN: llc < %s -mtriple=x86_64 -x86-asm-syntax=att | FileCheck %s --check-prefix=ATT
+; RUN: llc < %s -mtriple=x86_64 -x86-asm-syntax=intel | FileCheck %s --check-prefix=INTEL
+
+; INTEL: .intel_syntax noprefix
+; ATT: .att_syntax

--- a/llvm/test/CodeGen/X86/coal-sections.ll
+++ b/llvm/test/CodeGen/X86/coal-sections.ll
@@ -3,6 +3,7 @@
 ; Check that *coal* sections are not emitted.
 
 ; CHECK: .section  __TEXT,__text,regular,pure_instructions{{$}}
+; CHECK: .att_syntax
 ; CHECK-NEXT: .globl  _foo
 
 ; CHECK: .section  __TEXT,__const{{$}}


### PR DESCRIPTION
This eases interoperability by making it explicit in emitted assembly code which syntax is used. Refactored to remove X86-specific directives and logic from the generic MC(Asm)Streamer.

Motivated by building LLVM with `-mllvm -x86-asm-syntax=intel` (i.e. a global preference for Intel syntax). A Bolt test (`runtime/X86/fdata-escape-chars.ll`) was using `llc` to compile to assembly and then assembling with `clang`. The specific option causes Clang to assume Intel syntax but only for assembly and not inline assembly.