### PR TITLE
[lldb-dap] Add data breakpoints for bytes

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1239,19 +1239,13 @@ class DebugCommunication(object):
         stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=threadId)
         if stackFrame is None:
             return []
-        args_dict = (
-            {
-                "variablesReference": variablesReference,
-                "name": name,
-                "frameId": stackFrame["id"],
-            }
-            if size is None
-            else {
-                "bytes": size,
-                "name": name,
-                "asAddress": True,
-            }
-        )
+        args_dict = {"name": name}
+        if size is None:
+            args_dict["variablesReference"] = variablesReference
+            args_dict["frameId"] = stackFrame["id"]
+        else:
+            args_dict["asAddress"] = True
+            args_dict["bytes"] = size
         command_dict = {
             "command": "dataBreakpointInfo",
             "type": "request",

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1234,16 +1234,24 @@ class DebugCommunication(object):
         return response
 
     def request_dataBreakpointInfo(
-        self, variablesReference, name, frameIndex=0, threadId=None
+        self, variablesReference, name, size=None, frameIndex=0, threadId=None
     ):
         stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=threadId)
         if stackFrame is None:
             return []
-        args_dict = {
-            "variablesReference": variablesReference,
-            "name": name,
-            "frameId": stackFrame["id"],
-        }
+        args_dict = (
+            {
+                "variablesReference": variablesReference,
+                "name": name,
+                "frameId": stackFrame["id"],
+            }
+            if size is None
+            else {
+                "bytes": size,
+                "name": name,
+                "asAddress": True,
+            }
+        )
         command_dict = {
             "command": "dataBreakpointInfo",
             "type": "request",

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -169,6 +169,7 @@ class DAPTestCaseBase(TestBase):
                 if (
                     body["reason"] != "breakpoint"
                     and body["reason"] != "instruction breakpoint"
+                    and body["reason"] != "data breakpoint"
                 ):
                     continue
                 if "hitBreakpointIds" not in body:

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -39,18 +39,21 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             {"dataId": response_x["body"]["dataId"], "accessType": "write"},
         ]
         set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
-        self.assertEqual(
-            set_response["body"]["breakpoints"],
-            [{"verified": False}, {"verified": True}, {"verified": True}],
-        )
+        breakpoints = set_response["body"]["breakpoints"]
+        self.assertEqual(len(breakpoints), 3)
+        self.assertFalse(breakpoints[0]["verified"])
+        self.assertTrue(breakpoints[1]["verified"])
+        self.assertTrue(breakpoints[2]["verified"])
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[2]["id"]])
         x_val = self.dap_server.get_local_variable_value("x")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(x_val, "2")
         self.assertEqual(i_val, "1")
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[1]["id"]])
         arr_2 = self.dap_server.get_local_variable_child("arr", "[2]")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(arr_2["value"], "42")
@@ -79,18 +82,20 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             {"dataId": response_arr_2["body"]["dataId"], "accessType": "write"},
         ]
         set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
-        self.assertEqual(
-            set_response["body"]["breakpoints"],
-            [{"verified": True}, {"verified": True}],
-        )
+        breakpoints = set_response["body"]["breakpoints"]
+        self.assertEqual(len(breakpoints), 2)
+        self.assertTrue(breakpoints[0]["verified"])
+        self.assertTrue(breakpoints[1]["verified"])
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[0]["id"]])
         x_val = self.dap_server.get_local_variable_value("x")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(x_val, "2")
         self.assertEqual(i_val, "1")
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[1]["id"]])
         arr_2 = self.dap_server.get_local_variable_child("arr", "[2]")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(arr_2["value"], "42")
@@ -123,18 +128,20 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             {"dataId": response_arr_2["body"]["dataId"], "accessType": "write"},
         ]
         set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
-        self.assertEqual(
-            set_response["body"]["breakpoints"],
-            [{"verified": True}, {"verified": True}],
-        )
+        breakpoints = set_response["body"]["breakpoints"]
+        self.assertEqual(len(breakpoints), 2)
+        self.assertTrue(breakpoints[0]["verified"])
+        self.assertTrue(breakpoints[1]["verified"])
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[0]["id"]])
         x_val = self.dap_server.get_local_variable_value("x")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(x_val, "2")
         self.assertEqual(i_val, "1")
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[1]["id"]])
         arr_2 = self.dap_server.get_local_variable_child("arr", "[2]")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(arr_2["value"], "42")
@@ -153,8 +160,11 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             }
         ]
         set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
-        self.assertEqual(set_response["body"]["breakpoints"], [{"verified": True}])
-        self.continue_to_next_stop()
+        breakpoints = set_response["body"]["breakpoints"]
+        self.assertEqual(len(breakpoints), 1)
+        self.assertTrue(breakpoints[0]["verified"])
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[0]["id"]])
         x_val = self.dap_server.get_local_variable_value("x")
         self.assertEqual(x_val, "3")
 
@@ -167,8 +177,11 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             }
         ]
         set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
-        self.assertEqual(set_response["body"]["breakpoints"], [{"verified": True}])
-        self.continue_to_next_stop()
+        breakpoints = set_response["body"]["breakpoints"]
+        self.assertEqual(len(breakpoints), 1)
+        self.assertTrue(breakpoints[0]["verified"])
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[0]["id"]])
         x_val = self.dap_server.get_local_variable_value("x")
         self.assertEqual(x_val, "10")
 
@@ -206,18 +219,20 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             {"dataId": response_arr_2["body"]["dataId"], "accessType": "write"},
         ]
         set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
-        self.assertEqual(
-            set_response["body"]["breakpoints"],
-            [{"verified": True}, {"verified": True}],
-        )
+        breakpoints = set_response["body"]["breakpoints"]
+        self.assertEqual(len(breakpoints), 2)
+        self.assertTrue(breakpoints[0]["verified"])
+        self.assertTrue(breakpoints[1]["verified"])
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[0]["id"]])
         x_val = self.dap_server.get_local_variable_value("x")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(x_val, "2")
         self.assertEqual(i_val, "1")
 
-        self.continue_to_next_stop()
+        self.dap_server.request_continue()
+        self.verify_breakpoint_hit([breakpoints[1]["id"]])
         arr_2 = self.dap_server.get_local_variable_child("arr", "[2]")
         i_val = self.dap_server.get_local_variable_value("i")
         self.assertEqual(arr_2["value"], "42")

--- a/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
@@ -16,7 +16,7 @@
 
 namespace lldb_dap {
 
-static bool CheckAddress(DAP &dap, lldb::addr_t load_addr) {
+static bool IsRW(DAP &dap, lldb::addr_t load_addr) {
   lldb::SBMemoryRegionInfo region;
   lldb::SBError err =
       dap.target.GetProcess().GetMemoryRegionInfo(load_addr, region);
@@ -72,7 +72,7 @@ DataBreakpointInfoRequestHandler::Run(
       if (data.IsValid()) {
         size = llvm::utostr(data.GetByteSize());
         addr = llvm::utohexstr(load_addr);
-        if (!CheckAddress(dap, load_addr)) {
+        if (!IsRW(dap, load_addr)) {
           is_data_ok = false;
           response.description = "memory region for address " + addr +
                                  " has no read or write permissions";
@@ -89,7 +89,7 @@ DataBreakpointInfoRequestHandler::Run(
       addr = args.name.substr(2);
     else
       addr = llvm::utohexstr(std::stoull(args.name));
-    if (!CheckAddress(dap, std::stoull(addr, 0, 16))) {
+    if (!IsRW(dap, std::stoull(addr, 0, 16))) {
       is_data_ok = false;
       response.description = "memory region for address " + addr +
                              " has no read or write permissions";

--- a/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
@@ -89,13 +89,15 @@ DataBreakpointInfoRequestHandler::Run(
     }
   } else if (args.asAddress) {
     size = llvm::utostr(args.bytes.value_or(dap.target.GetAddressByteSize()));
-    lldb::addr_t load_addr;
+    lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;
     if (llvm::StringRef(args.name).getAsInteger<lldb::addr_t>(0, load_addr))
-      return llvm::make_error<DAPError>(args.name + " is not a valid address");
+      return llvm::make_error<DAPError>(args.name + " is not a valid address",
+                                        llvm::inconvertibleErrorCode(), false);
     addr = llvm::utohexstr(load_addr);
     if (!IsRW(dap, load_addr))
       return llvm::make_error<DAPError>("memory region for address " + addr +
-                                        " has no read or write permissions");
+                                            " has no read or write permissions",
+                                        llvm::inconvertibleErrorCode(), false);
   } else {
     is_data_ok = false;
     response.description = "variable not found: " + args.name;

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -432,6 +432,9 @@ class DataBreakpointInfoRequestHandler
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral GetCommand() { return "dataBreakpointInfo"; }
+  FeatureSet GetSupportedFeatures() const override {
+    return {protocol::eAdapterFeatureDataBreakpointBytes};
+  }
   llvm::Expected<protocol::DataBreakpointInfoResponseBody>
   Run(const protocol::DataBreakpointInfoArguments &args) const override;
 };

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -679,8 +679,8 @@ llvm::json::Value CreateThreadStopped(DAP &dap, lldb::SBThread &thread,
   case lldb::eStopReasonWatchpoint: {
     body.try_emplace("reason", "data breakpoint");
     lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(0);
-    std::vector<lldb::break_id_t> bp_ids = {bp_id};
-    body.try_emplace("hitBreakpointIds", llvm::json::Array(bp_ids));
+    body.try_emplace("hitBreakpointIds",
+                     llvm::json::Array{llvm::json::Value(bp_id)});
     EmplaceSafeString(body, "description",
                       llvm::formatv("data breakpoint {0}", bp_id).str());
   } break;

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -676,9 +676,16 @@ llvm::json::Value CreateThreadStopped(DAP &dap, lldb::SBThread &thread,
       EmplaceSafeString(body, "description", desc_str);
     }
   } break;
-  case lldb::eStopReasonWatchpoint:
-  case lldb::eStopReasonInstrumentation:
+  case lldb::eStopReasonWatchpoint: {
     body.try_emplace("reason", "data breakpoint");
+    lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(0);
+    std::vector<lldb::break_id_t> bp_ids = {bp_id};
+    body.try_emplace("hitBreakpointIds", llvm::json::Array(bp_ids));
+    EmplaceSafeString(body, "description",
+                      llvm::formatv("data breakpoint {0}", bp_id).str());
+  } break;
+  case lldb::eStopReasonInstrumentation:
+    body.try_emplace("reason", "breakpoint");
     break;
   case lldb::eStopReasonProcessorTrace:
     body.try_emplace("reason", "processor trace");

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -678,7 +678,7 @@ llvm::json::Value CreateThreadStopped(DAP &dap, lldb::SBThread &thread,
   } break;
   case lldb::eStopReasonWatchpoint:
   case lldb::eStopReasonInstrumentation:
-    body.try_emplace("reason", "breakpoint");
+    body.try_emplace("reason", "data breakpoint");
     break;
   case lldb::eStopReasonProcessorTrace:
     body.try_emplace("reason", "processor trace");

--- a/lldb/tools/lldb-dap/Watchpoint.cpp
+++ b/lldb/tools/lldb-dap/Watchpoint.cpp
@@ -45,6 +45,7 @@ protocol::Breakpoint Watchpoint::ToProtocolBreakpoint() {
       breakpoint.message = m_error.GetCString();
   } else {
     breakpoint.verified = true;
+    breakpoint.id = m_wp.GetID();
   }
 
   return breakpoint;


### PR DESCRIPTION
This patch adds support for `dataBreakpointInfoBytes` capability from DAP. You can test this feature in VSCode (`Add data breakpoint at address` button in breakpoints tab).
