### PR TITLE
[lldb] Disable TestLocationsAfterRebuild for remote targets

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
@@ -7,7 +7,7 @@ we still handle the remaining locations correctly.
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import skipIfWindows, skipIfRemote
 import os
 
 
@@ -19,6 +19,7 @@ class TestLocationsAfterRebuild(TestBase):
 
     # On Windows we cannot remove a file that lldb is debugging.
     @skipIfWindows
+    @skipIfRemote
     def test_remaining_location_spec(self):
         """If we rebuild a couple of times some of the old locations
         get removed.  Make sure the command-line breakpoint id


### PR DESCRIPTION
#160199 broke buildbots `lldb-remote-linux-ubuntu` and `lldb-remote-linux-win`. 
This patch must make these buildbots green for now.