### PR TITLE
[MLIR][BufferResultsToOutParamsPass] Add Option to Modify Public Function's Signature

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h
@@ -171,6 +171,9 @@ struct BufferResultsToOutParamsOpts {
   /// If true, the pass eliminates the memref.alloc and memcpy if the returned
   /// memref is allocated in the current function and has dynamic shape.
   bool hoistDynamicAllocs = false;
+
+  /// If true, the pass modifies the function signatures of public functions.
+  bool modifyPublicFunctions = false;
 };
 
 /// Replace buffers that are returned from a function with an out parameter.

--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
@@ -258,6 +258,9 @@ def BufferResultsToOutParamsPass
               /*default=*/"false", "Hoist static allocations to call sites.">,
        Option<"hoistDynamicAllocs", "hoist-dynamic-allocs", "bool",
               /*default=*/"false", "Hoist dynamic allocations to call sites.">,
+       Option<"modifyPublicFunctions", "modify-public-functions", "bool",
+              /*default=*/"false", "Modify function signatures of public "
+              "functions.">,
   ];
   let dependentDialects = ["memref::MemRefDialect"];
 }

--- a/mlir/test/Transforms/buffer-results-to-out-params-modify-public-functions.mlir
+++ b/mlir/test/Transforms/buffer-results-to-out-params-modify-public-functions.mlir
@@ -1,0 +1,36 @@
+// RUN: mlir-opt -buffer-results-to-out-params  %s | FileCheck %s
+
+// Test if `public` functions' return values are transformed into out parameters
+// when `buffer-results-to-out-params` is invoked with `modifyPublicFunctions`.
+
+
+// CHECK-LABEL:   func.func @basic() -> memref<f32> {
+// CHECK:           %[[VAL_0:.*]] = "test.source"() : () -> memref<f32>
+// CHECK:           return %[[VAL_0]] : memref<f32>
+// CHECK:         }
+func.func @basic() -> (memref<f32>) {
+  %0 = "test.source"() : () -> (memref<f32>)
+  return %0 : memref<f32>
+}
+
+// CHECK-LABEL:   func.func @presence_of_existing_arguments(
+// CHECK-SAME:      %[[ARG0:.*]]: memref<1xf32>) -> memref<2xf32> {
+// CHECK:           %[[VAL_0:.*]] = "test.source"() : () -> memref<2xf32>
+// CHECK:           return %[[VAL_0]] : memref<2xf32>
+// CHECK:         }
+func.func @presence_of_existing_arguments(%arg0: memref<1xf32>) -> (memref<2xf32>) {
+  %0 = "test.source"() : () -> (memref<2xf32>)
+  return %0 : memref<2xf32>
+}
+
+// CHECK-LABEL:   func.func @multiple_results() -> (memref<1xf32>, memref<2xf32>) {
+// CHECK:           %[[VAL_0:.*]]:2 = "test.source"() : () -> (memref<1xf32>, memref<2xf32>)
+// CHECK:           return %[[VAL_0]]#0, %[[VAL_0]]#1 : memref<1xf32>, memref<2xf32>
+// CHECK:         }
+func.func @multiple_results() -> (memref<1xf32>, memref<2xf32>) {
+  %0, %1 = "test.source"() : () -> (memref<1xf32>, memref<2xf32>)
+  return %0, %1 : memref<1xf32>, memref<2xf32>
+}
+
+
+

--- a/mlir/test/Transforms/buffer-results-to-out-params-modify-public-functions.mlir
+++ b/mlir/test/Transforms/buffer-results-to-out-params-modify-public-functions.mlir
@@ -1,12 +1,13 @@
-// RUN: mlir-opt -buffer-results-to-out-params  %s | FileCheck %s
+// RUN: mlir-opt -p 'builtin.module(buffer-results-to-out-params{modify-public-functions})' %s | FileCheck %s
 
 // Test if `public` functions' return values are transformed into out parameters
 // when `buffer-results-to-out-params` is invoked with `modifyPublicFunctions`.
 
-
-// CHECK-LABEL:   func.func @basic() -> memref<f32> {
+// CHECK-LABEL:   func.func @basic(
+// CHECK-SAME:                     %[[ARG0:.*]]: memref<f32>) {
 // CHECK:           %[[VAL_0:.*]] = "test.source"() : () -> memref<f32>
-// CHECK:           return %[[VAL_0]] : memref<f32>
+// CHECK:           memref.copy %[[VAL_0]], %[[ARG0]] : memref<f32> to memref<f32>
+// CHECK:           return
 // CHECK:         }
 func.func @basic() -> (memref<f32>) {
   %0 = "test.source"() : () -> (memref<f32>)
@@ -14,23 +15,26 @@ func.func @basic() -> (memref<f32>) {
 }
 
 // CHECK-LABEL:   func.func @presence_of_existing_arguments(
-// CHECK-SAME:      %[[ARG0:.*]]: memref<1xf32>) -> memref<2xf32> {
+// CHECK-SAME:      %[[ARG0:.*]]: memref<1xf32>,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<2xf32>) {
 // CHECK:           %[[VAL_0:.*]] = "test.source"() : () -> memref<2xf32>
-// CHECK:           return %[[VAL_0]] : memref<2xf32>
+// CHECK:           memref.copy %[[VAL_0]], %[[ARG1]] : memref<2xf32> to memref<2xf32>
+// CHECK:           return
 // CHECK:         }
 func.func @presence_of_existing_arguments(%arg0: memref<1xf32>) -> (memref<2xf32>) {
   %0 = "test.source"() : () -> (memref<2xf32>)
   return %0 : memref<2xf32>
 }
 
-// CHECK-LABEL:   func.func @multiple_results() -> (memref<1xf32>, memref<2xf32>) {
+// CHECK-LABEL:   func.func @multiple_results(
+// CHECK-SAME:      %[[ARG0:.*]]: memref<1xf32>,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<2xf32>) {
 // CHECK:           %[[VAL_0:.*]]:2 = "test.source"() : () -> (memref<1xf32>, memref<2xf32>)
-// CHECK:           return %[[VAL_0]]#0, %[[VAL_0]]#1 : memref<1xf32>, memref<2xf32>
+// CHECK:           memref.copy %[[VAL_0]]#0, %[[ARG0]] : memref<1xf32> to memref<1xf32>
+// CHECK:           memref.copy %[[VAL_0]]#1, %[[ARG1]] : memref<2xf32> to memref<2xf32>
+// CHECK:           return
 // CHECK:         }
 func.func @multiple_results() -> (memref<1xf32>, memref<2xf32>) {
   %0, %1 = "test.source"() : () -> (memref<1xf32>, memref<2xf32>)
   return %0, %1 : memref<1xf32>, memref<2xf32>
 }
-
-
-


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/162441, `buffer-results-to-out-params` transforms `private` functions only.

But, as mentioned in https://github.com/llvm/llvm-project/pull/162441#issuecomment-3404195242, this is a breaking change for pipelines handling C code. Our pipeline @EfficientComputer is also affected by this breaking change.

Therefore, this PR adds an opt-in flag to allow `public` functions to be transformed by `BufferResultsToOutParamsPass`.