### PR TITLE
[CodeGen][KCFI] Allow setting type hash from xxHash64 to FNV-1a

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -21,6 +21,7 @@
 #include "llvm/Frontend/Debug/Options.h"
 #include "llvm/Frontend/Driver/CodeGenOptions.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Hash.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizerOptions.h"
@@ -513,6 +514,9 @@ public:
   /// (files, functions) listed for instrumentation by sanitizer
   /// binary metadata pass should not be instrumented.
   std::vector<std::string> SanitizeMetadataIgnorelistFiles;
+
+  /// Hash algorithm to use for KCFI type IDs.
+  llvm::KCFIHashAlgorithm SanitizeKcfiHash;
 
   /// Name of the stack usage file (i.e., .su file) if user passes
   /// -fstack-usage. If empty, it can be implied that -fstack-usage is not

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2719,6 +2719,16 @@ def fsanitize_kcfi_arity : Flag<["-"], "fsanitize-kcfi-arity">,
                            Group<f_clang_Group>,
                            HelpText<"Embed function arity information into the KCFI patchable function prefix">,
                            MarshallingInfoFlag<CodeGenOpts<"SanitizeKcfiArity">>;
+def fsanitize_kcfi_hash_EQ
+    : Joined<["-"], "fsanitize-kcfi-hash=">,
+      HelpText<"Select hash algorithm for KCFI type IDs (xxHash64, FNV-1a)">,
+      Visibility<[ClangOption, CC1Option]>,
+      Values<"xxHash64,FNV-1a">,
+      NormalizedValuesScope<"llvm">,
+      NormalizedValues<["KCFIHashAlgorithm::xxHash64",
+                        "KCFIHashAlgorithm::FNV1a"]>,
+      MarshallingInfoEnum<CodeGenOpts<"SanitizeKcfiHash">,
+                          "KCFIHashAlgorithm::xxHash64">;
 defm sanitize_stats : BoolOption<"f", "sanitize-stats",
   CodeGenOpts<"SanitizeStats">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption], "Enable">,

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -67,10 +67,10 @@
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TimeProfiler.h"
-#include "llvm/Support/xxhash.h"
 #include "llvm/TargetParser/RISCVISAInfo.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/TargetParser/X86TargetParser.h"
+#include "llvm/Transforms/Instrumentation/KCFI.h"
 #include "llvm/Transforms/Utils/BuildLibCalls.h"
 #include <optional>
 #include <set>
@@ -2450,8 +2450,7 @@ llvm::ConstantInt *CodeGenModule::CreateKCFITypeId(QualType T, StringRef Salt) {
   if (getCodeGenOpts().SanitizeCfiICallGeneralizePointers)
     Out << ".generalized";
 
-  return llvm::ConstantInt::get(Int32Ty,
-                                static_cast<uint32_t>(llvm::xxHash64(OutName)));
+  return llvm::ConstantInt::get(Int32Ty, llvm::getKCFITypeID(OutName));
 }
 
 void CodeGenModule::SetLLVMFunctionAttributes(GlobalDecl GD,

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3205,7 +3205,8 @@ void CodeGenModule::finalizeKCFITypes() {
       continue;
 
     std::string Asm = (".weak __kcfi_typeid_" + Name + "\n.set __kcfi_typeid_" +
-                       Name + ", " + Twine(Type->getZExtValue()) + "\n")
+                       Name + ", " + Twine(Type->getZExtValue()) + " # " +
+                       Twine(Type->getSExtValue()) + "\n")
                           .str();
     M.appendModuleInlineAsm(Asm);
   }

--- a/clang/test/CodeGen/cfi-salt.c
+++ b/clang/test/CodeGen/cfi-salt.c
@@ -27,9 +27,9 @@ typedef unsigned int (* __cfi_salt ufn_salt_t)(void);
 
 /// Must emit __kcfi_typeid symbols for address-taken function declarations
 // CHECK: module asm ".weak __kcfi_typeid_[[F4:[a-zA-Z0-9_]+]]"
-// CHECK: module asm ".set __kcfi_typeid_[[F4]], [[#%d,LOW_SODIUM_HASH:]]"
+// CHECK: module asm ".set __kcfi_typeid_[[F4]], {{[0-9]+}} # [[#%d,LOW_SODIUM_HASH:]]"
 // CHECK: module asm ".weak __kcfi_typeid_[[F4_SALT:[a-zA-Z0-9_]+]]"
-// CHECK: module asm ".set __kcfi_typeid_[[F4_SALT]], [[#%d,ASM_SALTY_HASH:]]"
+// CHECK: module asm ".set __kcfi_typeid_[[F4_SALT]], {{[0-9]+}} # [[#%d,ASM_SALTY_HASH:]]"
 
 /// Must not __kcfi_typeid symbols for non-address-taken declarations
 // CHECK-NOT: module asm ".weak __kcfi_typeid_f6"

--- a/clang/test/CodeGen/kcfi-hash.c
+++ b/clang/test/CodeGen/kcfi-hash.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fsanitize=kcfi -o - %s | FileCheck --check-prefix=DEFAULT %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fsanitize=kcfi -fsanitize-kcfi-hash=xxHash64 -o - %s | FileCheck --check-prefix=XXHASH %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fsanitize=kcfi -fsanitize-kcfi-hash=FNV-1a -o - %s | FileCheck --check-prefix=FNV %s
+
+void foo(void) {}
+
+// DEFAULT: ![[#]] = !{i32 4, !"kcfi-hash", !"xxHash64"}
+// XXHASH: ![[#]] = !{i32 4, !"kcfi-hash", !"xxHash64"}
+// FNV: ![[#]] = !{i32 4, !"kcfi-hash", !"FNV-1a"}

--- a/clang/test/CodeGen/kcfi.c
+++ b/clang/test/CodeGen/kcfi.c
@@ -7,7 +7,7 @@
 
 /// Must emit __kcfi_typeid symbols for address-taken function declarations
 // CHECK: module asm ".weak __kcfi_typeid_[[F4:[a-zA-Z0-9_]+]]"
-// CHECK: module asm ".set __kcfi_typeid_[[F4]], [[#%d,HASH:]]"
+// CHECK: module asm ".set __kcfi_typeid_[[F4]], {{[0-9]+}} # [[#%d,HASH:]]"
 /// Must not __kcfi_typeid symbols for non-address-taken declarations
 // CHECK-NOT: module asm ".weak __kcfi_typeid_{{f6|_Z2f6v}}"
 

--- a/llvm/include/llvm/Support/Hash.h
+++ b/llvm/include/llvm/Support/Hash.h
@@ -1,0 +1,26 @@
+//===- llvm/Support/Hash.h - Hash functions --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides hash functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_HASH_H
+#define LLVM_SUPPORT_HASH_H
+
+#include "llvm/ADT/StringRef.h"
+#include <cstdint>
+
+namespace llvm {
+
+/// Compute KCFI type ID from mangled type name using FNV-1a hash.
+uint32_t getKCFITypeID(StringRef MangledTypeName);
+
+} // end namespace llvm
+
+#endif // LLVM_SUPPORT_HASH_H

--- a/llvm/include/llvm/Support/Hash.h
+++ b/llvm/include/llvm/Support/Hash.h
@@ -18,8 +18,18 @@
 
 namespace llvm {
 
-/// Compute KCFI type ID from mangled type name using FNV-1a hash.
-uint32_t getKCFITypeID(StringRef MangledTypeName);
+enum class KCFIHashAlgorithm { xxHash64, FNV1a };
+
+/// Parse a KCFI hash algorithm name.
+/// Returns xxHash64 if the name is not recognized.
+KCFIHashAlgorithm parseKCFIHashAlgorithm(StringRef Name);
+
+/// Convert a KCFI hash algorithm enum to its string representation.
+StringRef stringifyKCFIHashAlgorithm(KCFIHashAlgorithm Algorithm);
+
+/// Compute KCFI type ID from mangled type name.
+/// The algorithm can be xxHash64 or FNV-1a.
+uint32_t getKCFITypeID(StringRef MangledTypeName, KCFIHashAlgorithm Algorithm);
 
 } // end namespace llvm
 

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -202,6 +202,7 @@ add_llvm_component_library(LLVMSupport
   FormatVariadic.cpp
   GlobPattern.cpp
   GraphWriter.cpp
+  Hash.cpp
   HexagonAttributeParser.cpp
   HexagonAttributes.cpp
   InitLLVM.cpp

--- a/llvm/lib/Support/Hash.cpp
+++ b/llvm/lib/Support/Hash.cpp
@@ -1,0 +1,20 @@
+//===- Hash.cpp - Hash functions ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements hash functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Hash.h"
+#include "llvm/Support/xxhash.h"
+
+using namespace llvm;
+
+uint32_t llvm::getKCFITypeID(StringRef MangledTypeName) {
+  return static_cast<uint32_t>(xxHash64(MangledTypeName));
+}

--- a/llvm/lib/Support/Hash.cpp
+++ b/llvm/lib/Support/Hash.cpp
@@ -15,6 +15,37 @@
 
 using namespace llvm;
 
-uint32_t llvm::getKCFITypeID(StringRef MangledTypeName) {
-  return static_cast<uint32_t>(xxHash64(MangledTypeName));
+KCFIHashAlgorithm llvm::parseKCFIHashAlgorithm(StringRef Name) {
+  if (Name == "FNV-1a")
+    return KCFIHashAlgorithm::FNV1a;
+  // Default to xxHash64 for backward compatibility
+  return KCFIHashAlgorithm::xxHash64;
+}
+
+StringRef llvm::stringifyKCFIHashAlgorithm(KCFIHashAlgorithm Algorithm) {
+  switch (Algorithm) {
+  case KCFIHashAlgorithm::xxHash64:
+    return "xxHash64";
+  case KCFIHashAlgorithm::FNV1a:
+    return "FNV-1a";
+  }
+  llvm_unreachable("Unknown KCFI hash algorithm");
+}
+
+uint32_t llvm::getKCFITypeID(StringRef MangledTypeName,
+                             KCFIHashAlgorithm Algorithm) {
+  switch (Algorithm) {
+  case KCFIHashAlgorithm::xxHash64:
+    // Use lower 32 bits of xxHash64
+    return static_cast<uint32_t>(xxHash64(MangledTypeName));
+  case KCFIHashAlgorithm::FNV1a:
+    // FNV-1a hash (32-bit)
+    uint32_t Hash = 2166136261u; // FNV offset basis
+    for (unsigned char C : MangledTypeName) {
+      Hash ^= C;
+      Hash *= 16777619u; // FNV prime
+    }
+    return Hash;
+  }
+  llvm_unreachable("Unknown KCFI hash algorithm");
 }

--- a/llvm/lib/Transforms/Instrumentation/KCFI.cpp
+++ b/llvm/lib/Transforms/Instrumentation/KCFI.cpp
@@ -23,6 +23,7 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/xxhash.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/ModuleUtils.h"
-#include "llvm/Analysis/VectorUtils.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Analysis/VectorUtils.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
@@ -21,7 +21,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/xxhash.h"
+#include "llvm/Transforms/Instrumentation/KCFI.h"
 
 using namespace llvm;
 
@@ -208,10 +208,10 @@ void llvm::setKCFIType(Module &M, Function &F, StringRef MangledType) {
   std::string Type = MangledType.str();
   if (M.getModuleFlag("cfi-normalize-integers"))
     Type += ".normalized";
-  F.setMetadata(LLVMContext::MD_kcfi_type,
-                MDNode::get(Ctx, MDB.createConstant(ConstantInt::get(
-                                     Type::getInt32Ty(Ctx),
-                                     static_cast<uint32_t>(xxHash64(Type))))));
+  F.setMetadata(
+      LLVMContext::MD_kcfi_type,
+      MDNode::get(Ctx, MDB.createConstant(ConstantInt::get(
+                           Type::getInt32Ty(Ctx), getKCFITypeID(Type)))));
   // If the module was compiled with -fpatchable-function-entry, ensure
   // we use the same patchable-function-prefix.
   if (auto *MD = mdconst::extract_or_null<ConstantInt>(


### PR DESCRIPTION
Allow for switching the KCFI type id hash from xxHash64 to FNV-1a (to match the coming GCC KCFI implementation). Introduces the Clang `-fsanitize-kcfi-hash=` option and "kcfi-hash" IR module option.