### PR TITLE
[mlir]: Add handling of escaped memrefs to erase_dead_alloc_and_stores

### DIFF
--- a/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
+++ b/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
@@ -141,7 +141,7 @@ static bool resultIsNotRead(Operation *op, std::vector<Operation *> &uses) {
   for (OpOperand &use : op->getUses()) {
     Operation *useOp = use.getOwner();
     // Use escaped the scope
-    if (useOp->hasTrait<mlir::OpTrait::ReturnLike>())
+    if (useOp->mightHaveTrait<OpTrait::IsTerminator>())
       return false;
     if (isa<memref::DeallocOp>(useOp) ||
         (useOp->getNumResults() == 0 && useOp->getNumRegions() == 0 &&

--- a/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
+++ b/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
@@ -140,6 +140,9 @@ static bool resultIsNotRead(Operation *op, std::vector<Operation *> &uses) {
   std::vector<Operation *> opUses;
   for (OpOperand &use : op->getUses()) {
     Operation *useOp = use.getOwner();
+    // Use escaped the scope
+    if (useOp->hasTrait<mlir::OpTrait::ReturnLike>())
+      return false;
     if (isa<memref::DeallocOp>(useOp) ||
         (useOp->getNumResults() == 0 && useOp->getNumRegions() == 0 &&
          !mlir::hasEffect<MemoryEffects::Read>(useOp)) ||


### PR DESCRIPTION
Patch updates transform.memref.erase_dead_alloc_and_stores to not delete escaped allocations.
