### PR TITLE
Support: Add Unsigned Counted LEB128

### DIFF
--- a/llvm/lib/Support/LEB128.cpp
+++ b/llvm/lib/Support/LEB128.cpp
@@ -12,6 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/LEB128.h"
+#include "llvm/ADT/bit.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/EndianStream.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace llvm::support;
 
 namespace llvm {
 
@@ -39,5 +46,89 @@ unsigned getSLEB128Size(int64_t Value) {
   } while (IsMore);
   return Size;
 }
-
 }  // namespace llvm
+
+void llvm::encodeUCLeb128(uint64_t x, raw_ostream &os) {
+  // Fast path for n == 1
+  if (x < 128) {
+    os.write((x << 1) | 1);
+    return;
+  }
+
+  unsigned significantBits = 64 - countl_zero(x);
+  unsigned n = (significantBits + 6) / 7;
+  if (n > 8) {
+    // 9 bytes: 00000000 xxxxxxxx ...
+    os.write(0);
+    endian::write(os, x, endianness::little);
+    return;
+  }
+
+  uint64_t tagged = endian::byte_swap((x << n) | ((uint64_t)1 << (n - 1)),
+                                      endianness::little);
+  os.write((const char *)&tagged, n);
+}
+
+template <int n>
+static inline uint64_t getUCLeb128Case(const uint8_t *&p, uint8_t byte) {
+  uint64_t val = byte >> n;
+  int shift = 8 - n;
+  for (int i = 1; i < n; ++i) {
+    val |= (uint64_t)p[i] << shift;
+    shift += 8;
+  }
+  p += n;
+  return val;
+}
+
+template <bool CheckBounds>
+static uint64_t getUCLeb128Impl(const uint8_t *&p, const uint8_t *end) {
+  if constexpr (CheckBounds) {
+    if (p >= end)
+      return 0;
+  }
+  // Fast path for n == 1
+  uint8_t b0 = p[0];
+  if (b0 & 1) {
+    ++p;
+    return b0 >> 1;
+  }
+
+  unsigned n = llvm::countr_zero(b0) + 1;
+  if constexpr (CheckBounds) {
+    if (end - p < n)
+      return 0;
+  }
+  // Note: If n < 9 and we allow out-of-bounds read, we can use read64le(p) <<
+  // (64-8*n) >> (64-7*n) instead of the following switch statement.
+  switch (n) {
+  case 1:
+    return getUCLeb128Case<1>(p, b0);
+  case 2:
+    return getUCLeb128Case<2>(p, b0);
+  case 3:
+    return getUCLeb128Case<3>(p, b0);
+  case 4:
+    return getUCLeb128Case<4>(p, b0);
+  case 5:
+    return getUCLeb128Case<5>(p, b0);
+  case 6:
+    return getUCLeb128Case<6>(p, b0);
+  case 7:
+    return getUCLeb128Case<7>(p, b0);
+  case 8:
+    return getUCLeb128Case<8>(p, b0);
+  default:
+    // 9 bytes: 00000000 xxxxxxxx ...
+    p += 9;
+    return endian::read64le(p - 8);
+  }
+}
+
+uint64_t llvm::getUCLeb128(const uint8_t *&p, const uint8_t *end) {
+  return getUCLeb128Impl<true>(p, end);
+}
+
+uint64_t llvm::getUCLeb128Unsafe(const uint8_t *&p) {
+  return getUCLeb128Impl<false>(p, nullptr);
+}


### PR DESCRIPTION
https://mlir.llvm.org/docs/BytecodeFormat/#signed-variable-width-integers
(mlir/lib/Bytecode/Reader/BytecodeReader.cpp)
describes a variant of LEB128 where the length information is determined
by counting trailing zero bits in the first byte. Specifically, if the
first byte has n-1 trailing zeros, then the encoded integer occupies n
bytes total. The special case of a zero first byte signals a 9-byte
encoding.

The remaining bits in the first byte, plus all subsequent bytes, contain the
actual value in little-endian order.

Implements Counted LEB128 encoding/decoding to llvm/lib/Support.
This will be used by object file format features like
[ELF Compact Section Header
Table](https://discourse.llvm.org/t/compact-section-header-table-for-elf/88821)

The name CLEB128 is suggested by
https://groups.google.com/g/generic-abi/c/9DPPniRXFa8/m/MJ3jetzZAAAJ
