### PR TITLE
[BoundsSafety] build TypeLoc for CountAttributedType

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1304,6 +1304,7 @@ public:
   }
 };
 
+class Sema;
 struct BoundsAttributedLocInfo {
   SourceRange Range;
 };
@@ -1320,6 +1321,9 @@ public:
     getLocalData()->Range = Range;
   }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
+
+  StringRef getAttrNameAsWritten(Sema &S) const;
+  SourceRange getAttrNameRange(Sema &S) const;
 
   unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -19,7 +19,6 @@
 #include "clang/AST/NestedNameSpecifierBase.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeBase.h"
-#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
@@ -43,7 +42,6 @@ class ObjCInterfaceDecl;
 class ObjCProtocolDecl;
 class ObjCTypeParamDecl;
 class ParmVarDecl;
-class Sema;
 class TemplateTypeParmDecl;
 class UnqualTypeLoc;
 class UnresolvedUsingTypenameDecl;
@@ -1320,8 +1318,8 @@ public:
   void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
 
-  StringRef getAttrNameAsWritten(Sema &S) const;
-  SourceRange getAttrNameRange(Sema &S) const;
+  StringRef getAttrNameAsWritten(const ASTContext &Ctx) const;
+  SourceRange getAttrNameRange(const ASTContext &Ctx) const;
 
   unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1317,9 +1317,7 @@ public:
   void initializeLocal(ASTContext &Context, SourceLocation Loc) {
     setAttrRange({Loc, Loc});
   }
-  void setAttrRange(SourceRange Range) {
-    getLocalData()->Range = Range;
-  }
+  void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
 
   StringRef getAttrNameAsWritten(Sema &S) const;

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -43,6 +43,7 @@ class ObjCInterfaceDecl;
 class ObjCProtocolDecl;
 class ObjCTypeParamDecl;
 class ParmVarDecl;
+class Sema;
 class TemplateTypeParmDecl;
 class UnqualTypeLoc;
 class UnresolvedUsingTypenameDecl;
@@ -1304,7 +1305,6 @@ public:
   }
 };
 
-class Sema;
 struct BoundsAttributedLocInfo {
   SourceRange Range;
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1346,9 +1346,7 @@ public:
   void initializeLocal(ASTContext &Context, SourceLocation Loc) {
     setAttrRange({Loc, Loc});
   }
-  void setAttrRange(SourceRange Range) {
-    getLocalData()->Range = Range;
-  }
+  void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
 
   StringRef getAttrNameAsWritten(Sema &S) const;

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -43,6 +43,7 @@ class ObjCInterfaceDecl;
 class ObjCProtocolDecl;
 class ObjCTypeParamDecl;
 class ParmVarDecl;
+class Sema;
 class TemplateTypeParmDecl;
 class UnqualTypeLoc;
 class UnresolvedUsingTypenameDecl;
@@ -1333,7 +1334,6 @@ public:
   }
 };
 
-class Sema;
 struct BoundsAttributedLocInfo {
   SourceRange Range;
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1333,6 +1333,7 @@ public:
   }
 };
 
+class Sema;
 struct BoundsAttributedLocInfo {
   SourceRange Range;
 };
@@ -1349,6 +1350,9 @@ public:
     getLocalData()->Range = Range;
   }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
+
+  StringRef getAttrNameAsWritten(Sema &S) const;
+  SourceRange getAttrNameRange(Sema &S) const;
 
   unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -19,7 +19,6 @@
 #include "clang/AST/NestedNameSpecifierBase.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeBase.h"
-#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
@@ -43,7 +42,6 @@ class ObjCInterfaceDecl;
 class ObjCProtocolDecl;
 class ObjCTypeParamDecl;
 class ParmVarDecl;
-class Sema;
 class TemplateTypeParmDecl;
 class UnqualTypeLoc;
 class UnresolvedUsingTypenameDecl;
@@ -1349,8 +1347,8 @@ public:
   void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
 
-  StringRef getAttrNameAsWritten(Sema &S) const;
-  SourceRange getAttrNameRange(Sema &S) const;
+  StringRef getAttrNameAsWritten(const ASTContext &Ctx) const;
+  SourceRange getAttrNameRange(const ASTContext &Ctx) const;
 
   unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -19,6 +19,7 @@
 #include "clang/AST/NestedNameSpecifierBase.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeBase.h"
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
@@ -1332,7 +1333,9 @@ public:
   }
 };
 
-struct BoundsAttributedLocInfo {};
+struct BoundsAttributedLocInfo {
+  SourceRange Range;
+};
 class BoundsAttributedTypeLoc
     : public ConcreteTypeLoc<UnqualTypeLoc, BoundsAttributedTypeLoc,
                              BoundsAttributedType, BoundsAttributedLocInfo> {
@@ -1340,10 +1343,14 @@ public:
   TypeLoc getInnerLoc() const { return getInnerTypeLoc(); }
   QualType getInnerType() const { return getTypePtr()->desugar(); }
   void initializeLocal(ASTContext &Context, SourceLocation Loc) {
-    // nothing to do
+    setAttrRange({Loc, Loc});
   }
-  // LocalData is empty and TypeLocBuilder doesn't handle DataSize 1.
-  unsigned getLocalDataSize() const { return 0; }
+  void setAttrRange(SourceRange Range) {
+    getLocalData()->Range = Range;
+  }
+  SourceRange getAttrRange() const { return getLocalData()->Range; }
+
+  unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };
 
 class CountAttributedTypeLoc final
@@ -1354,8 +1361,6 @@ public:
   Expr *getCountExpr() const { return getTypePtr()->getCountExpr(); }
   bool isCountInBytes() const { return getTypePtr()->isCountInBytes(); }
   bool isOrNull() const { return getTypePtr()->isOrNull(); }
-
-  SourceRange getLocalSourceRange() const;
 };
 
 struct MacroQualifiedLocInfo {

--- a/clang/lib/AST/TypeLoc.cpp
+++ b/clang/lib/AST/TypeLoc.cpp
@@ -590,10 +590,6 @@ SourceRange AttributedTypeLoc::getLocalSourceRange() const {
   return getAttr() ? getAttr()->getRange() : SourceRange();
 }
 
-SourceRange CountAttributedTypeLoc::getLocalSourceRange() const {
-  return getCountExpr() ? getCountExpr()->getSourceRange() : SourceRange();
-}
-
 SourceRange BTFTagAttributedTypeLoc::getLocalSourceRange() const {
   return getAttr() ? getAttr()->getRange() : SourceRange();
 }

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -11,6 +11,7 @@
 /// (e.g. `counted_by`)
 ///
 //===----------------------------------------------------------------------===//
+
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/StmtVisitor.h"
@@ -22,7 +23,6 @@
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/Sema.h"
-
 #include "llvm/ADT/StringSwitch.h"
 
 namespace clang {

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -340,8 +340,10 @@ static void EmitIncompleteCountedByPointeeNotes(Sema &S,
       llvm::StringSwitch<StringRef>(Spelling)
           .Case("__counted_by", "__sized_by")
           .Case("counted_by", "sized_by")
+          .Case("__counted_by__", "__sized_by__")
           .Case("__counted_by_or_null", "__sized_by_or_null")
           .Case("counted_by_or_null", "sized_by_or_null")
+          .Case("__counted_by_or_null__", "__sized_by_or_null__")
           .Default("");
   FixItHint Fix;
   if (!FixedSpelling.empty())

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -263,16 +263,14 @@ SourceRange BoundsAttributedTypeLoc::getAttrNameRange(Sema &S) const {
 }
 
 static TypeSourceInfo *getTSI(const Decl *D) {
-  if (const auto* DD = dyn_cast<DeclaratorDecl>(D)) {
+  if (const auto *DD = dyn_cast<DeclaratorDecl>(D)) {
     return DD->getTypeSourceInfo();
   }
   return nullptr;
 }
 
 struct TypeLocFinder : public ConstStmtVisitor<TypeLocFinder, TypeLoc> {
-  TypeLoc VisitParenExpr(const ParenExpr* E) {
-    return Visit(E->getSubExpr());
-  }
+  TypeLoc VisitParenExpr(const ParenExpr *E) { return Visit(E->getSubExpr()); }
 
   TypeLoc VisitDeclRefExpr(const DeclRefExpr *E) {
     return getTSI(E->getDecl())->getTypeLoc();

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -244,24 +244,30 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
 
 // FIXME: for some reason diagnostics highlight the end character, while
 // getSourceText() does not include the end character.
-static SourceRange getAttrNameRangeImpl(const ASTContext &Ctx, SourceLocation Begin,
+static SourceRange getAttrNameRangeImpl(const ASTContext &Ctx,
+                                        SourceLocation Begin,
                                         bool IsForDiagnostics) {
   const SourceManager &SM = Ctx.getSourceManager();
   SourceLocation TokenStart = Begin;
   while (TokenStart.isMacroID())
     TokenStart = SM.getImmediateExpansionRange(TokenStart).getBegin();
   unsigned Offset = IsForDiagnostics ? 1 : 0;
-  SourceLocation End = Lexer::getLocForEndOfToken(TokenStart, Offset, SM, Ctx.getLangOpts());
+  SourceLocation End =
+      Lexer::getLocForEndOfToken(TokenStart, Offset, SM, Ctx.getLangOpts());
   return {TokenStart, End};
 }
 
-StringRef BoundsAttributedTypeLoc::getAttrNameAsWritten(const ASTContext &Ctx) const {
-  SourceRange Range = getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), false);
+StringRef
+BoundsAttributedTypeLoc::getAttrNameAsWritten(const ASTContext &Ctx) const {
+  SourceRange Range =
+      getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), false);
   CharSourceRange NameRange = CharSourceRange::getCharRange(Range);
-  return Lexer::getSourceText(NameRange, Ctx.getSourceManager(), Ctx.getLangOpts());
+  return Lexer::getSourceText(NameRange, Ctx.getSourceManager(),
+                              Ctx.getLangOpts());
 }
 
-SourceRange BoundsAttributedTypeLoc::getAttrNameRange(const ASTContext &Ctx) const {
+SourceRange
+BoundsAttributedTypeLoc::getAttrNameRange(const ASTContext &Ctx) const {
   return getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), true);
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -10,10 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TypeLocBuilder.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTMutationListener.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -24,6 +26,8 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Mangle.h"
 #include "clang/AST/Type.h"
+#include "clang/AST/TypeBase.h"
+#include "clang/AST/TypeLoc.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Cuda.h"
 #include "clang/Basic/DarwinSDKInfo.h"
@@ -6580,9 +6584,14 @@ static void handleCountedByAttrField(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (S.CheckCountedByAttrOnField(FD, CountExpr, CountInBytes, OrNull))
     return;
 
+  TypeLocBuilder TLB;
   QualType CAT = S.BuildCountAttributedArrayOrPointerType(
       FD->getType(), CountExpr, CountInBytes, OrNull);
+  TLB.pushFullCopy(FD->getTypeSourceInfo()->getTypeLoc());
+  CountAttributedTypeLoc CATL = TLB.push<CountAttributedTypeLoc>(CAT);
+  CATL.setAttrRange(AL.getRange());
   FD->setType(CAT);
+  FD->setTypeSourceInfo(TLB.getTypeSourceInfo(S.getASTContext(), CAT));
 }
 
 static void handleFunctionReturnThunksAttr(Sema &S, Decl *D,

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -10,10 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TypeLocBuilder.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTMutationListener.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/Availability.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
@@ -25,6 +27,8 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Mangle.h"
 #include "clang/AST/Type.h"
+#include "clang/AST/TypeBase.h"
+#include "clang/AST/TypeLoc.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Cuda.h"
 #include "clang/Basic/DarwinSDKInfo.h"
@@ -7092,9 +7096,14 @@ static void handleCountedByAttrField(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (S.CheckCountedByAttrOnField(FD, CountExpr, CountInBytes, OrNull))
     return;
 
+  TypeLocBuilder TLB;
   QualType CAT = S.BuildCountAttributedArrayOrPointerType(
       FD->getType(), CountExpr, CountInBytes, OrNull);
+  TLB.pushFullCopy(FD->getTypeSourceInfo()->getTypeLoc());
+  CountAttributedTypeLoc CATL = TLB.push<CountAttributedTypeLoc>(CAT);
+  CATL.setAttrRange(AL.getRange());
   FD->setType(CAT);
+  FD->setTypeSourceInfo(TLB.getTypeSourceInfo(S.getASTContext(), CAT));
 }
 
 static void handleFunctionReturnThunksAttr(Sema &S, Decl *D,

--- a/clang/test/Sema/bounds-safety-source-ranges.c
+++ b/clang/test/Sema/bounds-safety-source-ranges.c
@@ -1,5 +1,5 @@
-// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fdiagnostics-parseable-fixits %s 2>%t.txt
-// RUN: FileCheck %s --implicit-check-not error --implicit-check-not note --implicit-check-not fix --implicit-check-not warning < %t.txt
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fdiagnostics-parseable-fixits %s 2>&1 | \
+// RUN:   FileCheck %s --implicit-check-not error --implicit-check-not note --implicit-check-not fix --implicit-check-not warning
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 

--- a/clang/test/Sema/bounds-safety-source-ranges.c
+++ b/clang/test/Sema/bounds-safety-source-ranges.c
@@ -1,0 +1,197 @@
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fdiagnostics-parseable-fixits %s 2>%t.txt
+// RUN: FileCheck %s --implicit-check-not error --implicit-check-not note --implicit-check-not fix --implicit-check-not warning < %t.txt
+
+#define __counted_by(f)  __attribute__((counted_by(f)))
+
+struct IncompleteTy;
+typedef struct IncompleteTy Incomplete_t; 
+
+struct Container__cb {
+  int count;
+  struct IncompleteTy* buf __counted_by(count);
+  Incomplete_t* buf_typedef __counted_by(count);
+};
+
+void consume_struct_IncompleteTy(struct IncompleteTy* buf);
+int idx(void);
+
+void test_Container__cb(struct Container__cb* ptr) {
+  struct Container__cb uninit;
+  uninit.count = 0;
+
+  uninit.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:14:{[[@LINE-1]]:16-[[@LINE-1]]:19}: error: cannot assign to 'Container__cb::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+
+  struct IncompleteTy* addr_elt_zero_ptr = &ptr->buf[0];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:45:{[[@LINE-1]]:45-[[@LINE-1]]:53}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+
+  struct IncompleteTy* addr_elt_idx_ptr = &ptr->buf[idx()];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:44:{[[@LINE-1]]:44-[[@LINE-1]]:52}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  consume_struct_IncompleteTy(uninit.buf);
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:31:{[[@LINE-1]]:31-[[@LINE-1]]:41}: error: cannot use 'uninit.buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  consume_struct_IncompleteTy(ptr->buf);
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:31:{[[@LINE-1]]:31-[[@LINE-1]]:39}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+
+  uninit.buf[0] = uninit.buf[1];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:3:{[[@LINE-1]]:3-[[@LINE-1]]:13}: error: cannot use 'uninit.buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-6]]:19:{[[@LINE-6]]:19-[[@LINE-6]]:29}: error: cannot use 'uninit.buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  ptr->buf[0] = ptr->buf[1];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:3:{[[@LINE-1]]:3-[[@LINE-1]]:11}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-6]]:17:{[[@LINE-6]]:17-[[@LINE-6]]:25}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+}
+
+
+struct Container__cb___nomacro {
+  int count;
+  struct IncompleteTy* buf __attribute__((__counted_by__(count)));
+};
+
+void test_Container__cb___nomacro(struct Container__cb___nomacro* ptr) {
+  struct Container__cb___nomacro local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Container__cb___nomacro::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:43:{[[@LINE-9]]:43-[[@LINE-9]]:57}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:43-[[@LINE-10]]:57}:"__sized_by__"
+}
+
+
+struct Containercb_nomacro {
+  int count;
+  struct IncompleteTy* buf __attribute__((counted_by(count)));
+};
+
+void test_Containercb_nomacro(struct Containercb_nomacro* ptr) {
+  struct Containercb_nomacro local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Containercb_nomacro::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:43:{[[@LINE-9]]:43-[[@LINE-9]]:53}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:43-[[@LINE-10]]:53}:"sized_by"
+}
+
+
+#define aaaaaaaa(x) __attribute__((counted_by(x)))
+struct Container_aaaaaaaa {
+  int count;
+  struct IncompleteTy* buf aaaaaaaa(count);
+};
+
+void test_Container_aaaaaaaa(struct Container_aaaaaaaa* ptr) {
+  struct Container_aaaaaaaa local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Container_aaaaaaaa::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:28:{[[@LINE-9]]:28-[[@LINE-9]]:36}: note: consider using '__sized_by' instead of '__counted_by'
+  // no fix-it
+}
+
+
+struct Container_macro1 {
+  int count;
+  struct IncompleteTy* buf __attribute__((counted_by(count)));
+};
+
+#define A() \
+void test_Contain_macro1(struct Container_macro1* ptr) { \
+  struct Container_macro1 local; \
+  local.count = 0; \
+  local.buf = 0x0; \
+}
+
+A()
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:1:{[[@LINE-1]]:1-[[@LINE-1]]:4}: error: cannot assign to 'Container_macro1::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-5]]:13:{[[@LINE-5]]:15-[[@LINE-5]]:18}: note: expanded from macro 'A'
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-14]]:43:{[[@LINE-14]]:43-[[@LINE-14]]:53}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-15]]:43-[[@LINE-15]]:53}:"sized_by"
+
+
+#define B() \
+struct Container_macro2 { \
+  int count; \
+  struct IncompleteTy* buf __attribute__((counted_by(count))); \
+};
+B()
+
+void test_Contain_macro2(struct Container_macro2* ptr) {
+  struct Container_macro2 local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Container_macro2::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-8]]:1:{[[@LINE-8]]:1-[[@LINE-8]]:2}: note: consider using '__sized_by' instead of '__counted_by'
+  // no fix-it
+}
+
+
+#define counted_by(x) __attribute__((counted_by(x)))
+
+struct Containercb {
+  int count;
+  struct IncompleteTy* buf counted_by(count);
+};
+
+void test_Containercb(struct Containercb* ptr) {
+  struct Containercb local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Containercb::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:28:{[[@LINE-9]]:28-[[@LINE-9]]:38}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:28-[[@LINE-10]]:38}:"sized_by"
+}
+
+
+struct Containercbon {
+  int count;
+  struct IncompleteTy* buf __attribute__((counted_by_or_null(count)));
+};
+
+void test_Containercbon(struct Containercbon* ptr) {
+  struct Containercbon local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Containercbon::buf' with '__counted_by_or_null' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:43:{[[@LINE-9]]:43-[[@LINE-9]]:61}: note: consider using '__sized_by_or_null' instead of '__counted_by_or_null'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:43-[[@LINE-10]]:61}:"sized_by_or_null"
+}
+
+// prevent 'error' from being unmatched
+// CHECK: errors generated


### PR DESCRIPTION
This adds attribute SourceRange to CountAttributedTypeLoc and populates it, then uses it to replace a not-quite-correct source location fetched from the count expression.

Fixes https://github.com/llvm/llvm-project/issues/113582
Fixes https://github.com/llvm/llvm-project/issues/113585