### PR TITLE
[llvm][DebugInfo] Adjust ModuleDebugInfoPrinter to versioned language names

### DIFF
--- a/llvm/lib/Analysis/ModuleDebugInfoPrinter.cpp
+++ b/llvm/lib/Analysis/ModuleDebugInfoPrinter.cpp
@@ -43,13 +43,19 @@ static void printModuleDebugInfo(raw_ostream &O, const Module *M,
   // filenames), so just print a few useful things.
   for (DICompileUnit *CU : Finder.compile_units()) {
     O << "Compile unit: ";
-    auto Lang =
-        dwarf::LanguageString(CU->getSourceLanguage().getUnversionedName());
-    if (!Lang.empty())
-      O << Lang;
+
+    DISourceLanguageName Lang = CU->getSourceLanguage();
+    auto LangStr =
+        Lang.hasVersionedName()
+            ? dwarf::SourceLanguageNameString(
+                  static_cast<llvm::dwarf::SourceLanguageName>(Lang.getName()))
+            : dwarf::LanguageString(Lang.getName());
+
+    if (!LangStr.empty())
+      O << LangStr;
     else
-      O << "unknown-language(" << CU->getSourceLanguage().getUnversionedName()
-        << ")";
+      O << "unknown-language(" << CU->getSourceLanguage().getName() << ")";
+
     printFile(O, CU->getFilename(), CU->getDirectory());
     O << '\n';
   }

--- a/llvm/test/DebugInfo/Generic/debuginfofinder-cu-source-language-names.ll
+++ b/llvm/test/DebugInfo/Generic/debuginfofinder-cu-source-language-names.ll
@@ -1,0 +1,22 @@
+; RUN: opt -passes='print<module-debuginfo>' -disable-output 2>&1 < %s \
+; RUN:   | FileCheck %s
+
+; CHECK: Compile unit: DW_LANG_C99 from /tmp/test1.c
+; CHECK: Compile unit: DW_LNAME_C from /tmp/test2.c
+; CHECK: Compile unit: unknown-language(0) from /tmp/test3.c
+
+!llvm.dbg.cu = !{!0, !6, !10}
+!llvm.module.flags = !{!8, !9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, producer: "clang", isOptimized: false, emissionKind: FullDebug, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
+!1 = !DIFile(filename: "test1.c", directory: "/tmp")
+!2 = !{}
+!3 = !DIFile(filename: "test1.c", directory: "/tmp")
+!4 = !DISubroutineType(types: !7)
+!5 = !{null}
+!6 = distinct !DICompileUnit(sourceLanguageName: DW_LNAME_C, producer: "clang", isOptimized: false, emissionKind: FullDebug, file: !7, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
+!7 = !DIFile(filename: "test2.c", directory: "/tmp")
+!8 = !{i32 2, !"Dwarf Version", i32 4}
+!9 = !{i32 1, !"Debug Info Version", i32 3}
+!10 = distinct !DICompileUnit(sourceLanguageName: 0, producer: "clang", isOptimized: false, emissionKind: FullDebug, file: !11, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
+!11 = !DIFile(filename: "test3.c", directory: "/tmp")


### PR DESCRIPTION
We shouldn't be calling `getUnversionedName` unconditionally because DWARFv6-enabled Clang will emit versioned language names that are versioned (i.e., `sourceLanguageName`...see new test case). We need to check `hasVersionedName` and pick the appropriate API based on that. Otherwise we assert in `getUnversionedName`.