### PR TITLE
[mlir][NFC] Wrap TimingManager components into namespace

### DIFF
--- a/flang/include/flang/Support/Timing.h
+++ b/flang/include/flang/Support/Timing.h
@@ -19,7 +19,7 @@ namespace Fortran::support {
 
 /// Create a strategy to render the captured times in plain text. This is
 /// intended to be passed to a TimingManager.
-std::unique_ptr<mlir::OutputStrategy> createTimingFormatterText(
+std::unique_ptr<mlir::timing::OutputStrategy> createTimingFormatterText(
     llvm::raw_ostream &os);
 
 } // namespace Fortran::support

--- a/flang/lib/Support/Timing.cpp
+++ b/flang/lib/Support/Timing.cpp
@@ -13,14 +13,15 @@
 #include "flang/Support/Timing.h"
 #include "llvm/Support/Format.h"
 
-class OutputStrategyText : public mlir::OutputStrategy {
+class OutputStrategyText : public mlir::timing::OutputStrategy {
 protected:
   static constexpr llvm::StringLiteral header = "Flang execution timing report";
 
 public:
-  OutputStrategyText(llvm::raw_ostream &os) : mlir::OutputStrategy(os) {}
+  OutputStrategyText(llvm::raw_ostream &os)
+      : mlir::timing::OutputStrategy(os) {}
 
-  void printHeader(const mlir::TimeRecord &total) override {
+  void printHeader(const mlir::timing::TimeRecord &total) override {
     // Figure out how many spaces to description name.
     unsigned padding = (80 - header.size()) / 2;
     os << "===" << std::string(73, '-') << "===\n";
@@ -34,22 +35,24 @@ public:
 
   void printFooter() override { os.flush(); }
 
-  void printTime(
-      const mlir::TimeRecord &time, const mlir::TimeRecord &total) override {
+  void printTime(const mlir::timing::TimeRecord &time,
+      const mlir::timing::TimeRecord &total) override {
     os << llvm::format(
         "  %8.4f (%5.1f%%)", time.user, 100.0 * time.user / total.user);
     os << llvm::format(
         "  %8.4f (%5.1f%%)  ", time.wall, 100.0 * time.wall / total.wall);
   }
 
-  void printListEntry(llvm::StringRef name, const mlir::TimeRecord &time,
-      const mlir::TimeRecord &total, bool lastEntry) override {
+  void printListEntry(llvm::StringRef name,
+      const mlir::timing::TimeRecord &time,
+      const mlir::timing::TimeRecord &total, bool lastEntry) override {
     printTime(time, total);
     os << name << "\n";
   }
 
   void printTreeEntry(unsigned indent, llvm::StringRef name,
-      const mlir::TimeRecord &time, const mlir::TimeRecord &total) override {
+      const mlir::timing::TimeRecord &time,
+      const mlir::timing::TimeRecord &total) override {
     printTime(time, total);
     os.indent(indent) << name << "\n";
   }
@@ -59,7 +62,7 @@ public:
 
 namespace Fortran::support {
 
-std::unique_ptr<mlir::OutputStrategy> createTimingFormatterText(
+std::unique_ptr<mlir::timing::OutputStrategy> createTimingFormatterText(
     llvm::raw_ostream &os) {
   return std::make_unique<OutputStrategyText>(os);
 }

--- a/mlir/include/mlir/Support/Timing.h
+++ b/mlir/include/mlir/Support/Timing.h
@@ -320,6 +320,7 @@ private:
   Timer timer;
 };
 
+namespace timing {
 //===----------------------------------------------------------------------===//
 // OutputStrategy
 //===----------------------------------------------------------------------===//
@@ -366,6 +367,7 @@ public:
 
   raw_ostream &os;
 };
+} // namespace timing
 
 //===----------------------------------------------------------------------===//
 // DefaultTimingManager
@@ -428,7 +430,7 @@ public:
   DisplayMode getDisplayMode() const;
 
   /// Change the stream where the output will be printed to.
-  void setOutput(std::unique_ptr<OutputStrategy> output);
+  void setOutput(std::unique_ptr<timing::OutputStrategy> output);
 
   /// Print and clear the timing results. Only call this when there are no more
   /// references to nested timers around, as printing post-processes and clears
@@ -461,7 +463,7 @@ protected:
 
 private:
   const std::unique_ptr<detail::DefaultTimingManagerImpl> impl;
-  std::unique_ptr<OutputStrategy> out;
+  std::unique_ptr<timing::OutputStrategy> out;
 };
 
 /// Register a set of useful command-line options that can be used to configure
@@ -473,10 +475,12 @@ void registerDefaultTimingManagerCLOptions();
 /// 'registerDefaultTimingManagerOptions' to a `DefaultTimingManager`.
 void applyDefaultTimingManagerCLOptions(DefaultTimingManager &tm);
 
+namespace timing {
 /// Create an output strategy for the specified format, to be passed to
 /// DefaultTimingManager::setOutput().
 std::unique_ptr<OutputStrategy>
 createOutputStrategy(DefaultTimingManager::OutputFormat fmt, raw_ostream &os);
+} // namespace timing
 
 } // namespace mlir
 


### PR DESCRIPTION
TimingManager and its components (e.g. helper classes and utility functions) reside in mlir namespace. Certain components are generic enough that it makes sense to enclose them into an additional namespace.