### PR TITLE
[AArch64][llvm] GICv5 instruction `GIC CDEOI` takes no operand

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -2584,14 +2584,14 @@ foreach n=0-15 in {
 //===----------------------------------------------------------------------===//
 
 // GIC
-class GIC<string name, bits<3> op1, bits<4> crn, bits<4> crm, bits<3> op2> {
+class GIC<string name, bits<3> op1, bits<4> crn, bits<4> crm, bits<3> op2, bit needsreg = 1> {
   string Name = name;
   bits<14> Encoding;
   let Encoding{13-11} = op1;
   let Encoding{10-7} = crn;
   let Encoding{6-3} = crm;
   let Encoding{2-0} = op2;
-  bit NeedsReg = 1;
+  bit NeedsReg = needsreg;
   string RequiresStr = [{ {AArch64::FeatureGCIE} }];
 }
 
@@ -2668,12 +2668,12 @@ def : GSB<"ack",      0b000, 0b1100, 0b0000, 0b001>;
 def : GICR<"cdia",    0b000, 0b1100, 0b0011, 0b000>;
 def : GICR<"cdnmia",  0b000, 0b1100, 0b0011, 0b001>;
 
-//                    Op1    CRn     CRm     Op2
+//                    Op1    CRn     CRm     Op2,   needsreg
 def : GIC<"cdaff",    0b000, 0b1100, 0b0001, 0b011>;
 def : GIC<"cddi",     0b000, 0b1100, 0b0010, 0b000>;
 def : GIC<"cddis",    0b000, 0b1100, 0b0001, 0b000>;
 def : GIC<"cden",     0b000, 0b1100, 0b0001, 0b001>;
-def : GIC<"cdeoi",    0b000, 0b1100, 0b0001, 0b111>;
+def : GIC<"cdeoi",    0b000, 0b1100, 0b0001, 0b111, 0>;
 def : GIC<"cdhm",     0b000, 0b1100, 0b0010, 0b001>;
 def : GIC<"cdpend",   0b000, 0b1100, 0b0001, 0b100>;
 def : GIC<"cdpri",    0b000, 0b1100, 0b0001, 0b010>;

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -4052,7 +4052,7 @@ bool AArch64AsmParser::parseSysAlias(StringRef Name, SMLoc NameLoc,
       setRequiredFeatureString(GIC->getRequiredFeatures(), Str);
       return TokError(Str);
     }
-    ExpectRegister = true;
+    ExpectRegister = GIC->NeedsReg;
     createSysAlias(GIC->Encoding, Operands, S);
   } else if (Mnemonic == "gsb") {
     const AArch64GSB::GSB *GSB = AArch64GSB::lookupGSBByName(Op);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
@@ -1034,7 +1034,7 @@ bool AArch64InstPrinter::printSysAlias(const MCInst *MI,
       if (!GIC || !GIC->haveFeatures(STI.getFeatureBits()))
         return false;
 
-      NeedsReg = true;
+      NeedsReg = GIC->NeedsReg;
       Ins = "gic\t";
       Name = std::string(GIC->Name);
     } else {

--- a/llvm/test/MC/AArch64/armv9.7a-gcie-diagnostics.s
+++ b/llvm/test/MC/AArch64/armv9.7a-gcie-diagnostics.s
@@ -16,3 +16,7 @@ gicr x3, foo
 
 gic cdaff
 // CHECK-ERROR: error: specified gic op requires a register
+
+gic cdeoi, x3
+// CHECK-ERROR: error: specified gic op does not use a register
+

--- a/llvm/test/MC/AArch64/armv9.7a-gcie.s
+++ b/llvm/test/MC/AArch64/armv9.7a-gcie.s
@@ -828,10 +828,10 @@ GIC CDEN, x3
 // CHECK-UNKNOWN: d508c123 sys #0, c12, c1, #1, x3
 // CHECK-ERROR: error: GIC cden requires: gcie
 
-GIC CDEOI, x3
-// CHECK-INST:    gic cdeoi, x3
-// CHECK-ENCODING: [0xe3,0xc1,0x08,0xd5]
-// CHECK-UNKNOWN: d508c1e3 sys #0, c12, c1, #7, x3
+GIC CDEOI
+// CHECK-INST:    gic cdeoi
+// CHECK-ENCODING: [0xff,0xc1,0x08,0xd5]
+// CHECK-UNKNOWN: d508c1ff sys #0, c12, c1, #7
 // CHECK-ERROR: error: GIC cdeoi requires: gcie
 
 GIC CDHM, x3


### PR DESCRIPTION
There was a minor oversight in commit 6836261ee; the AArch64 GICv5
instruction `GIC CDEOI` takes no operands, since the text of the
specification says:
```
The Rt field should be set to 0b11111. If the Rt field is not
set to 0b11111, it is CONSTRAINED UNPREDICTABLE whether:
* The instruction is UNDEFINED.
* The instruction behaves as if the Rt field is set to 0b11111.
```