### PR TITLE
[NFC] DWARFVerifier: use C-style array instead of brace-enclosed init list

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1523,8 +1523,8 @@ void DWARFVerifier::verifyNameIndexAttribute(
   }
 
   if (AttrEnc.Index == dwarf::DW_IDX_parent) {
-    constexpr static auto AllowedForms = {dwarf::Form::DW_FORM_flag_present,
-                                          dwarf::Form::DW_FORM_ref4};
+    constexpr static dwarf::Form AllowedForms[] = {
+        dwarf::Form::DW_FORM_flag_present, dwarf::Form::DW_FORM_ref4};
     if (!is_contained(AllowedForms, AttrEnc.Form)) {
       ErrorCategory.Report("Unexpected NameIndex Abbreviation", [&]() {
         error() << formatv(


### PR DESCRIPTION
MSVC would issue a warning seeing a brace-enclosed initializer list constexpr variable. From collecting now-outdated information, it seems like it is (was) an MSVC bug that did not consider `constexpr auto X = { ... }` valid due to right-hand-side expression "not" being constant.
A quick fix is to use a C-style array instead which is more or less an equivalent form.