### PR TITLE
[MLIR][NVVM] Add lg2.approx.f32 Op

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -450,26 +450,22 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
 }
 
 //===----------------------------------------------------------------------===//
-// NVVM lg2 approximate op
+// Log2 approximate op
 //===----------------------------------------------------------------------===//
 
 def NVVM_Log2ApproxF32Op : NVVM_Op<"log2.approx.f", [Pure]> {
-
   let summary = "Compute approximate base-2 log (lg2.approx.f32)";
 
   let description = [{
     Compute the approximate base-2 logarithm of the input value.
     If 'ftz' is true, subnormal numbers are flushed to zero.
-    
-    [PTX ISA Reference for log2.approx]
-    (https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#floating-point-instructions-lg2)
-
+    [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#floating-point-instructions-lg2)
   }];
 
   let arguments = (ins 
     F32:$input,
     DefaultValuedAttr<BoolAttr, "false">:$ftz);
-  
+
   let results = (outs F32:$res);
 
   let assemblyFormat = "$input attr-dict `:` type($res)";
@@ -477,8 +473,7 @@ def NVVM_Log2ApproxF32Op : NVVM_Op<"log2.approx.f", [Pure]> {
   string llvmBuilder = [{
     llvm::Intrinsic::ID intrinsicID = 
       $ftz ? llvm::Intrinsic::nvvm_lg2_approx_ftz_f
-          : llvm::Intrinsic::nvvm_lg2_approx_f;
-    
+           : llvm::Intrinsic::nvvm_lg2_approx_f;
     $res = createIntrinsicCall(builder, intrinsicID, {$input});
   }];
 }

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -453,30 +453,33 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
 // NVVM lg2 approximate op
 //===----------------------------------------------------------------------===//
 
-def NVVM_Lg2ApproxF32Op : NVVM_Op<"lg2.approx.f", [Pure]> {
+def NVVM_Log2ApproxF32Op : NVVM_Op<"log2.approx.f", [Pure]> {
 
   let summary = "Compute approximate base-2 log (lg2.approx.f32)";
 
   let description = [{
     Compute the approximate base-2 logarithm of the input value.
     If 'ftz' is true, subnormal numbers are flushed to zero.
+    
+    [PTX ISA Reference for log2.approx]
+    (https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#floating-point-instructions-lg2)
+
   }];
 
   let arguments = (ins 
-    F32:$arg,
-    OptionalAttr<BoolAttr>:$ftz);
+    F32:$input,
+    DefaultValuedAttr<BoolAttr, "false">:$ftz);
   
   let results = (outs F32:$res);
 
-  let assemblyFormat = "$arg attr-dict `:` type($res)";
+  let assemblyFormat = "$input attr-dict `:` type($res)";
 
   string llvmBuilder = [{
-    bool ftz = $ftz && *$ftz;
     llvm::Intrinsic::ID intrinsicID = 
-      ftz ? llvm::Intrinsic::nvvm_lg2_approx_ftz_f
+      $ftz ? llvm::Intrinsic::nvvm_lg2_approx_ftz_f
           : llvm::Intrinsic::nvvm_lg2_approx_f;
     
-    $res = createIntrinsicCall(builder, intrinsicID, {$arg});
+    $res = createIntrinsicCall(builder, intrinsicID, {$input});
   }];
 }
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -449,16 +449,35 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
   let assemblyFormat = "$arg attr-dict `:` type($res)";
 }
 
-def NVVM_lg2ApproxF32Op : NVVM_IntrOp<"lg2.approx.f", [Pure], 1> {
-  let arguments = (ins F32:$arg);
-  let results = (outs F32:$res);
-  let assemblyFormat = "$arg attr-dict `:` type($res)";
-}
+//===----------------------------------------------------------------------===//
+// NVVM lg2 approximate op
+//===----------------------------------------------------------------------===//
 
-def NVVM_lg2ApproxFtzF32Op : NVVM_IntrOp<"lg2.approx.ftz.f", [Pure], 1> {
-  let arguments = (ins F32:$arg);
+def NVVM_Lg2ApproxF32Op : NVVM_Op<"lg2.approx.f", [Pure]> {
+
+  let summary = "Compute approximate base-2 log (lg2.approx.f32)";
+
+  let description = [{
+    Compute the approximate base-2 logarithm of the input value.
+    If 'ftz' is true, subnormal numbers are flushed to zero.
+  }];
+
+  let arguments = (ins 
+    F32:$arg,
+    OptionalAttr<BoolAttr>:$ftz);
+  
   let results = (outs F32:$res);
+
   let assemblyFormat = "$arg attr-dict `:` type($res)";
+
+  string llvmBuilder = [{
+    bool ftz = $ftz && *$ftz;
+    llvm::Intrinsic::ID intrinsicID = 
+      ftz ? llvm::Intrinsic::nvvm_lg2_approx_ftz_f
+          : llvm::Intrinsic::nvvm_lg2_approx_f;
+    
+    $res = createIntrinsicCall(builder, intrinsicID, {$arg});
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -449,6 +449,18 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
   let assemblyFormat = "$arg attr-dict `:` type($res)";
 }
 
+def NVVM_ex2ApproxFtzF32Op : NVVM_IntrOp<"ex2.approx.ftz.f", [Pure], 1> {
+  let arguments = (ins F32:$arg);
+  let results = (outs F32:$res);
+  let assemblyFormat = "$arg attr-dict `:` type($res)";
+}
+
+def NVVM_lg2ApproxFtzF32Op : NVVM_IntrOp<"lg2.approx.ftz.f", [Pure], 1> {
+  let arguments = (ins F32:$arg);
+  let results = (outs F32:$res);
+  let assemblyFormat = "$arg attr-dict `:` type($res)";
+}
+
 //===----------------------------------------------------------------------===//
 // NVVM redux op definitions
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -449,7 +449,7 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
   let assemblyFormat = "$arg attr-dict `:` type($res)";
 }
 
-def NVVM_ex2ApproxFtzF32Op : NVVM_IntrOp<"ex2.approx.ftz.f", [Pure], 1> {
+def NVVM_lg2ApproxF32Op : NVVM_IntrOp<"lg2.approx.f", [Pure], 1> {
   let arguments = (ins F32:$arg);
   let results = (outs F32:$res);
   let assemblyFormat = "$arg attr-dict `:` type($res)";

--- a/mlir/test/Dialect/LLVMIR/nvvm.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm.mlir
@@ -36,20 +36,6 @@ func.func @nvvm_rcp(%arg0: f32) -> f32 {
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: @nvvm_lg2_approx_f
-func.func @nvvm_lg2_approx_f(%arg0: f32) -> f32 {
-  // CHECK: nvvm.lg2.approx.f %arg0 : f32
-  %0 = nvvm.lg2.approx.f %arg0 : f32
-  llvm.return %0 : f32
-}
-
-// CHECK-LABEL: @nvvm_lg2_approx_ftz_f
-func.func @nvvm_lg2_approx_ftz_f(%arg0: f32) -> f32 {
-  // CHECK: nvvm.lg2.approx.f %arg0 {ftz = true} : f32
-  %0 = nvvm.lg2.approx.f %arg0 {ftz = true} : f32
-  llvm.return %0 : f32
-}
-
 // CHECK-LABEL: @llvm_nvvm_barrier0
 func.func @llvm_nvvm_barrier0() {
   // CHECK: nvvm.barrier0

--- a/mlir/test/Dialect/LLVMIR/nvvm.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm.mlir
@@ -36,17 +36,17 @@ func.func @nvvm_rcp(%arg0: f32) -> f32 {
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: @nvvm_lg2_f32
-func.func @nvvm_lg2_f32(%arg0: f32) -> f32 {
+// CHECK-LABEL: @nvvm_lg2_approx_f
+func.func @nvvm_lg2_approx_f(%arg0: f32) -> f32 {
   // CHECK: nvvm.lg2.approx.f %arg0 : f32
   %0 = nvvm.lg2.approx.f %arg0 : f32
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: @nvvm_lg2_ftz_f32
-func.func @nvvm_lg2_ftz_f32(%arg0: f32) -> f32 {
-  // CHECK: nvvm.lg2.approx.ftz.f %arg0 : f32
-  %0 = nvvm.lg2.approx.ftz.f %arg0 : f32
+// CHECK-LABEL: @nvvm_lg2_approx_ftz_f
+func.func @nvvm_lg2_approx_ftz_f(%arg0: f32) -> f32 {
+  // CHECK: nvvm.lg2.approx.f %arg0 {ftz = true} : f32
+  %0 = nvvm.lg2.approx.f %arg0 {ftz = true} : f32
   llvm.return %0 : f32
 }
 

--- a/mlir/test/Dialect/LLVMIR/nvvm.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm.mlir
@@ -36,15 +36,15 @@ func.func @nvvm_rcp(%arg0: f32) -> f32 {
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: @nvvm_ex2
-func.func @nvvm_ex2(%arg0: f32) -> f32 {
-  // CHECK: nvvm.ex2.approx.ftz.f %arg0 : f32
-  %0 = nvvm.ex2.approx.ftz.f %arg0 : f32
+// CHECK-LABEL: @nvvm_lg2_f32
+func.func @nvvm_lg2_f32(%arg0: f32) -> f32 {
+  // CHECK: nvvm.lg2.approx.f %arg0 : f32
+  %0 = nvvm.lg2.approx.f %arg0 : f32
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: @nvvm_lg2
-func.func @nvvm_lg2(%arg0: f32) -> f32 {
+// CHECK-LABEL: @nvvm_lg2_ftz_f32
+func.func @nvvm_lg2_ftz_f32(%arg0: f32) -> f32 {
   // CHECK: nvvm.lg2.approx.ftz.f %arg0 : f32
   %0 = nvvm.lg2.approx.ftz.f %arg0 : f32
   llvm.return %0 : f32

--- a/mlir/test/Dialect/LLVMIR/nvvm.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm.mlir
@@ -36,6 +36,20 @@ func.func @nvvm_rcp(%arg0: f32) -> f32 {
   llvm.return %0 : f32
 }
 
+// CHECK-LABEL: @nvvm_ex2
+func.func @nvvm_ex2(%arg0: f32) -> f32 {
+  // CHECK: nvvm.ex2.approx.ftz.f %arg0 : f32
+  %0 = nvvm.ex2.approx.ftz.f %arg0 : f32
+  llvm.return %0 : f32
+}
+
+// CHECK-LABEL: @nvvm_lg2
+func.func @nvvm_lg2(%arg0: f32) -> f32 {
+  // CHECK: nvvm.lg2.approx.ftz.f %arg0 : f32
+  %0 = nvvm.lg2.approx.ftz.f %arg0 : f32
+  llvm.return %0 : f32
+}
+
 // CHECK-LABEL: @llvm_nvvm_barrier0
 func.func @llvm_nvvm_barrier0() {
   // CHECK: nvvm.barrier0

--- a/mlir/test/Target/LLVMIR/nvvm/log2_approx.mlir
+++ b/mlir/test/Target/LLVMIR/nvvm/log2_approx.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// CHECK-LABEL: define float @nvvm_log2_approx_f(float %0)
+// CHECK: call float @llvm.nvvm.lg2.approx.f(float %0)
+llvm.func @nvvm_log2_approx_f(%arg0: f32) -> f32 {
+  %0 = nvvm.log2.approx.f %arg0 : f32
+  llvm.return %0 : f32
+}
+
+// CHECK-LABEL: define float @nvvm_log2_approx_ftz_f(float %0)
+// CHECK: call float @llvm.nvvm.lg2.approx.ftz.f(float %0)
+llvm.func @nvvm_log2_approx_ftz_f(%arg0: f32) -> f32 {
+  %0 = nvvm.log2.approx.f %arg0 {ftz = true} : f32
+  llvm.return %0 : f32
+}


### PR DESCRIPTION
This patch introduces the `nvvm.lg2.approx.f` operation to the NVVM dialect.

- Adds an NVVM op that maps to the PTX instruction `lg2.approx.f32`
- Supports an optional `ftz` (flush-to-zero) attribute:
  When `ftz = true`, maps to `lg2.approx.ftz.f32`
  Otherwise, maps to `lg2.approx.f32`

This enables MLIR lowering for approximate base-2 logarithm computations under NVVM.

- Added tests in `mlir/test/Dialect/LLVMIR/nvvm.mlir`
- Verified with `ninja check-mlir` — all tests passed