### PR TITLE
[BAZEL] Add missing dependency on /llvm:Support from XeGPUTransformOps

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -3888,6 +3888,7 @@ cc_library(
         ":XeGPUDialect",
         ":XeGPUTransformOpsIncGen",
         ":XeGPUUtils",
+        "//llvm:Support",
     ],
 )
 


### PR DESCRIPTION
Fixes 1553f90f93d30b41457097cf274c3791b182f316