### PR TITLE
[PowerPC] convert memmove to milicode call  .___memmove64[PR]  in 64-bit mode

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -2333,7 +2333,7 @@ defset list<RuntimeLibcallImpl> PPCRuntimeLibcalls = {
 
 defset list<RuntimeLibcallImpl> PPC64AIXCallList = {
   def ___memcmp64 : RuntimeLibcallImpl<MEMCMP>;
-  def ___memmove64 : RuntimeLibcallImpl<MEMCPY>;
+  def ___memmove64 : RuntimeLibcallImpl<MEMMOVE>;
   def ___memset64 : RuntimeLibcallImpl<MEMSET>;
   def ___bzero64 : RuntimeLibcallImpl<BZERO>;
   def ___strlen64 : RuntimeLibcallImpl<STRLEN>;

--- a/llvm/test/CodeGen/PowerPC/milicode64.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode64.ll
@@ -156,7 +156,7 @@ define ptr @test_memmove(ptr noundef %destination, ptr noundef %source, i64 noun
 ; CHECK-AIX-64-P9-NEXT:    std r3, 128(r1)
 ; CHECK-AIX-64-P9-NEXT:    std r4, 120(r1)
 ; CHECK-AIX-64-P9-NEXT:    std r5, 112(r1)
-; CHECK-AIX-64-P9-NEXT:    bl .memmove[PR]
+; CHECK-AIX-64-P9-NEXT:    bl .___memmove64[PR]
 ; CHECK-AIX-64-P9-NEXT:    nop
 ; CHECK-AIX-64-P9-NEXT:    mr r3, r31
 ; CHECK-AIX-64-P9-NEXT:    ld r31, 136(r1) # 8-byte Folded Reload


### PR DESCRIPTION
 conversion of bl memmove call to milicode bl .___memmove64[PR] in 64--bit mode is broken , the patch fix the problem.
 
in the  llvm/include/llvm/IR/RuntimeLibcalls.td,  we do not need to define the 

 `def ___memmove64 : RuntimeLibcallImpl<MEMCPY>` in PPC64AIXCallList 
` def ___memmove32 : RuntimeLibcallImpl<MEMCPY>` in PPC32AIXCallList
 
 since there is function 
 
```
   /// Return a function impl compatible with RTLIB::MEMCPY, or
  /// RTLIB::Unsupported if fully unsupported.
  RTLIB::LibcallImpl getMemcpyImpl() const {
    RTLIB::LibcallImpl Memcpy = getLibcallImpl(RTLIB::MEMCPY);
    if (Memcpy == RTLIB::Unsupported) {
      // Fallback to memmove if memcpy isn't available.
      return getLibcallImpl(RTLIB::MEMMOVE);
    }

    return Memcpy;
  }
```