### PR TITLE
[analyzer] StdVariantChecker: fix crashes and incorrect retrieval of template arguments

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -90,6 +90,9 @@ bool isStdVariant(const Type *Type) {
 static std::optional<ArrayRef<TemplateArgument>>
 getTemplateArgsFromVariant(const Type *VariantType) {
   const auto *TempSpecType = VariantType->getAs<TemplateSpecializationType>();
+  while (TempSpecType && TempSpecType->isTypeAlias())
+    TempSpecType =
+        TempSpecType->getAliasedType()->getAs<TemplateSpecializationType>();
   if (!TempSpecType)
     return {};
 

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -219,10 +219,12 @@ private:
   bool handleStdGetCall(const CallEvent &Call, CheckerContext &C) const {
     ProgramStateRef State = C.getState();
 
-    const auto &ArgType = Call.getArgSVal(0)
-                              .getType(C.getASTContext())
-                              ->getPointeeType()
-                              .getTypePtr();
+    SVal ArgSVal = Call.getArgSVal(0);
+    if (ArgSVal.isUnknown())
+      return false;
+
+    const auto &ArgType =
+        ArgSVal.getType(C.getASTContext())->getPointeeType().getTypePtr();
     // We have to make sure that the argument is an std::variant.
     // There is another std::get with std::pair argument
     if (!isStdVariant(ArgType))

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -356,3 +356,14 @@ void nonInlineFunctionCallPtr() {
   (void)a;
   (void)c;
 }
+
+// ----------------------------------------------------------------------------//
+// Misc
+// ----------------------------------------------------------------------------//
+
+using uintptr_t = unsigned long long;
+
+void unknownVal() {
+  // force the argument to be UnknownVal
+  (void)std::get<int>(*(std::variant<int, float>*)(uintptr_t)3.14f); // no crash
+}

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -361,9 +361,25 @@ void nonInlineFunctionCallPtr() {
 // Misc
 // ----------------------------------------------------------------------------//
 
-using uintptr_t = unsigned long long;
-
 void unknownVal() {
   // force the argument to be UnknownVal
-  (void)std::get<int>(*(std::variant<int, float>*)(uintptr_t)3.14f); // no crash
+  (void)std::get<int>(*(std::variant<int, float>*)(int)3.14f); // no crash
+}
+
+template <typename T>
+using MyVariant = std::variant<int, float>;
+
+void typeAlias() {
+  MyVariant<bool> v;
+
+  (void)std::get<int>(v); // no-warning
+}
+
+template <template<typename> typename Container>
+using MySpecialVariant = std::variant<int, float>;
+
+void complexTypeAlias() {
+  MySpecialVariant<std::vector> v;
+
+  (void)std::get<int>(v); // no crash
 }


### PR DESCRIPTION
Although very unusual, the SVal of the argument is not checked for UnknownVal, so we may get a null pointer dereference.

In addition, the template arguments of the variant are retrieved incorrectly when type aliases are involved, causing crashes and FPs/FNs.