### PR TITLE
[MLIR][XeGPU][TransformOps] Add convert_layout op

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
+++ b/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
@@ -253,37 +253,46 @@ def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
   let summary = "Convert xegpu.layout attribute for a value.";
   let description = [{
     Adds an `xegpu.convert_layout` op to convert the `xegpu.layout` attribute
-    of a value. The source layout is inferred by inspecting the producer ops. A
-    failure is emitted if source layout cannot be found. An
-    `xegpu.convert_layout` op, whose destination layout is defined by the
-    `sg_layout`, `sg_data` and optional `inst_data` attributes, is emitted
-    before the first use of the value. Returns a handle to the emitted
-    `xegpu.convert_layout` op.
+    of a value. The input and target layouts are defined by the `*sg_layout`,
+    `*sg_data` and optional `*inst_data` attributes. Returns a handle to the
+    emitted `xegpu.convert_layout` op.
   }];
 
   let arguments = (ins TransformValueHandleTypeInterface:$target,
-                   Variadic<TransformAnyParamTypeOrAnyHandle>:$sg_layout,
-                   Variadic<TransformAnyParamTypeOrAnyHandle>:$sg_data,
-                   Variadic<TransformAnyParamTypeOrAnyHandle>:$inst_data,
-                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_sg_layout,
-                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_sg_data,
-                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_inst_data
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$input_sg_layout,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$input_sg_data,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$input_inst_data,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$target_sg_layout,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$target_sg_data,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$target_inst_data,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_input_sg_layout,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_input_sg_data,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_input_inst_data,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_target_sg_layout,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_target_sg_data,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_target_inst_data
                    );
 
   let results = (outs TransformHandleTypeInterface:$newConvertOp);
   let builders = [
     OpBuilder<(ins "Value":$target,
-                   "ArrayRef<OpFoldResult>":$mixedSgLayout,
-                   "ArrayRef<OpFoldResult>":$mixedSgData,
-                   "ArrayRef<OpFoldResult>":$mixedInstData
+                   "ArrayRef<OpFoldResult>":$mixedInputSgLayout,
+                   "ArrayRef<OpFoldResult>":$mixedInputSgData,
+                   "ArrayRef<OpFoldResult>":$mixedInputInstData,
+                   "ArrayRef<OpFoldResult>":$mixedTargetSgLayout,
+                   "ArrayRef<OpFoldResult>":$mixedTargetSgData,
+                   "ArrayRef<OpFoldResult>":$mixedTargetInstData
                    )>,
   ];
 
   let assemblyFormat = [{
     $target
-    `sg_layout` `=` custom<DynamicIndexList>($sg_layout, $static_sg_layout)
-    `sg_data` `=` custom<DynamicIndexList>($sg_data, $static_sg_data)
-    (`inst_data` `=` custom<DynamicIndexList>($inst_data, $static_inst_data)^)?
+    `input_sg_layout` `=` custom<DynamicIndexList>($input_sg_layout, $static_input_sg_layout)
+    `input_sg_data` `=` custom<DynamicIndexList>($input_sg_data, $static_input_sg_data)
+    (`input_inst_data` `=` custom<DynamicIndexList>($input_inst_data, $static_input_inst_data)^)?
+    `target_sg_layout` `=` custom<DynamicIndexList>($target_sg_layout, $static_target_sg_layout)
+    `target_sg_data` `=` custom<DynamicIndexList>($target_sg_data, $static_target_sg_data)
+    (`target_inst_data` `=` custom<DynamicIndexList>($target_inst_data, $static_target_inst_data)^)?
     attr-dict `:` functional-type(operands, results)
   }];
 
@@ -293,17 +302,30 @@ def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
         ::mlir::transform::TransformResults &transformResults,
         ::mlir::transform::TransformState &state);
 
-    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedSgLayout() {
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedInputSgLayout() {
       Builder b(getContext());
-      return getMixedValues(getStaticSgLayout(), getSgLayout(), b);
+      return getMixedValues(getStaticInputSgLayout(), getInputSgLayout(), b);
     }
-    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedSgData() {
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedInputSgData() {
       Builder b(getContext());
-      return getMixedValues(getStaticSgData(), getSgData(), b);
+      return getMixedValues(getStaticInputSgData(), getInputSgData(), b);
     }
-    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedInstData() {
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedInputInstData() {
       Builder b(getContext());
-      return getMixedValues(getStaticInstData(), getInstData(), b);
+      return getMixedValues(getStaticInputInstData(), getInputInstData(), b);
+    }
+
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedTargetSgLayout() {
+      Builder b(getContext());
+      return getMixedValues(getStaticTargetSgLayout(), getTargetSgLayout(), b);
+    }
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedTargetSgData() {
+      Builder b(getContext());
+      return getMixedValues(getStaticTargetSgData(), getTargetSgData(), b);
+    }
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedTargetInstData() {
+      Builder b(getContext());
+      return getMixedValues(getStaticTargetInstData(), getTargetInstData(), b);
     }
   }];
 }

--- a/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
+++ b/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
@@ -257,7 +257,8 @@ def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
     failure is emitted if source layout cannot be found. An
     `xegpu.convert_layout` op, whose destination layout is defined by the
     `sg_layout`, `sg_data` and optional `inst_data` attributes, is emitted
-    before the first use of the value.
+    before the first use of the value. Returns a handle to the emitted
+    `xegpu.convert_layout` op.
   }];
 
   let arguments = (ins TransformValueHandleTypeInterface:$target,
@@ -269,7 +270,7 @@ def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
                    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_inst_data
                    );
 
-  let results = (outs);
+  let results = (outs TransformHandleTypeInterface:$newConvertOp);
   let builders = [
     OpBuilder<(ins "Value":$target,
                    "ArrayRef<OpFoldResult>":$mixedSgLayout,
@@ -283,7 +284,7 @@ def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
     `sg_layout` `=` custom<DynamicIndexList>($sg_layout, $static_sg_layout)
     `sg_data` `=` custom<DynamicIndexList>($sg_data, $static_sg_data)
     (`inst_data` `=` custom<DynamicIndexList>($inst_data, $static_inst_data)^)?
-    attr-dict `:` qualified(type(operands))
+    attr-dict `:` functional-type(operands, results)
   }];
 
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
+++ b/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
@@ -244,4 +244,66 @@ def InsertPrefetchOp : Op<Transform_Dialect, "xegpu.insert_prefetch", [
   }];
 }
 
+def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
+  AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  TransformOpInterface
+]> {
+
+  let summary = "Convert xegpu.layout attribute for a value.";
+  let description = [{
+    Adds an `xegpu.convert_layout` op to convert the `xegpu.layout` attribute
+    of a value. First, the `xegpu.load_nd` producer op of the value is found.
+    It must already be annotated with a layout. An `xegpu.convert_layout` op,
+    whose destination layout is defined by the `sg_layout`, `sg_data` and
+    optional `inst_data` attributes, is inserted after the load op.
+  }];
+
+  let arguments = (ins TransformValueHandleTypeInterface:$target,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$sg_layout,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$sg_data,
+                   Variadic<TransformAnyParamTypeOrAnyHandle>:$inst_data,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_sg_layout,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_sg_data,
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_inst_data
+                   );
+
+  let results = (outs);
+  let builders = [
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<OpFoldResult>":$mixedSgLayout,
+                   "ArrayRef<OpFoldResult>":$mixedSgData,
+                   "ArrayRef<OpFoldResult>":$mixedInstData
+                   )>,
+  ];
+
+  let assemblyFormat = [{
+    $target
+    `sg_layout` `=` custom<DynamicIndexList>($sg_layout, $static_sg_layout)
+    `sg_data` `=` custom<DynamicIndexList>($sg_data, $static_sg_data)
+    (`inst_data` `=` custom<DynamicIndexList>($inst_data, $static_inst_data)^)?
+    attr-dict `:` qualified(type(operands))
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure apply(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::transform::TransformResults &transformResults,
+        ::mlir::transform::TransformState &state);
+
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedSgLayout() {
+      Builder b(getContext());
+      return getMixedValues(getStaticSgLayout(), getSgLayout(), b);
+    }
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedSgData() {
+      Builder b(getContext());
+      return getMixedValues(getStaticSgData(), getSgData(), b);
+    }
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedInstData() {
+      Builder b(getContext());
+      return getMixedValues(getStaticInstData(), getInstData(), b);
+    }
+  }];
+}
+
 #endif // XEGPU_TRANSFORM_OPS

--- a/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
+++ b/mlir/include/mlir/Dialect/XeGPU/TransformOps/XeGPUTransformOps.td
@@ -253,10 +253,11 @@ def ConvertLayoutOp : Op<Transform_Dialect, "xegpu.convert_layout", [
   let summary = "Convert xegpu.layout attribute for a value.";
   let description = [{
     Adds an `xegpu.convert_layout` op to convert the `xegpu.layout` attribute
-    of a value. First, the `xegpu.load_nd` producer op of the value is found.
-    It must already be annotated with a layout. An `xegpu.convert_layout` op,
-    whose destination layout is defined by the `sg_layout`, `sg_data` and
-    optional `inst_data` attributes, is inserted after the load op.
+    of a value. The source layout is inferred by inspecting the producer ops. A
+    failure is emitted if source layout cannot be found. An
+    `xegpu.convert_layout` op, whose destination layout is defined by the
+    `sg_layout`, `sg_data` and optional `inst_data` attributes, is emitted
+    before the first use of the value.
   }];
 
   let arguments = (ins TransformValueHandleTypeInterface:$target,

--- a/mlir/lib/Dialect/XeGPU/TransformOps/XeGPUTransformOps.cpp
+++ b/mlir/lib/Dialect/XeGPU/TransformOps/XeGPUTransformOps.cpp
@@ -562,12 +562,10 @@ transform::ConvertLayoutOp::apply(transform::TransformRewriter &rewriter,
                                   transform::TransformResults &results,
                                   transform::TransformState &state) {
   auto targetValues = state.getPayloadValues(getTarget());
-  if (!llvm::hasSingleElement(targetValues)) {
+  if (!llvm::hasSingleElement(targetValues))
     return emitDefiniteFailure()
            << "requires exactly one target value handle (got "
            << llvm::range_size(targetValues) << ")";
-  }
-
   auto value = *targetValues.begin();
 
   xegpu::LayoutAttr layoutAttr = nullptr;
@@ -579,17 +577,15 @@ transform::ConvertLayoutOp::apply(transform::TransformRewriter &rewriter,
 
   // Get load op.
   auto maybeLoadOp = findProducerOfType<xegpu::LoadNdOp>(value);
-  if (!maybeLoadOp) {
+  if (!maybeLoadOp)
     return emitSilenceableFailure(getLoc()) << "Could not find load op.";
-  }
   auto loadOp = *maybeLoadOp;
   // Get load op operand value layout
   auto producerLayoutAttr =
       xegpu::getDistributeLayoutAttr(loadOp.getOperand(0));
-  if (!producerLayoutAttr) {
+  if (!producerLayoutAttr)
     return emitSilenceableFailure(getLoc())
            << "Operand producer op does not have a layout attr.";
-  }
 
   if (producerLayoutAttr != layoutAttr) {
     rewriter.setInsertionPointAfter(loadOp.getOperation());

--- a/mlir/python/mlir/dialects/transform/xegpu.py
+++ b/mlir/python/mlir/dialects/transform/xegpu.py
@@ -42,6 +42,15 @@ class GetDescOp(GetDescOp):
         )
 
 
+def get_desc_op(
+    target: Value,
+    *,
+    loc=None,
+    ip=None,
+) -> GetDescOp:
+    return GetDescOp(target, loc=loc, ip=ip)
+
+
 @_ods_cext.register_operation(_Dialect, replace=True)
 class SetDescLayoutOp(SetDescLayoutOp):
     """Specialization for SetDescLayoutOp class."""
@@ -86,6 +95,25 @@ class SetDescLayoutOp(SetDescLayoutOp):
             loc=loc,
             ip=ip,
         )
+
+
+def set_desc_layout(
+    target: Union[Operation, Value],
+    sg_layout: MixedValues,
+    sg_data: MixedValues,
+    *,
+    inst_data: Optional[MixedValues] = None,
+    loc=None,
+    ip=None,
+) -> SetDescLayoutOp:
+    return SetDescLayoutOp(
+        target,
+        sg_layout,
+        sg_data,
+        inst_data=inst_data,
+        loc=loc,
+        ip=ip,
+    )
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)
@@ -133,6 +161,29 @@ class SetOpLayoutAttrOp(SetOpLayoutAttrOp):
             loc=loc,
             ip=ip,
         )
+
+
+def set_op_layout_attr(
+    target: Union[Operation, Value],
+    sg_layout: MixedValues,
+    sg_data: MixedValues,
+    *,
+    inst_data: Optional[MixedValues] = None,
+    index: Optional[Union[int, Attribute]] = None,
+    result: Optional[Union[bool, Attribute]] = None,
+    loc=None,
+    ip=None,
+) -> SetOpLayoutAttrOp:
+    return SetOpLayoutAttrOp(
+        target,
+        sg_layout,
+        sg_data,
+        inst_data=inst_data,
+        index=index,
+        result=result,
+        loc=loc,
+        ip=ip,
+    )
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)
@@ -254,3 +305,22 @@ class ConvertLayoutOp(ConvertLayoutOp):
             loc=loc,
             ip=ip,
         )
+
+
+def convert_layout(
+    target: Value,
+    sg_layout: MixedValues,
+    sg_data: MixedValues,
+    *,
+    inst_data: Optional[MixedValues] = None,
+    loc=None,
+    ip=None,
+) -> ConvertLayoutOp:
+    return ConvertLayoutOp(
+        target,
+        sg_layout,
+        sg_data,
+        inst_data=inst_data,
+        loc=loc,
+        ip=ip,
+    )

--- a/mlir/python/mlir/dialects/transform/xegpu.py
+++ b/mlir/python/mlir/dialects/transform/xegpu.py
@@ -211,3 +211,46 @@ def insert_prefetch(
     ip=None,
 ) -> OpResult:
     return InsertPrefetchOp(target, nb_prefetch=nb_prefetch, loc=loc, ip=ip).result
+
+
+@_ods_cext.register_operation(_Dialect, replace=True)
+class ConvertLayoutOp(ConvertLayoutOp):
+    """Specialization for ConvertLayoutOp class."""
+
+    def __init__(
+        self,
+        target: Value,
+        sg_layout: MixedValues,
+        sg_data: MixedValues,
+        *,
+        inst_data: Optional[MixedValues] = None,
+        loc=None,
+        ip=None,
+    ):
+        inst_data = [] if inst_data is None else inst_data
+        (
+            dynamic_sg_layout,
+            static_sg_layout,
+            _,
+        ) = _dispatch_dynamic_index_list(sg_layout)
+        (
+            dynamic_sg_data,
+            static_sg_data,
+            _,
+        ) = _dispatch_dynamic_index_list(sg_data)
+        (
+            dynamic_inst_data,
+            static_inst_data,
+            _,
+        ) = _dispatch_dynamic_index_list(inst_data)
+        super().__init__(
+            target,
+            dynamic_sg_layout,
+            dynamic_sg_data,
+            dynamic_inst_data,
+            static_sg_layout=static_sg_layout,
+            static_sg_data=static_sg_data,
+            static_inst_data=static_inst_data,
+            loc=loc,
+            ip=ip,
+        )

--- a/mlir/python/mlir/dialects/transform/xegpu.py
+++ b/mlir/python/mlir/dialects/transform/xegpu.py
@@ -47,8 +47,8 @@ def get_desc_op(
     *,
     loc=None,
     ip=None,
-) -> GetDescOp:
-    return GetDescOp(target, loc=loc, ip=ip)
+) -> OpResult:
+    return GetDescOp(target, loc=loc, ip=ip).result
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)
@@ -105,7 +105,7 @@ def set_desc_layout(
     inst_data: Optional[MixedValues] = None,
     loc=None,
     ip=None,
-) -> SetDescLayoutOp:
+) -> OpResult:
     return SetDescLayoutOp(
         target,
         sg_layout,
@@ -113,7 +113,7 @@ def set_desc_layout(
         inst_data=inst_data,
         loc=loc,
         ip=ip,
-    )
+    ).result
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)

--- a/mlir/python/mlir/dialects/transform/xegpu.py
+++ b/mlir/python/mlir/dialects/transform/xegpu.py
@@ -295,6 +295,7 @@ class ConvertLayoutOp(ConvertLayoutOp):
             _,
         ) = _dispatch_dynamic_index_list(inst_data)
         super().__init__(
+            transform.AnyOpType.get(),
             target,
             dynamic_sg_layout,
             dynamic_sg_data,
@@ -323,4 +324,4 @@ def convert_layout(
         inst_data=inst_data,
         loc=loc,
         ip=ip,
-    )
+    ).result

--- a/mlir/python/mlir/dialects/transform/xegpu.py
+++ b/mlir/python/mlir/dialects/transform/xegpu.py
@@ -271,38 +271,63 @@ class ConvertLayoutOp(ConvertLayoutOp):
     def __init__(
         self,
         target: Value,
-        sg_layout: MixedValues,
-        sg_data: MixedValues,
+        input_sg_layout: MixedValues,
+        input_sg_data: MixedValues,
+        target_sg_layout: MixedValues,
+        target_sg_data: MixedValues,
         *,
-        inst_data: Optional[MixedValues] = None,
+        input_inst_data: Optional[MixedValues] = None,
+        target_inst_data: Optional[MixedValues] = None,
         loc=None,
         ip=None,
     ):
-        inst_data = [] if inst_data is None else inst_data
+        input_inst_data = [] if input_inst_data is None else input_inst_data
+        target_inst_data = [] if target_inst_data is None else target_inst_data
         (
-            dynamic_sg_layout,
-            static_sg_layout,
+            dynamic_input_sg_layout,
+            static_input_sg_layout,
             _,
-        ) = _dispatch_dynamic_index_list(sg_layout)
+        ) = _dispatch_dynamic_index_list(input_sg_layout)
         (
-            dynamic_sg_data,
-            static_sg_data,
+            dynamic_input_sg_data,
+            static_input_sg_data,
             _,
-        ) = _dispatch_dynamic_index_list(sg_data)
+        ) = _dispatch_dynamic_index_list(input_sg_data)
         (
-            dynamic_inst_data,
-            static_inst_data,
+            dynamic_input_inst_data,
+            static_input_inst_data,
             _,
-        ) = _dispatch_dynamic_index_list(inst_data)
+        ) = _dispatch_dynamic_index_list(input_inst_data)
+        (
+            dynamic_target_sg_layout,
+            static_target_sg_layout,
+            _,
+        ) = _dispatch_dynamic_index_list(target_sg_layout)
+        (
+            dynamic_target_sg_data,
+            static_target_sg_data,
+            _,
+        ) = _dispatch_dynamic_index_list(target_sg_data)
+        (
+            dynamic_target_inst_data,
+            static_target_inst_data,
+            _,
+        ) = _dispatch_dynamic_index_list(target_inst_data)
         super().__init__(
             transform.AnyOpType.get(),
             target,
-            dynamic_sg_layout,
-            dynamic_sg_data,
-            dynamic_inst_data,
-            static_sg_layout=static_sg_layout,
-            static_sg_data=static_sg_data,
-            static_inst_data=static_inst_data,
+            dynamic_input_sg_layout,
+            dynamic_input_sg_data,
+            dynamic_input_inst_data,
+            dynamic_target_sg_layout,
+            dynamic_target_sg_data,
+            dynamic_target_inst_data,
+            static_input_sg_layout=static_input_sg_layout,
+            static_input_sg_data=static_input_sg_data,
+            static_input_inst_data=static_input_inst_data,
+            static_target_sg_layout=static_target_sg_layout,
+            static_target_sg_data=static_target_sg_data,
+            static_target_inst_data=static_target_inst_data,
             loc=loc,
             ip=ip,
         )
@@ -310,18 +335,24 @@ class ConvertLayoutOp(ConvertLayoutOp):
 
 def convert_layout(
     target: Value,
-    sg_layout: MixedValues,
-    sg_data: MixedValues,
+    input_sg_layout: MixedValues,
+    input_sg_data: MixedValues,
+    target_sg_layout: MixedValues,
+    target_sg_data: MixedValues,
     *,
-    inst_data: Optional[MixedValues] = None,
+    input_inst_data: Optional[MixedValues] = None,
+    target_inst_data: Optional[MixedValues] = None,
     loc=None,
     ip=None,
 ) -> ConvertLayoutOp:
     return ConvertLayoutOp(
         target,
-        sg_layout,
-        sg_data,
-        inst_data=inst_data,
+        input_sg_layout,
+        input_sg_data,
+        target_sg_layout,
+        target_sg_data,
+        input_inst_data=input_inst_data,
+        target_inst_data=target_inst_data,
         loc=loc,
         ip=ip,
     ).result

--- a/mlir/test/Dialect/XeGPU/transform-ops-invalid.mlir
+++ b/mlir/test/Dialect/XeGPU/transform-ops-invalid.mlir
@@ -155,24 +155,3 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
-
-// -----
-
-// CHECK-LABEL: @convert_layout_no_producer_attr
-func.func @convert_layout_no_producer_attr(%arg0: vector<32x32xf16>, %arg1: vector<32x32xf16>) {
-  %c0 = arith.constant 0 : index
-  %0 = arith.addf %arg0, %arg1 : vector<32x32xf16>
-  %1 = arith.extf %0 : vector<32x32xf16> to vector<32x32xf32>
-  %2 = arith.truncf %1 : vector<32x32xf32> to vector<32x32xf16>
-  return
-}
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-    %0 = transform.structured.match ops{["arith.truncf"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
-    // expected-error@below {{Could not find a layout attribute in the producer chain.}}
-    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value) -> !transform.any_op
-    transform.yield
-  }
-}

--- a/mlir/test/Dialect/XeGPU/transform-ops-invalid.mlir
+++ b/mlir/test/Dialect/XeGPU/transform-ops-invalid.mlir
@@ -172,7 +172,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["arith.truncf"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
     // expected-error@below {{Could not find a layout attribute in the producer chain.}}
-    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value
+    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value) -> !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/XeGPU/transform-ops-invalid.mlir
+++ b/mlir/test/Dialect/XeGPU/transform-ops-invalid.mlir
@@ -155,3 +155,24 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+// CHECK-LABEL: @convert_layout_no_producer_attr
+func.func @convert_layout_no_producer_attr(%arg0: vector<32x32xf16>, %arg1: vector<32x32xf16>) {
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg1 : vector<32x32xf16>
+  %1 = arith.extf %0 : vector<32x32xf16> to vector<32x32xf32>
+  %2 = arith.truncf %1 : vector<32x32xf32> to vector<32x32xf16>
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["arith.truncf"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
+    // expected-error@below {{Could not find a layout attribute in the producer chain.}}
+    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/XeGPU/transform-ops.mlir
+++ b/mlir/test/Dialect/XeGPU/transform-ops.mlir
@@ -400,3 +400,66 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+// CHECK-LABEL: @convert_layout_a
+func.func @convert_layout_a(%arg0: memref<4096x4096xf16>, %arg1: memref<4096x4096xf16>, %arg2: memref<4096x4096xf16>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[V0:.+]] = xegpu.create_nd_tdesc %arg0
+  %0 = xegpu.create_nd_tdesc %arg0 : memref<4096x4096xf16> -> !xegpu.tensor_desc<256x32xf16, #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>>
+  // CHECK: %[[V1:.+]] = xegpu.load_nd %[[V0]]
+  %1 = xegpu.load_nd %0[%c0, %c0]  : !xegpu.tensor_desc<256x32xf16, #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>> -> vector<256x32xf16>
+  // CHECK: %[[V2:.+]] = xegpu.convert_layout %[[V1]]
+  // CHECK: input_layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>
+  // CHECK: target_layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [8, 16]>
+  %2 = xegpu.create_nd_tdesc %arg1 : memref<4096x4096xf16> -> !xegpu.tensor_desc<32x256xf16>
+  %3 = xegpu.load_nd %2[%c0, %c0]  : !xegpu.tensor_desc<32x256xf16> -> vector<32x256xf16>
+  %4 = xegpu.create_nd_tdesc %arg2 : memref<4096x4096xf16> -> !xegpu.tensor_desc<256x256xf16>
+  %5 = xegpu.load_nd %4[%c0, %c0]  : !xegpu.tensor_desc<256x256xf16> -> vector<256x256xf16>
+  // CHECK: = xegpu.dpas %[[V2]]
+  %6 = xegpu.dpas %1, %3, %5 : vector<256x32xf16>, vector<32x256xf16>, vector<256x256xf16> -> vector<256x256xf16>
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["xegpu.dpas"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
+    // CHECK: transform.xegpu.convert_layout %{{.*}}
+    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value
+    transform.yield
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @convert_layout_a_sg_param
+func.func @convert_layout_a_sg_param(%arg0: memref<4096x4096xf16>, %arg1: memref<4096x4096xf16>, %arg2: memref<4096x4096xf16>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[V0:.+]] = xegpu.create_nd_tdesc %arg0
+  %0 = xegpu.create_nd_tdesc %arg0 : memref<4096x4096xf16> -> !xegpu.tensor_desc<256x32xf16, #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>>
+  // CHECK: %[[V1:.+]] = xegpu.load_nd %[[V0]]
+  %1 = xegpu.load_nd %0[%c0, %c0]  : !xegpu.tensor_desc<256x32xf16, #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>> -> vector<256x32xf16>
+  // CHECK: %[[V2:.+]] = xegpu.convert_layout %[[V1]]
+  // CHECK: input_layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>
+  // CHECK: target_layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [8, 16]>
+  %2 = xegpu.create_nd_tdesc %arg1 : memref<4096x4096xf16> -> !xegpu.tensor_desc<32x256xf16>
+  %3 = xegpu.load_nd %2[%c0, %c0]  : !xegpu.tensor_desc<32x256xf16> -> vector<32x256xf16>
+  %4 = xegpu.create_nd_tdesc %arg2 : memref<4096x4096xf16> -> !xegpu.tensor_desc<256x256xf16>
+  %5 = xegpu.load_nd %4[%c0, %c0]  : !xegpu.tensor_desc<256x256xf16> -> vector<256x256xf16>
+  // CHECK: = xegpu.dpas %[[V2]]
+  %6 = xegpu.dpas %1, %3, %5 : vector<256x32xf16>, vector<32x256xf16>, vector<256x256xf16> -> vector<256x256xf16>
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["xegpu.dpas"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
+    // CHECK: transform.xegpu.convert_layout %{{.*}}
+    %layout0 = transform.param.constant 8 : i64 -> !transform.param<i64>
+    transform.xegpu.convert_layout %1 sg_layout = [%layout0, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value, !transform.param<i64>
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/XeGPU/transform-ops.mlir
+++ b/mlir/test/Dialect/XeGPU/transform-ops.mlir
@@ -427,7 +427,10 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["xegpu.dpas"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
     // CHECK: transform.xegpu.convert_layout %{{.*}}
-    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value) -> !transform.any_op
+    transform.xegpu.convert_layout %1
+      input_sg_layout = [8, 4] input_sg_data = [32, 32] input_inst_data = [32, 16]
+      target_sg_layout = [8, 4] target_sg_data = [32, 32] target_inst_data = [8, 16]
+      : (!transform.any_value) -> !transform.any_op
     transform.yield
   }
 }
@@ -459,35 +462,10 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
     %layout0 = transform.param.constant 8 : i64 -> !transform.param<i64>
     // CHECK: transform.xegpu.convert_layout %{{.*}}
-    transform.xegpu.convert_layout %1 sg_layout = [%layout0, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value, !transform.param<i64>) -> !transform.any_op
-    transform.yield
-  }
-}
-
-// -----
-
-// CHECK-LABEL: @convert_layout_producer_attr
-func.func @convert_layout_producer_attr(%arg0: vector<32x32xf16>, %arg1: vector<32x32xf16>) {
-  %c0 = arith.constant 0 : index
-  %0 = arith.addf %arg0, %arg1 {layout_result_0 =
-        #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>} :
-        vector<32x32xf16>
-  // CHECK: %[[V0:.+]] = arith.extf
-  %1 = arith.extf %0 : vector<32x32xf16> to vector<32x32xf32>
-  // CHECK: %[[V1:.+]] = xegpu.convert_layout %[[V0]]
-  // CHECK: input_layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [32, 16]>
-  // CHECK: target_layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32], inst_data = [8, 16]>
-  // CHECK: %[[V0:.+]] = arith.truncf %[[V1]]
-  %2 = arith.truncf %1 : vector<32x32xf32> to vector<32x32xf16>
-  return
-}
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-    %0 = transform.structured.match ops{["arith.truncf"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
-    // CHECK: transform.xegpu.convert_layout %{{.*}}
-    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value) -> !transform.any_op
+    transform.xegpu.convert_layout %1
+      input_sg_layout = [%layout0, 4] input_sg_data = [32, 32] input_inst_data = [32, 16]
+      target_sg_layout = [%layout0, 4] target_sg_data = [32, 32] target_inst_data = [8, 16]
+      : (!transform.any_value, !transform.param<i64>, !transform.param<i64>) -> !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/XeGPU/transform-ops.mlir
+++ b/mlir/test/Dialect/XeGPU/transform-ops.mlir
@@ -427,7 +427,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["xegpu.dpas"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
     // CHECK: transform.xegpu.convert_layout %{{.*}}
-    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value
+    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value) -> !transform.any_op
     transform.yield
   }
 }
@@ -459,7 +459,7 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
     %layout0 = transform.param.constant 8 : i64 -> !transform.param<i64>
     // CHECK: transform.xegpu.convert_layout %{{.*}}
-    transform.xegpu.convert_layout %1 sg_layout = [%layout0, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value, !transform.param<i64>
+    transform.xegpu.convert_layout %1 sg_layout = [%layout0, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value, !transform.param<i64>) -> !transform.any_op
     transform.yield
   }
 }
@@ -487,7 +487,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["arith.truncf"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_operand %0[0] : (!transform.any_op) -> !transform.any_value
     // CHECK: transform.xegpu.convert_layout %{{.*}}
-    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : !transform.any_value
+    transform.xegpu.convert_layout %1 sg_layout = [8, 4] sg_data = [32, 32] inst_data = [8, 16] : (!transform.any_value) -> !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/python/dialects/transform_xegpu_ext.py
+++ b/mlir/test/python/dialects/transform_xegpu_ext.py
@@ -25,7 +25,7 @@ def getDescOpDefaultIndex():
     )
     with InsertionPoint(sequence.body):
         operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [0])
-        desc_handle = xegpu.GetDescOp(operand)
+        desc_handle = xegpu.get_desc_op(operand)
         transform.YieldOp()
     # CHECK-LABEL: TEST: getDescOpDefaultIndex
     # CHECK: transform.xegpu.get_desc_op %
@@ -39,7 +39,7 @@ def setDescLayoutMinimal():
         transform.OperationType.get("xegpu.create_nd_tdesc"),
     )
     with InsertionPoint(sequence.body):
-        xegpu.SetDescLayoutOp(sequence.bodyTarget, sg_layout=[6, 4], sg_data=[32, 16])
+        xegpu.set_desc_layout(sequence.bodyTarget, sg_layout=[6, 4], sg_data=[32, 16])
         transform.YieldOp()
     # CHECK-LABEL: TEST: setDescLayoutMinimal
     # CHECK: %0 = transform.xegpu.set_desc_layout %
@@ -55,7 +55,7 @@ def setDescLayoutInstData():
         transform.OperationType.get("xegpu.create_nd_tdesc"),
     )
     with InsertionPoint(sequence.body):
-        xegpu.SetDescLayoutOp(
+        xegpu.set_desc_layout(
             sequence.bodyTarget, sg_layout=[6, 4], sg_data=[32, 16], inst_data=[8, 16]
         )
         transform.YieldOp()
@@ -74,7 +74,7 @@ def setOpLayoutAttrOperandMinimal():
         transform.OperationType.get("xegpu.dpas"),
     )
     with InsertionPoint(sequence.body):
-        xegpu.SetOpLayoutAttrOp(
+        xegpu.set_op_layout_attr(
             sequence.bodyTarget,
             sg_layout=[6, 4],
             sg_data=[32, 16],
@@ -97,7 +97,7 @@ def setOpLayoutAttrResult():
         transform.OperationType.get("xegpu.dpas"),
     )
     with InsertionPoint(sequence.body):
-        xegpu.SetOpLayoutAttrOp(
+        xegpu.set_op_layout_attr(
             sequence.bodyTarget,
             index=0,
             sg_layout=[6, 4],
@@ -204,7 +204,7 @@ def ConvertLayoutMinimal():
     )
     with InsertionPoint(sequence.body):
         operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [0])
-        xegpu.ConvertLayoutOp(
+        xegpu.convert_layout(
             operand,
             sg_layout=[6, 4],
             sg_data=[32, 16],
@@ -225,7 +225,7 @@ def ConvertLayout():
     )
     with InsertionPoint(sequence.body):
         operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [1])
-        xegpu.ConvertLayoutOp(
+        xegpu.convert_layout(
             operand,
             sg_layout=[6, 4],
             sg_data=[32, 16],

--- a/mlir/test/python/dialects/transform_xegpu_ext.py
+++ b/mlir/test/python/dialects/transform_xegpu_ext.py
@@ -206,14 +206,18 @@ def ConvertLayoutMinimal():
         operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [0])
         xegpu.convert_layout(
             operand,
-            sg_layout=[6, 4],
-            sg_data=[32, 16],
+            input_sg_layout=[6, 4],
+            input_sg_data=[32, 16],
+            target_sg_layout=[6, 4],
+            target_sg_data=[8, 16],
         )
         transform.YieldOp()
     # CHECK-LABEL: TEST: ConvertLayoutMinimal
     # CHECK: transform.xegpu.convert_layout %
-    # CHECK: sg_layout = [6, 4]
-    # CHECK: sg_data = [32, 16]
+    # CHECK: input_sg_layout = [6, 4]
+    # CHECK: input_sg_data = [32, 16]
+    # CHECK: target_sg_layout = [6, 4]
+    # CHECK: target_sg_data = [8, 16]
 
 
 @run
@@ -227,13 +231,19 @@ def ConvertLayout():
         operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [1])
         xegpu.convert_layout(
             operand,
-            sg_layout=[6, 4],
-            sg_data=[32, 16],
-            inst_data=[8, 16],
+            input_sg_layout=[6, 4],
+            input_sg_data=[32, 32],
+            input_inst_data=[32, 16],
+            target_sg_layout=[6, 4],
+            target_sg_data=[32, 32],
+            target_inst_data=[8, 16],
         )
         transform.YieldOp()
     # CHECK-LABEL: TEST: ConvertLayout
     # CHECK: transform.xegpu.convert_layout %
-    # CHECK: sg_layout = [6, 4]
-    # CHECK: sg_data = [32, 16]
-    # CHECK: inst_data = [8, 16]
+    # CHECK: input_sg_layout = [6, 4]
+    # CHECK: input_sg_data = [32, 32]
+    # CHECK: input_inst_data = [32, 16]
+    # CHECK: target_sg_layout = [6, 4]
+    # CHECK: target_sg_data = [32, 32]
+    # CHECK: target_inst_data = [8, 16]

--- a/mlir/test/python/dialects/transform_xegpu_ext.py
+++ b/mlir/test/python/dialects/transform_xegpu_ext.py
@@ -193,3 +193,47 @@ def insertPrefetchNbPrefetchParam():
     # CHECK: %[[PARAM_OP:.*]] = transform.param.constant 2
     # CHECK: transform.xegpu.insert_prefetch %[[OPR]]
     # CHECK-SAME: nb_prefetch = %[[PARAM_OP]]
+
+
+@run
+def ConvertLayoutMinimal():
+    sequence = transform.SequenceOp(
+        transform.FailurePropagationMode.Propagate,
+        [],
+        transform.OperationType.get("xegpu.dpas"),
+    )
+    with InsertionPoint(sequence.body):
+        operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [0])
+        xegpu.ConvertLayoutOp(
+            operand,
+            sg_layout=[6, 4],
+            sg_data=[32, 16],
+        )
+        transform.YieldOp()
+    # CHECK-LABEL: TEST: ConvertLayoutMinimal
+    # CHECK: transform.xegpu.convert_layout %
+    # CHECK: sg_layout = [6, 4]
+    # CHECK: sg_data = [32, 16]
+
+
+@run
+def ConvertLayout():
+    sequence = transform.SequenceOp(
+        transform.FailurePropagationMode.Propagate,
+        [],
+        transform.OperationType.get("xegpu.dpas"),
+    )
+    with InsertionPoint(sequence.body):
+        operand = transform.GetOperandOp(AnyValueType.get(), sequence.bodyTarget, [1])
+        xegpu.ConvertLayoutOp(
+            operand,
+            sg_layout=[6, 4],
+            sg_data=[32, 16],
+            inst_data=[8, 16],
+        )
+        transform.YieldOp()
+    # CHECK-LABEL: TEST: ConvertLayout
+    # CHECK: transform.xegpu.convert_layout %
+    # CHECK: sg_layout = [6, 4]
+    # CHECK: sg_data = [32, 16]
+    # CHECK: inst_data = [8, 16]


### PR DESCRIPTION
Adds `transform.xegpu.convert_layout` transform op that inserts an `xegpu.convert_layout` op for a given `Value`.

`convert_layout` op takes a value handle, and both input and target layout attributes. It returns a handle to the `xegpu.convert_layout` op:

```mlir
%tile_a = transform.get_operand %dpas_op[0] : (!transform.any_op) -> !transform.any_value
%conv_op = transform.xegpu.convert_layout %tile_a
      input_sg_layout = [8, 4] input_sg_data = [32, 32] input_inst_data = [32, 16]
      target_sg_layout = [8, 4] target_sg_data = [32, 32] target_inst_data = [8, 16]
      : (!transform.any_value) -> !transform.any_op
```