### PR TITLE
[libc] fwrite_unlocked: only return errno if an actual error occurred.

### DIFF
--- a/libc/src/stdio/printf_core/vfprintf_internal.h
+++ b/libc/src/stdio/printf_core/vfprintf_internal.h
@@ -54,8 +54,8 @@ LIBC_INLINE FileIOResult fwrite_unlocked(const void *ptr, size_t size,
   // which we need to propagate back into our code. fwrite only modifies errno
   // if there was an error, and errno may have previously been nonzero. Only
   // return errno if there was an error.
-  auto bytes = ::fwrite_unlocked(ptr, size, nmemb, f);
-  return {bytes, bytes == nmemb * size ? 0 : errno};
+  size_t bytes = ::fwrite_unlocked(ptr, size, nmemb, f);
+  return {bytes, bytes == size ? 0 : errno};
 }
 #endif // LIBC_COPT_STDIO_USE_SYSTEM_FILE
 } // namespace internal

--- a/libc/src/stdio/printf_core/vfprintf_internal.h
+++ b/libc/src/stdio/printf_core/vfprintf_internal.h
@@ -55,10 +55,7 @@ LIBC_INLINE FileIOResult fwrite_unlocked(const void *ptr, size_t size,
   // if there was an error, and errno may have previously been nonzero. Only
   // return errno if there was an error.
   auto bytes = ::fwrite_unlocked(ptr, size, nmemb, f);
-  if (bytes == nmemb * size)
-    return bytes;
-  else
-    return errno;
+  return {bytes, bytes == nmemb * size ? 0 : errno};
 }
 #endif // LIBC_COPT_STDIO_USE_SYSTEM_FILE
 } // namespace internal

--- a/libc/src/stdio/printf_core/vfprintf_internal.h
+++ b/libc/src/stdio/printf_core/vfprintf_internal.h
@@ -54,8 +54,8 @@ LIBC_INLINE FileIOResult fwrite_unlocked(const void *ptr, size_t size,
   // which we need to propagate back into our code. fwrite only modifies errno
   // if there was an error, and errno may have previously been nonzero. Only
   // return errno if there was an error.
-  size_t bytes = ::fwrite_unlocked(ptr, size, nmemb, f);
-  return {bytes, bytes == size ? 0 : errno};
+  size_t members_written = ::fwrite_unlocked(ptr, size, nmemb, f);
+  return {members_written, members_written == nmemb ? 0 : errno};
 }
 #endif // LIBC_COPT_STDIO_USE_SYSTEM_FILE
 } // namespace internal

--- a/libc/src/stdio/printf_core/vfprintf_internal.h
+++ b/libc/src/stdio/printf_core/vfprintf_internal.h
@@ -51,8 +51,14 @@ LIBC_INLINE void funlockfile(::FILE *f) { ::funlockfile(f); }
 LIBC_INLINE FileIOResult fwrite_unlocked(const void *ptr, size_t size,
                                          size_t nmemb, ::FILE *f) {
   // Need to use system errno in this case, as system write will set this errno
-  // which we need to propagate back into our code.
-  return {::fwrite_unlocked(ptr, size, nmemb, f), errno};
+  // which we need to propagate back into our code. fwrite only modifies errno
+  // if there was an error, and errno may have previously been nonzero. Only
+  // return errno if there was an error.
+  auto bytes = ::fwrite_unlocked(ptr, size, nmemb, f);
+  if (bytes == nmemb * size)
+    return bytes;
+  else
+    return errno;
 }
 #endif // LIBC_COPT_STDIO_USE_SYSTEM_FILE
 } // namespace internal


### PR DESCRIPTION
fwrite and friends don't modify errno if no error occurred. Therefore frite_unlocked's return value shouldn't be constructed from errno without checking if an error actually occurred.

This fixes an error introduced by https://github.com/llvm/llvm-project/commit/9e2f73fe9052a4fbf382a06e30b2441c6d99fb7e