### PR TITLE
Add default empty header filter regex to root .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
+HeaderFilterRegex: ''
 Checks: >
   -*,
   clang-diagnostic-*,


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/164165, we emit warnings from non-system headers by default.
This change only preserves functionality of `clang-tidy` as it was before the change.