### PR TITLE
[clang][test] Fix test issue under LLVM_REVERSE_ITERATION

### DIFF
--- a/clang/test/Analysis/analyzeOneFunction.cpp
+++ b/clang/test/Analysis/analyzeOneFunction.cpp
@@ -5,9 +5,9 @@
 // RUN:   -analyze-function="c:@S@Window@F@overloaded#I#"
 
 // RUN: %clang_extdef_map %s | FileCheck %s
-// CHECK:      27:c:@S@Window@F@overloaded#I#
-// CHECK-NEXT: 27:c:@S@Window@F@overloaded#C#
-// CHECK-NEXT: 27:c:@S@Window@F@overloaded#d#
+// CHECK-DAG: 27:c:@S@Window@F@overloaded#I#
+// CHECK-DAG: 27:c:@S@Window@F@overloaded#C#
+// CHECK-DAG: 27:c:@S@Window@F@overloaded#d#
 
 void clang_analyzer_warnIfReached();
 


### PR DESCRIPTION
The order of these items may not be the same if reverse iteration is
enabled. From what I can tell this is related to visitation order, and I
don't see an easy way to handle that using the typical solutions, like
MapVector, etc. For now, just use CHECK-DAG to get the test into a
passing state.

Fixes #167057