### PR TITLE
[NFC][Support] Replace "Return" with "Returns" in comments

### DIFF
--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -209,7 +209,7 @@ protected:
 
     Section(Section &&) = default;
 
-    // Returns name of the section, it's entire string in [].
+    // Returns name of the section, its entire string in [].
     StringRef name() const { return SectionStr; }
 
     // Returns true of string 'Name' matches section name interpreted as a glob.

--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -209,13 +209,13 @@ protected:
 
     Section(Section &&) = default;
 
-    // Return name of the section, its entire string in [].
+    // Returns name of the section, it's entire string in [].
     StringRef name() const { return SectionStr; }
 
-    // Returns true if string 'Name' matches section name interpreted as a glob.
+    // Returns true of string 'Name' matches section name interpreted as a glob.
     LLVM_ABI bool matchName(StringRef Name) const;
 
-    // Return sequence number of the file where this section is defined.
+    // Returns sequence number of the file where this section is defined.
     unsigned fileIndex() const { return FileIdx; }
 
     // Helper method to search by Prefix, Query, and Category. Returns

--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -212,7 +212,7 @@ protected:
     // Returns name of the section, its entire string in [].
     StringRef name() const { return SectionStr; }
 
-    // Returns true of string 'Name' matches section name interpreted as a glob.
+    // Returns true if string 'Name' matches section name interpreted as a glob.
     LLVM_ABI bool matchName(StringRef Name) const;
 
     // Returns sequence number of the file where this section is defined.


### PR DESCRIPTION
Fixes typos in comments in `SpecialCaseList.h`.
