### PR TITLE
[LTT] Mark as unkown weak function tests.

### DIFF
--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -1469,6 +1469,9 @@ void LowerTypeTestsModule::replaceWeakDeclarationWithJumpTablePtr(
                                      Constant::getNullValue(F->getType()));
     Value *Select = Builder.CreateSelect(ICmp, JT,
                                          Constant::getNullValue(F->getType()));
+
+    if (auto *SI = dyn_cast<SelectInst>(Select))
+      setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
     // For phi nodes, we need to update the incoming value for all operands
     // with the same predecessor.
     if (PN)

--- a/llvm/test/Transforms/LowerTypeTests/function-weak.ll
+++ b/llvm/test/Transforms/LowerTypeTests/function-weak.ll
@@ -32,10 +32,10 @@ target triple = "x86_64-unknown-linux-gnu"
 declare !type !0 extern_weak void @f()
 
 ; CHECK: define zeroext i1 @check_f()
-define zeroext i1 @check_f() {
+define zeroext i1 @check_f() !prof !{!"function_entry_count", i32 10} {
 entry:
 ; CHECK: [[CMP:%.*]] = icmp ne ptr @f, null
-; CHECK: [[SEL:%.*]] = select i1 [[CMP]], ptr @[[JT:.*]], ptr null
+; CHECK: [[SEL:%.*]] = select i1 [[CMP]], ptr @[[JT:.*]], ptr null, !prof ![[SELPROF:[0-9]+]]
 ; CHECK: [[PTI:%.*]] = ptrtoint ptr [[SEL]] to i1
 ; CHECK: ret i1 [[PTI]]
   ret i1 ptrtoint (ptr @f to i1)
@@ -165,3 +165,4 @@ define i1 @foo(ptr %p) {
 ; CHECK-NEXT: }
 
 !0 = !{i32 0, !"typeid1"}
+; CHECK: ![[SELPROF]] = !{!"unknown", !"lowertypetests"}


### PR DESCRIPTION
We don't have enough information to infer the probability of a weak function pointer being nullptr or not (open question if we could propagate this from the linker)

Issue #147390