### PR TITLE
[CIR] Upstream X86 builtin clflush, fence and pause

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -413,6 +413,18 @@ def CIR_ConstantOp : CIR_Op<"const", [
 
     template <typename T>
     T getValueAttr() { return mlir::dyn_cast<T>(getValue()); }
+
+    llvm::APInt getIntValue() {
+      if (const auto intAttr = getValueAttr<cir::IntAttr>())
+        return intAttr.getValue();
+      llvm_unreachable("Expected an IntAttr in ConstantOp");
+    }
+
+    bool getBoolValue() {
+      if (const auto boolAttr = getValueAttr<cir::BoolAttr>())
+        return boolAttr.getValue();
+      llvm_unreachable("Expected a BoolAttr in ConstantOp");
+    }
   }];
 
   let hasFolder = 1;
@@ -2577,6 +2589,39 @@ def CIR_FuncOp : CIR_Op<"func", [
                          OpAdaptor adaptor,
                          mlir::ConversionPatternRewriter &rewriter) const;
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// LLVMIntrinsicCallOp
+//===----------------------------------------------------------------------===//
+
+def CIR_LLVMIntrinsicCallOp : CIR_Op<"llvm.intrinsic"> {
+  let summary = "Call to llvm intrinsic functions that is not defined in CIR";
+  let description = [{
+    `cir.llvm.intrinsic` operation represents a call-like expression which has
+    return type and arguments that maps directly to a llvm intrinsic.
+    It only records intrinsic `intrinsic_name`.
+  }];
+
+  let results = (outs Optional<CIR_AnyType>:$result);
+  let arguments = (ins
+                   StrAttr:$intrinsic_name, Variadic<CIR_AnyType>:$arg_ops);
+
+  let skipDefaultBuilders = 1;
+
+  let assemblyFormat = [{
+    $intrinsic_name $arg_ops `:` functional-type($arg_ops, $result) attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::StringAttr":$intrinsic_name, "mlir::Type":$resType,
+              CArg<"mlir::ValueRange", "{}">:$operands), [{
+      $_state.addAttribute("intrinsic_name", intrinsic_name);
+      $_state.addOperands(operands);
+      if (resType)
+        $_state.addTypes(resType);
+    }]>,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2598,7 +2598,7 @@ def CIR_FuncOp : CIR_Op<"func", [
 def CIR_LLVMIntrinsicCallOp : CIR_Op<"call_llvm_intrinsic"> {
   let summary = "Call to llvm intrinsic functions that is not defined in CIR";
   let description = [{
-    `cir.llvm.intrinsic` operation represents a call-like expression which has
+    `cir.call_llvm_intrinsic` operation represents a call-like expression which has
     return type and arguments that maps directly to a llvm intrinsic.
     It only records intrinsic `intrinsic_name`.
   }];

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2595,7 +2595,7 @@ def CIR_FuncOp : CIR_Op<"func", [
 // LLVMIntrinsicCallOp
 //===----------------------------------------------------------------------===//
 
-def CIR_LLVMIntrinsicCallOp : CIR_Op<"llvm.intrinsic"> {
+def CIR_LLVMIntrinsicCallOp : CIR_Op<"call_llvm_intrinsic"> {
   let summary = "Call to llvm intrinsic functions that is not defined in CIR";
   let description = [{
     `cir.llvm.intrinsic` operation represents a call-like expression which has

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -270,8 +270,8 @@ struct MissingFeatures {
   static bool innermostEHScope() { return false; }
   static bool insertBuiltinUnpredictable() { return false; }
   static bool instrumentation() { return false; }
+  static bool intrinsicElementTypeSupport() { return false; }
   static bool intrinsics() { return false; }
-  static bool intrinsicElementTypeSupport() {return false; }
   static bool isMemcpyEquivalentSpecialMember() { return false; }
   static bool isTrivialCtorOrDtor() { return false; }
   static bool lambdaCaptures() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -271,6 +271,7 @@ struct MissingFeatures {
   static bool insertBuiltinUnpredictable() { return false; }
   static bool instrumentation() { return false; }
   static bool intrinsics() { return false; }
+  static bool intrinsicElementTypeSupport() {return false; }
   static bool isMemcpyEquivalentSpecialMember() { return false; }
   static bool isTrivialCtorOrDtor() { return false; }
   static bool lambdaCaptures() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -21,7 +21,6 @@
 using namespace clang;
 using namespace clang::CIRGen;
 
-
 template <typename... Operands>
 static mlir::Value emitIntrinsicCallOp(CIRGenFunction &cgf, const CallExpr *e,
                                        const std::string &str,

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -31,11 +31,10 @@ static mlir::Value emitClFlush(CIRGenFunction& cgf,
                                mlir::Value& op) {
     mlir::Type voidTy = cir::VoidType::get(&cgf.getMLIRContext());
     mlir::Location location = cgf.getLoc(e->getExprLoc());
-    return cgf.getBuilder()
-        .create<cir::LLVMIntrinsicCallOp>(
-            location, cgf.getBuilder().getStringAttr("x86.sse2.clflush"),
-            voidTy, op)
-        .getResult();
+    return cir::LLVMIntrinsicCallOp::create(
+          cgf.getBuilder(), location, 
+          cgf.getBuilder().getStringAttr("x86.sse2.clflush"), voidTy, op)
+      .getResult();
 }
 
 static mlir::Value emitPrefetch(CIRGenFunction& cgf,

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1430,14 +1430,14 @@ mlir::Value CIRGenFunction::emitPromotedScalarExpr(const Expr *e,
   return ScalarExprEmitter(*this, builder).Visit(const_cast<Expr *>(e));
 }
 
-mlir::Value CIRGenFunction::emitScalarOrConstFoldImmArg(unsigned ICEArguments,
+mlir::Value CIRGenFunction::emitScalarOrConstFoldImmArg(unsigned iceArguments,
                                                         unsigned index,
                                                         const CallExpr *e) {
   mlir::Value arg{};
 
   // The bit at the specified index indicates whether the argument is required
   // to be a constant integer expression.
-  bool isArgRequiredToBeConstant = (ICEArguments & (1 << index));
+  bool isArgRequiredToBeConstant = (iceArguments & (1 << index));
 
   if (!isArgRequiredToBeConstant) {
     arg = emitScalarExpr(e->getArg(index));

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1530,7 +1530,7 @@ public:
                              bool ignoreResultAssign = false);
 
   mlir::Value emitScalarOrConstFoldImmArg(unsigned iceArguments, unsigned index,
-                                          const CallExpr *e);
+                                          const Expr *e);
 
   mlir::Value emitScalarPrePostIncDec(const UnaryOperator *e, LValue lv,
                                       cir::UnaryOpKind kind, bool isPre);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1529,6 +1529,10 @@ public:
   mlir::Value emitScalarExpr(const clang::Expr *e,
                              bool ignoreResultAssign = false);
 
+  mlir::Value emitScalarOrConstFoldImmArg(unsigned ICEArguments,
+                                          unsigned index,
+                                          const CallExpr *e);
+
   mlir::Value emitScalarPrePostIncDec(const UnaryOperator *e, LValue lv,
                                       cir::UnaryOpKind kind, bool isPre);
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1529,8 +1529,7 @@ public:
   mlir::Value emitScalarExpr(const clang::Expr *e,
                              bool ignoreResultAssign = false);
 
-  mlir::Value emitScalarOrConstFoldImmArg(unsigned ICEArguments,
-                                          unsigned index,
+  mlir::Value emitScalarOrConstFoldImmArg(unsigned iceArguments, unsigned index,
                                           const CallExpr *e);
 
   mlir::Value emitScalarPrePostIncDec(const UnaryOperator *e, LValue lv,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1530,7 +1530,7 @@ public:
                              bool ignoreResultAssign = false);
 
   mlir::Value emitScalarOrConstFoldImmArg(unsigned iceArguments, unsigned index,
-                                          const Expr *e);
+                                          const Expr *arg);
 
   mlir::Value emitScalarPrePostIncDec(const UnaryOperator *e, LValue lv,
                                       cir::UnaryOpKind kind, bool isPre);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -320,6 +320,20 @@ static mlir::LLVM::CallIntrinsicOp replaceOpWithCallLLVMIntrinsicOp(
   return callIntrinOp;
 }
 
+mlir::LogicalResult CIRToLLVMLLVMIntrinsicCallOpLowering::matchAndRewrite(
+    cir::LLVMIntrinsicCallOp op,
+    OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Type llvmResTy =
+      getTypeConverter()->convertType(op->getResultTypes()[0]);
+  if (!llvmResTy)
+    return op.emitError("expected LLVM result type");
+  StringRef name = op.getIntrinsicName();
+  replaceOpWithCallLLVMIntrinsicOp(rewriter, op, "llvm." + name, llvmResTy,
+                                   adaptor.getOperands());
+  return mlir::success();
+}
+
 /// IntAttr visitor.
 mlir::Value CIRAttrToValue::visitCirAttr(cir::IntAttr intAttr) {
   mlir::Location loc = parentOp->getLoc();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -328,7 +328,7 @@ mlir::LogicalResult CIRToLLVMLLVMIntrinsicCallOpLowering::matchAndRewrite(
   if (!llvmResTy)
     return op.emitError("expected LLVM result type");
   StringRef name = op.getIntrinsicName();
-  
+
   // Some LLVM intrinsics require ElementType attribute to be attached to
   // the argument of pointer type. That prevents us from generating LLVM IR
   // because from LLVM dialect, we have LLVM IR like the below which fails

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -321,14 +321,24 @@ static mlir::LLVM::CallIntrinsicOp replaceOpWithCallLLVMIntrinsicOp(
 }
 
 mlir::LogicalResult CIRToLLVMLLVMIntrinsicCallOpLowering::matchAndRewrite(
-    cir::LLVMIntrinsicCallOp op,
-    OpAdaptor adaptor,
+    cir::LLVMIntrinsicCallOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Type llvmResTy =
       getTypeConverter()->convertType(op->getResultTypes()[0]);
   if (!llvmResTy)
     return op.emitError("expected LLVM result type");
   StringRef name = op.getIntrinsicName();
+  
+  // Some LLVM intrinsics require ElementType attribute to be attached to
+  // the argument of pointer type. That prevents us from generating LLVM IR
+  // because from LLVM dialect, we have LLVM IR like the below which fails
+  // LLVM IR verification.
+  // %3 = call i64 @llvm.aarch64.ldxr.p0(ptr %2)
+  // The expected LLVM IR should be like
+  // %3 = call i64 @llvm.aarch64.ldxr.p0(ptr elementtype(i32) %2)
+  // TODO(cir): MLIR LLVM dialect should handle this part as CIR has no way
+  // to set LLVM IR attribute.
+  assert(!cir::MissingFeatures::intrinsicElementTypeSupport());
   replaceOpWithCallLLVMIntrinsicOp(rewriter, op, "llvm." + name, llvmResTy,
                                    adaptor.getOperands());
   return mlir::success();

--- a/clang/test/CIR/CodeGen/X86/sse-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse-builtins.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM --input-file=%t.ll %s
+
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM --input-file=%t.ll %s
+
+// This test mimics clang/test/CodeGen/X86/sse-builtins.c, which eventually
+// CIR shall be able to support fully.
+
+#include <immintrin.h>
+
+
+void test_mm_prefetch(char const* p) {
+  // CIR-LABEL: test_mm_prefetch
+  // LLVM-LABEL: test_mm_prefetch
+  _mm_prefetch(p, 0);
+  // CIR: cir.prefetch read locality(0) %{{.*}} : !cir.ptr<!void>
+  // LLVM: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 0, i32 1)
+}

--- a/clang/test/CIR/CodeGen/X86/sse-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse-builtins.c
@@ -8,6 +8,9 @@
 // RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -fclangir -emit-llvm -o %t.ll -Wall -Werror
 // RUN: FileCheck --check-prefixes=LLVM --input-file=%t.ll %s
 
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -emit-llvm -o - -Wall -Werror | FileCheck %s -check-prefix=OGCG
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -emit-llvm -o - -Wall -Werror | FileCheck %s -check-prefix=OGCG
+
 // This test mimics clang/test/CodeGen/X86/sse-builtins.c, which eventually
 // CIR shall be able to support fully.
 
@@ -17,7 +20,9 @@
 void test_mm_sfence(void) {
   // CIR-LABEL: test_mm_sfence
   // LLVM-LABEL: test_mm_sfence
+  // OGCG-LABEL: test_mm_sfence
   _mm_sfence();
   // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse.sfence" : () -> !void
   // LLVM: call void @llvm.x86.sse.sfence()
+  // OGCG: call void @llvm.x86.sse.sfence()
 }

--- a/clang/test/CIR/CodeGen/X86/sse-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse-builtins.c
@@ -14,14 +14,6 @@
 #include <immintrin.h>
 
 
-void test_mm_prefetch(char const* p) {
-  // CIR-LABEL: test_mm_prefetch
-  // LLVM-LABEL: test_mm_prefetch
-  _mm_prefetch(p, 0);
-  // CIR: cir.prefetch read locality(0) %{{.*}} : !cir.ptr<!void>
-  // LLVM: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 0, i32 1)
-}
-
 void test_mm_sfence(void) {
   // CIR-LABEL: test_mm_sfence
   // LLVM-LABEL: test_mm_sfence

--- a/clang/test/CIR/CodeGen/X86/sse-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse-builtins.c
@@ -21,3 +21,11 @@ void test_mm_prefetch(char const* p) {
   // CIR: cir.prefetch read locality(0) %{{.*}} : !cir.ptr<!void>
   // LLVM: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 0, i32 1)
 }
+
+void test_mm_sfence(void) {
+  // CIR-LABEL: test_mm_sfence
+  // LLVM-LABEL: test_mm_sfence
+  _mm_sfence();
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse.sfence" : () -> !void
+  // LLVM: call void @llvm.x86.sse.sfence()
+}

--- a/clang/test/CIR/CodeGen/X86/sse2-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse2-builtins.c
@@ -21,3 +21,27 @@ void test_mm_clflush(void* A) {
   // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
   // LLVM-CHECK: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
 }
+
+void test_mm_lfence(void) {
+  // CIR-CHECK-LABEL: test_mm_lfence
+  // LLVM-CHECK-LABEL: test_mm_lfence
+  _mm_lfence();
+  // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.lfence" : () -> !void
+  // LLVM-CHECK: call void @llvm.x86.sse2.lfence()
+}
+
+void test_mm_mfence(void) {
+  // CIR-CHECK-LABEL: test_mm_mfence
+  // LLVM-CHECK-LABEL: test_mm_mfence
+  _mm_mfence();
+  // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.mfence" : () -> !void
+  // LLVM-CHECK: call void @llvm.x86.sse2.mfence()
+}
+
+void test_mm_pause(void) {
+  // CIR-LABEL: test_mm_pause
+  // LLVM-LABEL: test_mm_pause
+  _mm_pause();
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.pause" : () -> !void
+  // LLVM: call void @llvm.x86.sse2.pause()
+}

--- a/clang/test/CIR/CodeGen/X86/sse2-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse2-builtins.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+
+// This test mimics clang/test/CodeGen/X86/sse2-builtins.c, which eventually
+// CIR shall be able to support fully.
+
+#include <immintrin.h>
+
+
+void test_mm_clflush(void* A) {
+  // CIR-LABEL: test_mm_clflush
+  // LLVM-LABEL: teh
+  _mm_clflush(A);
+  // CIR-CHECK: {{%.*}} = cir.llvm.intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
+  // LLVM-CHECK: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
+}

--- a/clang/test/CIR/CodeGen/X86/sse2-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse2-builtins.c
@@ -1,12 +1,15 @@
 // RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-cir -o %t.cir -Wall -Werror
-// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+// RUN: FileCheck --check-prefixes=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
-// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+// RUN: FileCheck --check-prefixes=CIR --input-file=%t.cir %s
 
 // RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-llvm -o %t.ll -Wall -Werror
-// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+// RUN: FileCheck --check-prefixes=LLVM --input-file=%t.ll %s
 // RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
-// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+// RUN: FileCheck --check-prefixes=LLVM --input-file=%t.ll %s
+
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -emit-llvm -o - -Wall -Werror | FileCheck %s -check-prefix=OGCG
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse -emit-llvm -o - -Wall -Werror | FileCheck %s -check-prefix=OGCG
 
 // This test mimics clang/test/CodeGen/X86/sse2-builtins.c, which eventually
 // CIR shall be able to support fully.
@@ -16,32 +19,40 @@
 
 void test_mm_clflush(void* A) {
   // CIR-LABEL: test_mm_clflush
-  // LLVM-LABEL: teh
+  // LLVM-LABEL: test_mm_clflush
+  // OGCG-LABEL: test_mm_clflush
   _mm_clflush(A);
-  // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
-  // LLVM-CHECK: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
+  // LLVM: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
+  // OGCG: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
 }
 
 void test_mm_lfence(void) {
-  // CIR-CHECK-LABEL: test_mm_lfence
-  // LLVM-CHECK-LABEL: test_mm_lfence
+  // CIR-LABEL: test_mm_lfence
+  // LLVM-LABEL: test_mm_lfence
+  // OGCG-LABEL: test_mm_lfence
   _mm_lfence();
-  // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.lfence" : () -> !void
-  // LLVM-CHECK: call void @llvm.x86.sse2.lfence()
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.lfence" : () -> !void
+  // LLVM: call void @llvm.x86.sse2.lfence()
+  // OGCG: call void @llvm.x86.sse2.lfence()
 }
 
 void test_mm_mfence(void) {
-  // CIR-CHECK-LABEL: test_mm_mfence
-  // LLVM-CHECK-LABEL: test_mm_mfence
+  // CIR-LABEL: test_mm_mfence
+  // LLVM-LABEL: test_mm_mfence
+  // OGCG-LABEL: test_mm_mfence
   _mm_mfence();
-  // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.mfence" : () -> !void
-  // LLVM-CHECK: call void @llvm.x86.sse2.mfence()
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.mfence" : () -> !void
+  // LLVM: call void @llvm.x86.sse2.mfence()
+  // OGCG: call void @llvm.x86.sse2.mfence()
 }
 
 void test_mm_pause(void) {
   // CIR-LABEL: test_mm_pause
   // LLVM-LABEL: test_mm_pause
+  // OGCG-LABEL: test_mm_pause
   _mm_pause();
   // CIR: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.pause" : () -> !void
   // LLVM: call void @llvm.x86.sse2.pause()
+  // OGCG: call void @llvm.x86.sse2.pause()
 }

--- a/clang/test/CIR/CodeGen/X86/sse2-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse2-builtins.c
@@ -18,6 +18,6 @@ void test_mm_clflush(void* A) {
   // CIR-LABEL: test_mm_clflush
   // LLVM-LABEL: teh
   _mm_clflush(A);
-  // CIR-CHECK: {{%.*}} = cir.llvm.intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
+  // CIR-CHECK: {{%.*}} = cir.call_llvm_intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
   // LLVM-CHECK: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
 }


### PR DESCRIPTION
This PR upstreams the intrinsics `_mm_prefetch`, `_mm_(l|m)fenche`, `_mm_pause` and `_mm_clflush` from the incubator repository.