### PR TITLE
[llc] Fix save-stats test in read only directories

### DIFF
--- a/llvm/test/tools/llc/save-stats.ll
+++ b/llvm/test/tools/llc/save-stats.ll
@@ -1,5 +1,6 @@
 ; REQUIRES: asserts
 
+; RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 ; RUN: llc --save-stats=obj -o %t.s %s && cat %t.stats | FileCheck %s
 ; RUN: llc --save-stats=cwd -o %t.s %s && cat %{t:stem}.tmp.stats | FileCheck %s
 ; RUN: llc --save-stats -o %t.s %s && cat %{t:stem}.tmp.stats | FileCheck %s


### PR DESCRIPTION
The save stats test would fail downstream due to the tests being run
from a read only directory. The cwd flag would attempt to place the
statistics in that read only directory, causing an error. This patch
ensures that the tests are always run from a temp directory.
