### PR TITLE
[lldb] Fix reading duplicate objc class metdata from shared cache

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -537,7 +537,7 @@ __lldb_apple_objc_v2_get_shared_cache_class_info (void *objc_opt_ro_ptr,
 
             for (uint32_t i=0; i<duplicate_count; ++i)
             {
-                const uint64_t objectCacheOffset = classOffsets[i].objectCacheOffset;
+                const uint64_t objectCacheOffset = duplicateClassOffsets[i].objectCacheOffset;
                 DEBUG_PRINTF("objectCacheOffset[%u] = %u\n", i, objectCacheOffset);
 
                 if (classOffsets[i].isDuplicate) {
@@ -576,6 +576,7 @@ __lldb_apple_objc_v2_get_shared_cache_class_info (void *objc_opt_ro_ptr,
                     }
                     class_infos[idx].hash = h;
                 }
+                ++idx;
             }
         }
         else if (objc_opt->version >= 12 && objc_opt->version <= 15)


### PR DESCRIPTION
The code for v16 of the shared cache objc class layout was copy/pasted
from the previous versions incorrectly. Namely, the wrong class offset
list was used and the class_infos index was never updated.
    
rdar://164430695