### PR TITLE
[clang-tidy] Add vbvictor to list of maintainers

### DIFF
--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -33,6 +33,9 @@ clang-tidy
 | Piotr Zegar
 | me@piotrzegar.pl (email), PiotrZSL (GitHub), PiotrZSL (Discourse), PiotrZSL (Discord)
 
+| Victor Baranov
+| bar.victor.2002@gmail.com (email), vbvictor (GitHub), vbvictor (Discourse), vbvictor  (Discord)
+
 
 clang-query
 -----------


### PR DESCRIPTION
I've been actively contributing to the `clang-tidy` project this year and was reviewing patches practically daily for the past half a year. [As per LLVM policy](https://llvm.org/docs/DeveloperPolicy.html#maintainers), I believe I've successfully carried out maintainer responsibilities, thus I volunteer to become one.
I'm looking forward to staying engaged with LLVM community, help newcomers and develop `clang-tidy` as well as other LLVM projects.