### PR TITLE
[libc] Use a sensible default when TEST_UNDECLARED_OUTPUTS_DIR is unset.

### DIFF
--- a/libc/test/UnitTest/BazelFilePath.cpp
+++ b/libc/test/UnitTest/BazelFilePath.cpp
@@ -20,6 +20,10 @@ namespace testing {
 CString libc_make_test_file_path_func(const char *file_name) {
   // This is the path to the folder bazel wants the test outputs written to.
   const char *UNDECLARED_OUTPUTS_PATH = getenv("TEST_UNDECLARED_OUTPUTS_DIR");
+  // Do something sensible if not run under bazel, otherwise this may segfault
+  // when constructing the string.
+  if (UNDECLARED_OUTPUTS_PATH == nullptr)
+    UNDECLARED_OUTPUTS_PATH = "";
 
   return cpp::string(UNDECLARED_OUTPUTS_PATH) + file_name;
 }


### PR DESCRIPTION
There is no guarantee that this environment variable is set. Eg, when running a test outside of the build system, such as under a debugger. And passing a nullptr to the string constructor is undefined.

Use an empty string, which seems like it is close to the original intent.