### PR TITLE
[clang] Defer handling of function type attributes in type aliases

### DIFF
--- a/clang/test/AST/cfi-unchecked-callee.cpp
+++ b/clang/test/AST/cfi-unchecked-callee.cpp
@@ -7,3 +7,6 @@ void func(void);
 
 // CHECK-NEXT: FunctionDecl {{0x[a-z0-9]*}} prev [[PTR]] {{.*}}func 'void () __attribute__((cfi_unchecked_callee))'
 void func(void) {}
+
+// CHECK: TypeAliasDecl {{0x[a-z0-9]*}} {{.*}}CfiCheckFunction 'void () __attribute__((cfi_unchecked_callee))'
+using CfiCheckFunction [[clang::cfi_unchecked_callee]] = void(void);

--- a/clang/test/AST/regparm.cpp
+++ b/clang/test/AST/regparm.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -triple i386-unknown-unknown -ast-dump %s | FileCheck %s
+
+// CHECK: TypeAliasDecl {{0x[a-z0-9]*}} {{.*}}T1 'void (int) __attribute__((regparm (2)))'
+using T1 [[gnu::regparm(2)]] = void(int);

--- a/clang/test/Frontend/cfi-unchecked-callee-attribute.cpp
+++ b/clang/test/Frontend/cfi-unchecked-callee-attribute.cpp
@@ -238,3 +238,5 @@ void lambdas() {
 CFI_UNCHECKED_CALLEE
 void func(void);
 void func(void) {}  // No warning expected.
+
+using CfiCheckFunction [[clang::cfi_unchecked_callee]] = void(void* entry, const void* diag_data);

--- a/clang/test/Frontend/regparm.cpp
+++ b/clang/test/Frontend/regparm.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -triple i386-unknown-unknown %s -verify
+// expected-no-diagnostics
+
+using T1 [[gnu::regparm(2)]] = void(int);

--- a/clang/test/Parser/cxx0x-keyword-attributes.cpp
+++ b/clang/test/Parser/cxx0x-keyword-attributes.cpp
@@ -137,10 +137,10 @@ using ATTR_USE alignas(4)ATTR_USE ns::i;          // expected-warning 2 {{ISO C+
                                                                    expected-error 2 {{'ATTR_NAME' only applies to non-K&R-style functions}}
 using ATTR_USE alignas(4) ATTR_USE foobar = int; // expected-error {{'ATTR_NAME' cannot appear here}} \
                                                                   expected-error {{'alignas' attribute only applies to}} \
-                                                                  expected-error 2 {{'ATTR_NAME' only applies to function types}}
+                                                                  expected-error 2 {{'ATTR_NAME' only applies to non-K&R-style functions}}
 
 ATTR_USE using T = int; // expected-error {{'ATTR_NAME' cannot appear here}}
-using T ATTR_USE = int; // expected-error {{'ATTR_NAME' only applies to function types}}
+using T ATTR_USE = int; // expected-error {{'ATTR_NAME' only applies to non-K&R-style functions}}
 template<typename T> using U ATTR_USE = T; // expected-error {{'ATTR_NAME' only applies to function types}}
 using ns::i ATTR_USE; // expected-warning {{ISO C++}} \
                                 expected-error {{'ATTR_NAME' only applies to non-K&R-style functions}}
@@ -162,7 +162,7 @@ struct using_in_struct : using_in_struct_base {
 using ATTR_USE ns::i; // expected-warning {{ISO C++}} \
                                 expected-error {{'ATTR_NAME' cannot appear here}} \
                                 expected-error {{'ATTR_NAME' only applies to non-K&R-style functions}}
-using T ATTR_USE = int; // expected-error {{'ATTR_NAME' only applies to function types}}
+using T ATTR_USE = int; // expected-error {{'ATTR_NAME' only applies to non-K&R-style functions}}
 
 auto trailing() -> ATTR_USE const int; // expected-error {{'ATTR_NAME' cannot appear here}}
 auto trailing() -> const ATTR_USE int; // expected-error {{'ATTR_NAME' cannot appear here}}


### PR DESCRIPTION
Function type attributes like cfi_unchecked_callee and regparm couldn't be used in `using` type aliases via the syntax:

```
  using T1 [[clang::cfi_unchecked_callee]] = void(int);
```

This would result in the warning `'cfi_unchecked_callee' only applies to function types; type here is 'void' [-Wignored-attributes]` where the type is incorrect. This only seems to occur when the type is a function type and we're only handling the return type.

This patch defers the function attribute handling until we have the full type and allows function type attributes to be attached to the alias with some tests for cfi_unchecked_callee and regparm. This does however change the diagnostic for `__arm_streaming` in a type alias to a slightly different one.