### PR TITLE
[lldb] Add a gtest matcher for lldb_private::Value

### DIFF
--- a/lldb/unittests/Expression/CMakeLists.txt
+++ b/lldb/unittests/Expression/CMakeLists.txt
@@ -10,6 +10,7 @@ add_lldb_unittest(ExpressionTests
   DWARFExpressionTest.cpp
   CppModuleConfigurationTest.cpp
   ExpressionTest.cpp
+  ValueMatcher.cpp
 
   LINK_COMPONENTS
     Support

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
 #include "lldb/Expression/DWARFExpression.h"
+#include "ValueMatcher.h"
 #ifdef ARCH_AARCH64
 #include "Plugins/ABI/AArch64/ABISysV_arm64.h"
 #endif
@@ -135,40 +135,18 @@ private:
 };
 } // namespace
 
-static llvm::Expected<Scalar> Evaluate(llvm::ArrayRef<uint8_t> expr,
-                                       lldb::ModuleSP module_sp = {},
-                                       DWARFUnit *unit = nullptr,
-                                       ExecutionContext *exe_ctx = nullptr,
-                                       RegisterContext *reg_ctx = nullptr) {
+static llvm::Expected<Value> Evaluate(llvm::ArrayRef<uint8_t> expr,
+                                      lldb::ModuleSP module_sp = {},
+                                      DWARFUnit *unit = nullptr,
+                                      ExecutionContext *exe_ctx = nullptr,
+                                      RegisterContext *reg_ctx = nullptr) {
   DataExtractor extractor(expr.data(), expr.size(), lldb::eByteOrderLittle,
                           /*addr_size*/ 4);
 
-  llvm::Expected<Value> result = DWARFExpression::Evaluate(
-      exe_ctx, reg_ctx, module_sp, extractor, unit, lldb::eRegisterKindLLDB,
-      /*initial_value_ptr=*/nullptr,
-      /*object_address_ptr=*/nullptr);
-  if (!result)
-    return result.takeError();
-
-  switch (result->GetValueType()) {
-  case Value::ValueType::Scalar:
-    return result->GetScalar();
-  case Value::ValueType::LoadAddress:
-    return LLDB_INVALID_ADDRESS;
-  case Value::ValueType::HostAddress: {
-    // Convert small buffers to scalars to simplify the tests.
-    DataBufferHeap &buf = result->GetBuffer();
-    if (buf.GetByteSize() <= 8) {
-      uint64_t val = 0;
-      memcpy(&val, buf.GetBytes(), buf.GetByteSize());
-      return Scalar(llvm::APInt(buf.GetByteSize() * 8, val, false));
-    }
-  }
-    [[fallthrough]];
-  default:
-    break;
-  }
-  return llvm::createStringError("unsupported value type");
+  return DWARFExpression::Evaluate(exe_ctx, reg_ctx, module_sp, extractor, unit,
+                                   lldb::eRegisterKindLLDB,
+                                   /*initial_value_ptr=*/nullptr,
+                                   /*object_address_ptr=*/nullptr);
 }
 
 class DWARFExpressionTester : public YAMLModuleTester {
@@ -177,17 +155,10 @@ public:
       : YAMLModuleTester(yaml_data, cu_index) {}
 
   using YAMLModuleTester::YAMLModuleTester;
-  llvm::Expected<Scalar> Eval(llvm::ArrayRef<uint8_t> expr) {
+  llvm::Expected<Value> Eval(llvm::ArrayRef<uint8_t> expr) {
     return ::Evaluate(expr, m_module_sp, m_dwarf_unit);
   }
 };
-
-/// Unfortunately Scalar's operator==() is really picky.
-static Scalar GetScalar(unsigned bits, uint64_t value, bool sign) {
-  Scalar scalar(value);
-  scalar.TruncOrExtendTo(bits, sign);
-  return scalar;
-}
 
 /// This is needed for the tests that use a mock process.
 class DWARFExpressionMockProcessTest : public ::testing::Test {
@@ -255,48 +226,48 @@ public:
 
 TEST(DWARFExpression, DW_OP_pick) {
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit1, DW_OP_lit0, DW_OP_pick, 0}),
-                       llvm::HasValue(0));
+                       ExpectScalar(0));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit1, DW_OP_lit0, DW_OP_pick, 1}),
-                       llvm::HasValue(1));
+                       ExpectScalar(1));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit1, DW_OP_lit0, DW_OP_pick, 2}),
                        llvm::Failed());
 }
 
 TEST(DWARFExpression, DW_OP_const) {
   // Extend to address size.
-  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0x88}), llvm::HasValue(0x88));
+  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0x88}), ExpectScalar(0x88));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1s, 0x88}),
-                       llvm::HasValue(0xffffff88));
+                       ExpectScalar(0xffffff88));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const2u, 0x47, 0x88}),
-                       llvm::HasValue(0x8847));
+                       ExpectScalar(0x8847));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const2s, 0x47, 0x88}),
-                       llvm::HasValue(0xffff8847));
+                       ExpectScalar(0xffff8847));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const4u, 0x44, 0x42, 0x47, 0x88}),
-                       llvm::HasValue(0x88474244));
+                       ExpectScalar(0x88474244));
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const4s, 0x44, 0x42, 0x47, 0x88}),
-                       llvm::HasValue(0x88474244));
+                       ExpectScalar(0x88474244));
 
   // Truncate to address size.
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_const8u, 0x00, 0x11, 0x22, 0x33, 0x44, 0x42, 0x47, 0x88}),
-      llvm::HasValue(0x33221100));
+      ExpectScalar(0x33221100));
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_const8s, 0x00, 0x11, 0x22, 0x33, 0x44, 0x42, 0x47, 0x88}),
-      llvm::HasValue(0x33221100));
+      ExpectScalar(0x33221100));
 
   // Don't truncate to address size for compatibility with clang (pr48087).
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_constu, 0x81, 0x82, 0x84, 0x88, 0x90, 0xa0, 0x40}),
-      llvm::HasValue(0x01010101010101));
+      ExpectScalar(0x01010101010101));
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_consts, 0x81, 0x82, 0x84, 0x88, 0x90, 0xa0, 0x40}),
-      llvm::HasValue(0xffff010101010101));
+      ExpectScalar(0xffff010101010101));
 }
 
 TEST(DWARFExpression, DW_OP_skip) {
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0x42, DW_OP_skip, 0x02, 0x00,
                                  DW_OP_const1u, 0xff}),
-                       llvm::HasValue(0x42));
+                       ExpectScalar(0x42));
 }
 
 TEST(DWARFExpression, DW_OP_bra) {
@@ -309,7 +280,7 @@ TEST(DWARFExpression, DW_OP_bra) {
         DW_OP_const1u, 0xff,     // push 0xff
       }),
       // clang-format on
-      llvm::HasValue(0x42));
+      ExpectScalar(0x42));
 
   EXPECT_THAT_ERROR(Evaluate({DW_OP_bra, 0x01, 0x00}).takeError(),
                     llvm::Failed());
@@ -414,42 +385,42 @@ DWARF:
   EXPECT_THAT_EXPECTED(
       t.Eval({DW_OP_const4u, 0x11, 0x22, 0x33, 0x44, //
               DW_OP_convert, offs_uint32_t, DW_OP_stack_value}),
-      llvm::HasValue(GetScalar(64, 0x44332211, not_signed)));
+      ExpectScalar(64, 0x44332211, not_signed));
 
   // Zero-extend to 64 bits.
   EXPECT_THAT_EXPECTED(
       t.Eval({DW_OP_const4u, 0x11, 0x22, 0x33, 0x44, //
               DW_OP_convert, offs_uint64_t, DW_OP_stack_value}),
-      llvm::HasValue(GetScalar(64, 0x44332211, not_signed)));
+      ExpectScalar(64, 0x44332211, not_signed));
 
   // Sign-extend to 64 bits.
   EXPECT_THAT_EXPECTED(
       t.Eval({DW_OP_const4s, 0xcc, 0xdd, 0xee, 0xff, //
               DW_OP_convert, offs_sint64_t, DW_OP_stack_value}),
-      llvm::HasValue(GetScalar(64, 0xffffffffffeeddcc, is_signed)));
+      ExpectScalar(64, 0xffffffffffeeddcc, is_signed));
 
   // Sign-extend, then truncate.
   EXPECT_THAT_EXPECTED(
       t.Eval({DW_OP_const4s, 0xcc, 0xdd, 0xee, 0xff, //
               DW_OP_convert, offs_sint64_t,          //
               DW_OP_convert, offs_uint32_t, DW_OP_stack_value}),
-      llvm::HasValue(GetScalar(32, 0xffeeddcc, not_signed)));
+      ExpectScalar(32, 0xffeeddcc, not_signed));
 
   // Truncate to default unspecified (pointer-sized) type.
   EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 0xcc, 0xdd, 0xee, 0xff, //
                                DW_OP_convert, offs_sint64_t,          //
                                DW_OP_convert, 0x00, DW_OP_stack_value}),
-                       llvm::HasValue(GetScalar(32, 0xffeeddcc, not_signed)));
+                       ExpectScalar(32, 0xffeeddcc, not_signed));
 
   // Truncate to 8 bits.
   EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', DW_OP_convert,
                                offs_uchar, DW_OP_stack_value}),
-                       llvm::HasValue(GetScalar(8, 'A', not_signed)));
+                       ExpectScalar(8, 'A', not_signed));
 
   // Also truncate to 8 bits.
   EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', DW_OP_convert,
                                offs_schar, DW_OP_stack_value}),
-                       llvm::HasValue(GetScalar(8, 'A', is_signed)));
+                       ExpectScalar(8, 'A', is_signed));
 
   //
   // Errors.
@@ -479,33 +450,21 @@ TEST(DWARFExpression, DW_OP_stack_value) {
 TEST(DWARFExpression, DW_OP_piece) {
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const2u, 0x11, 0x22, DW_OP_piece, 2,
                                  DW_OP_const2u, 0x33, 0x44, DW_OP_piece, 2}),
-                       llvm::HasValue(GetScalar(32, 0x44332211, true)));
+                       ExpectHostAddress({0x11, 0x22, 0x33, 0x44}));
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_piece, 1, DW_OP_const1u, 0xff, DW_OP_piece, 1}),
       // Note that the "00" should really be "undef", but we can't
       // represent that yet.
-      llvm::HasValue(GetScalar(16, 0xff00, true)));
-}
-
-TEST(DWARFExpression, DW_OP_piece_host_address) {
-  static const uint8_t expr_data[] = {DW_OP_lit2, DW_OP_stack_value,
-                                      DW_OP_piece, 40};
-  llvm::ArrayRef<uint8_t> expr(expr_data, sizeof(expr_data));
-  DataExtractor extractor(expr.data(), expr.size(), lldb::eByteOrderLittle, 4);
+      ExpectHostAddress({0x00, 0xff}));
 
   // This tests if ap_int is extended to the right width.
   // expect 40*8 = 320 bits size.
-  llvm::Expected<Value> result =
-      DWARFExpression::Evaluate(nullptr, nullptr, nullptr, extractor, nullptr,
-                                lldb::eRegisterKindDWARF, nullptr, nullptr);
-  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
-  ASSERT_EQ(result->GetValueType(), Value::ValueType::HostAddress);
-  ASSERT_EQ(result->GetBuffer().GetByteSize(), 40ul);
-  const uint8_t *data = result->GetBuffer().GetBytes();
-  ASSERT_EQ(data[0], 2);
-  for (int i = 1; i < 40; i++) {
-    ASSERT_EQ(data[i], 0);
-  }
+  std::vector<uint8_t> expected_host_buffer(40, 0);
+  expected_host_buffer[0] = 2;
+
+  EXPECT_THAT_EXPECTED(
+      Evaluate({{DW_OP_lit2, DW_OP_stack_value, DW_OP_piece, 40}}),
+      ExpectHostAddress(expected_host_buffer));
 }
 
 TEST(DWARFExpression, DW_OP_implicit_value) {
@@ -513,7 +472,7 @@ TEST(DWARFExpression, DW_OP_implicit_value) {
 
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_implicit_value, bytes, 0x11, 0x22, 0x33, 0x44}),
-      llvm::HasValue(GetScalar(8 * bytes, 0x44332211, true)));
+      ExpectHostAddress({0x11, 0x22, 0x33, 0x44}));
 }
 
 TEST(DWARFExpression, DW_OP_unknown) {
@@ -548,20 +507,13 @@ TEST_F(DWARFExpressionMockProcessTest, DW_OP_deref) {
   // Implicit location: *0x4.
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_lit4, DW_OP_deref, DW_OP_stack_value}, {}, {}, &exe_ctx),
-      llvm::HasValue(GetScalar(32, 0x07060504, false)));
+      ExpectScalar(32, 0x07060504, false));
   // Memory location: *(*0x4).
-  // Evaluate returns LLDB_INVALID_ADDRESS for all load addresses.
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit4, DW_OP_deref}, {}, {}, &exe_ctx),
-                       llvm::HasValue(Scalar(LLDB_INVALID_ADDRESS)));
+                       ExpectLoadAddress(0x07060504));
   // Memory location: *0x4.
-  // Evaluate returns LLDB_INVALID_ADDRESS for all load addresses.
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit4}, {}, {}, &exe_ctx),
-                       llvm::HasValue(Scalar(4)));
-  // Implicit location: *0x4.
-  // Evaluate returns LLDB_INVALID_ADDRESS for all load addresses.
-  EXPECT_THAT_EXPECTED(
-      Evaluate({DW_OP_lit4, DW_OP_deref, DW_OP_stack_value}, {}, {}, &exe_ctx),
-      llvm::HasValue(GetScalar(32, 0x07060504, false)));
+                       ExpectScalar(Scalar(4)));
 }
 
 TEST_F(DWARFExpressionMockProcessTest, WASM_DW_OP_addr) {
@@ -581,18 +533,9 @@ TEST_F(DWARFExpressionMockProcessTest, WASM_DW_OP_addr) {
 
   ExecutionContext exe_ctx(target_sp, false);
   // DW_OP_addr takes a single operand of address size width:
-  uint8_t expr[] = {DW_OP_addr, 0x40, 0x0, 0x0, 0x0};
-  DataExtractor extractor(expr, sizeof(expr), lldb::eByteOrderLittle,
-                          /*addr_size*/ 4);
-
-  llvm::Expected<Value> result = DWARFExpression::Evaluate(
-      &exe_ctx, /*reg_ctx*/ nullptr, /*module_sp*/ {}, extractor,
-      /*unit*/ nullptr, lldb::eRegisterKindLLDB,
-      /*initial_value_ptr*/ nullptr,
-      /*object_address_ptr*/ nullptr);
-
-  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
-  ASSERT_EQ(result->GetValueType(), Value::ValueType::LoadAddress);
+  EXPECT_THAT_EXPECTED(
+      Evaluate({DW_OP_addr, 0x40, 0x0, 0x0, 0x0}, {}, {}, &exe_ctx),
+      ExpectLoadAddress(0x40));
 }
 
 TEST_F(DWARFExpressionMockProcessTest, WASM_DW_OP_addr_index) {
@@ -676,15 +619,11 @@ DWARF:
   DWARFExpression expr(extractor);
 
   llvm::Expected<Value> result = evaluate(expr);
-  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
-  ASSERT_EQ(result->GetValueType(), Value::ValueType::LoadAddress);
-  ASSERT_EQ(result->GetScalar().UInt(), 0x5678u);
+  EXPECT_THAT_EXPECTED(result, ExpectLoadAddress(0x5678u));
 
   ASSERT_TRUE(expr.Update_DW_OP_addr(dwarf_cu, 0xdeadbeef));
   result = evaluate(expr);
-  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
-  ASSERT_EQ(result->GetValueType(), Value::ValueType::LoadAddress);
-  ASSERT_EQ(result->GetScalar().UInt(), 0xdeadbeefu);
+  EXPECT_THAT_EXPECTED(result, ExpectLoadAddress(0xdeadbeefu));
 }
 
 class CustomSymbolFileDWARF : public SymbolFileDWARF {
@@ -778,11 +717,12 @@ static auto testExpressionVendorExtensions(lldb::ModuleSP module_sp,
                                            RegisterContext *reg_ctx) {
   // Test that expression extensions can be evaluated, for example
   // DW_OP_WASM_location which is not currently handled by DWARFExpression:
-  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_WASM_location, 0x03, // WASM_GLOBAL:0x03
-                                 0x04, 0x00, 0x00,          // index:u32
-                                 0x00, DW_OP_stack_value},
-                                module_sp, &dwarf_unit, nullptr, reg_ctx),
-                       llvm::HasValue(GetScalar(32, 42, false)));
+  EXPECT_THAT_EXPECTED(
+      Evaluate({DW_OP_WASM_location, 0x03, // WASM_GLOBAL:0x03
+                0x04, 0x00, 0x00,          // index:u32
+                0x00, DW_OP_stack_value},
+               module_sp, &dwarf_unit, nullptr, reg_ctx),
+      ExpectScalar(32, 42, false, Value::ContextType::RegisterInfo));
 
   // Test that searches for opcodes work in the presence of extensions:
   uint8_t expr[] = {DW_OP_WASM_location,   0x03, 0x04, 0x00, 0x00, 0x00,
@@ -1148,17 +1088,8 @@ TEST_F(DWARFExpressionMockProcessTest, DW_OP_piece_file_addr) {
 
   uint8_t expr[] = {DW_OP_addr, 0x40, 0x0, 0x0, 0x0, DW_OP_piece, 1,
                     DW_OP_addr, 0x50, 0x0, 0x0, 0x0, DW_OP_piece, 1};
-  DataExtractor extractor(expr, sizeof(expr), lldb::eByteOrderLittle,
-                          /*addr_size=*/4);
-  llvm::Expected<Value> result = DWARFExpression::Evaluate(
-      &exe_ctx, /*reg_ctx=*/nullptr, /*module_sp=*/{}, extractor,
-      /*unit=*/nullptr, lldb::eRegisterKindLLDB,
-      /*initial_value_ptr=*/nullptr,
-      /*object_address_ptr=*/nullptr);
-
-  ASSERT_THAT_EXPECTED(result, llvm::Succeeded());
-  ASSERT_EQ(result->GetValueType(), Value::ValueType::HostAddress);
-  ASSERT_THAT(result->GetBuffer().GetData(), ElementsAre(0x11, 0x22));
+  EXPECT_THAT_EXPECTED(Evaluate(expr, {}, {}, &exe_ctx),
+                       ExpectHostAddress({0x11, 0x22}));
 }
 
 /// A Process whose `ReadMemory` override queries a DenseMap.
@@ -1228,28 +1159,15 @@ TEST_F(DWARFExpressionMockProcessTestWithAArch, DW_op_deref_no_ptr_fixing) {
   process_sp->GetThreadList().AddThread(thread);
 
   auto evaluate_expr = [&](auto &expr_data) {
-    DataExtractor extractor(expr_data, sizeof(expr_data),
-                            lldb::eByteOrderLittle,
-                            /*addr_size*/ 8);
-    DWARFExpression expr(extractor);
-
     ExecutionContext exe_ctx(process_sp);
-    llvm::Expected<Value> result = DWARFExpression::Evaluate(
-        &exe_ctx, reg_ctx_sp.get(), /*module_sp*/ nullptr, extractor,
-        /*unit*/ nullptr, lldb::eRegisterKindLLDB,
-        /*initial_value_ptr=*/nullptr,
-        /*object_address_ptr=*/nullptr);
-    return result;
+    return Evaluate(expr_data, {}, {}, &exe_ctx, reg_ctx_sp.get());
   };
 
   uint8_t expr_reg[] = {DW_OP_breg22, 0};
   llvm::Expected<Value> result_reg = evaluate_expr(expr_reg);
-  ASSERT_THAT_EXPECTED(result_reg, llvm::Succeeded());
-  ASSERT_EQ(result_reg->GetValueType(), Value::ValueType::LoadAddress);
-  ASSERT_EQ(result_reg->GetScalar().ULongLong(), addr);
+  EXPECT_THAT_EXPECTED(result_reg, ExpectLoadAddress(addr));
 
   uint8_t expr_deref[] = {DW_OP_breg22, 0, DW_OP_deref};
   llvm::Expected<Value> result_deref = evaluate_expr(expr_deref);
-  ASSERT_THAT_EXPECTED(result_deref, llvm::Succeeded());
-  ASSERT_EQ(result_deref->GetScalar().ULongLong(), expected_value);
+  EXPECT_THAT_EXPECTED(result_deref, ExpectLoadAddress(expected_value));
 }

--- a/lldb/unittests/Expression/ValueMatcher.cpp
+++ b/lldb/unittests/Expression/ValueMatcher.cpp
@@ -1,0 +1,185 @@
+//===-- ValueMatcher.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ValueMatcher.h"
+#include "llvm/Support/Format.h"
+#include <iomanip>
+
+using namespace lldb_private;
+
+static void FormatValueDetails(llvm::raw_ostream &os, Value::ValueType value_type,
+                        Value::ContextType context_type, const Scalar &scalar,
+                        llvm::ArrayRef<uint8_t> buffer_data) {
+  os << "Value(";
+  os << "value_type=" << Value::GetValueTypeAsCString(value_type);
+  os << ", context_type=" << Value::GetContextTypeAsCString(context_type);
+
+  if (value_type == Value::ValueType::HostAddress) {
+    os << ", buffer=[";
+    for (size_t i = 0; i < std::min(buffer_data.size(), size_t(16)); ++i) {
+      if (i > 0)
+        os << " ";
+      os << llvm::format("%02x", static_cast<unsigned>(buffer_data[i]));
+    }
+    if (buffer_data.size() > 16) {
+      os << " ...";
+    }
+    os << "] (" << buffer_data.size() << " bytes)";
+  } else {
+    os << ", value=" << scalar;
+  }
+  os << ")";
+}
+
+void lldb_private::PrintTo(const Value &val, std::ostream *os) {
+  if (!os)
+    return;
+
+  llvm::raw_os_ostream raw_os(*os);
+  FormatValueDetails(raw_os, val.GetValueType(), val.GetContextType(),
+                     val.GetScalar(), val.GetBuffer().GetData());
+}
+
+bool ValueMatcher::MatchAndExplain(
+    const Value &val, testing::MatchResultListener *listener) const {
+  if (val.GetValueType() != m_value_type) {
+    *listener << "value_type mismatch: expected "
+              << Value::GetValueTypeAsCString(m_value_type) << ", got "
+              << Value::GetValueTypeAsCString(val.GetValueType()) << " ";
+    return false;
+  }
+
+  if (val.GetContextType() != m_context_type) {
+    *listener << "context_type mismatch: expected "
+              << Value::GetContextTypeAsCString(m_context_type) << ", got "
+              << Value::GetContextTypeAsCString(val.GetContextType()) << " ";
+    return false;
+  }
+
+  if (m_value_type == Value::ValueType::HostAddress) {
+    const DataBufferHeap &buffer = val.GetBuffer();
+    const size_t buffer_size = buffer.GetByteSize();
+    if (buffer_size != m_expected_bytes.size()) {
+      *listener << "buffer size mismatch: expected " << m_expected_bytes.size()
+                << ", got " << buffer_size << " ";
+      return false;
+    }
+
+    const uint8_t *data = buffer.GetBytes();
+    for (size_t i = 0; i < buffer_size; ++i) {
+      if (data[i] != m_expected_bytes[i]) {
+        *listener << "byte mismatch at index " << i << ": expected " << "0x"
+                  << std::hex << std::setw(2) << std::setfill('0')
+                  << static_cast<int>(m_expected_bytes[i]) << ", got " << "0x"
+                  << std::hex << std::setw(2) << std::setfill('0')
+                  << static_cast<int>(data[i]) << " ";
+        return false;
+      }
+    }
+  } else {
+    // For Scalar, FileAddress, and LoadAddress - compare m_value
+    const Scalar &actual_scalar = val.GetScalar();
+    if (actual_scalar != m_expected_scalar) {
+      std::string expected_str, actual_str;
+      llvm::raw_string_ostream expected_os(expected_str);
+      llvm::raw_string_ostream actual_os(actual_str);
+      expected_os << m_expected_scalar;
+      actual_os << actual_scalar;
+      *listener << "scalar value mismatch: expected " << expected_os.str()
+                << ", got " << actual_os.str() << " ";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void ValueMatcher::DescribeTo(std::ostream *os) const {
+  if (!os)
+    return;
+  llvm::raw_os_ostream raw_os(*os);
+  FormatValueDetails(raw_os, m_value_type, m_context_type, m_expected_scalar,
+                     m_expected_bytes);
+}
+
+void ValueMatcher::DescribeNegationTo(std::ostream *os) const {
+  if (!os)
+    return;
+  *os << "value does not match";
+}
+
+testing::Matcher<Value> lldb_private::MatchScalarValue(Value::ValueType value_type,
+                                         const Scalar &expected_scalar,
+                                         Value::ContextType context_type) {
+  return ValueMatcher(value_type, expected_scalar, context_type);
+}
+
+testing::Matcher<Value> lldb_private::MatchHostValue(Value::ValueType value_type,
+                                       const std::vector<uint8_t> &expected_bytes,
+                                       Value::ContextType context_type) {
+  return ValueMatcher(value_type, expected_bytes, context_type);
+}
+
+testing::Matcher<Value> lldb_private::IsScalar(const Scalar &expected_scalar,
+                                 Value::ContextType context_type) {
+  return MatchScalarValue(Value::ValueType::Scalar, expected_scalar,
+                          context_type);
+}
+
+testing::Matcher<Value> lldb_private::IsLoadAddress(const Scalar &expected_address,
+                                      Value::ContextType context_type) {
+  return MatchScalarValue(Value::ValueType::LoadAddress, expected_address,
+                          context_type);
+}
+
+testing::Matcher<Value> lldb_private::IsFileAddress(const Scalar &expected_address,
+                                      Value::ContextType context_type) {
+  return MatchScalarValue(Value::ValueType::FileAddress, expected_address,
+                          context_type);
+}
+
+testing::Matcher<Value> lldb_private::IsHostValue(const std::vector<uint8_t> &expected_bytes,
+                                    Value::ContextType context_type) {
+  return MatchHostValue(Value::ValueType::HostAddress, expected_bytes,
+                        context_type);
+}
+
+Scalar lldb_private::GetScalar(unsigned bits, uint64_t value, bool sign) {
+  Scalar scalar(value);
+  scalar.TruncOrExtendTo(bits, sign);
+  return scalar;
+}
+
+llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
+lldb_private::ExpectScalar(const Scalar &expected_scalar, Value::ContextType context_type) {
+  return llvm::HasValue(IsScalar(expected_scalar, context_type));
+}
+
+llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
+lldb_private::ExpectScalar(unsigned bits, uint64_t value, bool sign,
+             Value::ContextType context_type) {
+  return ExpectScalar(GetScalar(bits, value, sign), context_type);
+}
+
+llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
+lldb_private::ExpectLoadAddress(const Scalar &expected_address,
+                  Value::ContextType context_type) {
+  return llvm::HasValue(IsLoadAddress(expected_address, context_type));
+}
+
+llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
+lldb_private::ExpectFileAddress(const Scalar &expected_address,
+                  Value::ContextType context_type) {
+  return llvm::HasValue(IsFileAddress(expected_address, context_type));
+}
+
+llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
+lldb_private::ExpectHostAddress(const std::vector<uint8_t> &expected_bytes,
+                  Value::ContextType context_type) {
+  return llvm::HasValue(IsHostValue(expected_bytes, context_type));
+}

--- a/lldb/unittests/Expression/ValueMatcher.cpp
+++ b/lldb/unittests/Expression/ValueMatcher.cpp
@@ -124,38 +124,44 @@ void ValueMatcher::DescribeNegationTo(std::ostream *os) const {
   *os << "value does not match";
 }
 
-testing::Matcher<Value> lldb_private::MatchScalarValue(Value::ValueType value_type,
-                                         const Scalar &expected_scalar,
-                                         Value::ContextType context_type) {
+testing::Matcher<Value>
+lldb_private::MatchScalarValue(Value::ValueType value_type,
+                               const Scalar &expected_scalar,
+                               Value::ContextType context_type) {
   return ValueMatcher(value_type, expected_scalar, context_type);
 }
 
-testing::Matcher<Value> lldb_private::MatchHostValue(Value::ValueType value_type,
-                                       const std::vector<uint8_t> &expected_bytes,
-                                       Value::ContextType context_type) {
+testing::Matcher<Value>
+lldb_private::MatchHostValue(Value::ValueType value_type,
+                             const std::vector<uint8_t> &expected_bytes,
+                             Value::ContextType context_type) {
   return ValueMatcher(value_type, expected_bytes, context_type);
 }
 
-testing::Matcher<Value> lldb_private::IsScalar(const Scalar &expected_scalar,
-                                 Value::ContextType context_type) {
+testing::Matcher<Value>
+lldb_private::IsScalar(const Scalar &expected_scalar,
+                       Value::ContextType context_type) {
   return MatchScalarValue(Value::ValueType::Scalar, expected_scalar,
                           context_type);
 }
 
-testing::Matcher<Value> lldb_private::IsLoadAddress(const Scalar &expected_address,
-                                      Value::ContextType context_type) {
+testing::Matcher<Value>
+lldb_private::IsLoadAddress(const Scalar &expected_address,
+                            Value::ContextType context_type) {
   return MatchScalarValue(Value::ValueType::LoadAddress, expected_address,
                           context_type);
 }
 
-testing::Matcher<Value> lldb_private::IsFileAddress(const Scalar &expected_address,
-                                      Value::ContextType context_type) {
+testing::Matcher<Value>
+lldb_private::IsFileAddress(const Scalar &expected_address,
+                            Value::ContextType context_type) {
   return MatchScalarValue(Value::ValueType::FileAddress, expected_address,
                           context_type);
 }
 
-testing::Matcher<Value> lldb_private::IsHostValue(const std::vector<uint8_t> &expected_bytes,
-                                    Value::ContextType context_type) {
+testing::Matcher<Value>
+lldb_private::IsHostValue(const std::vector<uint8_t> &expected_bytes,
+                          Value::ContextType context_type) {
   return MatchHostValue(Value::ValueType::HostAddress, expected_bytes,
                         context_type);
 }
@@ -167,30 +173,31 @@ Scalar lldb_private::GetScalar(unsigned bits, uint64_t value, bool sign) {
 }
 
 llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
-lldb_private::ExpectScalar(const Scalar &expected_scalar, Value::ContextType context_type) {
+lldb_private::ExpectScalar(const Scalar &expected_scalar,
+                           Value::ContextType context_type) {
   return llvm::HasValue(IsScalar(expected_scalar, context_type));
 }
 
 llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
 lldb_private::ExpectScalar(unsigned bits, uint64_t value, bool sign,
-             Value::ContextType context_type) {
+                           Value::ContextType context_type) {
   return ExpectScalar(GetScalar(bits, value, sign), context_type);
 }
 
 llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
 lldb_private::ExpectLoadAddress(const Scalar &expected_address,
-                  Value::ContextType context_type) {
+                                Value::ContextType context_type) {
   return llvm::HasValue(IsLoadAddress(expected_address, context_type));
 }
 
 llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
 lldb_private::ExpectFileAddress(const Scalar &expected_address,
-                  Value::ContextType context_type) {
+                                Value::ContextType context_type) {
   return llvm::HasValue(IsFileAddress(expected_address, context_type));
 }
 
 llvm::detail::ValueMatchesPoly<testing::Matcher<Value>>
 lldb_private::ExpectHostAddress(const std::vector<uint8_t> &expected_bytes,
-                  Value::ContextType context_type) {
+                                Value::ContextType context_type) {
   return llvm::HasValue(IsHostValue(expected_bytes, context_type));
 }

--- a/lldb/unittests/Expression/ValueMatcher.cpp
+++ b/lldb/unittests/Expression/ValueMatcher.cpp
@@ -50,10 +50,10 @@ void lldb_private::PrintTo(const Value &val, std::ostream *os) {
                      val.GetScalar(), val.GetBuffer().GetData());
 }
 
-bool ValueMatcher::MatchAndExplain(
-    const Value &val, testing::MatchResultListener *listener) const {
-  if (listener && listener->stream()) {
-    llvm::raw_os_ostream os(*listener->stream());
+bool ValueMatcher::MatchAndExplain(const Value &val,
+                                   std::ostream *stream) const {
+  if (stream) {
+    llvm::raw_os_ostream os(*stream);
     return MatchAndExplainImpl(val, os);
   }
 
@@ -61,6 +61,9 @@ bool ValueMatcher::MatchAndExplain(
   return MatchAndExplainImpl(val, os);
 }
 
+// Match the provided value and explain any mismatches using
+// the raw_ostream. We use the llvm::raw_ostream here to simplify the formatting
+// of Scalar values which already know how to print themselves to that stream.
 bool ValueMatcher::MatchAndExplainImpl(const Value &val,
                                        llvm::raw_ostream &os) const {
   if (val.GetValueType() != m_value_type) {

--- a/lldb/unittests/Expression/ValueMatcher.cpp
+++ b/lldb/unittests/Expression/ValueMatcher.cpp
@@ -1,4 +1,4 @@
-//===-- ValueMatcher.cpp --------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -97,7 +97,7 @@ bool ValueMatcher::MatchAndExplainImpl(const Value &val,
       }
     }
   } else {
-    // For Scalar, FileAddress, and LoadAddress - compare m_value
+    // For Scalar, FileAddress, and LoadAddress compare m_value.
     const Scalar &actual_scalar = val.GetScalar();
     if (actual_scalar != m_expected_scalar) {
       os << "scalar value mismatch: expected " << m_expected_scalar << ", got "

--- a/lldb/unittests/Expression/ValueMatcher.cpp
+++ b/lldb/unittests/Expression/ValueMatcher.cpp
@@ -10,7 +10,6 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_os_ostream.h"
 #include "llvm/Support/raw_ostream.h"
-#include <iomanip>
 
 using namespace lldb_private;
 

--- a/lldb/unittests/Expression/ValueMatcher.cpp
+++ b/lldb/unittests/Expression/ValueMatcher.cpp
@@ -32,9 +32,8 @@ static void FormatValueDetails(llvm::raw_ostream &os,
           os << llvm::format("%02x", static_cast<unsigned>(byte));
         },
         [&]() { os << " "; });
-    if (buffer_data.size() > 16) {
+    if (buffer_data.size() > 16)
       os << " ...";
-    }
     os << "] (" << buffer_data.size() << " bytes)";
   } else {
     os << ", value=" << scalar;

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -70,6 +70,8 @@ private:
   Value::ContextType m_context_type = Value::ContextType::Invalid;
   Scalar m_expected_scalar{};
   std::vector<uint8_t> m_expected_bytes{};
+
+  bool MatchAndExplainImpl(const Value &val, llvm::raw_ostream &os) const;
 };
 
 /// Matcher for Value with Scalar, FileAddress, or LoadAddress types.

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -15,10 +15,7 @@
 #define LLDB_UNITTESTS_EXPRESSION_VALUEMATCHER_H
 
 #include "lldb/Core/Value.h"
-#include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Scalar.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -1,0 +1,283 @@
+//===-- ValueMatcher.h ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file contains the definition of the ValueMatcher class which is a used
+/// to match lldb_private::Value in gtest assert/expect macros. It also contains
+/// several helper functions to create matchers for common Value types.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UNITTESTS_EXPRESSION_VALUEMATCHER_H
+#define LLDB_UNITTESTS_EXPRESSION_VALUEMATCHER_H
+
+#include "lldb/Core/Value.h"
+#include "lldb/Utility/DataBufferHeap.h"
+#include "lldb/Utility/Scalar.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+#include <cstdint>
+#include <iomanip>
+#include <vector>
+
+namespace lldb_private {
+
+/// Helper function to format Value details to an ostream.
+///
+/// This is used for format the details coming from either a Value directly
+/// or the parts stored in the ValueMatcher object.
+inline void FormatValueDetails(std::ostream &os, Value::ValueType value_type,
+                               Value::ContextType context_type,
+                               const Scalar &scalar,
+                               llvm::ArrayRef<uint8_t> buffer_data) {
+  os << "Value(";
+  os << "value_type=" << Value::GetValueTypeAsCString(value_type);
+  os << ", context_type=" << Value::GetContextTypeAsCString(context_type);
+
+  if (value_type == Value::ValueType::HostAddress) {
+    os << ", buffer=[";
+    for (size_t i = 0; i < std::min(buffer_data.size(), size_t(16)); ++i) {
+      if (i > 0)
+        os << " ";
+      os << std::hex << std::setw(2) << std::setfill('0')
+         << static_cast<int>(buffer_data[i]);
+    }
+    if (buffer_data.size() > 16) {
+      os << " ...";
+    }
+    os << std::dec << "] (" << buffer_data.size() << " bytes)";
+  } else {
+    std::string scalar_str;
+    llvm::raw_string_ostream scalar_os(scalar_str);
+    scalar_os << scalar;
+    os << ", value=" << scalar_os.str();
+  }
+  os << ")";
+}
+
+/// Custom printer for Value objects to make test failures more readable.
+inline void PrintTo(const Value &val, std::ostream *os) {
+  if (!os)
+    return;
+
+  FormatValueDetails(*os, val.GetValueType(), val.GetContextType(),
+                     val.GetScalar(), val.GetBuffer().GetData());
+}
+
+/// Custom matcher for Value.
+///
+/// It matches against an expected value_type, and context_type.
+/// For HostAddress value types it will match the expected contents of
+/// the host buffer. For other value types it matches against an expected
+/// scalar value.
+class ValueMatcher : public testing::MatcherInterface<const Value &> {
+public:
+  ValueMatcher(Value::ValueType value_type, const Scalar &expected_scalar,
+               Value::ContextType context_type)
+      : m_value_type(value_type), m_context_type(context_type),
+        m_expected_scalar(expected_scalar) {
+    assert(value_type == Value::ValueType::Scalar ||
+           value_type == Value::ValueType::FileAddress ||
+           value_type == Value::ValueType::LoadAddress);
+  }
+
+  ValueMatcher(Value::ValueType value_type,
+               const std::vector<uint8_t> &expected_bytes,
+               Value::ContextType context_type)
+      : m_value_type(value_type), m_context_type(context_type),
+        m_expected_bytes(expected_bytes) {
+    assert(value_type == Value::ValueType::HostAddress);
+  }
+
+  bool MatchAndExplain(const Value &val,
+                       testing::MatchResultListener *listener) const override {
+    if (val.GetValueType() != m_value_type) {
+      *listener << "value_type mismatch: expected "
+                << Value::GetValueTypeAsCString(m_value_type) << ", got "
+                << Value::GetValueTypeAsCString(val.GetValueType()) << " ";
+      return false;
+    }
+
+    if (val.GetContextType() != m_context_type) {
+      *listener << "context_type mismatch: expected "
+                << Value::GetContextTypeAsCString(m_context_type) << ", got "
+                << Value::GetContextTypeAsCString(val.GetContextType()) << " ";
+      return false;
+    }
+
+    if (m_value_type == Value::ValueType::HostAddress) {
+      const DataBufferHeap &buffer = val.GetBuffer();
+      const size_t buffer_size = buffer.GetByteSize();
+      if (buffer_size != m_expected_bytes.size()) {
+        *listener << "buffer size mismatch: expected "
+                  << m_expected_bytes.size() << ", got " << buffer_size << " ";
+        return false;
+      }
+
+      const uint8_t *data = buffer.GetBytes();
+      for (size_t i = 0; i < buffer_size; ++i) {
+        if (data[i] != m_expected_bytes[i]) {
+          *listener << "byte mismatch at index " << i << ": expected "
+                    << "0x" << std::hex << std::setw(2) << std::setfill('0')
+                    << static_cast<int>(m_expected_bytes[i]) << ", got "
+                    << "0x" << std::hex << std::setw(2) << std::setfill('0')
+                    << static_cast<int>(data[i]) << " ";
+          return false;
+        }
+      }
+    } else {
+      // For Scalar, FileAddress, and LoadAddress - compare m_value
+      const Scalar &actual_scalar = val.GetScalar();
+      if (actual_scalar != m_expected_scalar) {
+        std::string expected_str, actual_str;
+        llvm::raw_string_ostream expected_os(expected_str);
+        llvm::raw_string_ostream actual_os(actual_str);
+        expected_os << m_expected_scalar;
+        actual_os << actual_scalar;
+        *listener << "scalar value mismatch: expected " << expected_os.str()
+                  << ", got " << actual_os.str() << " ";
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void DescribeTo(std::ostream *os) const override {
+    if (!os)
+      return;
+    FormatValueDetails(*os, m_value_type, m_context_type, m_expected_scalar,
+                       m_expected_bytes);
+  }
+
+  void DescribeNegationTo(std::ostream *os) const override {
+    if (!os)
+      return;
+    *os << "value does not match";
+  }
+
+private:
+  Value::ValueType m_value_type = Value::ValueType::Invalid;
+  Value::ContextType m_context_type = Value::ContextType::Invalid;
+  Scalar m_expected_scalar{};
+  std::vector<uint8_t> m_expected_bytes{};
+};
+
+/// Matcher for Value with Scalar, FileAddress, or LoadAddress types.
+/// Use with llvm::HasValue() to match Expected<Value>:
+/// EXPECT_THAT_EXPECTED(result, llvm::HasValue(MatchScalarValue(...)));
+inline testing::Matcher<Value>
+MatchScalarValue(Value::ValueType value_type, const Scalar &expected_scalar,
+                 Value::ContextType context_type) {
+  return testing::Matcher<Value>(
+      new ValueMatcher(value_type, expected_scalar, context_type));
+}
+
+/// Matcher for Value with HostAddress type.
+/// Use with llvm::HasValue() to match Expected<Value>:
+/// EXPECT_THAT_EXPECTED(result, llvm::HasValue(MatchHostValue(...)));
+inline testing::Matcher<Value>
+MatchHostValue(Value::ValueType value_type,
+               const std::vector<uint8_t> &expected_bytes,
+               Value::ContextType context_type) {
+  return testing::Matcher<Value>(
+      new ValueMatcher(value_type, expected_bytes, context_type));
+}
+
+/// Helper to match a Scalar value and context type.
+/// Use with llvm::HasValue() to match Expected<Value>:
+/// EXPECT_THAT_EXPECTED(result, llvm::HasValue(IsScalar(42)));
+inline testing::Matcher<Value> IsScalar(const Scalar &expected_scalar,
+                                        Value::ContextType context_type) {
+  return MatchScalarValue(Value::ValueType::Scalar, expected_scalar,
+                          context_type);
+}
+
+/// Helper to match a LoadAddress value and context type.
+/// Use with llvm::HasValue() to match Expected<Value>:
+/// EXPECT_THAT_EXPECTED(result, llvm::HasValue(IsLoadAddress(0x1000)));
+inline testing::Matcher<Value> IsLoadAddress(const Scalar &expected_address,
+                                             Value::ContextType context_type) {
+  return MatchScalarValue(Value::ValueType::LoadAddress, expected_address,
+                          context_type);
+}
+
+/// Helper to match a FileAddress value and context type.
+/// Use with llvm::HasValue() to match Expected<Value>:
+/// EXPECT_THAT_EXPECTED(result, llvm::HasValue(IsFileAddress(Scalar(0x1000))));
+inline testing::Matcher<Value> IsFileAddress(const Scalar &expected_address,
+                                             Value::ContextType context_type) {
+  return MatchScalarValue(Value::ValueType::FileAddress, expected_address,
+                          context_type);
+}
+
+/// Helper to match a HostAddress value and context type.
+/// Use with llvm::HasValue() to match Expected<Value>:
+/// EXPECT_THAT_EXPECTED(result, llvm::HasValue(IsHostValue({0x11, 0x22})));
+inline testing::Matcher<Value>
+IsHostValue(const std::vector<uint8_t> &expected_bytes,
+            Value::ContextType context_type) {
+  return MatchHostValue(Value::ValueType::HostAddress, expected_bytes,
+                        context_type);
+}
+
+/// Helper to create a scalar because Scalar's operator==() is really picky.
+inline Scalar GetScalar(unsigned bits, uint64_t value, bool sign) {
+  Scalar scalar(value);
+  scalar.TruncOrExtendTo(bits, sign);
+  return scalar;
+}
+
+/// Helper that combines IsScalar with llvm::HasValue for Expected<Value>.
+/// Use it on an Expected<Value> like this:
+/// EXPECT_THAT_EXPECTED(result, ExpectScalar(42));
+inline auto
+ExpectScalar(const Scalar &expected_scalar,
+             Value::ContextType context_type = Value::ContextType::Invalid) {
+  return llvm::HasValue(IsScalar(expected_scalar, context_type));
+}
+
+/// Helper that combines GetScalar with ExpectScalar to get a precise scalar.
+/// Use it on an Expected<Value> like this:
+/// EXPECT_THAT_EXPECTED(result, ExpectScalar(8, 42, true));
+inline auto
+ExpectScalar(unsigned bits, uint64_t value, bool sign,
+             Value::ContextType context_type = Value::ContextType::Invalid) {
+  return ExpectScalar(GetScalar(bits, value, sign), context_type);
+}
+
+/// Helper that combines IsLoadAddress with llvm::HasValue for Expected<Value>.
+/// Use it on an Expected<Value> like this:
+/// EXPECT_THAT_EXPECTED(result, ExpectLoadAddress(0x1000));
+inline auto ExpectLoadAddress(
+    const Scalar &expected_address,
+    Value::ContextType context_type = Value::ContextType::Invalid) {
+  return llvm::HasValue(IsLoadAddress(expected_address, context_type));
+}
+
+/// Helper that combines IsFileAddress with llvm::HasValue for Expected<Value>.
+/// Use it on an Expected<Value> like this:
+/// EXPECT_THAT_EXPECTED(result, ExpectFileAddress(Scalar(0x2000)));
+inline auto ExpectFileAddress(
+    const Scalar &expected_address,
+    Value::ContextType context_type = Value::ContextType::Invalid) {
+  return llvm::HasValue(IsFileAddress(expected_address, context_type));
+}
+
+/// Helper that combines IsHostValue with llvm::HasValue for Expected<Value>.
+/// Use it on an Expected<Value> like this:
+/// EXPECT_THAT_EXPECTED(result, ExpectHostAddress({0x11, 0x22}));
+inline auto ExpectHostAddress(
+    const std::vector<uint8_t> &expected_bytes,
+    Value::ContextType context_type = Value::ContextType::Invalid) {
+  return llvm::HasValue(IsHostValue(expected_bytes, context_type));
+}
+
+} // namespace lldb_private
+
+#endif // LLDB_UNITTESTS_EXPRESSION_VALUEMATCHER_H

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -65,8 +65,8 @@ public:
 private:
   Value::ValueType m_value_type = Value::ValueType::Invalid;
   Value::ContextType m_context_type = Value::ContextType::Invalid;
-  Scalar m_expected_scalar{};
-  std::vector<uint8_t> m_expected_bytes{};
+  Scalar m_expected_scalar;
+  std::vector<uint8_t> m_expected_bytes;
 
   bool MatchAndExplainImpl(const Value &val, llvm::raw_ostream &os) const;
 };

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -1,4 +1,4 @@
-//===-- ValueMatcher.h ----------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -9,6 +9,9 @@
 /// This file contains the definition of the ValueMatcher class which is a used
 /// to match lldb_private::Value in gtest assert/expect macros. It also contains
 /// several helper functions to create matchers for common Value types.
+///
+/// The ValueMatcher class was created using the gtest guide found here:
+//  https://google.github.io/googletest/gmock_cook_book.html#writing-new-monomorphic-matchers
 //===----------------------------------------------------------------------===//
 
 #ifndef LLDB_UNITTESTS_EXPRESSION_VALUEMATCHER_H

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -58,8 +58,7 @@ public:
   // Typedef to hook into the gtest matcher machinery.
   using is_gtest_matcher = void;
 
-  bool MatchAndExplain(const Value &val,
-                       testing::MatchResultListener *listener) const;
+  bool MatchAndExplain(const Value &val, std::ostream *os) const;
 
   void DescribeTo(std::ostream *os) const;
 

--- a/lldb/unittests/Expression/ValueMatcher.h
+++ b/lldb/unittests/Expression/ValueMatcher.h
@@ -75,7 +75,7 @@ inline void PrintTo(const Value &val, std::ostream *os) {
 /// For HostAddress value types it will match the expected contents of
 /// the host buffer. For other value types it matches against an expected
 /// scalar value.
-class ValueMatcher : public testing::MatcherInterface<const Value &> {
+class ValueMatcher {
 public:
   ValueMatcher(Value::ValueType value_type, const Scalar &expected_scalar,
                Value::ContextType context_type)
@@ -94,8 +94,11 @@ public:
     assert(value_type == Value::ValueType::HostAddress);
   }
 
+  // Typedef to hook into the gtest matcher machinery.
+  using is_gtest_matcher = void;
+
   bool MatchAndExplain(const Value &val,
-                       testing::MatchResultListener *listener) const override {
+                       testing::MatchResultListener *listener) const {
     if (val.GetValueType() != m_value_type) {
       *listener << "value_type mismatch: expected "
                 << Value::GetValueTypeAsCString(m_value_type) << ", got "
@@ -148,14 +151,14 @@ public:
     return true;
   }
 
-  void DescribeTo(std::ostream *os) const override {
+  void DescribeTo(std::ostream *os) const {
     if (!os)
       return;
     FormatValueDetails(*os, m_value_type, m_context_type, m_expected_scalar,
                        m_expected_bytes);
   }
 
-  void DescribeNegationTo(std::ostream *os) const override {
+  void DescribeNegationTo(std::ostream *os) const {
     if (!os)
       return;
     *os << "value does not match";
@@ -174,8 +177,7 @@ private:
 inline testing::Matcher<Value>
 MatchScalarValue(Value::ValueType value_type, const Scalar &expected_scalar,
                  Value::ContextType context_type) {
-  return testing::Matcher<Value>(
-      new ValueMatcher(value_type, expected_scalar, context_type));
+  return ValueMatcher(value_type, expected_scalar, context_type);
 }
 
 /// Matcher for Value with HostAddress type.
@@ -185,8 +187,7 @@ inline testing::Matcher<Value>
 MatchHostValue(Value::ValueType value_type,
                const std::vector<uint8_t> &expected_bytes,
                Value::ContextType context_type) {
-  return testing::Matcher<Value>(
-      new ValueMatcher(value_type, expected_bytes, context_type));
+  return ValueMatcher(value_type, expected_bytes, context_type);
 }
 
 /// Helper to match a Scalar value and context type.


### PR DESCRIPTION
This commit adds a new `ValueMatcher` class that can be used in gtest matching contexts to match against `lldb_private::Value` objects. We always match against the values `value_type` and `context_type`. For HostAddress values we will also match against the expected host buffer contents. For Scalar, FileAddress, and LoadAddress values we match against an expected Scalar value.

The matcher is used to improve the quality of the tests in the `DwarfExpressionTest.cpp` file. Previously, the local `Evaluate` function would return an `Expected<Scalar>` value which makes it hard to verify that we actually get a Value of the expected type without adding custom evaluation code. Now we return an `Expected<Value>` so that we can match against the full value contents.

The resulting change improves the quality of the existing checks and in some cases eliminates the need for special code to explicitly check value types.

I followed the gtest [guide](https://google.github.io/googletest/gmock_cook_book.html#writing-new-monomorphic-matchers) for writing a new value matcher.