### PR TITLE
[GitHub][CI] Add parallel to the ci-container-abi-tests container

### DIFF
--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -108,6 +108,7 @@ RUN apt-get update && \
     abi-compliance-checker \
     abi-dumper \
     autoconf \
+    parallel \
     pkg-config && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This way we can use the container for the libclang-abi-tests too.