### PR TITLE
[Github] Add Workflow to test Unprivileged Download Artifact Action

### DIFF
--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -1,0 +1,47 @@
+name: Test Unprivileged Download Artifact Action
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/test-unprivileged-download-artifact.yml
+      - '.github/workflows/unprivileged-download-artifact/**'
+  pull_request:
+    paths:
+      - .github/workflows/test-unprivileged-download-artifact.yml
+      - '.github/workflows/unprivileged-download-artifact/**'
+
+jobs:
+  test-unprivileged-download-artifact:
+    name: Test Unprivileged Download Artifact
+    if: github.repository_owner == 'llvm'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout LLVM
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            .github/workflows/
+      - name: Create Test File
+        run: |
+          echo "test" > comment
+      - name: Upload Test File
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: workflow-args
+          path: |
+            comments
+      - name: Download Artifact
+        uses: ./.github/workflows/unprivileged-download-artifact
+        id: download-artifact
+        with:
+          run-id: ${{ github.run_id }}
+          artifact-name: workflow-args
+      - name: Assert That Contents are the Same
+        run: |
+          cat test
+          cat workflow-args

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -35,7 +35,7 @@ jobs:
     name: Test Unprivileged Download Artifact
     if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
-    needs: [ upload-test-artifacts ]
+    needs: [ upload-test-artifact ]
     steps:
       - name: Download Artifact
         uses: ./.github/workflows/unprivileged-download-artifact

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -16,16 +16,11 @@ on:
       - '.github/workflows/unprivileged-download-artifact/**'
 
 jobs:
-  test-unprivileged-download-artifact:
+  upload-test-artifact:
     name: Test Unprivileged Download Artifact
     if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout LLVM
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          sparse-checkout: |
-            .github/workflows/
       - name: Create Test File
         run: |
           echo "test" > comment
@@ -35,6 +30,13 @@ jobs:
           name: workflow-args
           path: |
             comments
+
+  test-download:
+    name: Test Unprivileged Download Artifact
+    if: github.repository_owner == 'llvm'
+    runs-on: ubuntu-24.04
+    needs: upload-test-artifacts
+    steps:
       - name: Download Artifact
         uses: ./.github/workflows/unprivileged-download-artifact
         id: download-artifact

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: workflow-args
           path: |
-            comments
+            comment
 
   test-download:
     name: Test Unprivileged Download Artifact

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Assert That Contents are the Same
         run: |
           cat comment
-          cat workflow-args
+          [[ "$(cat comment)" == "test" ]]

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -35,7 +35,7 @@ jobs:
     name: Test Unprivileged Download Artifact
     if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
-    needs: upload-test-artifacts
+    needs: [ upload-test-artifacts ]
     steps:
       - name: Download Artifact
         uses: ./.github/workflows/unprivileged-download-artifact

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   upload-test-artifact:
-    name: Test Unprivileged Download Artifact
+    name: Upload Test Artifact
     if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
     steps:
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [ upload-test-artifact ]
     steps:
+      - name: Chekcout LLVM
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            .github/workflows/unprivileged-download-artifact/action.yml
       - name: Download Artifact
         uses: ./.github/workflows/unprivileged-download-artifact
         id: download-artifact

--- a/.github/workflows/test-unprivileged-download-artifact.yml
+++ b/.github/workflows/test-unprivileged-download-artifact.yml
@@ -43,5 +43,5 @@ jobs:
           artifact-name: workflow-args
       - name: Assert That Contents are the Same
         run: |
-          cat test
+          cat comment
           cat workflow-args


### PR DESCRIPTION
Since this is a composite action, we do not get any testing currently
when updating the action. This patch adds a simple workflow to test the
action so we can ensure we do not break it when modifying it.
