### PR TITLE
[DAG] SDPatternMatch - add m_SpecificFP matcher

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1144,6 +1144,28 @@ inline SpecificInt_match m_SpecificInt(uint64_t V) {
   return SpecificInt_match(APInt(64, V));
 }
 
+struct SpecificFP_match {
+  APFloat Val;
+
+  explicit SpecificFP_match(APFloat V) : Val(V) {}
+
+  template <typename MatchContext>
+  bool match(const MatchContext &Ctx, SDValue V) {
+    if (const auto *CFP = dyn_cast<ConstantFPSDNode>(V.getNode()))
+      return CFP->isExactlyValue(Val);
+    if (ConstantFPSDNode *C = isConstOrConstSplatFP(V, /*AllowUndefs=*/true))
+      return C->getValueAPF().compare(Val) == APFloat::cmpEqual;
+    return false;
+  }
+};
+
+/// Match a specific float constant.
+inline SpecificFP_match m_SpecificFP(APFloat V) { return SpecificFP_match(V); }
+
+inline SpecificFP_match m_SpecificFP(double V) {
+  return SpecificFP_match(APFloat(V));
+}
+
 struct Zero_match {
   bool AllowUndefs;
 

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -354,6 +354,46 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
       sd_match(InsertELT, m_InsertElt(m_Value(), m_Value(), m_SpecificInt(1))));
 }
 
+TEST_F(SelectionDAGPatternMatchTest, matchSpecificFpOp) {
+  SDLoc DL;
+  APFloat Value(1.5f);
+  auto Float32VT = EVT::getFloatingPointVT(32);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Float32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Float32VT);
+  SDValue Op2 = DAG->getConstantFP(Value, DL, Float32VT);
+  SDValue FAdd0 = DAG->getNode(ISD::FADD, DL, Float32VT, Op0, Op1);
+  SDValue FAdd1 = DAG->getNode(ISD::FADD, DL, Float32VT, Op1, Op2);
+
+  using namespace SDPatternMatch;
+
+  EXPECT_FALSE(sd_match(Op1, m_SpecificFP(Value)));
+  EXPECT_TRUE(sd_match(Op2, m_SpecificFP(Value)));
+
+  EXPECT_FALSE(sd_match(
+      FAdd0, m_BinOp(ISD::FADD, m_Specific(Op0), m_SpecificFP(Value))));
+  EXPECT_TRUE(sd_match(
+      FAdd1, m_BinOp(ISD::FADD, m_Specific(Op1), m_SpecificFP(Value))));
+  EXPECT_TRUE(sd_match(
+      FAdd1, m_c_BinOp(ISD::FADD, m_SpecificFP(Value), m_Specific(Op1))));
+
+  auto VFloat32VT = EVT::getVectorVT(Context, Float32VT, 2);
+  SDValue VOp0 = DAG->getSplat(VFloat32VT, DL, Op0);
+  SDValue VOp1 = DAG->getSplat(VFloat32VT, DL, Op1);
+  SDValue VOp2 = DAG->getSplat(VFloat32VT, DL, Op2);
+
+  EXPECT_FALSE(sd_match(VOp0, m_SpecificFP(Value)));
+  EXPECT_TRUE(sd_match(VOp2, m_SpecificFP(Value)));
+
+  SDValue VFAdd0 = DAG->getNode(ISD::FADD, DL, VFloat32VT, VOp0, VOp1);
+  SDValue VFAdd1 = DAG->getNode(ISD::FADD, DL, VFloat32VT, VOp1, VOp2);
+  EXPECT_FALSE(sd_match(
+      VFAdd0, m_BinOp(ISD::FADD, m_Specific(VOp0), m_SpecificFP(Value))));
+  EXPECT_TRUE(sd_match(
+      VFAdd1, m_BinOp(ISD::FADD, m_Specific(VOp1), m_SpecificFP(Value))));
+  EXPECT_TRUE(sd_match(
+      VFAdd1, m_c_BinOp(ISD::FADD, m_SpecificFP(Value), m_Specific(VOp1))));
+}
+
 TEST_F(SelectionDAGPatternMatchTest, matchGenericTernaryOp) {
   SDLoc DL;
   auto Float32VT = EVT::getFloatingPointVT(32);


### PR DESCRIPTION
This patch introduces SpecificFP matcher for SelectionDAG nodes.

This includes:

Adding SpecificFP_match() in SDPatternMatch.h.
Adding test coverage in SelectionDAGPatternMatchTest.cpp.

Closes #165566