### PR TITLE
[LTO] Parse global inline assembly with +all target flags

### DIFF
--- a/clang/test/CodeGen/AArch64/global-inline-asm-flags.c
+++ b/clang/test/CodeGen/AArch64/global-inline-asm-flags.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -target-feature +pauth -flto=thin -emit-llvm -o - %s | FileCheck %s
+// REQUIRES: aarch64-registered-target
+
+// Check that +pauth target flag is enabled for global inline assembler.
+
+// CHECK: module asm ".text"
+// CHECK: module asm ".balign 16"
+// CHECK: module asm ".globl foo"
+// CHECK: module asm "pacib     x30, x27"
+// CHECK: module asm "retab"
+// CHECK: module asm ".previous"
+
+asm (
+    ".text" "\n"
+    ".balign 16" "\n"
+    ".globl foo\n"
+    "pacib     x30, x27" "\n"
+    "retab" "\n"
+    ".previous" "\n"
+);

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -90,7 +90,8 @@ initializeRecordStreamer(const Module &M,
   if (!MAI)
     return;
 
-  std::unique_ptr<MCSubtargetInfo> STI(T->createMCSubtargetInfo(TT, "", ""));
+  std::unique_ptr<MCSubtargetInfo> STI(
+      T->createMCSubtargetInfo(TT, "", "+all"));
   if (!STI)
     return;
 


### PR DESCRIPTION
`ModuleSymbolTable` extracts symbol names from global inline assembly by running the target asm parser with a generic CPU and no target flags.

This used to cause problems for top-level inline assembly where instructions require a target feature. For example, in `global-inline-asm-flags.c` we have PACIB and RETAB instructions that need a `+pauth` target flag. This test used to fail with a diagnostic:
```
    <inline asm>:4:1: error: instruction requires: pauth
        4 | pacib     x30, x27
    <inline asm>:5:1: error: instruction requires: pauth
        5 | retab
```
`ModuleSymbolTable` does not always have a `TargetMachine`, so I don't see how we can get a CPU and target flags that are set in command line. Instead, the patch changes initialization routine to pass `+all` target flags, assuming that flags do not change symbols, and we don't use this asm parser for code generation.