### PR TITLE
workflows/release-binaries: Drop use of setup-windows action

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -191,12 +191,6 @@ jobs:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@42d80571b13f4599bbefbc7189728b64723c7f78 # main
 
-    - name: Setup Windows
-      if: startsWith(runner.os, 'Windows')
-      uses: llvm/actions/setup-windows@42d80571b13f4599bbefbc7189728b64723c7f78 # main
-      with:
-        arch: amd64
-
     - name: Set Build Prefix
       id: setup-stage
       shell: bash


### PR DESCRIPTION
We don't actually support Windows builds at this time, so this is not needed.  I plan to add a different implementation once the release-binaries workflow supports Windows again.