### PR TITLE
Modify llvm-dwp to be able to emit string tables over 4GB without losing data

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -376,10 +376,6 @@ void DWARFUnit::SetDwoStrOffsetsBase() {
 
     // Skip padding.
     baseOffset += 2;
-  } else {
-    // Size of offset for .debug_str_offsets is same as DWARF offset byte size
-    // of the DWARFUnit for DWARF version 4 and earlier.
-    m_str_offsets_size = m_header.getDwarfOffsetByteSize();
   }
 
   SetStrOffsetsBase(baseOffset);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -376,6 +376,10 @@ void DWARFUnit::SetDwoStrOffsetsBase() {
 
     // Skip padding.
     baseOffset += 2;
+  } else {
+    // Size of offset for .debug_str_offsets is same as DWARF offset byte size
+    // of the DWARFUnit for DWARF version 4 and earlier.
+    m_str_offsets_size = m_header.getDwarfOffsetByteSize();
   }
 
   SetStrOffsetsBase(baseOffset);

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -22,7 +22,7 @@ enum OnCuIndexOverflow {
   Continue,
 };
 
-enum Dwarf64StrOffsets {
+enum Dwarf64StrOffsetsPromotion {
   Disabled, ///< Don't do any conversion of .debug_str_offsets tables.
   Enabled,  ///< Convert any .debug_str_offsets tables to DWARF64 if needed.
   Always,   ///< Always emit .debug_str_offsets talbes as DWARF64 for testing.
@@ -75,7 +75,7 @@ struct CompileUnitIdentifiers {
 
 LLVM_ABI Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
                      OnCuIndexOverflow OverflowOptValue,
-                     Dwarf64StrOffsets StrOffsetsOptValue);
+                     Dwarf64StrOffsetsPromotion StrOffsetsOptValue);
 
 typedef std::vector<std::pair<DWARFSectionKind, uint32_t>> SectionLengths;
 

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -24,7 +24,7 @@ enum OnCuIndexOverflow {
 
 enum Dwarf64StrOffsets {
   Disabled, ///< Don't do any conversion of .debug_str_offsets tables.
-  Enabled,  ///< Convert any .debug_str_offsets tables to DWARD64 if needed.
+  Enabled,  ///< Convert any .debug_str_offsets tables to DWARF64 if needed.
   Always,   ///< Always emit .debug_str_offsets talbes as DWARF64 for testing.
 };
 

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -70,6 +70,8 @@ struct CompileUnitIdentifiers {
 LLVM_ABI Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
                      OnCuIndexOverflow OverflowOptValue);
 
+typedef std::vector<std::pair<DWARFSectionKind, uint32_t>> SectionLengths;
+
 LLVM_ABI Error handleSection(
     const StringMap<std::pair<MCSection *, DWARFSectionKind>> &KnownSections,
     const MCSection *StrSection, const MCSection *StrOffsetSection,
@@ -82,7 +84,7 @@ LLVM_ABI Error handleSection(
     std::vector<StringRef> &CurTypesSection,
     std::vector<StringRef> &CurInfoSection, StringRef &AbbrevSection,
     StringRef &CurCUIndexSection, StringRef &CurTUIndexSection,
-    std::vector<std::pair<DWARFSectionKind, uint32_t>> &SectionLength);
+    SectionLengths &SectionLength);
 
 LLVM_ABI Expected<InfoSectionUnitHeader>
 parseInfoSectionUnitHeader(StringRef Info);

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -22,6 +22,12 @@ enum OnCuIndexOverflow {
   Continue,
 };
 
+enum Dwarf64StrOffsets {
+  Disabled, ///< Don't do any conversion of .debug_str_offsets tables.
+  Enabled,  ///< Convert any .debug_str_offsets tables to DWARD64 if needed.
+  Always,   ///< Always emit .debug_str_offsets talbes as DWARF64 for testing.
+};
+
 struct UnitIndexEntry {
   DWARFUnitIndex::Entry::SectionContribution Contributions[8];
   std::string Name;
@@ -69,7 +75,7 @@ struct CompileUnitIdentifiers {
 
 LLVM_ABI Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
                      OnCuIndexOverflow OverflowOptValue,
-                     bool ForceDwarf64StringOffsets);
+                     Dwarf64StrOffsets StrOffsetsOptValue);
 
 typedef std::vector<std::pair<DWARFSectionKind, uint32_t>> SectionLengths;
 

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -68,7 +68,8 @@ struct CompileUnitIdentifiers {
 };
 
 LLVM_ABI Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
-                     OnCuIndexOverflow OverflowOptValue);
+                     OnCuIndexOverflow OverflowOptValue,
+                     bool ForceDwarf64StringOffsets);
 
 typedef std::vector<std::pair<DWARFSectionKind, uint32_t>> SectionLengths;
 

--- a/llvm/include/llvm/DWP/DWPStringPool.h
+++ b/llvm/include/llvm/DWP/DWPStringPool.h
@@ -32,13 +32,13 @@ class DWPStringPool {
 
   MCStreamer &Out;
   MCSection *Sec;
-  DenseMap<const char *, uint32_t, CStrDenseMapInfo> Pool;
-  uint32_t Offset = 0;
+  DenseMap<const char *, uint64_t, CStrDenseMapInfo> Pool;
+  uint64_t Offset = 0;
 
 public:
   DWPStringPool(MCStreamer &Out, MCSection *Sec) : Out(Out), Sec(Sec) {}
 
-  uint32_t getOffset(const char *Str, unsigned Length) {
+  uint64_t getOffset(const char *Str, unsigned Length) {
     assert(strlen(Str) + 1 == Length && "Ensure length hint is correct");
 
     auto Pair = Pool.insert(std::make_pair(Str, Offset));

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -413,33 +413,43 @@ Expected<InfoSectionUnitHeader> parseInfoSectionUnitHeader(StringRef Info) {
 }
 
 static void writeNewOffsetsTo(MCStreamer &Out, DataExtractor &Data,
-                              DenseMap<uint64_t, uint32_t> &OffsetRemapping,
-                              uint64_t &Offset, uint64_t &Size) {
+                              DenseMap<uint64_t, uint64_t> &OffsetRemapping,
+                              uint64_t &Offset, const uint64_t Size,
+                              uint32_t OldOffsetSize, uint32_t NewOffsetSize) {
 
   while (Offset < Size) {
-    auto OldOffset = Data.getU32(&Offset);
-    auto NewOffset = OffsetRemapping[OldOffset];
-    Out.emitIntValue(NewOffset, 4);
+    const uint64_t OldOffset = Data.getUnsigned(&Offset, OldOffsetSize);
+    const uint64_t NewOffset = OffsetRemapping[OldOffset];
+    assert(NewOffsetSize == 8 || NewOffset <= UINT32_MAX);
+    Out.emitIntValue(NewOffset, NewOffsetSize);
   }
 }
 
 void writeStringsAndOffsets(MCStreamer &Out, DWPStringPool &Strings,
                             MCSection *StrOffsetSection,
                             StringRef CurStrSection,
-                            StringRef CurStrOffsetSection, uint16_t Version) {
+                            StringRef CurStrOffsetSection, uint16_t Version,
+                            SectionLengths &SectionLength) {
   // Could possibly produce an error or warning if one of these was non-null but
   // the other was null.
   if (CurStrSection.empty() || CurStrOffsetSection.empty())
     return;
 
-  DenseMap<uint64_t, uint32_t> OffsetRemapping;
+  DenseMap<uint64_t, uint64_t> OffsetRemapping;
 
   DataExtractor Data(CurStrSection, true, 0);
   uint64_t LocalOffset = 0;
   uint64_t PrevOffset = 0;
+
+  // Keep track if any new string offsets exceed UINT32_MAX. If any do, we can
+  // emit a DWARF64 .debug_str_offsets table for this compile unit.
+  uint32_t OldOffsetSize = 4;
+  uint32_t NewOffsetSize = 4;
   while (const char *S = Data.getCStr(&LocalOffset)) {
-    OffsetRemapping[PrevOffset] =
-        Strings.getOffset(S, LocalOffset - PrevOffset);
+    uint64_t NewOffset = Strings.getOffset(S, LocalOffset - PrevOffset);
+    OffsetRemapping[PrevOffset] = NewOffset;
+    if (NewOffset > UINT32_MAX)
+      NewOffsetSize = 8;
     PrevOffset = LocalOffset;
   }
 
@@ -451,7 +461,7 @@ void writeStringsAndOffsets(MCStreamer &Out, DWPStringPool &Strings,
   uint64_t Size = CurStrOffsetSection.size();
   if (Version > 4) {
     while (Offset < Size) {
-      uint64_t HeaderSize = debugStrOffsetsHeaderSize(Data, Version);
+      const uint64_t HeaderSize = debugStrOffsetsHeaderSize(Data, Version);
       assert(HeaderSize <= Size - Offset &&
              "StrOffsetSection size is less than its header");
 
@@ -461,16 +471,52 @@ void writeStringsAndOffsets(MCStreamer &Out, DWPStringPool &Strings,
       if (HeaderSize == 8) {
         ContributionSize = Data.getU32(&HeaderLengthOffset);
       } else if (HeaderSize == 16) {
+        OldOffsetSize = 8;
         HeaderLengthOffset += 4; // skip the dwarf64 marker
         ContributionSize = Data.getU64(&HeaderLengthOffset);
       }
       ContributionEnd = ContributionSize + HeaderLengthOffset;
-      Out.emitBytes(Data.getBytes(&Offset, HeaderSize));
-      writeNewOffsetsTo(Out, Data, OffsetRemapping, Offset, ContributionEnd);
+
+      StringRef HeaderBytes = Data.getBytes(&Offset, HeaderSize);
+      if (OldOffsetSize == 4 && NewOffsetSize == 8) {
+        // We had a DWARF32 .debug_str_offsets header, but we need to emit
+        // some string offsets that require 64 bit offsets on the .debug_str
+        // section. Emit the .debug_str_offsets header in DWARF64 format so we
+        // can emit string offsets that exceed UINT32_MAX without truncating
+        // the string offset.
+
+        // 2 bytes for DWARF version, 2 bytes pad.
+        const uint64_t VersionPadSize = 4;
+        const uint64_t NewLength =
+            (ContributionSize - VersionPadSize) * 2 + VersionPadSize;
+        // Emit the DWARF64 length that starts with a 4 byte DW_LENGTH_DWARF64
+        // value followed by the 8 byte updated length.
+        Out.emitIntValue(llvm::dwarf::DW_LENGTH_DWARF64, 4);
+        Out.emitIntValue(NewLength, 8);
+        // Emit DWARF version as a 2 byte integer.
+        Out.emitIntValue(Version, 2);
+        // Emit 2 bytes of padding.
+        Out.emitIntValue(0, 2);
+        // Update the .debug_str_offsets section length contribution for the
+        // this .dwo file.
+        for (auto &Pair : SectionLength) {
+          if (Pair.first == DW_SECT_STR_OFFSETS) {
+            Pair.second = NewLength + 12;
+            break;
+          }
+        }
+      } else {
+        // Just emit the same .debug_str_offsets header.
+        Out.emitBytes(HeaderBytes);
+      }
+      writeNewOffsetsTo(Out, Data, OffsetRemapping, Offset, ContributionEnd,
+                        OldOffsetSize, NewOffsetSize);
     }
 
   } else {
-    writeNewOffsetsTo(Out, Data, OffsetRemapping, Offset, Size);
+    assert(OldOffsetSize == NewOffsetSize);
+    writeNewOffsetsTo(Out, Data, OffsetRemapping, Offset, Size, OldOffsetSize,
+                      NewOffsetSize);
   }
 }
 
@@ -562,7 +608,7 @@ Error handleSection(
     std::vector<StringRef> &CurTypesSection,
     std::vector<StringRef> &CurInfoSection, StringRef &AbbrevSection,
     StringRef &CurCUIndexSection, StringRef &CurTUIndexSection,
-    std::vector<std::pair<DWARFSectionKind, uint32_t>> &SectionLength) {
+    SectionLengths &SectionLength) {
   if (Section.isBSS())
     return Error::success();
 
@@ -684,7 +730,7 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
     // This maps each section contained in this file to its length.
     // This information is later on used to calculate the contributions,
     // i.e. offset and length, of each compile/type unit to a section.
-    std::vector<std::pair<DWARFSectionKind, uint32_t>> SectionLength;
+    SectionLengths SectionLength;
 
     for (const auto &Section : Obj.sections())
       if (auto Err = handleSection(
@@ -713,7 +759,7 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
     }
 
     writeStringsAndOffsets(Out, Strings, StrOffsetSection, CurStrSection,
-                           CurStrOffsetSection, Header.Version);
+                           CurStrOffsetSection, Header.Version, SectionLength);
 
     for (auto Pair : SectionLength) {
       auto Index = getContributionIndex(Pair.first, IndexVersion);

--- a/llvm/test/tools/llvm-dwp/X86/dwarf64-str-offsets.test
+++ b/llvm/test/tools/llvm-dwp/X86/dwarf64-str-offsets.test
@@ -7,11 +7,11 @@
 
 # RUN: yaml2obj %s -o %t.dwo
 # RUN: llvm-dwp %t.dwo -o %t.dwp
-# RUN: llvm-dwp %t.dwo -o %t.default.dwp --dwarf64-str-offsets
-# RUN: llvm-dwp %t.dwo -o %t.disabled.dwp --dwarf64-str-offsets=disabled
-# RUN: llvm-dwp %t.dwo -o %t.enabled.dwp --dwarf64-str-offsets=enabled
-# RUN: llvm-dwp %t.dwo -o %t.always.dwp --dwarf64-str-offsets=always
-# RUN: not llvm-dwp %t.dwo -o %t.invalid.dwp --dwarf64-str-offsets=invalid 2>&1 | FileCheck --check-prefixes=ERROR %s
+# RUN: llvm-dwp %t.dwo -o %t.default.dwp --dwarf64-str-offsets-promotion
+# RUN: llvm-dwp %t.dwo -o %t.disabled.dwp --dwarf64-str-offsets-promotion=disabled
+# RUN: llvm-dwp %t.dwo -o %t.enabled.dwp --dwarf64-str-offsets-promotion=enabled
+# RUN: llvm-dwp %t.dwo -o %t.always.dwp --dwarf64-str-offsets-promotion=always
+# RUN: not llvm-dwp %t.dwo -o %t.invalid.dwp --dwarf64-str-offsets-promotion=invalid 2>&1 | FileCheck --check-prefixes=ERROR %s
 # RUN: llvm-dwarfdump --debug-str-offsets %t.dwp | FileCheck --check-prefixes=DWARF32 %s
 # RUN: llvm-dwarfdump --debug-str-offsets %t.default.dwp | FileCheck --check-prefixes=DWARF32 %s
 # RUN: llvm-dwarfdump --debug-str-offsets %t.disabled.dwp | FileCheck --check-prefixes=DWARF32 %s
@@ -40,7 +40,7 @@
 # DWARF64-NEXT: 0x00000040: 0000000000000046 "simple.cpp"
 # DWARF64-NEXT: 0x00000048: 0000000000000051 "simple.dwo"
 
-# ERROR: invalid value for --dwarf64-str-offsets. Valid values are one of: "enabled", "disabled" or "always".
+# ERROR: invalid value for --dwarf64-str-offsets-promotion. Valid values are one of: "enabled", "disabled" or "always".
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-dwp/X86/dwarf64-str-offsets.test
+++ b/llvm/test/tools/llvm-dwp/X86/dwarf64-str-offsets.test
@@ -1,0 +1,72 @@
+# This test tests that llvm-dwp can successfully promote .debug_str_offsets to
+# DWARF64. We do this by using a hidden option to llvm-dwp which is
+# "--force-dwarf64-str-offsets". This allows us to test if llvm-dwp can
+# successfully promote a DWARF32 version of .debug_str_offsets to a DWARF64
+# version. This allows us to test the functionality without having to create a
+# 4GB .dwo file.
+
+# RUN: yaml2obj %s -o %t.dwo
+# RUN: llvm-dwp %t.dwo -o %t.32.dwp
+# RUN: llvm-dwp %t.dwo -o %t.64.dwp --force-dwarf64-str-offsets
+# RUN: llvm-dwarfdump --debug-str-offsets %t.32.dwp | FileCheck --check-prefixes=DWARF32 %s
+# RUN: llvm-dwarfdump --debug-str-offsets %t.64.dwp | FileCheck --check-prefixes=DWARF64 %s
+
+# DWARF32:      .debug_str_offsets.dwo contents:
+# DWARF32-NEXT: 0x00000000: Contribution size = 36, Format = DWARF32, Version = 5
+# DWARF32-NEXT: 0x00000008: 00000000 "main"
+# DWARF32-NEXT: 0x0000000c: 00000005 "int"
+# DWARF32-NEXT: 0x00000010: 00000009 "argc"
+# DWARF32-NEXT: 0x00000014: 0000000e "argv"
+# DWARF32-NEXT: 0x00000018: 00000013 "char"
+# DWARF32-NEXT: 0x0000001c: 00000018 "Apple clang version 17.0.0 (clang-1700.4.4.1)"
+# DWARF32-NEXT: 0x00000020: 00000046 "simple.cpp"
+# DWARF32-NEXT: 0x00000024: 00000051 "simple.dwo"
+
+# DWARF64:      .debug_str_offsets.dwo contents:
+# DWARF64-NEXT: 0x00000000: Contribution size = 68, Format = DWARF64, Version = 5
+# DWARF64-NEXT: 0x00000010: 0000000000000000 "main"
+# DWARF64-NEXT: 0x00000018: 0000000000000005 "int"
+# DWARF64-NEXT: 0x00000020: 0000000000000009 "argc"
+# DWARF64-NEXT: 0x00000028: 000000000000000e "argv"
+# DWARF64-NEXT: 0x00000030: 0000000000000013 "char"
+# DWARF64-NEXT: 0x00000038: 0000000000000018 "Apple clang version 17.0.0 (clang-1700.4.4.1)"
+# DWARF64-NEXT: 0x00000040: 0000000000000046 "simple.cpp"
+# DWARF64-NEXT: 0x00000048: 0000000000000051 "simple.dwo"
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_REL
+  Machine:         EM_X86_64
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name:            .debug_str_offsets.dwo
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_EXCLUDE ]
+    AddressAlign:    0x1
+    Content:         '24000000050000000000000005000000090000000E00000013000000180000004600000051000000'
+  - Name:            .debug_str.dwo
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_EXCLUDE, SHF_MERGE, SHF_STRINGS ]
+    AddressAlign:    0x1
+    EntSize:         0x1
+    Content:         6D61696E00696E74006172676300617267760063686172004170706C6520636C616E672076657273696F6E2031372E302E302028636C616E672D313730302E342E342E31290073696D706C652E6370700073696D706C652E64776F00
+  - Name:            .debug_info.dwo
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_EXCLUDE ]
+    AddressAlign:    0x1
+    Content:         540000000500050800000000031DD228762F8E1C0105210006070200190000000156000001400000000302917802000140000000030291700300014400000000040105040549000000054E00000006530000000404060100
+  - Name:            .debug_abbrev.dwo
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_EXCLUDE ]
+    AddressAlign:    0x1
+    Content:         01110125251305032576250000022E01111B1206401803253A0B3B0B49133F190000030500021803253A0B3B0B4913000004240003253E0B0B0B0000050F00491300000626004913000000
+  - Type:            SectionHeaderTable
+    Sections:
+      - Name:            .strtab
+      - Name:            .debug_str_offsets.dwo
+      - Name:            .debug_str.dwo
+      - Name:            .debug_info.dwo
+      - Name:            .debug_abbrev.dwo
+...

--- a/llvm/test/tools/llvm-dwp/X86/dwarf64-str-offsets.test
+++ b/llvm/test/tools/llvm-dwp/X86/dwarf64-str-offsets.test
@@ -6,10 +6,17 @@
 # 4GB .dwo file.
 
 # RUN: yaml2obj %s -o %t.dwo
-# RUN: llvm-dwp %t.dwo -o %t.32.dwp
-# RUN: llvm-dwp %t.dwo -o %t.64.dwp --force-dwarf64-str-offsets
-# RUN: llvm-dwarfdump --debug-str-offsets %t.32.dwp | FileCheck --check-prefixes=DWARF32 %s
-# RUN: llvm-dwarfdump --debug-str-offsets %t.64.dwp | FileCheck --check-prefixes=DWARF64 %s
+# RUN: llvm-dwp %t.dwo -o %t.dwp
+# RUN: llvm-dwp %t.dwo -o %t.default.dwp --dwarf64-str-offsets
+# RUN: llvm-dwp %t.dwo -o %t.disabled.dwp --dwarf64-str-offsets=disabled
+# RUN: llvm-dwp %t.dwo -o %t.enabled.dwp --dwarf64-str-offsets=enabled
+# RUN: llvm-dwp %t.dwo -o %t.always.dwp --dwarf64-str-offsets=always
+# RUN: not llvm-dwp %t.dwo -o %t.invalid.dwp --dwarf64-str-offsets=invalid 2>&1 | FileCheck --check-prefixes=ERROR %s
+# RUN: llvm-dwarfdump --debug-str-offsets %t.dwp | FileCheck --check-prefixes=DWARF32 %s
+# RUN: llvm-dwarfdump --debug-str-offsets %t.default.dwp | FileCheck --check-prefixes=DWARF32 %s
+# RUN: llvm-dwarfdump --debug-str-offsets %t.disabled.dwp | FileCheck --check-prefixes=DWARF32 %s
+# RUN: llvm-dwarfdump --debug-str-offsets %t.enabled.dwp | FileCheck --check-prefixes=DWARF32 %s
+# RUN: llvm-dwarfdump --debug-str-offsets %t.always.dwp | FileCheck --check-prefixes=DWARF64 %s
 
 # DWARF32:      .debug_str_offsets.dwo contents:
 # DWARF32-NEXT: 0x00000000: Contribution size = 36, Format = DWARF32, Version = 5
@@ -32,6 +39,8 @@
 # DWARF64-NEXT: 0x00000038: 0000000000000018 "Apple clang version 17.0.0 (clang-1700.4.4.1)"
 # DWARF64-NEXT: 0x00000040: 0000000000000046 "simple.cpp"
 # DWARF64-NEXT: 0x00000048: 0000000000000051 "simple.dwo"
+
+# ERROR: invalid value for --dwarf64-str-offsets. Valid values are one of: "enabled", "disabled" or "always".
 
 --- !ELF
 FileHeader:

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -17,11 +17,17 @@ def continueOnCuIndexOverflow_EQ : Joined<["-", "--"], "continue-on-cu-index-ove
     "\t\tthe 32 bit/4GB limits of the format.">,
   Values<"continue,soft-stop">;
 
-def dwarf64StringOffsets : Flag<["-", "--"], "dwarf64-str-offsets">;
-def dwarf64StringOffsets_EQ : Joined<["-", "--"], "dwarf64-str-offsets=">,
-  HelpText<"default = enabled, This allows .debug_str tables to exceed the 4GB limit\n"
-    "and have any DWARF32 .debug_str_offsets tables converted to DWARF64 only for tables\n"
-    "that require 64 bit string offsets. = disabled, This setting doesn't convert DWARF32\n"
-    ".debug_str_offsets tables in .dwo files to DWARF64 in the .dwp file. = always, This\n"
-    "forces all .debug_str_offsets tables to be emitted as DWARF64. This is used for testing.">,
-  Values<"disabled,enabled,always">;
+def dwarf64StringOffsets : Flag<["-", "--"], "dwarf64-str-offsets-promotion">;
+def dwarf64StringOffsets_EQ
+    : Joined<["-", "--"], "dwarf64-str-offsets-promotion=">,
+      HelpText<"default = enabled, This allows .debug_str tables to exceed the "
+               "4GB limit\n"
+               "and have any DWARF32 .debug_str_offsets tables converted to "
+               "DWARF64 only for tables\n"
+               "that require 64 bit string offsets. = disabled, This setting "
+               "doesn't convert DWARF32\n"
+               ".debug_str_offsets tables in .dwo files to DWARF64 in the .dwp "
+               "file. = always, This\n"
+               "forces all .debug_str_offsets tables to be emitted as DWARF64. "
+               "This is used for testing.">,
+      Values<"disabled,enabled,always">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -22,6 +22,6 @@ def dwarf64StringOffsets_EQ : Joined<["-", "--"], "dwarf64-str-offsets=">,
   HelpText<"default = enabled, This allows .debug_str tables to exceed the 4GB limit\n"
     "and have any DWARF32 .debug_str_offsets tables converted to DWARF64 only for tables\n"
     "that require 64 bit string offsets. = disabled, This setting doesn't convert DWARF32\n"
-    " .debug_str_offsets tables in .dwo files to DWARF64 in the .dwp file. = always, This\n"
+    ".debug_str_offsets tables in .dwo files to DWARF64 in the .dwp file. = always, This\n"
     "forces all .debug_str_offsets tables to be emitted as DWARF64. This is used for testing.">,
   Values<"disabled,enabled,always">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -19,10 +19,9 @@ def continueOnCuIndexOverflow_EQ : Joined<["-", "--"], "continue-on-cu-index-ove
 
 def dwarf64StringOffsets : Flag<["-", "--"], "dwarf64-str-offsets">;
 def dwarf64StringOffsets_EQ : Joined<["-", "--"], "dwarf64-str-offsets=">,
-  HelpText<"default = disabled, This setting doesn't convert DWARF32 .debug_str_offsets\n"
-    "tables in .dwo files to DWARF64 in the .dwp file. = enabled, This allows .debug_str\n"
-    "tables to exceed the 4GB limit and have any DWARF32 .debug_str_offsets tables\n"
-    "converted to DWARF64 only for tables that require 64 bit string offsets.\n"
-    "= always, This forces all .debug_str_offsets tables to be emitted as DWARF64.\n"
-    "This is used for testing.">,
+  HelpText<"default = enabled, This allows .debug_str tables to exceed the 4GB limit\n"
+    "and have any DWARF32 .debug_str_offsets tables converted to DWARF64 only for tables\n"
+    "that require 64 bit string offsets. = disabled, This setting doesn't convert DWARF32\n"
+    " .debug_str_offsets tables in .dwo files to DWARF64 in the .dwp file. = always, This\n"
+    "forces all .debug_str_offsets tables to be emitted as DWARF64. This is used for testing.">,
   Values<"disabled,enabled,always">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -16,3 +16,7 @@ def continueOnCuIndexOverflow_EQ : Joined<["-", "--"], "continue-on-cu-index-ove
     "\t\ttruncated but valid DWP file, discarding any DWO files that would not fit within \n"
     "\t\tthe 32 bit/4GB limits of the format.">,
   Values<"continue,soft-stop">;
+def forceDwarf64StringOffsets : Flag<["-", "--"], "force-dwarf64-str-offsets">,
+  Flags<[HelpHidden]>,
+  HelpText<"Force all .debug_str_offsets to be emitted as DWARF64 tables. This "
+    "option is used for testing.">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -16,7 +16,13 @@ def continueOnCuIndexOverflow_EQ : Joined<["-", "--"], "continue-on-cu-index-ove
     "\t\ttruncated but valid DWP file, discarding any DWO files that would not fit within \n"
     "\t\tthe 32 bit/4GB limits of the format.">,
   Values<"continue,soft-stop">;
-def forceDwarf64StringOffsets : Flag<["-", "--"], "force-dwarf64-str-offsets">,
-  Flags<[HelpHidden]>,
-  HelpText<"Force all .debug_str_offsets to be emitted as DWARF64 tables. This "
-    "option is used for testing.">;
+
+def dwarf64StringOffsets : Flag<["-", "--"], "dwarf64-str-offsets">;
+def dwarf64StringOffsets_EQ : Joined<["-", "--"], "dwarf64-str-offsets=">,
+  HelpText<"default = disabled, This setting doesn't convert DWARF32 .debug_str_offsets\n"
+    "tables in .dwo files to DWARF64 in the .dwp file. = enabled, This allows .debug_str\n"
+    "tables to exceed the 4GB limit and have any DWARF32 .debug_str_offsets tables\n"
+    "converted to DWARF64 only for tables that require 64 bit string offsets.\n"
+    "= always, This forces all .debug_str_offsets tables to be emitted as DWARF64.\n"
+    "This is used for testing.">,
+  Values<"disabled,enabled,always">;

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -125,7 +125,8 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   llvm::BumpPtrAllocator A;
   llvm::StringSaver Saver{A};
   OnCuIndexOverflow OverflowOptValue = OnCuIndexOverflow::HardStop;
-  Dwarf64StrOffsets Dwarf64StrOffsetsValue = Dwarf64StrOffsets::Disabled;
+  Dwarf64StrOffsetsPromotion Dwarf64StrOffsetsValue =
+      Dwarf64StrOffsetsPromotion::Disabled;
 
   opt::InputArgList Args =
       Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [&](StringRef Msg) {
@@ -166,19 +167,19 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (Arg *Arg = Args.getLastArg(OPT_dwarf64StringOffsets,
                                  OPT_dwarf64StringOffsets_EQ)) {
     if (Arg->getOption().matches(OPT_dwarf64StringOffsets)) {
-      Dwarf64StrOffsetsValue = Dwarf64StrOffsets::Enabled;
+      Dwarf64StrOffsetsValue = Dwarf64StrOffsetsPromotion::Enabled;
     } else {
       std::string OptValue = Arg->getValue();
       if (OptValue == "disabled") {
-        Dwarf64StrOffsetsValue = Dwarf64StrOffsets::Disabled;
+        Dwarf64StrOffsetsValue = Dwarf64StrOffsetsPromotion::Disabled;
       } else if (OptValue == "enabled") {
-        Dwarf64StrOffsetsValue = Dwarf64StrOffsets::Enabled;
+        Dwarf64StrOffsetsValue = Dwarf64StrOffsetsPromotion::Enabled;
       } else if (OptValue == "always") {
-        Dwarf64StrOffsetsValue = Dwarf64StrOffsets::Always;
+        Dwarf64StrOffsetsValue = Dwarf64StrOffsetsPromotion::Always;
       } else {
         llvm::errs()
-            << "invalid value for --dwarf64-str-offsets. Valid values "
-               "are one of: \"enabled\", \"disabled\" or \"always\".\n";
+            << "invalid value for --dwarf64-str-offsets-promotion. Valid "
+               "values are one of: \"enabled\", \"disabled\" or \"always\".\n";
         exit(1);
       }
     }

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -176,8 +176,9 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
       } else if (OptValue == "always") {
         Dwarf64StrOffsetsValue = Dwarf64StrOffsets::Always;
       } else {
-        llvm::errs() << "invalid value for --dwarf64-str-offsets. Valid values "
-            "are one of: \"enabled\", \"disabled\" or \"always\".\n";
+        llvm::errs()
+            << "invalid value for --dwarf64-str-offsets. Valid values "
+               "are one of: \"enabled\", \"disabled\" or \"always\".\n";
         exit(1);
       }
     }
@@ -296,8 +297,8 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (!MS)
     return error("no object streamer for target " + TripleName, Context);
 
-  if (auto Err = write(*MS, DWOFilenames, OverflowOptValue,
-                       Dwarf64StrOffsetsValue)) {
+  if (auto Err =
+          write(*MS, DWOFilenames, OverflowOptValue, Dwarf64StrOffsetsValue)) {
     logAllUnhandledErrors(std::move(Err), WithColor::error());
     return 1;
   }

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -73,6 +73,7 @@ public:
 static std::vector<std::string> ExecFilenames;
 static std::string OutputFilename;
 static std::string ContinueOption;
+static bool ForceDwarf64StringOffsets = false;
 
 static Expected<SmallVector<std::string, 16>>
 getDWOFilenames(StringRef ExecFilename) {
@@ -160,6 +161,8 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
       }
     }
   }
+  if (Args.getLastArg(OPT_forceDwarf64StringOffsets))
+    ForceDwarf64StringOffsets = true;
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))
     ExecFilenames.emplace_back(A->getValue());
@@ -274,7 +277,8 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (!MS)
     return error("no object streamer for target " + TripleName, Context);
 
-  if (auto Err = write(*MS, DWOFilenames, OverflowOptValue)) {
+  if (auto Err = write(*MS, DWOFilenames, OverflowOptValue,
+                       ForceDwarf64StringOffsets)) {
     logAllUnhandledErrors(std::move(Err), WithColor::error());
     return 1;
   }


### PR DESCRIPTION
We can change llvm-dwp to emit DWARF64 version of the .debug_str_offsets tables for .dwo files in a .dwp file. This allows the string table to exceed 4GB without truncating string offsets into the .debug_str section and losing data. llvm-dwp will append all strings to the .debug_str section for a .dwo file, and if any of the new string offsets exceed UINT32_MAX, it will upgrade the .debug_str_offsets table to a DWARF64 header and then each string offset in that table can now have a 64 bit offset.

Fixed LLDB to be able to successfully load the 64 bit string tables in .dwp files.

Fixed llvm-dwarfdump and LLVM DWARF parsing code to do the right thing with DWARF64 string table headers.