### PR TITLE
[MLIR][Python] Wrappers for scf.index_switch

### DIFF
--- a/mlir/python/mlir/dialects/scf.py
+++ b/mlir/python/mlir/dialects/scf.py
@@ -6,7 +6,6 @@
 from ._scf_ops_gen import *
 from ._scf_ops_gen import _Dialect
 from .arith import constant
-import builtins
 
 try:
     from ..ir import *
@@ -264,7 +263,7 @@ class IndexSwitchOp(IndexSwitchOp):
 
     def __init__(
         self,
-        results_,
+        results,
         arg,
         cases,
         case_body_builder=None,
@@ -274,7 +273,7 @@ class IndexSwitchOp(IndexSwitchOp):
     ):
         cases = DenseI64ArrayAttr.get(cases)
         super().__init__(
-            results_, arg, cases, num_caseRegions=len(cases), loc=loc, ip=ip
+            results, arg, cases, num_caseRegions=len(cases), loc=loc, ip=ip
         )
         for region in self.regions:
             region.blocks.append()
@@ -288,22 +287,22 @@ class IndexSwitchOp(IndexSwitchOp):
                 with InsertionPoint(self.case_block(i)):
                     case_body_builder(self, i, self.cases[i])
 
-    @builtins.property
+    @property
     def default_region(self) -> Region:
         return self.regions[0]
 
-    @builtins.property
+    @property
     def default_block(self) -> Block:
         return self.default_region.blocks[0]
 
-    @builtins.property
+    @property
     def case_regions(self) -> Sequence[Region]:
         return self.regions[1:]
 
     def case_region(self, i: int) -> Region:
         return self.case_regions[i]
 
-    @builtins.property
+    @property
     def case_blocks(self) -> Sequence[Block]:
         return [region.blocks[0] for region in self.case_regions]
 
@@ -312,7 +311,7 @@ class IndexSwitchOp(IndexSwitchOp):
 
 
 def index_switch(
-    results_,
+    results,
     arg,
     cases,
     case_body_builder=None,
@@ -321,7 +320,7 @@ def index_switch(
     ip=None,
 ) -> Union[OpResult, OpResultList, IndexSwitchOp]:
     op = IndexSwitchOp(
-        results_=results_,
+        results=results,
         arg=arg,
         cases=cases,
         case_body_builder=case_body_builder,

--- a/mlir/python/mlir/dialects/scf.py
+++ b/mlir/python/mlir/dialects/scf.py
@@ -298,7 +298,7 @@ class IndexSwitchOp(IndexSwitchOp):
 
     @builtins.property
     def case_regions(self) -> Sequence[Region]:
-        return [self.regions[1 + i] for i in range(len(self.cases))]
+        return self.regions[1:]
 
     def case_region(self, i: int) -> Region:
         return self.case_regions[i]

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -1,10 +1,14 @@
 # RUN: %PYTHON %s | FileCheck %s
 
 from mlir.ir import *
-from mlir.dialects import arith
-from mlir.dialects import func
-from mlir.dialects import memref
-from mlir.dialects import scf
+from mlir.extras import types as T
+from mlir.dialects import (
+    arith,
+    func,
+    memref,
+    scf,
+    cf,
+)
 from mlir.passmanager import PassManager
 
 
@@ -355,3 +359,117 @@ def testIfWithElse():
 # CHECK:   scf.yield %[[TWO]], %[[THREE]]
 # CHECK: arith.addi %[[RET]]#0, %[[RET]]#1
 # CHECK: return
+
+
+@constructAndPrintInModule
+def testIndexSwitch():
+    i32 = T.i32()
+
+    @func.FuncOp.from_py_func(T.index(), results=[i32])
+    def index_switch(index):
+        c1 = arith.constant(i32, 1)
+        c0 = arith.constant(i32, 0)
+        value = arith.constant(i32, 5)
+        switch_op = scf.IndexSwitchOp([i32], index, range(3))
+
+        assert switch_op.regions[0] == switch_op.default_region
+        assert switch_op.regions[1] == switch_op.case_regions[0]
+        assert switch_op.regions[1] == switch_op.case_region(0)
+        assert len(switch_op.case_regions) == 3
+        assert len(switch_op.regions) == 4
+
+        with InsertionPoint(switch_op.default_block):
+            cf.assert_(arith.constant(T.bool(), 0), "Whoops!")
+            scf.yield_([c1])
+
+        for i, block in enumerate(switch_op.case_blocks):
+            with InsertionPoint(block):
+                scf.yield_([arith.constant(i32, i)])
+
+        func.return_([switch_op.results[0]])
+
+    return index_switch
+
+
+# CHECK-LABEL:   func.func @index_switch(
+# CHECK-SAME:      %[[ARG0:.*]]: index) -> i32 {
+# CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+# CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+# CHECK:           %[[CONSTANT_2:.*]] = arith.constant 5 : i32
+# CHECK:           %[[INDEX_SWITCH_0:.*]] = scf.index_switch %[[ARG0]] -> i32
+# CHECK:           case 0 {
+# CHECK:             %[[CONSTANT_3:.*]] = arith.constant 0 : i32
+# CHECK:             scf.yield %[[CONSTANT_3]] : i32
+# CHECK:           }
+# CHECK:           case 1 {
+# CHECK:             %[[CONSTANT_4:.*]] = arith.constant 1 : i32
+# CHECK:             scf.yield %[[CONSTANT_4]] : i32
+# CHECK:           }
+# CHECK:           case 2 {
+# CHECK:             %[[CONSTANT_5:.*]] = arith.constant 2 : i32
+# CHECK:             scf.yield %[[CONSTANT_5]] : i32
+# CHECK:           }
+# CHECK:           default {
+# CHECK:             %[[CONSTANT_6:.*]] = arith.constant false
+# CHECK:             cf.assert %[[CONSTANT_6]], "Whoops!"
+# CHECK:             scf.yield %[[CONSTANT_0]] : i32
+# CHECK:           }
+# CHECK:           return %[[INDEX_SWITCH_0]] : i32
+# CHECK:         }
+
+
+@constructAndPrintInModule
+def testIndexSwitchWithBodyBuilders():
+    i32 = T.i32()
+
+    @func.FuncOp.from_py_func(T.index(), results=[i32])
+    def index_switch(index):
+        c1 = arith.constant(i32, 1)
+        c0 = arith.constant(i32, 0)
+        value = arith.constant(i32, 5)
+
+        def default_body_builder(switch_op):
+            cf.assert_(arith.constant(T.bool(), 0), "Whoops!")
+            scf.yield_([c1])
+
+        def case_body_builder(switch_op, case_index: int, case_value: int):
+            scf.yield_([arith.constant(i32, case_value)])
+
+        result = scf.index_switch(
+            results_=[i32],
+            arg=index,
+            cases=range(3),
+            case_body_builder=case_body_builder,
+            default_body_builder=default_body_builder,
+        )
+
+        func.return_([result])
+
+    return index_switch
+
+
+# CHECK-LABEL:   func.func @index_switch(
+# CHECK-SAME:      %[[ARG0:.*]]: index) -> i32 {
+# CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+# CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+# CHECK:           %[[CONSTANT_2:.*]] = arith.constant 5 : i32
+# CHECK:           %[[INDEX_SWITCH_0:.*]] = scf.index_switch %[[ARG0]] -> i32
+# CHECK:           case 0 {
+# CHECK:             %[[CONSTANT_3:.*]] = arith.constant 0 : i32
+# CHECK:             scf.yield %[[CONSTANT_3]] : i32
+# CHECK:           }
+# CHECK:           case 1 {
+# CHECK:             %[[CONSTANT_4:.*]] = arith.constant 1 : i32
+# CHECK:             scf.yield %[[CONSTANT_4]] : i32
+# CHECK:           }
+# CHECK:           case 2 {
+# CHECK:             %[[CONSTANT_5:.*]] = arith.constant 2 : i32
+# CHECK:             scf.yield %[[CONSTANT_5]] : i32
+# CHECK:           }
+# CHECK:           default {
+# CHECK:             %[[CONSTANT_6:.*]] = arith.constant false
+# CHECK:             cf.assert %[[CONSTANT_6]], "Whoops!"
+# CHECK:             scf.yield %[[CONSTANT_0]] : i32
+# CHECK:           }
+# CHECK:           return %[[INDEX_SWITCH_0]] : i32
+# CHECK:         }

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -436,7 +436,7 @@ def testIndexSwitchWithBodyBuilders():
             scf.yield_([arith.constant(i32, case_value)])
 
         result = scf.index_switch(
-            results_=[i32],
+            results=[i32],
             arg=index,
             cases=range(3),
             case_body_builder=case_body_builder,

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1212,7 +1212,7 @@ def testIndexSwitch():
             @func.FuncOp.from_py_func(T.index())
             def index_switch(index):
                 c1 = arith.constant(i32, 1)
-                switch_op = scf.IndexSwitchOp(results_=[i32], arg=index, cases=range(3))
+                switch_op = scf.IndexSwitchOp(results=[i32], arg=index, cases=range(3))
 
                 assert len(switch_op.regions) == 4
                 assert len(switch_op.regions[2:]) == 2

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1213,7 +1213,7 @@ def testIndexSwitch():
             def index_switch(index):
                 c1 = arith.constant(i32, 1)
                 switch_op = scf.IndexSwitchOp(
-                    results_=[i32], arg=index, cases=range(3), num_caseRegions=3
+                    results_=[i32], arg=index, cases=range(3)
                 )
 
                 assert len(switch_op.regions) == 4

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1212,9 +1212,7 @@ def testIndexSwitch():
             @func.FuncOp.from_py_func(T.index())
             def index_switch(index):
                 c1 = arith.constant(i32, 1)
-                switch_op = scf.IndexSwitchOp(
-                    results_=[i32], arg=index, cases=range(3)
-                )
+                switch_op = scf.IndexSwitchOp(results_=[i32], arg=index, cases=range(3))
 
                 assert len(switch_op.regions) == 4
                 assert len(switch_op.regions[2:]) == 2


### PR DESCRIPTION
The C++ index switch op has utilities for `getCaseBlock(int i)` and `getDefaultBlock()`, so these have been added.
Optional body builder args have been added for the default case and each switch case.