### PR TITLE
Revert "[LoongArch] Add `isSafeToMove` hook to prevent unsafe instruction motion"

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1765,17 +1765,6 @@ public:
     return true;
   }
 
-  /// Return true if it's safe to move a machine instruction.
-  /// This allows the backend to prevent certain special instruction
-  /// sequences from being broken by instruction motion in optimization
-  /// passes.
-  /// By default, this returns true for every instruction.
-  virtual bool isSafeToMove(const MachineInstr &MI,
-                            const MachineBasicBlock *MBB,
-                            const MachineFunction &MF) const {
-    return true;
-  }
-
   /// Test if the given instruction should be considered a scheduling boundary.
   /// This primarily includes labels and terminators.
   virtual bool isSchedulingBoundary(const MachineInstr &MI,

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -1979,7 +1979,6 @@ bool BranchFolder::HoistCommonCodeInSuccs(MachineBasicBlock *MBB) {
   MachineBasicBlock::iterator FIB = FBB->begin();
   MachineBasicBlock::iterator TIE = TBB->end();
   MachineBasicBlock::iterator FIE = FBB->end();
-  MachineFunction &MF = *MBB->getParent();
   while (TIB != TIE && FIB != FIE) {
     // Skip dbg_value instructions. These do not count.
     TIB = skipDebugInstructionsForward(TIB, TIE, false);
@@ -1992,10 +1991,6 @@ bool BranchFolder::HoistCommonCodeInSuccs(MachineBasicBlock *MBB) {
 
     if (TII->isPredicated(*TIB))
       // Hard to reason about register liveness with predicated instruction.
-      break;
-
-    if (!TII->isSafeToMove(*TIB, MBB, MF))
-      // Don't hoist the instruction if it isn't safe to move.
       break;
 
     bool IsSafe = true;

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.h
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.h
@@ -66,9 +66,6 @@ public:
   bool isBranchOffsetInRange(unsigned BranchOpc,
                              int64_t BrOffset) const override;
 
-  bool isSafeToMove(const MachineInstr &MI, const MachineBasicBlock *MBB,
-                    const MachineFunction &MF) const override;
-
   bool isSchedulingBoundary(const MachineInstr &MI,
                             const MachineBasicBlock *MBB,
                             const MachineFunction &MF) const override;


### PR DESCRIPTION
Reverts llvm/llvm-project#163725