### PR TITLE
[ConstantFolding] Stop folding NaNs

### DIFF
--- a/llvm/lib/IR/ConstantFold.cpp
+++ b/llvm/lib/IR/ConstantFold.cpp
@@ -845,6 +845,8 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
     if (ConstantFP *CFP2 = dyn_cast<ConstantFP>(C2)) {
       const APFloat &C1V = CFP1->getValueAPF();
       const APFloat &C2V = CFP2->getValueAPF();
+      if (C1V.isNaN() || C2V.isNaN())
+        return nullptr;
       APFloat C3V = C1V;  // copy for modification
       switch (Opcode) {
       default:

--- a/llvm/test/Transforms/EarlyCSE/atan.ll
+++ b/llvm/test/Transforms/EarlyCSE/atan.ll
@@ -136,8 +136,9 @@ define float @callatan2_flush_to_zero() {
 
 define float @callatan2_NaN() {
 ; CHECK-LABEL: @callatan2_NaN(
-; CHECK-NEXT:    ret float 0x7FF8000000000000
-;
+; CHECK-NEXT:    [[CALL:%.*]] = call float @atan2f(float 0x7FF8000000000000, float 0x7FF8000000000000)
+; CHECK-NEXT:    ret float [[CALL]]
+
   %call = call float @atan2f(float 0x7FF8000000000000, float 0x7FF8000000000000)
   ret float %call
 }

--- a/llvm/test/Transforms/InstCombine/frexp.ll
+++ b/llvm/test/Transforms/InstCombine/frexp.ll
@@ -199,7 +199,8 @@ define { float, i32 } @frexp_neginf() {
 
 define { float, i32 } @frexp_qnan() {
 ; CHECK-LABEL: define { float, i32 } @frexp_qnan() {
-; CHECK-NEXT:    ret { float, i32 } { float 0x7FF8000000000000, i32 0 }
+; CHECK-NEXT:    [[RET:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float 0x7FF8000000000000)
+; CHECK-NEXT:    ret { float, i32 } [[RET]]
 ;
   %ret = call { float, i32 } @llvm.frexp.f32.i32(float 0x7FF8000000000000)
   ret { float, i32 } %ret
@@ -207,7 +208,8 @@ define { float, i32 } @frexp_qnan() {
 
 define { float, i32 } @frexp_snan() {
 ; CHECK-LABEL: define { float, i32 } @frexp_snan() {
-; CHECK-NEXT:    ret { float, i32 } { float 0x7FF8000020000000, i32 0 }
+; CHECK-NEXT:    [[RET:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float 0x7FF0000020000000)
+; CHECK-NEXT:    ret { float, i32 } [[RET]]
 ;
   %ret = call { float, i32 } @llvm.frexp.f32.i32(float bitcast (i32 2139095041 to float))
   ret { float, i32 } %ret
@@ -263,7 +265,8 @@ define { <2 x float>, <2 x i32> } @frexp_splat_4() {
 
 define { <2 x float>, <2 x i32> } @frexp_splat_qnan() {
 ; CHECK-LABEL: define { <2 x float>, <2 x i32> } @frexp_splat_qnan() {
-; CHECK-NEXT:    ret { <2 x float>, <2 x i32> } { <2 x float> splat (float 0x7FF8000000000000), <2 x i32> zeroinitializer }
+; CHECK-NEXT:    [[RET:%.*]] = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> splat (float 0x7FF8000000000000))
+; CHECK-NEXT:    ret { <2 x float>, <2 x i32> } [[RET]]
 ;
   %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float 0x7FF8000000000000, float 0x7FF8000000000000>)
   ret { <2 x float>, <2 x i32> } %ret

--- a/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
+++ b/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
@@ -164,23 +164,24 @@ entry:
   ret double %result
 }
 
-; Verify that trunc(SNAN) is folded to QNAN if the exception behavior mode is 'ignore'.
+; Verify that trunc(SNAN) is not folded if the exception behavior mode is 'ignore'.
 define double @nonfinite_02() #0 {
 ; CHECK-LABEL: @nonfinite_02(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret double 0x7FF8000000000000
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.trunc.f64(double 0x7FF4000000000000, metadata !"fpexcept.ignore") #[[ATTR0]]
+; CHECK-NEXT:    ret double [[RESULT]]
 ;
 entry:
   %result = call double @llvm.experimental.constrained.trunc.f64(double 0x7ff4000000000000, metadata !"fpexcept.ignore") #0
   ret double %result
 }
 
-; Verify that trunc(QNAN) is folded even if the exception behavior mode is not 'ignore'.
+; Verify that trunc(QNAN) is not folded if the exception behavior mode is not 'ignore'.
 define double @nonfinite_03() #0 {
 ; CHECK-LABEL: @nonfinite_03(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.trunc.f64(double 0x7FF8000000000000, metadata !"fpexcept.strict") #[[ATTR0]]
-; CHECK-NEXT:    ret double 0x7FF8000000000000
+; CHECK-NEXT:    ret double [[RESULT]]
 ;
 entry:
   %result = call double @llvm.experimental.constrained.trunc.f64(double 0x7ff8000000000000, metadata !"fpexcept.strict") #0
@@ -451,7 +452,8 @@ entry:
 define i1 @cmp_eq_03() #0 {
 ; CHECK-LABEL: @cmp_eq_03(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    [[RESULT:%.*]] = call i1 @llvm.experimental.constrained.fcmp.f64(double 2.000000e+00, double 0x7FF8000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #[[ATTR0]]
+; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
 entry:
   %result = call i1 @llvm.experimental.constrained.fcmp.f64(double 2.0, double 0x7ff8000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #0
@@ -461,7 +463,8 @@ entry:
 define i1 @cmp_eq_04() #0 {
 ; CHECK-LABEL: @cmp_eq_04(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    [[RESULT:%.*]] = call i1 @llvm.experimental.constrained.fcmp.f64(double 2.000000e+00, double 0x7FF4000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #[[ATTR0]]
+; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
 entry:
   %result = call i1 @llvm.experimental.constrained.fcmp.f64(double 2.0, double 0x7ff4000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #0
@@ -471,7 +474,8 @@ entry:
 define i1 @cmp_eq_05() #0 {
 ; CHECK-LABEL: @cmp_eq_05(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    [[RESULT:%.*]] = call i1 @llvm.experimental.constrained.fcmps.f64(double 2.000000e+00, double 0x7FF8000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #[[ATTR0]]
+; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
 entry:
   %result = call i1 @llvm.experimental.constrained.fcmps.f64(double 2.0, double 0x7ff8000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #0
@@ -481,7 +485,8 @@ entry:
 define i1 @cmp_eq_06() #0 {
 ; CHECK-LABEL: @cmp_eq_06(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    [[RESULT:%.*]] = call i1 @llvm.experimental.constrained.fcmps.f64(double 2.000000e+00, double 0x7FF4000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #[[ATTR0]]
+; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
 entry:
   %result = call i1 @llvm.experimental.constrained.fcmps.f64(double 2.0, double 0x7ff4000000000000, metadata !"oeq", metadata !"fpexcept.ignore") #0
@@ -516,7 +521,7 @@ define i1 @cmp_eq_nan_03() #0 {
 ; CHECK-LABEL: @cmp_eq_nan_03(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i1 @llvm.experimental.constrained.fcmp.f64(double 0x7FF8000000000000, double 1.000000e+00, metadata !"oeq", metadata !"fpexcept.strict") #[[ATTR0]]
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
 entry:
   %result = call i1 @llvm.experimental.constrained.fcmp.f64(double 0x7ff8000000000000, double 1.0, metadata !"oeq", metadata !"fpexcept.strict") #0

--- a/llvm/test/Transforms/InstSimplify/fptoi-sat.ll
+++ b/llvm/test/Transforms/InstSimplify/fptoi-sat.ll
@@ -139,7 +139,8 @@ define i32 @fptosi_f64_to_i32_neg_inf() {
 
 define i32 @fptosi_f64_to_i32_nan1() {
 ; CHECK-LABEL: @fptosi_f64_to_i32_nan1(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f64(double 0x7FF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f64(double 0x7ff8000000000000)
   ret i32 %r
@@ -147,7 +148,8 @@ define i32 @fptosi_f64_to_i32_nan1() {
 
 define i32 @fptosi_f64_to_i32_nan2() {
 ; CHECK-LABEL: @fptosi_f64_to_i32_nan2(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f64(double 0x7FF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f64(double 0x7ff4000000000000)
   ret i32 %r
@@ -155,7 +157,8 @@ define i32 @fptosi_f64_to_i32_nan2() {
 
 define i32 @fptosi_f64_to_i32_nan3() {
 ; CHECK-LABEL: @fptosi_f64_to_i32_nan3(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f64(double 0xFFF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f64(double 0xfff8000000000000)
   ret i32 %r
@@ -163,7 +166,8 @@ define i32 @fptosi_f64_to_i32_nan3() {
 
 define i32 @fptosi_f64_to_i32_nan4() {
 ; CHECK-LABEL: @fptosi_f64_to_i32_nan4(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f64(double 0xFFF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f64(double 0xfff4000000000000)
   ret i32 %r
@@ -281,7 +285,8 @@ define i32 @fptoui_f64_to_i32_neg_inf() {
 
 define i32 @fptoui_f64_to_i32_nan1() {
 ; CHECK-LABEL: @fptoui_f64_to_i32_nan1(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f64(double 0x7FF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f64(double 0x7ff8000000000000)
   ret i32 %r
@@ -289,7 +294,8 @@ define i32 @fptoui_f64_to_i32_nan1() {
 
 define i32 @fptoui_f64_to_i32_nan2() {
 ; CHECK-LABEL: @fptoui_f64_to_i32_nan2(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f64(double 0x7FF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f64(double 0x7ff4000000000000)
   ret i32 %r
@@ -297,7 +303,8 @@ define i32 @fptoui_f64_to_i32_nan2() {
 
 define i32 @fptoui_f64_to_i32_nan3() {
 ; CHECK-LABEL: @fptoui_f64_to_i32_nan3(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f64(double 0xFFF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f64(double 0xfff8000000000000)
   ret i32 %r
@@ -305,7 +312,8 @@ define i32 @fptoui_f64_to_i32_nan3() {
 
 define i32 @fptoui_f64_to_i32_nan4() {
 ; CHECK-LABEL: @fptoui_f64_to_i32_nan4(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f64(double 0xFFF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f64(double 0xfff4000000000000)
   ret i32 %r
@@ -439,7 +447,8 @@ define i32 @fptosi_f32_to_i32_neg_inf() {
 
 define i32 @fptosi_f32_to_i32_nan1() {
 ; CHECK-LABEL: @fptosi_f32_to_i32_nan1(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f32(float 0x7FF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f32(float 0x7ff8000000000000)
   ret i32 %r
@@ -447,7 +456,8 @@ define i32 @fptosi_f32_to_i32_nan1() {
 
 define i32 @fptosi_f32_to_i32_nan2() {
 ; CHECK-LABEL: @fptosi_f32_to_i32_nan2(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f32(float 0x7FF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f32(float 0x7ff4000000000000)
   ret i32 %r
@@ -455,7 +465,8 @@ define i32 @fptosi_f32_to_i32_nan2() {
 
 define i32 @fptosi_f32_to_i32_nan3() {
 ; CHECK-LABEL: @fptosi_f32_to_i32_nan3(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f32(float 0xFFF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f32(float 0xfff8000000000000)
   ret i32 %r
@@ -463,7 +474,8 @@ define i32 @fptosi_f32_to_i32_nan3() {
 
 define i32 @fptosi_f32_to_i32_nan4() {
 ; CHECK-LABEL: @fptosi_f32_to_i32_nan4(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptosi.sat.i32.f32(float 0xFFF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptosi.sat.i32.f32(float 0xfff4000000000000)
   ret i32 %r
@@ -573,7 +585,8 @@ define i32 @fptoui_f32_to_i32_neg_inf() {
 
 define i32 @fptoui_f32_to_i32_nan1() {
 ; CHECK-LABEL: @fptoui_f32_to_i32_nan1(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f32(float 0x7FF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f32(float 0x7ff8000000000000)
   ret i32 %r
@@ -581,7 +594,8 @@ define i32 @fptoui_f32_to_i32_nan1() {
 
 define i32 @fptoui_f32_to_i32_nan2() {
 ; CHECK-LABEL: @fptoui_f32_to_i32_nan2(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f32(float 0x7FF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f32(float 0x7ff4000000000000)
   ret i32 %r
@@ -589,7 +603,8 @@ define i32 @fptoui_f32_to_i32_nan2() {
 
 define i32 @fptoui_f32_to_i32_nan3() {
 ; CHECK-LABEL: @fptoui_f32_to_i32_nan3(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f32(float 0xFFF8000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f32(float 0xfff8000000000000)
   ret i32 %r
@@ -597,7 +612,8 @@ define i32 @fptoui_f32_to_i32_nan3() {
 
 define i32 @fptoui_f32_to_i32_nan4() {
 ; CHECK-LABEL: @fptoui_f32_to_i32_nan4(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fptoui.sat.i32.f32(float 0xFFF4000000000000)
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = call i32 @llvm.fptoui.sat.i32.f32(float 0xfff4000000000000)
   ret i32 %r

--- a/llvm/test/Transforms/InstSimplify/strictfp-fadd.ll
+++ b/llvm/test/Transforms/InstSimplify/strictfp-fadd.ll
@@ -364,7 +364,7 @@ define float @fold_fadd_qnan_qnan_ebmaytrap() #0 {
 define float @fold_fadd_qnan_qnan_ebstrict() #0 {
 ; CHECK-LABEL: @fold_fadd_qnan_qnan_ebstrict(
 ; CHECK-NEXT:    [[ADD:%.*]] = call float @llvm.experimental.constrained.fadd.f32(float 0x7FF8000000000000, float 0x7FF8000000000000, metadata !"round.tonearest", metadata !"fpexcept.strict") #[[ATTR0]]
-; CHECK-NEXT:    ret float 0x7FF8000000000000
+; CHECK-NEXT:    ret float [[ADD]]
 ;
   %add = call float @llvm.experimental.constrained.fadd.f32(float 0x7ff8000000000000, float 0x7ff8000000000000, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret float %add

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/revec.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/revec.ll
@@ -227,9 +227,10 @@ define ptr @test4() {
 define i32 @test5() {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP0:%.*]] = fadd <8 x double> zeroinitializer, <double 0x7FF8000000000000, double 0x7FF8000000000000, double 0.000000e+00, double 0.000000e+00, double 0x7FF8000000000000, double 0x7FF8000000000000, double 0.000000e+00, double 0.000000e+00>
 ; CHECK-NEXT:    br label [[FOR_END47:%.*]]
 ; CHECK:       for.end47:
-; CHECK-NEXT:    [[TMP0:%.*]] = phi <8 x double> [ <double 0x7FF8000000000000, double 0x7FF8000000000000, double 0.000000e+00, double 0.000000e+00, double 0x7FF8000000000000, double 0x7FF8000000000000, double 0.000000e+00, double 0.000000e+00>, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = phi <8 x double> [ [[TMP0]], [[ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i32 0
 ;
 entry:

--- a/llvm/test/Transforms/SLPVectorizer/X86/split-node-full-match.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/split-node-full-match.ll
@@ -24,15 +24,17 @@ define void @test(double %0) {
 ; CHECK:       [[_LR_PH272_PREHEADER:.*:]]
 ; CHECK-NEXT:    br i1 false, [[DOT_CRIT_EDGE]], label %[[BB14:.*]]
 ; CHECK:       [[BB14]]:
+; CHECK-NEXT:    [[TMP16:%.*]] = fsub <2 x double> zeroinitializer, splat (double 0x7FF8000000000000)
 ; CHECK-NEXT:    [[TMP14:%.*]] = shufflevector <6 x double> [[TMP12]], <6 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:    [[TMP15:%.*]] = shufflevector <4 x double> [[TMP14]], <4 x double> poison, <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison>
-; CHECK-NEXT:    [[TMP17:%.*]] = shufflevector <6 x double> [[TMP15]], <6 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000, double undef, double undef, double undef, double undef>, <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 6, i32 7>
-; CHECK-NEXT:    br i1 false, label %[[BB18:.*]], [[DOT_CRIT_EDGE]]
-; CHECK:       [[BB18]]:
+; CHECK-NEXT:    [[TMP20:%.*]] = shufflevector <2 x double> [[TMP16]], <2 x double> poison, <6 x i32> <i32 0, i32 1, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP19:%.*]] = shufflevector <6 x double> [[TMP15]], <6 x double> [[TMP20]], <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 6, i32 7>
+; CHECK-NEXT:    br i1 false, label %[[BB20:.*]], [[DOT_CRIT_EDGE]]
+; CHECK:       [[BB20]]:
 ; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <6 x double> <double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double poison, double 0.000000e+00, double 0.000000e+00>, double [[TMP0]], i32 3
 ; CHECK-NEXT:    br [[DOT_CRIT_EDGE]]
 ; CHECK:       [[__CRIT_EDGE:.*:]]
-; CHECK-NEXT:    [[TMP20:%.*]] = phi <6 x double> [ [[TMP12]], %[[BB7]] ], [ [[TMP18]], %[[BB18]] ], [ [[TMP17]], %[[BB14]] ], [ [[TMP12]], %[[DOTLR_PH272_PREHEADER]] ]
+; CHECK-NEXT:    [[TMP22:%.*]] = phi <6 x double> [ [[TMP12]], %[[BB7]] ], [ [[TMP18]], %[[BB20]] ], [ [[TMP19]], %[[BB14]] ], [ [[TMP12]], %[[DOTLR_PH272_PREHEADER]] ]
 ; CHECK-NEXT:    ret void
 ;
 .thread:


### PR DESCRIPTION
Not-a-Number (NaN) is a special floating-point datum that does not represent any floating-point value. Its purpose is to represent runtime errors detected during floating-point operations. It makes constfolding instructions that produce NaN inappropriate.

NaN is produced by operations that are typically considered wrong, like `0.0 / 0.0` or `sqrt(-1.0)`. It is unlikely that this is the intended behavior. It is more probable that this is an error the frontend could not detect, but which is exposed by deep transformations like LTO. Constant-folding such instructions is not useful.

An instruction that produces NaN can be located in a debugger because it raises an exception. If such an instruction is replaced by a constant, the NaN would silently propagate throughout subsequent expressions, making it more difficult to find the original faulty instruction. Constfolding is undesirable in this case.

Constant folding can be undesirable in the case when the execution environment creates NaNs with non-trivial payloads.

This change prevents the constant folding of instructions that produce NaN, as well as those that propagate NaN from their operands to the result.

Users may still use NaNs for non-computational purposes, such as a sentinel, for example. In such cases the NaN is not intended to be used as an operand in calculations, but only in checks. Users can obtain NaN value using expressions like:

    static const double NaN = 0.0 / 0.0;

Such expressions can be evaluated in compile time by the frontend, which also can emit warnings if it detects use of NaN as an operand in calculations. The produced IR can be made free from NaN misuse in such cases.