### PR TITLE
[llvm][llvm-dis] Fix 'llvm-dis' with '--materialize-metadata --show-annotations' crashes

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2931,7 +2931,7 @@ private:
 
   // printInfoComment - Print a little comment after the instruction indicating
   // which slot it occupies.
-  void printInfoComment(const Value &V);
+  void printInfoComment(const Value &V, bool isMaterializable = false);
 
   // printGCRelocateComment - print comment after call to the gc.relocate
   // intrinsic indicating base and derived pointer names.
@@ -3963,7 +3963,7 @@ void AssemblyWriter::printGlobal(const GlobalVariable *GV) {
   if (Attrs.hasAttributes())
     Out << " #" << Machine.getAttributeGroupSlot(Attrs);
 
-  printInfoComment(*GV);
+  printInfoComment(*GV, GV->isMaterializable());
 }
 
 void AssemblyWriter::printAlias(const GlobalAlias *GA) {
@@ -4001,7 +4001,7 @@ void AssemblyWriter::printAlias(const GlobalAlias *GA) {
     Out << '"';
   }
 
-  printInfoComment(*GA);
+  printInfoComment(*GA, GA->isMaterializable());
   Out << '\n';
 }
 
@@ -4040,7 +4040,7 @@ void AssemblyWriter::printIFunc(const GlobalIFunc *GI) {
     printMetadataAttachments(MDs, ", ");
   }
 
-  printInfoComment(*GI);
+  printInfoComment(*GI, GI->isMaterializable());
   Out << '\n';
 }
 
@@ -4319,13 +4319,12 @@ void AssemblyWriter::printGCRelocateComment(const GCRelocateInst &Relocate) {
 
 /// printInfoComment - Print a little comment after the instruction indicating
 /// which slot it occupies.
-void AssemblyWriter::printInfoComment(const Value &V) {
+void AssemblyWriter::printInfoComment(const Value &V, bool isMaterializable) {
   if (const auto *Relocate = dyn_cast<GCRelocateInst>(&V))
     printGCRelocateComment(*Relocate);
 
-  if (AnnotationWriter) {
+  if (AnnotationWriter && !isMaterializable)
     AnnotationWriter->printInfoComment(V, Out);
-  }
 
   if (PrintInstDebugLocs) {
     if (auto *I = dyn_cast<Instruction>(&V)) {

--- a/llvm/test/Assembler/metadata-annotations.ll
+++ b/llvm/test/Assembler/metadata-annotations.ll
@@ -1,9 +1,23 @@
 ; RUN: llvm-as < %s | llvm-dis --materialize-metadata --show-annotations | FileCheck %s
 
+; CHECK: @global_var = global i32 1
+; CHECK: @alias = alias i32, ptr @global_var
+; CHECK: @ifunc = ifunc i32 (), ptr @ifunc_resolver
+@global_var = global i32 1
+@alias = alias i32, ptr @global_var
+@ifunc = ifunc i32 (), ptr @ifunc_resolver
+
 ; CHECK: ; Materializable
-; CHECK-NEXT: define dso_local i32 @test() {}
-define dso_local i32 @test() {
-entry:
-  ret i32 0
+; CHECK-NEXT: define ptr @ifunc_resolver() {}
+define ptr @ifunc_resolver() {
+  ret ptr @defined_function
 }
 
+; CHECK: ; Materializable
+; CHECK-NEXT: define void @defined_function() {}
+define void @defined_function() {
+  ret void
+}
+
+; CHECK: declare void @declared_function()
+declare void @declared_function()


### PR DESCRIPTION
Added handling the case of a non-materialized module, also don't call printInfoComment for immaterializable values