### PR TITLE
[ARM] Add missing cases of SubsumesPredicate

### DIFF
--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -481,7 +481,9 @@ bool ARMBaseInstrInfo::SubsumesPredicate(ArrayRef<MachineOperand> Pred1,
   case ARMCC::GE:
     return CC2 == ARMCC::GT;
   case ARMCC::LE:
-    return CC2 == ARMCC::LT;
+    return CC2 == ARMCC::LT || CC2 == ARMCC::EQ;
+  case ARMCC::NE:
+    return CC2 == ARMCC::HI || CC2 == ARMCC::GT;
   }
 }
 


### PR DESCRIPTION
LE subsumes EQ because LE is (Z==1) || (N!=V). Z == 1 is EQ

NE is Z == 0, and HI and GT subsume NE because HI is (C==1) && (Z==0) and GT is  (Z==0) && (N==V)