### PR TITLE
[CIR] Cast record size to uint64 to prevent overflow

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -341,7 +341,7 @@ RecordType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
   if (isUnion())
     return dataLayout.getTypeSize(getLargestMember(dataLayout));
 
-  unsigned recordSize = computeStructSize(dataLayout);
+  auto recordSize = static_cast<uint64_t>(computeStructSize(dataLayout));
   return llvm::TypeSize::getFixed(recordSize * 8);
 }
 


### PR DESCRIPTION
`llvm::TypeSize` uses 64bit integers, so we should cast the `recordSize` before multiplying by 8 to prevent an overflow.