### PR TITLE
[ProfCheck] Mark Some profverify Tests as Unsupported

### DIFF
--- a/llvm/test/Transforms/PGOProfile/prof-verify-no-entrycount.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify-no-entrycount.ll
@@ -1,3 +1,7 @@
+; This test fails under the profcheck configuration due to profcheck creating
+; metadata.
+; UNSUPPORTED: profcheck
+
 ; Test prof-verify for functions without entry count
 
 ; RUN: not opt -passes=prof-verify %s -o - 2>&1 | FileCheck %s

--- a/llvm/test/Transforms/PGOProfile/prof-verify.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify.ll
@@ -1,3 +1,7 @@
+; This test fails under the profcheck configuration due to profcheck creating
+; metadata.
+; UNSUPPORTED: profcheck
+
 ; Test prof-inject and prof-verify
 
 ; RUN: opt -passes=prof-inject %s -S -o - | FileCheck %s --check-prefix=INJECT

--- a/llvm/test/Transforms/PGOProfile/profcheck-select.ll
+++ b/llvm/test/Transforms/PGOProfile/profcheck-select.ll
@@ -1,3 +1,7 @@
+; This test fails under the profcheck configuration due to profcheck creating
+; metadata.
+; UNSUPPORTED: profcheck
+
 ; RUN: split-file %s %t
 
 ; RUN: opt -passes=prof-inject %t/inject.ll -S -o - | FileCheck %t/inject.ll

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -69,6 +69,8 @@ if config.enable_profcheck:
     # profiling doesn't work quite well on GPU, excluding
     config.excludes.append("AMDGPU")
 
+    config.available_features.add("profcheck")
+
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -614,9 +614,6 @@ Transforms/PGOProfile/chr-lifetimes.ll
 Transforms/PGOProfile/chr-poison.ll
 Transforms/PGOProfile/comdat.ll
 Transforms/PGOProfile/memop_profile_funclet_wasm.ll
-Transforms/PGOProfile/profcheck-select.ll
-Transforms/PGOProfile/prof-verify.ll
-Transforms/PGOProfile/prof-verify-no-entrycount.ll
 Transforms/PGOProfile/X86/macho.ll
 Transforms/PhaseOrdering/AArch64/constraint-elimination-placement.ll
 Transforms/PhaseOrdering/AArch64/globals-aa-required-for-vectorization.ll


### PR DESCRIPTION
These tests fail in the profcheck configuration because profinject gets added to the pipeline and adds metadata that changes the input PGO information.