### PR TITLE
PPC: Disable type checking in xfailed sincospi test

### DIFF
--- a/llvm/test/CodeGen/PowerPC/llvm.sincospi.ppcfp128.ll
+++ b/llvm/test/CodeGen/PowerPC/llvm.sincospi.ppcfp128.ll
@@ -1,6 +1,6 @@
 ; XFAIL: *
 ; FIXME: asserts
-; RUN: llc -mcpu=pwr9 -mtriple=powerpc64le-gnu-linux -filetype=null \
+; RUN: llc -mcpu=pwr9 -mtriple=powerpc64le-gnu-linux -filetype=null -enable-legalize-types-checking=0 \
 ; RUN:   -ppc-vsr-nums-as-vr -ppc-asm-full-reg-names %s
 
 define { ppc_fp128, ppc_fp128 } @test_sincospi_ppcf128(ppc_fp128 %a) {


### PR DESCRIPTION
This hangs in expensive_checks