### PR TITLE
[compiler-rt][asan] Fix a test on Windows

### DIFF
--- a/compiler-rt/lib/asan/tests/asan_test.cpp
+++ b/compiler-rt/lib/asan/tests/asan_test.cpp
@@ -1121,6 +1121,8 @@ TEST(AddressSanitizer, StressStackReuseTest) {
 TEST(AddressSanitizer, ThreadedStressStackReuseTest) {
   const int kNumThreads = 20;
   pthread_t t[kNumThreads];
+// pthread_attr isn't supported on Windows.
+#ifndef _WIN32
   size_t curStackSize = 0;
   pthread_attr_t attr;
   pthread_attr_init(&attr);
@@ -1130,13 +1132,20 @@ TEST(AddressSanitizer, ThreadedStressStackReuseTest) {
     int rc = pthread_attr_setstacksize(&attr, MIN_STACK_SIZE);
     ASSERT_EQ(0, rc);
   }
+#endif
   for (int i = 0; i < kNumThreads; i++) {
+#ifdef _WIN32
+    PTHREAD_CREATE(&t[i], 0, (void* (*)(void *x))LotsOfStackReuse, 0);
+#else
     PTHREAD_CREATE(&t[i], &attr, (void* (*)(void* x))LotsOfStackReuse, 0);
+#endif
   }
   for (int i = 0; i < kNumThreads; i++) {
     PTHREAD_JOIN(t[i], 0);
   }
+#ifndef _WIN32
   pthread_attr_destroy(&attr);
+#endif
 }
 
 // pthread_exit tries to perform unwinding stuff that leads to dlopen'ing

--- a/compiler-rt/lib/asan/tests/asan_test.cpp
+++ b/compiler-rt/lib/asan/tests/asan_test.cpp
@@ -1135,7 +1135,7 @@ TEST(AddressSanitizer, ThreadedStressStackReuseTest) {
 #endif
   for (int i = 0; i < kNumThreads; i++) {
 #ifdef _WIN32
-    PTHREAD_CREATE(&t[i], 0, (void* (*)(void *x))LotsOfStackReuse, 0);
+    PTHREAD_CREATE(&t[i], 0, (void* (*)(void* x))LotsOfStackReuse, 0);
 #else
     PTHREAD_CREATE(&t[i], &attr, (void* (*)(void* x))LotsOfStackReuse, 0);
 #endif


### PR DESCRIPTION
Windows doesn't support `pthread_attr`, which was introduced to asan_test.cpp in #165198, so this change `#ifdef`s out the changes made in that PR.

Originally reported by Chrome as https://crbug.com/459880605.