### PR TITLE
[PowerPC] Use MCRegister instead of unsigned. NFC

### DIFF
--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.cpp
@@ -619,11 +619,11 @@ bool PPCInstPrinter::showRegistersWithPercentPrefix(const char *RegName) const {
 /// getVerboseConditionalRegName - This method expands the condition register
 /// when requested explicitly or targetting Darwin.
 const char *
-PPCInstPrinter::getVerboseConditionRegName(unsigned RegNum,
+PPCInstPrinter::getVerboseConditionRegName(MCRegister Reg,
                                            unsigned RegEncoding) const {
   if (!FullRegNames && !MAI.useFullRegisterNames())
     return nullptr;
-  if (RegNum < PPC::CR0EQ || RegNum > PPC::CR7UN)
+  if (Reg < PPC::CR0EQ || Reg > PPC::CR7UN)
     return nullptr;
   const char *CRBits[] = {
     "lt", "gt", "eq", "un",

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.h
@@ -23,7 +23,7 @@ class PPCInstPrinter : public MCInstPrinter {
 private:
   bool showRegistersWithPercentPrefix(const char *RegName) const;
   bool showRegistersWithPrefix() const;
-  const char *getVerboseConditionRegName(unsigned RegNum,
+  const char *getVerboseConditionRegName(MCRegister Reg,
                                          unsigned RegEncoding) const;
 
 public:

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.h
@@ -287,11 +287,11 @@ using llvm::MCPhysReg;
 
 namespace llvm {
 namespace PPC {
-static inline bool isVFRegister(unsigned Reg) {
+static inline bool isVFRegister(MCRegister Reg) {
   return Reg >= PPC::VF0 && Reg <= PPC::VF31;
 }
 
-static inline bool isVRRegister(unsigned Reg) {
+static inline bool isVRRegister(MCRegister Reg) {
   return Reg >= PPC::V0 && Reg <= PPC::V31;
 }
 


### PR DESCRIPTION
I'm considering a operator>(MCRegister, unsigned) and operator<(MCRegister, unsigned) so I have not updated those lines. Such comparisons are common on MCRegister.