### PR TITLE
[libclc] Fix floating-point __clc_atomic_store/exchange cast mismatch

### DIFF
--- a/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
@@ -29,6 +29,10 @@
 #define __CLC_AS_RETTYPE(x) x
 #endif
 
+#ifndef __CLC_AS_INTTYPE
+#define __CLC_AS_INTTYPE(x) x
+#endif
+
 #ifdef __CLC_NO_VALUE_ARG
 #define __CLC_DEFINE_ATOMIC(ADDRSPACE)                                         \
   _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_FUNCTION(                         \
@@ -51,8 +55,8 @@
   _CLC_OVERLOAD _CLC_DEF void __CLC_FUNCTION(                                  \
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, __CLC_GENTYPE Value,              \
       int MemoryOrder, int MemoryScope) {                                      \
-    __CLC_IMPL_FUNCTION((ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr, Value,            \
-                        MemoryOrder, MemoryScope);                             \
+    __CLC_IMPL_FUNCTION((ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr,                   \
+                        __CLC_AS_INTTYPE(Value), MemoryOrder, MemoryScope);    \
   }
 #else
 #define __CLC_DEFINE_ATOMIC(ADDRSPACE)                                         \

--- a/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
@@ -47,8 +47,7 @@
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, int MemoryOrder,                  \
       int MemoryScope) {                                                       \
     return __CLC_AS_RETTYPE(                                                   \
-        __CLC_IMPL_FUNCTION((ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr,               \
-                            (__CLC_GENTYPE)1, MemoryOrder, MemoryScope));      \
+        __CLC_IMPL_FUNCTION(Ptr, (__CLC_GENTYPE)1, MemoryOrder, MemoryScope)); \
   }
 #elif defined(__CLC_RETURN_VOID)
 #define __CLC_DEFINE_ATOMIC(ADDRSPACE)                                         \
@@ -63,9 +62,9 @@
   _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_FUNCTION(                         \
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, __CLC_GENTYPE Value,              \
       int MemoryOrder, int MemoryScope) {                                      \
-    return __CLC_AS_RETTYPE(                                                   \
-        __CLC_IMPL_FUNCTION((ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr, Value,        \
-                            MemoryOrder, MemoryScope));                        \
+    return __CLC_AS_RETTYPE(__CLC_IMPL_FUNCTION(                               \
+        (ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr, __CLC_AS_INTTYPE(Value),          \
+        MemoryOrder, MemoryScope));                                            \
   }
 #endif
 

--- a/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
@@ -21,16 +21,16 @@
 
 #ifdef __CLC_HAS_ATOMIC
 
-#ifndef __CLC_PTR_CASTTYPE
-#define __CLC_PTR_CASTTYPE __CLC_GENTYPE
+#ifndef __CLC_CASTTYPE
+#define __CLC_CASTTYPE __CLC_GENTYPE
 #endif
 
 #ifndef __CLC_AS_RETTYPE
 #define __CLC_AS_RETTYPE(x) x
 #endif
 
-#ifndef __CLC_AS_INTTYPE
-#define __CLC_AS_INTTYPE(x) x
+#ifndef __CLC_AS_CASTTYPE
+#define __CLC_AS_CASTTYPE(x) x
 #endif
 
 #ifdef __CLC_NO_VALUE_ARG
@@ -39,7 +39,7 @@
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, int MemoryOrder,                  \
       int MemoryScope) {                                                       \
     return __CLC_AS_RETTYPE(__CLC_IMPL_FUNCTION(                               \
-        (ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr, MemoryOrder, MemoryScope));       \
+        (ADDRSPACE __CLC_CASTTYPE *)Ptr, MemoryOrder, MemoryScope));           \
   }
 #elif defined(__CLC_INC_DEC)
 #define __CLC_DEFINE_ATOMIC(ADDRSPACE)                                         \
@@ -54,8 +54,8 @@
   _CLC_OVERLOAD _CLC_DEF void __CLC_FUNCTION(                                  \
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, __CLC_GENTYPE Value,              \
       int MemoryOrder, int MemoryScope) {                                      \
-    __CLC_IMPL_FUNCTION((ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr,                   \
-                        __CLC_AS_INTTYPE(Value), MemoryOrder, MemoryScope);    \
+    __CLC_IMPL_FUNCTION((ADDRSPACE __CLC_CASTTYPE *)Ptr,                       \
+                        __CLC_AS_CASTTYPE(Value), MemoryOrder, MemoryScope);   \
   }
 #else
 #define __CLC_DEFINE_ATOMIC(ADDRSPACE)                                         \
@@ -63,7 +63,7 @@
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, __CLC_GENTYPE Value,              \
       int MemoryOrder, int MemoryScope) {                                      \
     return __CLC_AS_RETTYPE(__CLC_IMPL_FUNCTION(                               \
-        (ADDRSPACE __CLC_PTR_CASTTYPE *)Ptr, __CLC_AS_INTTYPE(Value),          \
+        (ADDRSPACE __CLC_CASTTYPE *)Ptr, __CLC_AS_CASTTYPE(Value),             \
         MemoryOrder, MemoryScope));                                            \
   }
 #endif

--- a/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
@@ -46,8 +46,8 @@
   _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_FUNCTION(                         \
       volatile ADDRSPACE __CLC_GENTYPE *Ptr, int MemoryOrder,                  \
       int MemoryScope) {                                                       \
-    return __CLC_AS_RETTYPE(                                                   \
-        __CLC_IMPL_FUNCTION(Ptr, (__CLC_GENTYPE)1, MemoryOrder, MemoryScope)); \
+    return __CLC_IMPL_FUNCTION(Ptr, (__CLC_GENTYPE)1, MemoryOrder,             \
+                               MemoryScope);                                   \
   }
 #elif defined(__CLC_RETURN_VOID)
 #define __CLC_DEFINE_ATOMIC(ADDRSPACE)                                         \

--- a/libclc/clc/lib/generic/atomic/clc_atomic_exchange.cl
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_exchange.cl
@@ -14,12 +14,12 @@
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_PTR_CASTTYPE
+#undef __CLC_CASTTYPE
 #undef __CLC_AS_RETTYPE
-#undef __CLC_AS_INTTYPE
-#define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
+#undef __CLC_AS_CASTTYPE
+#define __CLC_CASTTYPE __CLC_BIT_INTN
 #define __CLC_AS_RETTYPE(x) __CLC_AS_GENTYPE(x)
-#define __CLC_AS_INTTYPE __CLC_AS_S_GENTYPE
+#define __CLC_AS_CASTTYPE __CLC_AS_S_GENTYPE
 
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/atomic/clc_atomic_exchange.cl
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_exchange.cl
@@ -16,8 +16,10 @@
 
 #undef __CLC_PTR_CASTTYPE
 #undef __CLC_AS_RETTYPE
+#undef __CLC_AS_INTTYPE
 #define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
 #define __CLC_AS_RETTYPE(x) __CLC_AS_GENTYPE(x)
+#define __CLC_AS_INTTYPE __CLC_AS_S_GENTYPE
 
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/atomic/clc_atomic_load.cl
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_load.cl
@@ -15,9 +15,9 @@
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_PTR_CASTTYPE
+#undef __CLC_CASTTYPE
 #undef __CLC_AS_RETTYPE
-#define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
+#define __CLC_CASTTYPE __CLC_BIT_INTN
 #define __CLC_AS_RETTYPE(x) __CLC_AS_GENTYPE(x)
 
 #define __CLC_BODY <clc_atomic_def.inc>

--- a/libclc/clc/lib/generic/atomic/clc_atomic_store.cl
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_store.cl
@@ -17,6 +17,8 @@
 
 #undef __CLC_PTR_CASTTYPE
 #define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
+#undef __CLC_AS_INTTYPE
+#define __CLC_AS_INTTYPE __CLC_AS_S_GENTYPE
 
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/atomic/clc_atomic_store.cl
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_store.cl
@@ -16,8 +16,8 @@
 #include <clc/integer/gentype.inc>
 
 #undef __CLC_PTR_CASTTYPE
-#define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
 #undef __CLC_AS_INTTYPE
+#define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
 #define __CLC_AS_INTTYPE __CLC_AS_S_GENTYPE
 
 #define __CLC_BODY <clc_atomic_def.inc>

--- a/libclc/clc/lib/generic/atomic/clc_atomic_store.cl
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_store.cl
@@ -15,10 +15,10 @@
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_PTR_CASTTYPE
-#undef __CLC_AS_INTTYPE
-#define __CLC_PTR_CASTTYPE __CLC_BIT_INTN
-#define __CLC_AS_INTTYPE __CLC_AS_S_GENTYPE
+#undef __CLC_CASTTYPE
+#undef __CLC_AS_CASTTYPE
+#define __CLC_CASTTYPE __CLC_BIT_INTN
+#define __CLC_AS_CASTTYPE __CLC_AS_S_GENTYPE
 
 #define __CLC_BODY <clc_atomic_def.inc>
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
When pointer element type is casted to integer type, the stored value should be casted to integer type to avoid type mistmatch. LLVM IR change in function _Z18__clc_atomic_storePU3AS1Vffii:
    >   %5 = bitcast float %1 to i32   (New)
    <   %5 = fptosi float %1 to i32    (Old)