### PR TITLE
[orc-rt] Make Session explicitly immovable.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -42,6 +42,8 @@ public:
   // Sessions are not copyable or moveable.
   Session(const Session &) = delete;
   Session &operator=(const Session &) = delete;
+  Session(Session &&) = delete;
+  Session &operator=(Session &&) = delete;
 
   ~Session();
 


### PR DESCRIPTION
NFCI -- the deleted copy constructor already made this immovable. The explicit operations just make clear that this was intentional.