### PR TITLE
[lit][ci] Enable testing Release Lit workflow in forks

### DIFF
--- a/.github/workflows/release-lit.yml
+++ b/.github/workflows/release-lit.yml
@@ -4,13 +4,16 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
-    inputs:
-      release-version:
-        description: 'Release Version'
-        required: true
-        type: string
-
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/release-lit.yml
+      - 'llvm/utils/lit/**'
+  pull_request:
+    paths:
+      - .github/workflows/release-lit.yml
+      - 'llvm/utils/lit/**'
   workflow_call:
     inputs:
       release-version:
@@ -21,9 +24,21 @@ on:
       RELEASE_TASKS_USER_TOKEN:
         description: "Secret used to check user permissions."
         required: false
+  workflow_dispatch:
+    inputs:
+      description_only:
+        description: Workflow dispatch only triggers a dry run, no upload to PyPI will occur.
+        type: string
+        default: 'Please read the description above.'
+        required: false
+      release-version:
+        description: 'Release Version'
+        required: true
+        type: string
 
 jobs:
   release-lit:
+    if: github.repository_owner == 'llvm' || github.event_name == 'workflow_dispatch'
     name: Release Lit
     runs-on: ubuntu-24.04
     steps:
@@ -38,6 +53,7 @@ jobs:
           sudo apt-get install -y python3-setuptools python3-psutil python3-github
 
       - name: Check Permissions
+        if: contains(github.workflow_ref, '/.github/workflows/release-tasks.yml') && github.event_name != 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
@@ -47,7 +63,7 @@ jobs:
       - name: Setup Cpp
         uses: aminya/setup-cpp@a276e6e3d1db9160db5edc458e99a30d3b109949 # v1.7.1
         with:
-          compiler: llvm-16.0.6
+          compiler: llvm-19.1.7
           cmake: true
           ninja: true
 
@@ -65,7 +81,14 @@ jobs:
           sed -i 's/ + "dev"//g' lit/__init__.py
           python3 setup.py sdist bdist_wheel
 
+      - name: Save lit package as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lit-artifact
+          path: llvm/utils/lit/dist/
+
       - name: Upload lit to test.pypi.org
+        if: contains(github.workflow_ref, '/.github/workflows/release-tasks.yml') && github.event_name != 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           password: ${{ secrets.LLVM_LIT_TEST_PYPI_API_TOKEN }}
@@ -73,6 +96,7 @@ jobs:
           packages-dir: llvm/utils/lit/dist/
 
       - name: Upload lit to pypi.org
+        if: contains(github.workflow_ref, '/.github/workflows/release-tasks.yml') && github.event_name != 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           password: ${{ secrets.LLVM_LIT_PYPI_API_TOKEN }}


### PR DESCRIPTION
I'm looking at Python packaging of some parts of LLVM and updating them to use current best practices (https://github.com/llvm/llvm-project/issues/125220#issuecomment-2635940515), and couldn't test the CI release workflow in my fork.

This updates the CI workflow to:
* Enable building in forks without erroring on the permissions/upload steps by only running those steps when the workflow is running in the repo within the main LLVM org
* Add an option to save the built package as an artifact to download for local testing/inspection
* Add a dry-run option for testing the release workflow within the main LLVM repository without actually doing the upload (also as an input for workflow_call, so in the future the release workflow that releases everything can also be set up to do a test of the release workflows without uploading anything.)

These things could be split out into separate PRs if desired. The first two are probably the key ones needed to facilitate testing in forks.