### PR TITLE
[clang] Fix conflicting declaration error with using_if_exists

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -12938,7 +12938,7 @@ bool Sema::CheckUsingShadowDecl(BaseUsingDecl *BUD, NamedDecl *Orig,
     if (!NonTag && !Tag)
       return false;
 
-    // Only check report the error if this using_if_exists decl can be a
+    // Only report the error if this using_if_exists decl can be a
     // substitute for the original decl. LookupResult will find things with
     // the same name but we also want to take into account namespaces and
     // other scopes. GlobalDecl helps take care of that.

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -23,7 +23,6 @@
 #include "clang/AST/EvaluatedExprVisitor.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
-#include "clang/AST/GlobalDecl.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/TypeLoc.h"
@@ -12931,28 +12930,11 @@ bool Sema::CheckUsingShadowDecl(BaseUsingDecl *BUD, NamedDecl *Orig,
   if (FoundEquivalentDecl)
     return false;
 
-  // Always emit a diagnostic for a mismatch between an unresolved
-  // using_if_exists and a resolved using declaration in either direction.
+  // This using_if_exists decl cannot be a subsitute for the original decl,
+  // so do not create a shadow decl for this case.
   if (isa<UnresolvedUsingIfExistsDecl>(Target) !=
-      (isa_and_nonnull<UnresolvedUsingIfExistsDecl>(NonTag))) {
-    if (!NonTag && !Tag)
-      return false;
-
-    // Only report the error if this using_if_exists decl can be a
-    // substitute for the original decl. LookupResult will find things with
-    // the same name but we also want to take into account namespaces and
-    // other scopes. GlobalDecl helps take care of that.
-    NamedDecl *UsedTag = NonTag ? NonTag : Tag;
-    if (GlobalDecl(Target) != GlobalDecl(UsedTag))
-      return false;
-
-    Diag(BUD->getLocation(), diag::err_using_decl_conflict);
-    Diag(Target->getLocation(), diag::note_using_decl_target);
-    Diag((NonTag ? NonTag : Tag)->getLocation(),
-         diag::note_using_decl_conflict);
-    BUD->setInvalidDecl();
-    return true;
-  }
+      (isa_and_nonnull<UnresolvedUsingIfExistsDecl>(NonTag)))
+    return false;
 
   if (FunctionDecl *FD = Target->getAsFunction()) {
     NamedDecl *OldDecl = nullptr;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -23,6 +23,7 @@
 #include "clang/AST/EvaluatedExprVisitor.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/AST/GlobalDecl.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/TypeLoc.h"
@@ -12936,6 +12937,15 @@ bool Sema::CheckUsingShadowDecl(BaseUsingDecl *BUD, NamedDecl *Orig,
       (isa_and_nonnull<UnresolvedUsingIfExistsDecl>(NonTag))) {
     if (!NonTag && !Tag)
       return false;
+
+    // Only check report the error if this using_if_exists decl can be a
+    // substitute for the original decl. LookupResult will find things with
+    // the same name but we also want to take into account namespaces and
+    // other scopes. GlobalDecl helps take care of that.
+    NamedDecl *UsedTag = NonTag ? NonTag : Tag;
+    if (GlobalDecl(Target) != GlobalDecl(UsedTag))
+      return false;
+
     Diag(BUD->getLocation(), diag::err_using_decl_conflict);
     Diag(Target->getLocation(), diag::note_using_decl_target);
     Diag((NonTag ? NonTag : Tag)->getLocation(),

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -637,8 +637,22 @@ void LookupResult::resolveKind() {
     getSema().diagnoseEquivalentInternalLinkageDeclarations(
         getNameLoc(), HasNonFunction, EquivalentNonFunctions);
 
-  if ((HasNonFunction && (HasFunction || HasUnresolved)) ||
-      (HideTags && HasTag && (HasFunction || HasNonFunction || HasUnresolved)))
+  // A lookup can be ambiguous if we find multiple declarations that cannot
+  // coexist. This occurs if:
+  //
+  // 1. We have a non-function (like a variable or namespace), which cannot
+  //    be overloaded, and either a function or an unresolved using declaration.
+  bool ConflictWithNonFunction =
+      HasNonFunction && (HasFunction || HasUnresolved);
+
+  // 2. We have a hidden tag (struct or enum) and another declaration, and
+  //    Because they both remain in the results, they must be from different
+  //    scopes. If they were in the same scope, the tag would have been hidden
+  //    and removed prior.
+  bool HiddenTagConflict =
+      HideTags && HasTag && (HasFunction || HasNonFunction || HasUnresolved);
+
+  if (ConflictWithNonFunction || HiddenTagConflict)
     Ambiguous = true;
 
   if (Ambiguous && UnresolvedUsingDecls.count()) {

--- a/clang/test/SemaCXX/using-if-exists.cpp
+++ b/clang/test/SemaCXX/using-if-exists.cpp
@@ -36,7 +36,7 @@ int i = A();      // OK since `A` resolved to the single UIE in the previous lin
 using NS1::B UIE; // OK since this declaration shouldn't exist since `B` is not in `NS1`
 using NS2::B UIE; // OK since this declaration shouldn't exist since `B` is not in `NS2 
 using NS3::B UIE; // OK since prior UIEs of `B` shouldn't have declare anything since they don't exist
-B myB;            // OK since `B` resolved to the single UIE in the previous lin
+B myB;            // OK since `B` resolved to the single UIE in the previous line
 
 using NS3::C UIE;
 using NS2::C UIE; // OK since NS2::C doesn't exist


### PR DESCRIPTION
This fixes an issue with using_if_exists where we would hit `conflicts with target of using declaration already in scope` with a using_if_exists attribute referring to a declaration which did not exist. That is, if we have `using ::bar
__attribute__((using_if_exists))` but `bar` is not in the global namespace, then nothing should actually be declared here.

This PR contains the following changes:
1. Ensure we only diagnose this error if the target decl and [Non]Tag decl can be substitutes for each other.
2. Prevent LookupResult from considering UnresolvedUsingIfExistsDecls in the event of ambiguous results.
3. Update tests. This includes the minimal repo for a regression test, and changes to existing tests which also seem to exhibit this bug.

Fixes #85335