### PR TITLE
[VPlan] Re-enable narrowing masked interleave groups & mask stores

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -4168,7 +4168,7 @@ static bool canNarrowLoad(VPWidenRecipe *WideMember0, unsigned OpIdx,
 static bool isConsecutiveInterleaveGroup(VPInterleaveRecipe *InterleaveR,
                                          unsigned VF, VPTypeAnalysis &TypeInfo,
                                          unsigned VectorRegWidth) {
-  if (!InterleaveR || InterleaveR->getMask())
+  if (!InterleaveR)
     return false;
 
   Type *GroupElementTy = nullptr;
@@ -4364,7 +4364,8 @@ void VPlanTransforms::narrowInterleaveGroups(VPlan &Plan, ElementCount VF,
     auto *SI =
         cast<StoreInst>(StoreGroup->getInterleaveGroup()->getInsertPos());
     auto *S = new VPWidenStoreRecipe(
-        *SI, StoreGroup->getAddr(), Res, nullptr, /*Consecutive=*/true,
+        *SI, StoreGroup->getAddr(), Res, StoreGroup->getMask(),
+        /*Consecutive=*/true,
         /*Reverse=*/false, {}, StoreGroup->getDebugLoc());
     S->insertBefore(StoreGroup);
     StoreGroup->eraseFromParent();


### PR DESCRIPTION
When isConsecutiveInterleaveGroup was first added in c73ad7ba204fa05b074c1316b2244063aa10410f, there was no restriction on interleave groups that were masked.

8d29d09309 then moved the transform earlier, but this supposedly caused some crashes related to masking.

aca53f4375d1792cfd706ef4215ab4b350042c5c then restricted the transform to only non-masked interleave groups to fix said crashes, but after other issues were reported 8d29d09309 was ultimately reverted in bfc322dd724735bedf763705f373749dd1b7ed65.

It looks like the mask restriction added in aca53f4375d1792cfd706ef4215ab4b350042c5c was left behind though, so this patch does two things:

1. It removes the restriction under the assumption that it was only a temporary workaround for 8d29d09309 which is no longer in tree
2. Separately it fixes an issue where we didn't apply the mask on the new widened store (but we were applying it on the widened load)

I gave this a quick test on armv9-a and rva23u64 on llvm-test-suite/SPEC CPU 2017 and didn't notice any crashes.
