### PR TITLE
[AArch64] Fix SVE FADDP latency on Neoverse-N3

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseN3.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseN3.td
@@ -1926,7 +1926,6 @@ def : InstRW<[N3Write_2c_1V], (instregex "^FAB[SD]_ZPmZ_[HSD]",
 // Floating point arithmetic
 def : InstRW<[N3Write_2c_1V], (instregex "^F(ADD|SUB)_(ZPm[IZ]|ZZZ)_[HSD]",
                                          "^F(ADD|SUB)_ZPZ[IZ]_[HSD]",
-                                         "^FADDP_ZPmZZ_[HSD]",
                                          "^FNEG_ZPmZ_[HSD]",
                                          "^FSUBR_ZPm[IZ]_[HSD]",
                                          "^FSUBR_(ZPZI|ZPZZ)_[HSD]")>;
@@ -2001,7 +2000,8 @@ def : InstRW<[N3Write_10c_4V0], (instregex "^FDIVR?_(ZPmZ|ZPZZ)_S")>;
 def : InstRW<[N3Write_13c_2V0], (instregex "^FDIVR?_(ZPmZ|ZPZZ)_D")>;
 
 // Floating point arith, min/max pairwise
-def : InstRW<[N3Write_3c_1V], (instregex "^F(MAX|MIN)(NM)?P_ZPmZZ_[HSD]")>;
+def : InstRW<[N3Write_3c_1V], (instregex "FADDP_ZPmZZ_[HSD]",
+                                         "^F(MAX|MIN)(NM)?P_ZPmZZ_[HSD]")>;
 
 // Floating point min/max
 def : InstRW<[N3Write_2c_1V], (instregex "^F(MAX|MIN)(NM)?_ZPm[IZ]_[HSD]",

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseN3.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseN3.td
@@ -2000,7 +2000,7 @@ def : InstRW<[N3Write_10c_4V0], (instregex "^FDIVR?_(ZPmZ|ZPZZ)_S")>;
 def : InstRW<[N3Write_13c_2V0], (instregex "^FDIVR?_(ZPmZ|ZPZZ)_D")>;
 
 // Floating point arith, min/max pairwise
-def : InstRW<[N3Write_3c_1V], (instregex "FADDP_ZPmZZ_[HSD]",
+def : InstRW<[N3Write_3c_1V], (instregex "^FADDP_ZPmZZ_[HSD]",
                                          "^F(MAX|MIN)(NM)?P_ZPmZZ_[HSD]")>;
 
 // Floating point min/max

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-sve-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-sve-instructions.s
@@ -3993,9 +3993,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      4     1.00                        fadda	d0, p7, d0, z31.d
 # CHECK-NEXT:  8      16    4.00                        fadda	h0, p7, h0, z31.h
 # CHECK-NEXT:  4      8     2.00                        fadda	s0, p7, s0, z31.s
-# CHECK-NEXT:  1      2     0.50                        faddp	z0.h, p0/m, z0.h, z1.h
-# CHECK-NEXT:  1      2     0.50                        faddp	z29.s, p3/m, z29.s, z30.s
-# CHECK-NEXT:  1      2     0.50                        faddp	z31.d, p7/m, z31.d, z30.d
+# CHECK-NEXT:  1      3     0.50                        faddp	z0.h, p0/m, z0.h, z1.h
+# CHECK-NEXT:  1      3     0.50                        faddp	z29.s, p3/m, z29.s, z30.s
+# CHECK-NEXT:  1      3     0.50                        faddp	z31.d, p7/m, z31.d, z30.d
 # CHECK-NEXT:  1      2     0.50                        faddv	d0, p7, z31.d
 # CHECK-NEXT:  3      6     1.50                        faddv	h0, p7, z31.h
 # CHECK-NEXT:  2      4     1.00                        faddv	s0, p7, z31.s


### PR DESCRIPTION
This patch fixes the latency of the SVE FADDP instruction for the Neoverse-N3 SWOG. The latency of flaoting point arith, min/max pairwise SVE FADDP should be 3, as per the N3 SWOG.