### PR TITLE
[DTLTO][PS4,PS5] Suppress system headers directory warning

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -488,6 +488,9 @@ toolchains::PS4PS5Base::PS4PS5Base(const Driver &D, const llvm::Triple &Triple,
   // control of header or library search. If we're not linking, don't check
   // for missing libraries.
   auto CheckSDKPartExists = [&](StringRef Dir, StringRef Desc) {
+    // In ThinLTO code generation mode SDK files are not required.
+    if (Args.hasArgNoClaim(options::OPT_fthinlto_index_EQ))
+      return true;
     if (llvm::sys::fs::exists(Dir))
       return true;
     D.Diag(clang::diag::warn_drv_unable_to_find_directory_expected)

--- a/clang/test/Driver/ps4-sdk-root.c
+++ b/clang/test/Driver/ps4-sdk-root.c
@@ -36,7 +36,7 @@
 
 /// -fthinlto-index= warning suppression.
 // RUN: touch %t_dummy.o
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %t_dummy.o -fthinlto-index=ignored 2>&1 | FileCheck -check-prefixes=NO-WARN %s
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %t_dummy.o -fthinlto-index=ignored -c 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
 /// If `-c`, `-S`, `-E` or `-emit-ast` is supplied, the existence check for SDK
 /// libraries is skipped because no linking will be performed. We only expect

--- a/clang/test/Driver/ps4-sdk-root.c
+++ b/clang/test/Driver/ps4-sdk-root.c
@@ -11,6 +11,9 @@
 ///
 /// The default <SDKROOT> for both headers and libraries is taken from the
 /// SCE_ORBIS_SDK_DIR environment variable.
+///
+/// In ThinLTO code generation mode (-fthinlto-index=) SDK files are not required
+/// so all warnings are suppressed.
 
 // RUN: echo "-### -Winvalid-or-nonexistent-directory -target x86_64-scei-ps4" > %t.rsp
 
@@ -30,6 +33,11 @@
 /// When compiling and linking, we should see a warnings about both missing
 /// headers and libraries.
 // RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s 2>&1 | FileCheck -check-prefixes=WARN-SYS-HEADERS,WARN-SYS-LIBS,NO-WARN %s
+
+/// -fthinlto-index= warning suppression.
+// RUN: %clang -O2 %s -flto=thin -c -o %t.o
+// RUN: llvm-lto -thinlto -o %t %t.o
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %t.o -fthinlto-index=%t.thinlto.bc 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
 /// If `-c`, `-S`, `-E` or `-emit-ast` is supplied, the existence check for SDK
 /// libraries is skipped because no linking will be performed. We only expect

--- a/clang/test/Driver/ps4-sdk-root.c
+++ b/clang/test/Driver/ps4-sdk-root.c
@@ -35,9 +35,8 @@
 // RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s 2>&1 | FileCheck -check-prefixes=WARN-SYS-HEADERS,WARN-SYS-LIBS,NO-WARN %s
 
 /// -fthinlto-index= warning suppression.
-// RUN: %clang -O2 %s -flto=thin -c -o %t.o
-// RUN: llvm-lto -thinlto -o %t %t.o
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %t.o -fthinlto-index=%t.thinlto.bc 2>&1 | FileCheck -check-prefixes=NO-WARN %s
+// RUN: touch %t_dummy.o
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %t_dummy.o -fthinlto-index=ignored 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
 /// If `-c`, `-S`, `-E` or `-emit-ast` is supplied, the existence check for SDK
 /// libraries is skipped because no linking will be performed. We only expect

--- a/clang/test/Driver/ps5-sdk-root.c
+++ b/clang/test/Driver/ps5-sdk-root.c
@@ -13,6 +13,9 @@
 ///
 /// The default <SDKROOT> for both headers and libraries is taken from the
 /// SCE_PROSPERO_SDK_DIR environment variable.
+///
+/// In ThinLTO code generation mode (-fthinlto-index=) SDK files are not required
+/// so all warnings are suppressed.
 
 // RUN: echo "-### -Winvalid-or-nonexistent-directory -target x86_64-sie-ps5" > %t.rsp
 
@@ -32,6 +35,11 @@
 /// When compiling and linking, we should see a warnings about both missing
 /// headers and libraries.
 // RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %s 2>&1 | FileCheck -check-prefixes=WARN-SYS-HEADERS,WARN-SYS-LIBS,NO-WARN %s
+
+/// -fthinlto-index= warning suppression.
+// RUN: %clang -O2 %s -flto=thin -c -o %t.o
+// RUN: llvm-lto -thinlto -o %t %t.o
+// RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %t.o -fthinlto-index=%t.thinlto.bc 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
 /// If `-c`, `-S`, `-E` or `-emit-ast` is supplied, the existence check for SDK
 /// libraries is skipped because no linking will be performed. We only expect

--- a/clang/test/Driver/ps5-sdk-root.c
+++ b/clang/test/Driver/ps5-sdk-root.c
@@ -37,9 +37,8 @@
 // RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %s 2>&1 | FileCheck -check-prefixes=WARN-SYS-HEADERS,WARN-SYS-LIBS,NO-WARN %s
 
 /// -fthinlto-index= warning suppression.
-// RUN: %clang -O2 %s -flto=thin -c -o %t.o
-// RUN: llvm-lto -thinlto -o %t %t.o
-// RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %t.o -fthinlto-index=%t.thinlto.bc 2>&1 | FileCheck -check-prefixes=NO-WARN %s
+// RUN: touch %t_dummy.o
+// RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %t_dummy.o -fthinlto-index=ignored 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
 /// If `-c`, `-S`, `-E` or `-emit-ast` is supplied, the existence check for SDK
 /// libraries is skipped because no linking will be performed. We only expect

--- a/clang/test/Driver/ps5-sdk-root.c
+++ b/clang/test/Driver/ps5-sdk-root.c
@@ -38,7 +38,7 @@
 
 /// -fthinlto-index= warning suppression.
 // RUN: touch %t_dummy.o
-// RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %t_dummy.o -fthinlto-index=ignored 2>&1 | FileCheck -check-prefixes=NO-WARN %s
+// RUN: env SCE_PROSPERO_SDK_DIR=.. %clang @%t.rsp %t_dummy.o -fthinlto-index=ignored -c 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
 /// If `-c`, `-S`, `-E` or `-emit-ast` is supplied, the existence check for SDK
 /// libraries is skipped because no linking will be performed. We only expect


### PR DESCRIPTION
Our driver warns under various circumstances if SDK directories can't be found.

This warning is not applicable in ThinLTO codegen mode (-fthinlto-index=). Suppress it.

The motivation for doing this is that we sometimes see this warning emitted when DTLTO invokes the compiler on a remote machine to do the LTO backend compilations (with -fthinlto-index=).

Internal Ref: TOOLCHAIN-20592