### PR TITLE
[llvm][release] Reveal download links based on uploaded assets

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write # For updating the release message.
-    if: always()
+    if: '!cancelled()'
     needs:
       - release-binaries
 

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -120,9 +120,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write # For updating the release message.
+    if: always()
     needs:
-      - validate-tag
-      - release-create
       - release-binaries
 
     steps:

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -78,7 +78,7 @@ release_links = (
         ),
         (
             "MACOS_X86",
-            "* [macOS Intel]({0}) (x86-64) ([signature]({1})])",
+            "* [macOS Intel]({0}) (x86-64) ([signature]({1}))",
             "LLVM-{release}-macOS-X64.tar.xz",
             "LLVM-{release}-macOS-X64.tar.xz.jsonl",
         ),

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -34,6 +34,103 @@ import sys
 from textwrap import dedent
 
 
+# This is a tuple of sections of download links. Each section then contains
+# an entry for each line in that section. Each line entry contains:
+# * A unique tag to go in "<!-- <tag>" so we can find it later in the release
+#   message.
+# * A format string for the line's content.
+# * Filenames to substitute into the format string. Before substitution into
+#   the format string, file names will have the base download URL prepended to
+#   them and 'release' replaced with the release version.
+#
+# Between each set of links, an empty line will be added.
+#
+# This data is used to generate the links for the release message, and by
+# uncomment_download_links to verify whether for any given link line, all files
+# linked to are present in the release's assets.
+release_links = (
+    (
+        (
+            "LINUX_X86",
+            "* [Linux x86_64]({0}) ([signature]({1}))",
+            "LLVM-{release}-Linux-X64.tar.xz",
+            "LLVM-{release}-Linux-X64.tar.xz.jsonl",
+        ),
+        (
+            "LINUX_ARM64",
+            "* [Linux Arm64]({0}) ([signature]({1}))",
+            "LLVM-{release}-Linux-ARM64.tar.xz",
+            "LLVM-{release}-Linux-ARM64.tar.xz.jsonl",
+        ),
+        (
+            "LINUX_ARMV7A",
+            "* [Linux Armv7-a]({0}) ([signature]({1}))",
+            "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz",
+            "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig",
+        ),
+    ),
+    (
+        (
+            "MACOS_ARM64",
+            "* [macOS Apple Silicon]({0}) (ARM64) ([signature]({1}))",
+            "LLVM-{release}-macOS-ARM64.tar.xz",
+            "LLVM-{release}-macOS-ARM64.tar.xz.jsonl",
+        ),
+        (
+            "MACOS_X86",
+            "* [macOS Intel]({0}) (x86-64) ([signature]({1})])",
+            "LLVM-{release}-macOS-X64.tar.xz",
+            "LLVM-{release}-macOS-X64.tar.xz.jsonl",
+        ),
+    ),
+    (
+        (
+            "WINDOWS_X64",
+            "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
+            "LLVM-{release}-win64.exe",
+            "LLVM-{release}-win64.exe.sig",
+            "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
+            "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig",
+        ),
+        (
+            "WINDOWS_X86",
+            "* Windows x86 (32-bit): [installer]({0}) ([signature]({1}))",
+            "LLVM-{release}-win32.exe",
+            "LLVM-{release}-win32.exe.sig",
+        ),
+        (
+            "WINDOWS_ARM64",
+            "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
+            "LLVM-{release}-woa64.exe",
+            "LLVM-{release}-woa64.exe.sig",
+            "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
+            "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig",
+        ),
+    ),
+)
+
+
+def generate_download_links(release):
+    base_url = (
+        f"https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/"
+    )
+    markdown_lines = []
+
+    for section in release_links:
+        for line in section:
+            comment_tag, format_string, *files = line
+            markdown_line = f"<!-- {comment_tag} "
+            files = [base_url + f.format(release=release) for f in files]
+            markdown_line += format_string.format(*files)
+            markdown_line += " -->"
+            markdown_lines.append(markdown_line)
+
+        # Blank line between each section.
+        markdown_lines.append("")
+
+    return "\n".join(markdown_lines)
+
+
 def create_release(repo, release, tag=None, name=None, message=None):
     if not tag:
         tag = "llvmorg-{}".format(release)
@@ -45,33 +142,15 @@ def create_release(repo, release, tag=None, name=None, message=None):
         # Note that these lines are not length limited because if we do so, GitHub
         # assumes that should be how it is laid out on the page. We want GitHub to
         # do the reflowing for us instead.
-        #
-        # Once all the atuomatic binary builds have completed, the HTML comments
-        # with UPPERCASE markers in them will be removed to reveal the download
-        # links later. Other lines are surrounded in <!-- --> for release uploaders
-        # to manually uncomment when they upload that package.
+        download_links = generate_download_links(release)
         message = dedent(
-            """\
+            f"""\
 ## LLVM {release} Release
 
-<!-- AUTOMATIC_DOWNLOAD_LINKS_BEGIN
-* [Linux x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-X64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-X64.tar.xz.jsonl))
-* [Linux Arm64](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-ARM64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-ARM64.tar.xz.jsonl))
-AUTOMATIC_DOWNLOAD_LINKS_END -->
-<!-- * [Linux Armv7-a](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig)) -->
+{download_links}
+Download links for common platforms will appear above, if they are available. Check the full list of release packages at the bottom of this release page if you do not find a link above.
 
-<!-- AUTOMATIC_DOWNLOAD_LINKS_BEGIN
-* [macOS Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-ARM64.tar.xz) (ARM64) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-ARM64.tar.xz.jsonl))
-* [macOS Intel](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-X64.tar.xz) (x86-64) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-X64.tar.xz.jsonl))
-AUTOMATIC_DOWNLOAD_LINKS_END -->
-
-<!-- * Windows x64 (64-bit): [installer](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-win64.exe) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-win64.exe.sig)), [archive](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig)) -->
-<!-- * Windows x86 (32-bit): [installer](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-win32.exe) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-win32.exe.sig)) -->
-<!-- * Windows on Arm (ARM64): [installer](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-woa64.exe) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-woa64.exe.sig)), [archive](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig)) -->
-
-Download links will appear here once builds have completed. <!-- AUTOMATIC_DOWNLOAD_LINKS_PLACEHOLDER -->
-
-For any other variants of platform and architecture, check the full list of release packages at the bottom of this release page. If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available. If you rely on a platform or configuration that is not one of the defaults, we suggest you use the binaries that your platform provides, or build your own release packages.
+If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available. If you rely on a platform or configuration that is not one of the defaults, we suggest you use the binaries that your platform provides, or build your own release packages.
 
 ## Package Types
 
@@ -100,7 +179,7 @@ $ gh attestation verify --repo llvm/llvm-project <package file name>
 $ gh attestation verify --repo llvm/llvm-project <package file name> --bundle <package file name>.jsonl
 (using attestation file on disk)
 ```"""
-        ).format(release=release)
+        )
 
     prerelease = True if "rc" in release else False
 
@@ -115,28 +194,48 @@ def upload_files(repo, release, files):
         print("Done")
 
 
-def uncomment_download_links(repo, release):
-    release = repo.get_release("llvmorg-{}".format(release))
+def uncomment_download_links(repo, release_version):
+    release = repo.get_release("llvmorg-{}".format(release_version))
+
+    # At this point any automatic builds have finished and if
+    # they succeeded, uploaded files to the release assets.
+    release_assets = set([a.name for a in release.assets])
+    print("Found release assets: ", release_assets)
 
     new_message = []
-    to_remove = [
-        "AUTOMATIC_DOWNLOAD_LINKS_BEGIN",
-        "AUTOMATIC_DOWNLOAD_LINKS_END",
-        "AUTOMATIC_DOWNLOAD_LINKS_PLACEHOLDER",
-    ]
+    modified = False
     for line in release.body.splitlines():
-        for comment in to_remove:
-            if comment in line:
-                break
-        else:
-            new_message.append(line)
+        # All hidden download links are of the form:
+        # <!-- <some unique tag> <markdown content> -->
+        if line.startswith("<!--"):
+            for section in release_links:
+                for comment_tag, _, *files in section:
+                    if comment_tag in line:
+                        print(f'Found link line "{comment_tag}":')
+                        files = set([f.format(release=release_version) for f in files])
+                        print("  Files required:", files)
+                        if files.issubset(release_assets):
+                            print("  All files present, revealing link line.")
+                            line.replace("<!--", "").replace(comment_tag, "").replace(
+                                "-->", ""
+                            ).strip()
+                            modified = True
+                        else:
+                            print(
+                                "  These files are not present:",
+                                files.difference(release_assets),
+                            )
+                            print("  Link line will remain hidden.")
 
-    release.update_release(
-        name=release.title,
-        message="\n".join(new_message),
-        draft=release.draft,
-        prerelease=release.prerelease,
-    )
+        new_message.append(line)
+
+    if modified:
+        release.update_release(
+            name=release.title,
+            message="\n".join(new_message),
+            draft=release.draft,
+            prerelease=release.prerelease,
+        )
 
 
 parser = argparse.ArgumentParser()

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -221,7 +221,7 @@ def uncomment_download_links(repo, release_version):
                 print("  Files required:", files)
                 if files.issubset(release_assets):
                     print("  All files present, revealing link line.")
-                    line.replace("<!--", "").replace(comment_tag, "").replace(
+                    line = line.replace("<!--", "").replace(comment_tag, "").replace(
                         "-->", ""
                     ).strip()
                     modified = True

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -53,58 +53,71 @@ release_links = (
         (
             "LINUX_X86",
             "* [Linux x86_64]({0}) ([signature]({1}))",
-            ["LLVM-{release}-Linux-X64.tar.xz",
-            "LLVM-{release}-Linux-X64.tar.xz.jsonl"],
+            [
+                "LLVM-{release}-Linux-X64.tar.xz",
+                "LLVM-{release}-Linux-X64.tar.xz.jsonl",
+            ],
         ),
         (
             "LINUX_ARM64",
             "* [Linux Arm64]({0}) ([signature]({1}))",
-            ["LLVM-{release}-Linux-ARM64.tar.xz",
-            "LLVM-{release}-Linux-ARM64.tar.xz.jsonl"],
+            [
+                "LLVM-{release}-Linux-ARM64.tar.xz",
+                "LLVM-{release}-Linux-ARM64.tar.xz.jsonl",
+            ],
         ),
         (
             "LINUX_ARMV7A",
             "* [Linux Armv7-a]({0}) ([signature]({1}))",
-            ["clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz",
-            "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig"],
+            [
+                "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz",
+                "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig",
+            ],
         ),
     ),
     (
         (
             "MACOS_ARM64",
             "* [macOS Apple Silicon]({0}) (ARM64) ([signature]({1}))",
-            ["LLVM-{release}-macOS-ARM64.tar.xz",
-            "LLVM-{release}-macOS-ARM64.tar.xz.jsonl"],
+            [
+                "LLVM-{release}-macOS-ARM64.tar.xz",
+                "LLVM-{release}-macOS-ARM64.tar.xz.jsonl",
+            ],
         ),
         (
             "MACOS_X86",
             "* [macOS Intel]({0}) (x86-64) ([signature]({1}))",
-            ["LLVM-{release}-macOS-X64.tar.xz",
-            "LLVM-{release}-macOS-X64.tar.xz.jsonl"],
+            [
+                "LLVM-{release}-macOS-X64.tar.xz",
+                "LLVM-{release}-macOS-X64.tar.xz.jsonl",
+            ],
         ),
     ),
     (
         (
             "WINDOWS_X64",
             "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
-            ["LLVM-{release}-win64.exe",
-            "LLVM-{release}-win64.exe.sig",
-            "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
-            "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig"],
+            [
+                "LLVM-{release}-win64.exe",
+                "LLVM-{release}-win64.exe.sig",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig",
+            ],
         ),
         (
             "WINDOWS_X86",
             "* Windows x86 (32-bit): [installer]({0}) ([signature]({1}))",
-            ["LLVM-{release}-win32.exe",
-            "LLVM-{release}-win32.exe.sig"],
+            ["LLVM-{release}-win32.exe", "LLVM-{release}-win32.exe.sig"],
         ),
         (
             "WINDOWS_ARM64",
             "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
-            ["LLVM-{release}-woa64.exe",
-            "LLVM-{release}-woa64.exe.sig",
-            "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
-            "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig"],
+            [
+                "LLVM-{release}-woa64.exe",
+                "LLVM-{release}-woa64.exe.sig",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig",
+            ],
         ),
     ),
 )
@@ -221,9 +234,12 @@ def uncomment_download_links(repo, release_version):
                 print("  Files required:", files)
                 if files.issubset(release_assets):
                     print("  All files present, revealing link line.")
-                    line = line.replace("<!--", "").replace(comment_tag, "").replace(
-                        "-->", ""
-                    ).strip()
+                    line = (
+                        line.replace("<!--", "")
+                        .replace(comment_tag, "")
+                        .replace("-->", "")
+                        .strip()
+                    )
                     modified = True
                 else:
                     print(

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -207,25 +207,30 @@ def uncomment_download_links(repo, release_version):
     for line in release.body.splitlines():
         # All hidden download links are of the form:
         # <!-- <some unique tag> <markdown content> -->
-        if line.startswith("<!--"):
-            for section in release_links:
-                for comment_tag, _, *files in section:
-                    if comment_tag in line:
-                        print(f'Found link line "{comment_tag}":')
-                        files = set([f.format(release=release_version) for f in files])
-                        print("  Files required:", files)
-                        if files.issubset(release_assets):
-                            print("  All files present, revealing link line.")
-                            line.replace("<!--", "").replace(comment_tag, "").replace(
-                                "-->", ""
-                            ).strip()
-                            modified = True
-                        else:
-                            print(
-                                "  These files are not present:",
-                                files.difference(release_assets),
-                            )
-                            print("  Link line will remain hidden.")
+        if not line.startswith("<!--"):
+            new_message.append(line)
+            continue
+
+        for section in release_links:
+            for comment_tag, _, *files in section:
+                if not comment_tag in line:
+                    continue
+
+                print(f'Found link line "{comment_tag}":')
+                files = set([f.format(release=release_version) for f in files])
+                print("  Files required:", files)
+                if files.issubset(release_assets):
+                    print("  All files present, revealing link line.")
+                    line.replace("<!--", "").replace(comment_tag, "").replace(
+                        "-->", ""
+                    ).strip()
+                    modified = True
+                else:
+                    print(
+                        "  These files are not present:",
+                        files.difference(release_assets),
+                    )
+                    print("  Link line will remain hidden.")
 
         new_message.append(line)
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -39,7 +39,7 @@ from textwrap import dedent
 # * A unique tag to go in "<!-- <tag>" so we can find it later in the release
 #   message.
 # * A format string for the line's content.
-# * Filenames to substitute into the format string. Before substitution into
+# * A list of filenames to substitute into the format string. Before substitution into
 #   the format string, file names will have the base download URL prepended to
 #   them and 'release' replaced with the release version.
 #
@@ -53,58 +53,58 @@ release_links = (
         (
             "LINUX_X86",
             "* [Linux x86_64]({0}) ([signature]({1}))",
-            "LLVM-{release}-Linux-X64.tar.xz",
-            "LLVM-{release}-Linux-X64.tar.xz.jsonl",
+            ["LLVM-{release}-Linux-X64.tar.xz",
+            "LLVM-{release}-Linux-X64.tar.xz.jsonl"],
         ),
         (
             "LINUX_ARM64",
             "* [Linux Arm64]({0}) ([signature]({1}))",
-            "LLVM-{release}-Linux-ARM64.tar.xz",
-            "LLVM-{release}-Linux-ARM64.tar.xz.jsonl",
+            ["LLVM-{release}-Linux-ARM64.tar.xz",
+            "LLVM-{release}-Linux-ARM64.tar.xz.jsonl"],
         ),
         (
             "LINUX_ARMV7A",
             "* [Linux Armv7-a]({0}) ([signature]({1}))",
-            "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz",
-            "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig",
+            ["clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz",
+            "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig"],
         ),
     ),
     (
         (
             "MACOS_ARM64",
             "* [macOS Apple Silicon]({0}) (ARM64) ([signature]({1}))",
-            "LLVM-{release}-macOS-ARM64.tar.xz",
-            "LLVM-{release}-macOS-ARM64.tar.xz.jsonl",
+            ["LLVM-{release}-macOS-ARM64.tar.xz",
+            "LLVM-{release}-macOS-ARM64.tar.xz.jsonl"],
         ),
         (
             "MACOS_X86",
             "* [macOS Intel]({0}) (x86-64) ([signature]({1}))",
-            "LLVM-{release}-macOS-X64.tar.xz",
-            "LLVM-{release}-macOS-X64.tar.xz.jsonl",
+            ["LLVM-{release}-macOS-X64.tar.xz",
+            "LLVM-{release}-macOS-X64.tar.xz.jsonl"],
         ),
     ),
     (
         (
             "WINDOWS_X64",
             "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
-            "LLVM-{release}-win64.exe",
+            ["LLVM-{release}-win64.exe",
             "LLVM-{release}-win64.exe.sig",
             "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
-            "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig",
+            "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig"],
         ),
         (
             "WINDOWS_X86",
             "* Windows x86 (32-bit): [installer]({0}) ([signature]({1}))",
-            "LLVM-{release}-win32.exe",
-            "LLVM-{release}-win32.exe.sig",
+            ["LLVM-{release}-win32.exe",
+            "LLVM-{release}-win32.exe.sig"],
         ),
         (
             "WINDOWS_ARM64",
             "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
-            "LLVM-{release}-woa64.exe",
+            ["LLVM-{release}-woa64.exe",
             "LLVM-{release}-woa64.exe.sig",
             "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
-            "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig",
+            "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig"],
         ),
     ),
 )
@@ -118,7 +118,7 @@ def generate_download_links(release):
 
     for section in release_links:
         for line in section:
-            comment_tag, format_string, *files = line
+            comment_tag, format_string, files = line
             markdown_line = f"<!-- {comment_tag} "
             files = [base_url + f.format(release=release) for f in files]
             markdown_line += format_string.format(*files)
@@ -212,7 +212,7 @@ def uncomment_download_links(repo, release_version):
             continue
 
         for section in release_links:
-            for comment_tag, _, *files in section:
+            for comment_tag, _, files in section:
                 if not comment_tag in line:
                     continue
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -148,7 +148,7 @@ def create_release(repo, release, tag=None, name=None, message=None):
 ## LLVM {release} Release
 
 {download_links}
-Download links for common platforms will appear above, if they are available. Check the full list of release packages at the bottom of this release page if you do not find a link above.
+Download links for common platforms will appear above once builds have completed, if they are available. Check the full list of release packages at the bottom of this release page if you do not find a link above.
 
 If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available. If you rely on a platform or configuration that is not one of the defaults, we suggest you use the binaries that your platform provides, or build your own release packages.
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -195,7 +195,7 @@ def upload_files(repo, release, files):
 
 
 def uncomment_download_links(repo, release_version):
-    release = repo.get_release("llvmorg-{}".format(release_version))
+    release = repo.get_release(f"llvmorg-{release_version}")
 
     # At this point any automatic builds have finished and if
     # they succeeded, uploaded files to the release assets.

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -53,71 +53,71 @@ release_links = (
         (
             "LINUX_X86",
             "* [Linux x86_64]({0}) ([signature]({1}))",
-            [
+            (
                 "LLVM-{release}-Linux-X64.tar.xz",
                 "LLVM-{release}-Linux-X64.tar.xz.jsonl",
-            ],
+            ),
         ),
         (
             "LINUX_ARM64",
             "* [Linux Arm64]({0}) ([signature]({1}))",
-            [
+            (
                 "LLVM-{release}-Linux-ARM64.tar.xz",
                 "LLVM-{release}-Linux-ARM64.tar.xz.jsonl",
-            ],
+            ),
         ),
         (
             "LINUX_ARMV7A",
             "* [Linux Armv7-a]({0}) ([signature]({1}))",
-            [
+            (
                 "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz",
                 "clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz.sig",
-            ],
+            ),
         ),
     ),
     (
         (
             "MACOS_ARM64",
             "* [macOS Apple Silicon]({0}) (ARM64) ([signature]({1}))",
-            [
+            (
                 "LLVM-{release}-macOS-ARM64.tar.xz",
                 "LLVM-{release}-macOS-ARM64.tar.xz.jsonl",
-            ],
+            ),
         ),
         (
             "MACOS_X86",
             "* [macOS Intel]({0}) (x86-64) ([signature]({1}))",
-            [
+            (
                 "LLVM-{release}-macOS-X64.tar.xz",
                 "LLVM-{release}-macOS-X64.tar.xz.jsonl",
-            ],
+            ),
         ),
     ),
     (
         (
             "WINDOWS_X64",
             "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
-            [
+            (
                 "LLVM-{release}-win64.exe",
                 "LLVM-{release}-win64.exe.sig",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig",
-            ],
+            ),
         ),
         (
             "WINDOWS_X86",
             "* Windows x86 (32-bit): [installer]({0}) ([signature]({1}))",
-            ["LLVM-{release}-win32.exe", "LLVM-{release}-win32.exe.sig"],
+            ("LLVM-{release}-win32.exe", "LLVM-{release}-win32.exe.sig"),
         ),
         (
             "WINDOWS_ARM64",
             "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
-            [
+            (
                 "LLVM-{release}-woa64.exe",
                 "LLVM-{release}-woa64.exe.sig",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig",
-            ],
+            ),
         ),
     ),
 )


### PR DESCRIPTION
For the 21.x release, download links were supposed to be revealed once all the release builds had completed successfully. In reality, MacOS never had a successful build so I had to hand edit the release messages. This PR fixes this by focusing instead on what is in the release assets after the release build step has finished (in whatever state that might be).

1. Links are now built from a format string, with the linked files being format arguments for that string. This is a balance between ease of editing the format, and having the file names for use later (I tried regex-ing file names out of the final links, which can work but is error prone and will be hard to debug in production).

Here's an example line:
```
  <!-- LINUX_X86 * [Linux x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-vX.Y.Z-1/LLVM-vX.Y.Z-1-Linux-X64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-vX.Y.Z-1/LLVM-vX.Y.Z-1-Linux-X64.tar.xz.jsonl)) -->
```

2. `uncomment_download_links` now looks at the release assets to decide whether to reveal a given link line. If all the files that line links to are present, it will be revealed. This means we can run this at the end of release-tasks.yml, where it will be atomic.

This process is done for all assets we would like to link to, not just the ones currently built in GitHub. So if some become automatically built, they will "just work". If we want to hand edit the links in, that's still an option because the full links are in the release message, but hidden from view.

As we are looking for `<!-- SOME_TAG`, the script can be run multiple times on the same release and it will not try to edit anything already revealed.

As it's possible no link lines have all their files, the text immediately after the links has been updated to make sense when there are no links.

Initially I was going to accumulate the statuses from the release build matrix job, but this does not seem to be possible (https://github.com/orgs/community/discussions/17245). Workarounds for this often include uploading artifacts from each job, which for us, is the same as checking the release's assets.