### PR TITLE
[MLIR Attr] Allow LocationAttr to be used as an operation attribute

### DIFF
--- a/mlir/include/mlir/IR/CommonAttrConstraints.td
+++ b/mlir/include/mlir/IR/CommonAttrConstraints.td
@@ -188,7 +188,12 @@ class AnyAttrOf<list<Attr> allowedAttrs, string summary = "",
 }
 
 def LocationAttr : Attr<CPred<"::llvm::isa<::mlir::LocationAttr>($_self)">,
-                        "location attribute">;
+                        "location attribute"> {
+  let storageType = [{ ::mlir::LocationAttr }];
+  let returnType = [{ ::mlir::Location }];
+  let convertFromStorage = "::mlir::Location($_self)";
+  let constBuilderCall = "(::mlir::LocationAttr)$0";
+}
 
 def BoolAttr : Attr<CPred<"::llvm::isa<::mlir::BoolAttr>($_self)">, "bool attribute"> {
   let storageType = [{ ::mlir::BoolAttr }];

--- a/mlir/test/IR/locations.mlir
+++ b/mlir/test/IR/locations.mlir
@@ -105,3 +105,10 @@ func.func @dialect_location() {
   test.attr_with_loc("dialectLoc" loc(#test.custom_location<"foo.mlir"*32>))
   return
 }
+
+// CHECK-LABEL: @location_attr
+// CHECK: test.op_with_loc_attr loc("cheetos":10:20)
+func.func @location_attr() {
+  test.op_with_loc_attr loc("cheetos":10:20)
+  return
+}

--- a/mlir/test/IR/locations.mlir
+++ b/mlir/test/IR/locations.mlir
@@ -107,8 +107,8 @@ func.func @dialect_location() {
 }
 
 // CHECK-LABEL: @location_attr
-// CHECK: test.op_with_loc_attr loc("cheetos":10:20)
+// CHECK: test.op_with_loc_attr loc("loc1":10:20) {foo.discardable_loc_attr = loc("loc2":20:30)} loc({{.*}}locations.mlir":[[# @LINE+2]]:3)
 func.func @location_attr() {
-  test.op_with_loc_attr loc("cheetos":10:20)
+  test.op_with_loc_attr loc("loc1":10:20) {foo.discardable_loc_attr = loc("loc2":20:30)}
   return
 }

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -1192,6 +1192,12 @@ def TestLocationDstNoResOp : TEST_Op<"loc_dst_no_res"> {
   let results = (outs);
 }
 
+def TestLocationAttrOp : TEST_Op<"op_with_loc_attr"> {
+  let arguments = (ins LocationAttr:$loc_attr);
+  let results = (outs );
+  let assemblyFormat = "$loc_attr attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Test Patterns
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Enables locations to be used as operation attributes.

In contrast to the implicit source location every operation carries (`Operation::getLoc()`)—which may be fused or modified during transformations—a `LocationAttr` used as an operation attribute has explicit semantics defined by the operation itself.

For example, in our Zig-like language frontend (where types are first-class values), we use a location attribute on struct type operations to store the declaration location, which is part of the type's semantic identity. Using an explicit attribute instead of `Operation::getLoc()` ensures this semantic information is preserved during transformations.