### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (4 of N)

### DIFF
--- a/flang/test/Lower/Intrinsics/adjustl.f90
+++ b/flang/test/Lower/Intrinsics/adjustl.f90
@@ -16,4 +16,3 @@ subroutine adjustl_test
   ! CHECK: fir.call @_FortranAAdjustl(%[[r3]], %[[r4]], %[[r5]], %{{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
     adjust_str = adjustl(adjust_str)
   end subroutine
-  

--- a/flang/test/Lower/Intrinsics/adjustr.f90
+++ b/flang/test/Lower/Intrinsics/adjustr.f90
@@ -16,4 +16,3 @@ subroutine adjustr_test
   ! CHECK: fir.call @_FortranAAdjustr(%[[r3]], %[[r4]], %[[r5]], %{{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
     adjust_str = adjustr(adjust_str)
   end subroutine
-  

--- a/flang/test/Lower/Intrinsics/associated.f90
+++ b/flang/test/Lower/Intrinsics/associated.f90
@@ -23,11 +23,11 @@ subroutine associated_test(scalar, array)
     ! CHECK: fir.call @_FortranAPointerIsAssociatedWith(%[[sbox]], %[[zbox]]) {{.*}}: (!fir.box<none>, !fir.box<none>) -> i1
     print *, associated(scalar, ziel)
   end subroutine
-  
+
   subroutine test_func_results()
     interface
       function get_pointer()
-        real, pointer :: get_pointer(:) 
+        real, pointer :: get_pointer(:)
       end function
     end interface
     ! CHECK: %[[result:.*]] = fir.call @_QPget_pointer() {{.*}}: () -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
@@ -38,7 +38,7 @@ subroutine associated_test(scalar, array)
     ! CHECK:  arith.cmpi ne, %[[addr_cast]], %c0{{.*}} : i64
     print *, associated(get_pointer())
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_optional_target_1(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>> {fir.bindc_name = "optionales_ziel", fir.optional, fir.target}) {
@@ -61,7 +61,7 @@ subroutine associated_test(scalar, array)
   ! CHECK:  %[[VAL_15:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.array<10xf32>>) -> !fir.box<none>
   ! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_14]], %[[VAL_15]]) {{.*}}: (!fir.box<none>, !fir.box<none>) -> i1
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_optional_target_2(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "optionales_ziel", fir.optional, fir.target}) {
@@ -81,7 +81,7 @@ subroutine associated_test(scalar, array)
   ! CHECK:  %[[VAL_12:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   ! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_11]], %[[VAL_12]]) {{.*}}: (!fir.box<none>, !fir.box<none>) -> i1
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_optional_target_3(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "optionales_ziel", fir.optional}) {
@@ -102,7 +102,7 @@ subroutine associated_test(scalar, array)
   ! CHECK:  %[[VAL_13:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
   ! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_12]], %[[VAL_13]]) {{.*}}: (!fir.box<none>, !fir.box<none>) -> i1
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_optional_target_4(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.bindc_name = "optionales_ziel", fir.optional, fir.target}) {
@@ -123,7 +123,7 @@ subroutine associated_test(scalar, array)
   ! CHECK:  %[[VAL_13:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.box<none>
   ! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_12]], %[[VAL_13]]) {{.*}}: (!fir.box<none>, !fir.box<none>) -> i1
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_pointer_target(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "pointer_ziel"}) {
@@ -137,7 +137,7 @@ subroutine associated_test(scalar, array)
   ! CHECK:  %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
   ! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_9]], %[[VAL_10]]) {{.*}}: (!fir.box<none>, !fir.box<none>) -> i1
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_allocatable_target(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.bindc_name = "allocatable_ziel", fir.target}) {

--- a/flang/test/Lower/Intrinsics/btest.f90
+++ b/flang/test/Lower/Intrinsics/btest.f90
@@ -15,4 +15,3 @@ function btest_test(i, j)
     ! CHECK: return %[[VAL_9]] : !fir.logical<4>
     btest_test = btest(i, j)
   end
-  

--- a/flang/test/Lower/Intrinsics/ceiling.f90
+++ b/flang/test/Lower/Intrinsics/ceiling.f90
@@ -16,5 +16,3 @@ subroutine ceiling_test1(i, a)
     ! CHECK: %[[f:.*]] = math.ceil %{{.*}} : f32
     ! CHECK: fir.convert %[[f]] : (f32) -> i64
   end subroutine
-  
-  

--- a/flang/test/Lower/Intrinsics/count.f90
+++ b/flang/test/Lower/Intrinsics/count.f90
@@ -11,7 +11,7 @@ subroutine count_test1(rslt, mask)
     rslt = count(mask)
   ! CHECK:  %[[a5:.*]] = fir.call @_FortranACount(%[[a2]], %{{.*}}, %{{.*}}, %[[a4]]) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64
   end subroutine
-  
+
   ! CHECK-LABEL: test_count2
   ! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>{{.*}})
   subroutine test_count2(rslt, mask)
@@ -29,7 +29,7 @@ subroutine count_test1(rslt, mask)
   ! CHECK:  %[[a12:.*]] = fir.box_addr %[[a10]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
   ! CHECK:  fir.freemem %[[a12]]
   end subroutine
-  
+
   ! CHECK-LABEL: test_count3
   ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}})
   subroutine test_count3(rslt, mask)

--- a/flang/test/Lower/Intrinsics/cpu_time.f90
+++ b/flang/test/Lower/Intrinsics/cpu_time.f90
@@ -8,4 +8,3 @@ subroutine cpu_time_test(t)
     ! CHECK: fir.store %[[result32]] to %arg0 : !fir.ref<f32>
     call cpu_time(t)
   end subroutine
-  

--- a/flang/test/Lower/Intrinsics/date_and_time.f90
+++ b/flang/test/Lower/Intrinsics/date_and_time.f90
@@ -18,13 +18,13 @@ subroutine date_and_time_test(date, time, zone, values)
     ! CHECK: fir.call @_FortranADateAndTime(%[[dateBuffer]], %[[dateLen]], %[[timeBuffer]], %[[timeLen]], %[[zoneBuffer]], %[[zoneLen]], %{{.*}}, %{{.*}}, %[[valuesCast]]) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, !fir.ref<i8>, i64, !fir.ref<i8>, i32, !fir.box<none>) -> ()
     call date_and_time(date, time, zone, values)
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPdate_and_time_test2(
   ! CHECK-SAME: %[[date:.*]]: !fir.boxchar<1>{{.*}})
   subroutine date_and_time_test2(date)
     character(*) :: date
     ! CHECK: %[[dateUnbox:.*]]:2 = fir.unboxchar %[[date]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-    ! CHECK: %[[values:.*]] = fir.absent !fir.box<none> 
+    ! CHECK: %[[values:.*]] = fir.absent !fir.box<none>
     ! CHECK: %[[dateBuffer:.*]] = fir.convert %[[dateUnbox]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
     ! CHECK: %[[dateLen:.*]] = fir.convert %[[dateUnbox]]#1 : (index) -> i64
     ! CHECK: %[[timeBuffer:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.ref<i8>
@@ -34,7 +34,7 @@ subroutine date_and_time_test(date, time, zone, values)
     ! CHECK: fir.call @_FortranADateAndTime(%[[dateBuffer]], %[[dateLen]], %[[timeBuffer]], %[[timeLen]], %[[zoneBuffer]], %[[zoneLen]], %{{.*}}, %{{.*}}, %[[values]]) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, !fir.ref<i8>, i64, !fir.ref<i8>, i32, !fir.box<none>) -> ()
     call date_and_time(date)
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPdate_and_time_dynamic_optional(
   ! CHECK-SAME:  %[[VAL_0:[^:]*]]: !fir.boxchar<1>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>

--- a/flang/test/Lower/Intrinsics/eoshift.f90
+++ b/flang/test/Lower/Intrinsics/eoshift.f90
@@ -13,16 +13,16 @@ subroutine eoshift_test1(arr, shift)
   ! CHECK: fir.store %[[init]] to %[[resBox]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
   ! CHECK:  %[[boundBox:.*]] = fir.absent !fir.box<none>
   ! CHECK: %[[shift:.*]] = fir.load %arg1 : !fir.ref<i32>
-  
+
     res = eoshift(arr, shift)
-  
+
   ! CHECK: %[[resIRBox:.*]] = fir.convert %[[resBox]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK: %[[arrBox:.*]] = fir.convert %[[arr]] : (!fir.box<!fir.array<3x!fir.logical<4>>>) -> !fir.box<none>
   ! CHECK: %[[shiftBox:.*]] = fir.convert %[[shift]] : (i32) -> i64
   ! CHECK: fir.call @_FortranAEoshiftVector(%[[resIRBox]], %[[arrBox]], %[[shiftBox]], %[[boundBox]], {{.*}}, {{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, i64, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   ! CHECK: fir.array_merge_store %[[resLoad]], {{.*}} to %[[res]] : !fir.array<3x!fir.logical<4>>, !fir.array<3x!fir.logical<4>>, !fir.ref<!fir.array<3x!fir.logical<4>>>
   end subroutine eoshift_test1
-  
+
   ! CHECK-LABEL: eoshift_test2
   subroutine eoshift_test2(arr, shift, bound, dim)
     integer, dimension(3,3) :: arr, res
@@ -31,9 +31,9 @@ subroutine eoshift_test1(arr, shift)
   ! CHECK: %[[resBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xi32>>>
   ! CHECK: %[[res:.*]] = fir.alloca !fir.array<3x3xi32> {bindc_name = "res", uniq_name = "_QFeoshift_test2Eres"}
   !CHECK: %[[resLoad:.*]] = fir.array_load %[[res]]({{.*}}) : (!fir.ref<!fir.array<3x3xi32>>, !fir.shape<2>) -> !fir.array<3x3xi32>
-    
+
     res = eoshift(arr, shift, bound, dim)
-  
+
   ! CHECK: %[[arr:.*]] = fir.embox %arg0({{.*}}) : (!fir.ref<!fir.array<3x3xi32>>, !fir.shape<2>) -> !fir.box<!fir.array<3x3xi32>>
   ! CHECK: %[[boundBox:.*]] = fir.embox %arg2 : (!fir.ref<i32>) -> !fir.box<i32>
   ! CHECK: %[[dim:.*]] = fir.load %arg3 : !fir.ref<i32>
@@ -42,16 +42,16 @@ subroutine eoshift_test1(arr, shift)
   ! CHECK: %[[arrBox:.*]] = fir.convert %[[arr]] : (!fir.box<!fir.array<3x3xi32>>) -> !fir.box<none>
   ! CHECK: %[[shiftBoxNone:.*]] = fir.convert %[[shiftBox]] : (!fir.box<!fir.array<3xi32>>) -> !fir.box<none>
   ! CHECK: %[[boundBoxNone:.*]] = fir.convert %[[boundBox]] : (!fir.box<i32>) -> !fir.box<none>
-  
+
   ! CHECK: fir.call @_FortranAEoshift(%[[resIRBox]], %[[arrBox]], %[[shiftBoxNone]], %[[boundBoxNone]], %[[dim]], {{.*}}, {{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
   ! CHECK: fir.array_merge_store %[[resLoad]], {{.*}} to %[[res]] : !fir.array<3x3xi32>, !fir.array<3x3xi32>, !fir.ref<!fir.array<3x3xi32>>
   end subroutine eoshift_test2
-  
+
   ! CHECK-LABEL: eoshift_test3
   subroutine eoshift_test3(arr, shift, dim)
     character(4), dimension(3,3) :: arr, res
     integer :: shift, dim
-  
+
   ! CHECK: %[[resBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,4>>>>
   ! CHECK: %[[arr:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK: %[[array:.*]] = fir.convert %[[arr]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<3x3x!fir.char<1,4>>>
@@ -59,9 +59,9 @@ subroutine eoshift_test1(arr, shift)
   ! CHECK: %[[resLoad:.*]] = fir.array_load %[[res]]({{.*}}) : (!fir.ref<!fir.array<3x3x!fir.char<1,4>>>, !fir.shape<2>) -> !fir.array<3x3x!fir.char<1,4>>
   ! CHECK: %[[arrayBox:.*]] = fir.embox %[[array]]({{.*}}) : (!fir.ref<!fir.array<3x3x!fir.char<1,4>>>, !fir.shape<2>) -> !fir.box<!fir.array<3x3x!fir.char<1,4>>>
   ! CHECK: %[[dim:.*]] = fir.load %arg2 : !fir.ref<i32>
-  
+
     res = eoshift(arr, SHIFT=shift, DIM=dim)
-  
+
   ! CHECK: %[[boundBox:.*]] = fir.absent !fir.box<none>
   ! CHECK: %[[shiftBox:.*]] = fir.embox %arg1 : (!fir.ref<i32>) -> !fir.box<i32>
   ! CHECK: %[[resIRBox:.*]] = fir.convert %[[resBox]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,4>>>>>) -> !fir.ref<!fir.box<none>>
@@ -70,7 +70,7 @@ subroutine eoshift_test1(arr, shift)
   ! CHECK: fir.call @_FortranAEoshift(%[[resIRBox]], %[[arrayBoxNone]], %[[shiftBoxNone]], %[[boundBox]], %[[dim]], {{.*}}, {{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
   ! CHECK: fir.array_merge_store %[[resLoad]], {{.*}} to %[[res]] : !fir.array<3x3x!fir.char<1,4>>, !fir.array<3x3x!fir.char<1,4>>, !fir.ref<!fir.array<3x3x!fir.char<1,4>>>
   end subroutine eoshift_test3
-  
+
   ! CHECK-LABEL: func @_QPeoshift_test_dynamic_optional(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32>

--- a/flang/test/Lower/Intrinsics/execute_command_line-optional.f90
+++ b/flang/test/Lower/Intrinsics/execute_command_line-optional.f90
@@ -12,9 +12,9 @@ subroutine all_args_optional(command, isWait, exitVal, cmdVal, msg)
   LOGICAL, OPTIONAL :: isWait
   ! Note: command is not optional in execute_command_line and must be present
   call execute_command_line(command, isWait, exitVal, cmdVal, msg)
-! CHECK-NEXT:    %[[c14:.*]] = arith.constant 14 : i32 
-! CHECK-NEXT:    %true = arith.constant true 
-! CHECK-NEXT:    %[[c0:.*]] = arith.constant 0 : i64 
+! CHECK-NEXT:    %[[c14:.*]] = arith.constant 14 : i32
+! CHECK-NEXT:    %true = arith.constant true
+! CHECK-NEXT:    %[[c0:.*]] = arith.constant 0 : i64
 ! CHECK-NEXT:    %[[DSCOPE:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK-NEXT:    %[[cmdstatDeclare:.*]] = fir.declare %[[cmdstatArg]] dummy_scope %[[DSCOPE]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QFall_args_optionalEcmdval"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
 ! CHECK-NEXT:    %[[commandUnbox:.*]]:2 = fir.unboxchar %[[commandArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -35,7 +35,7 @@ subroutine all_args_optional(command, isWait, exitVal, cmdVal, msg)
 ! CHECK-NEXT:    %[[cmdstatArgBox:.*]] = fir.embox %[[cmdstatDeclare]] : (!fir.ref<i32>) -> !fir.box<i32>
 ! CHECK-NEXT:    %[[cmdstatBox:.*]] = arith.select %[[cmdstatIsPresent]], %[[cmdstatArgBox]], %[[absentBoxi32]] : !fir.box<i32>
 ! CHECK-NEXT:    %[[cmdmsgArgBox:.*]] = fir.embox %[[cmdmsgDeclare]] typeparams %[[cmdmsgUnbox]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK-NEXT:    %[[absentBox:.*]] = fir.absent !fir.box<!fir.char<1,?>> 
+! CHECK-NEXT:    %[[absentBox:.*]] = fir.absent !fir.box<!fir.char<1,?>>
 ! CHECK-NEXT:    %[[cmdmsgBox:.*]] = arith.select %[[cmdmsgIsPresent]], %[[cmdmsgArgBox]], %[[absentBox]] : !fir.box<!fir.char<1,?>>
 ! CHECK-NEXT:    %[[waitCast:.*]] = fir.convert %[[waitDeclare]]  : (!fir.ref<!fir.logical<4>>) -> i64
 ! CHECK-NEXT:    %[[waitPresent:.*]] = arith.cmpi ne, %[[waitCast]], %[[c0]] : i64

--- a/flang/test/Lower/Intrinsics/execute_command_line.f90
+++ b/flang/test/Lower/Intrinsics/execute_command_line.f90
@@ -11,9 +11,9 @@ CHARACTER(30) :: command, msg
 INTEGER :: exitVal, cmdVal
 LOGICAL :: isWait
 call execute_command_line(command, isWait, exitVal, cmdVal, msg)
-! CHECK-NEXT:        %[[c13:.*]] = arith.constant 13 : i32 
-! CHECK-NEXT:        %true = arith.constant true 
-! CHECK-NEXT:        %[[c0:.*]] = arith.constant 0 : i64 
+! CHECK-NEXT:        %[[c13:.*]] = arith.constant 13 : i32
+! CHECK-NEXT:        %true = arith.constant true
+! CHECK-NEXT:        %[[c0:.*]] = arith.constant 0 : i64
 ! CHECK-NEXT:        %[[c30:.*]] = arith.constant 30 : index
 ! CHECK-NEXT:        %[[DSCOPE:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK-NEXT:        %[[cmdstatsDeclare:.*]] = fir.declare %[[cmdstatArg]] dummy_scope %[[DSCOPE]] arg {{[0-9]+}} {uniq_name = "_QFall_argsEcmdval"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
@@ -51,8 +51,8 @@ end subroutine all_args
 subroutine only_command_default_wait_true(command)
 CHARACTER(30) :: command
 call execute_command_line(command)
-! CHECK-NEXT:     %[[c52:.*]] = arith.constant 53 : i32 
-! CHECK-NEXT:     %true = arith.constant true 
+! CHECK-NEXT:     %[[c52:.*]] = arith.constant 53 : i32
+! CHECK-NEXT:     %true = arith.constant true
 ! CHECK-NEXT:     %[[c30:.*]] = arith.constant 30 : index
 ! CHECK-NEXT:        %[[DSCOPE:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK-NEXT:     %[[commandUnbox:.*]]:2 = fir.unboxchar %[[cmdArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -60,7 +60,7 @@ call execute_command_line(command)
 ! CHECK-NEXT:     %[[commandDeclare:.*]] = fir.declare %[[commandCast]] typeparams %[[c30]] dummy_scope %[[DSCOPE]] arg {{[0-9]+}} {uniq_name = "_QFonly_command_default_wait_trueEcommand"} : (!fir.ref<!fir.char<1,30>>, index, !fir.dscope) -> !fir.ref<!fir.char<1,30>>
 ! CHECK-NEXT:     %[[commandBox:.*]] = fir.embox %[[commandDeclare]] : (!fir.ref<!fir.char<1,30>>) -> !fir.box<!fir.char<1,30>>
 ! CHECK-NEXT:     %[[absent:.*]] = fir.absent !fir.box<none>
-! CHECK:          %[[command:.*]] = fir.convert %[[commandBox]] : (!fir.box<!fir.char<1,30>>) -> !fir.box<none> 
+! CHECK:          %[[command:.*]] = fir.convert %[[commandBox]] : (!fir.box<!fir.char<1,30>>) -> !fir.box<none>
 ! CHECK:          fir.call @_FortranAExecuteCommandLine(%[[command]], %true, %[[absent]], %[[absent]], %[[absent]], %[[VAL_7:.*]], %[[c52]]) fastmath<contract> : (!fir.box<none>, i1, !fir.box<none>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
 ! CHECK-NEXT:     return
 end subroutine only_command_default_wait_true

--- a/flang/test/Lower/Intrinsics/exit.f90
+++ b/flang/test/Lower/Intrinsics/exit.f90
@@ -10,7 +10,7 @@ subroutine exit_test1
   ! CHECK-32: fir.call @_FortranAExit(%[[status]]) {{.*}}: (i32) -> ()
   ! CHECK-64: fir.call @_FortranAExit(%[[statusConvert]]) {{.*}}: (i32) -> ()
   end subroutine exit_test1
-  
+
   ! CHECK-LABEL: func @_QPexit_test2(
   ! CHECK-SAME: %[[statusArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}) {
   subroutine exit_test2(status)

--- a/flang/test/Lower/Intrinsics/extends_type_of.f90
+++ b/flang/test/Lower/Intrinsics/extends_type_of.f90
@@ -9,7 +9,7 @@ module extends_type_of_mod
   type, extends(p1) :: p2
     integer :: b
   end type
- 
+
   type k1(a)
     integer, kind :: a
   end type

--- a/flang/test/Lower/Intrinsics/floor.f90
+++ b/flang/test/Lower/Intrinsics/floor.f90
@@ -16,4 +16,3 @@ subroutine floor_test1(i, a)
     ! CHECK: %[[f:.*]] = math.floor %{{.*}} : f32
     ! CHECK: fir.convert %[[f]] : (f32) -> i64
   end subroutine
-  

--- a/flang/test/Lower/Intrinsics/get_command_argument-optional.f90
+++ b/flang/test/Lower/Intrinsics/get_command_argument-optional.f90
@@ -7,11 +7,11 @@
 ! CHECK-SAME:  %[[lengthParam:.*]]: !fir.ref<i32> {fir.bindc_name = "length", fir.optional},
 ! CHECK-SAME:  %[[statusParam:.*]]: !fir.ref<i32> {fir.bindc_name = "status", fir.optional},
 ! CHECK-SAME:  %[[errmsgParam:.*]]: !fir.boxchar<1> {fir.bindc_name = "errmsg", fir.optional}) {
-subroutine test(number, value, length, status, errmsg) 
+subroutine test(number, value, length, status, errmsg)
   integer, optional :: number, status, length
   character(*), optional :: value, errmsg
   ! Note: number cannot be absent
-  call get_command_argument(number, value, length, status, errmsg) 
+  call get_command_argument(number, value, length, status, errmsg)
 ! CHECK:  %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsgParam]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:  %[[valueUnboxed:.*]]:2 = fir.unboxchar %[[valueParam]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:  %[[number:.*]] = fir.load %[[numberParam]] : !fir.ref<i32>

--- a/flang/test/Lower/Intrinsics/ichar.f90
+++ b/flang/test/Lower/Intrinsics/ichar.f90
@@ -37,7 +37,7 @@ end subroutine
 subroutine no_extui(ch)
   integer, parameter :: kind = selected_char_kind('ISO_10646')
   character(*, kind), intent(in) :: ch(:)
-  integer :: i, j 
+  integer :: i, j
   ! CHECK-NOT: arith.extui
   j = ichar(ch(i)(i:i))
 end subroutine

--- a/flang/test/Lower/Intrinsics/ishftc.f90
+++ b/flang/test/Lower/Intrinsics/ishftc.f90
@@ -40,7 +40,7 @@ function ishftc_test(i, j, k)
     ! CHECK: return %[[VAL_36]] : i32
     ishftc_test = ishftc(i, j, k)
   end
-  
+
   ! Test cases where the size argument presence can only be know at runtime
   module test_ishftc
   contains
@@ -67,9 +67,9 @@ function ishftc_test(i, j, k)
     ! CHECK:  %[[VAL_19:.*]] = arith.xori %[[VAL_9]], %[[VAL_18]] : i32
     ! CHECK:  %[[VAL_20:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : i32
     ! CHECK:  %[[VAL_21:.*]] = arith.subi %[[VAL_11]], %[[VAL_20]] : i32
-    ! ... as in non optional case 
+    ! ... as in non optional case
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QMtest_ishftcPdyn_optional_array_scalar(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "i"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "shift"},
@@ -90,11 +90,11 @@ function ishftc_test(i, j, k)
   ! CHECK:      %[[VAL_26:.*]] = arith.constant 32 : i32
   ! CHECK:      fir.result %[[VAL_26]] : i32
   ! CHECK:    }
-  ! ... as in non optional case 
+  ! ... as in non optional case
   ! CHECK:  }
     print *, ishftc(i, shift, size)
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QMtest_ishftcPdyn_optional_array(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "i"},
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "shift"},
@@ -117,22 +117,22 @@ function ishftc_test(i, j, k)
   ! CHECK:      %[[VAL_32:.*]] = arith.constant 32 : i32
   ! CHECK:      fir.result %[[VAL_32]] : i32
   ! CHECK:    }
-  ! ... as in non optional case 
+  ! ... as in non optional case
   ! CHECK:    }
     print *, ishftc(i, shift, size)
   end subroutine
   end module
-  
+
     use test_ishftc
     integer :: i(4) = [333, 334, 335, 336]
     integer :: shift(4) = [2, 1, -1, -2]
     integer :: size(4) = [2, 4, 8, 16]
     call dyn_optional_scalar(i(1), shift(1))
     call dyn_optional_scalar(i(1), shift(1), size(1))
-  
+
     call dyn_optional_array_scalar(i, shift)
     call dyn_optional_array_scalar(i, shift, size(1))
-  
+
     call dyn_optional_array(i, shift)
     call dyn_optional_array(i, shift, size)
   end

--- a/flang/test/Lower/Intrinsics/max.f90
+++ b/flang/test/Lower/Intrinsics/max.f90
@@ -31,8 +31,8 @@ module max_test
     ! CHECK:    fir.result %[[VAL_36]] : !fir.array<?xi32>
     ! CHECK:  }
       print *, max(a, b, c)
-    end subroutine 
-    
+    end subroutine
+
     ! CHECK-LABEL: func @_QMmax_testPdynamic_optional_array_expr_scalar_optional(
     ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"},
     ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "b"},
@@ -60,8 +60,8 @@ module max_test
     ! CHECK:    %[[VAL_30:.*]] = fir.array_update %[[VAL_21]], %[[VAL_26]], %[[VAL_20]] : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
     ! CHECK:    fir.result %[[VAL_30]] : !fir.array<?xi32>
     ! CHECK:  }
-    end subroutine 
-    
+    end subroutine
+
     ! CHECK-LABEL: func @_QMmax_testPdynamic_optional_scalar(
     ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
     ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"},
@@ -84,8 +84,8 @@ module max_test
     ! CHECK:    fir.result %[[VAL_12]] : i32
     ! CHECK:  }
     ! CHECK:  fir.call @_FortranAioOutputInteger32(%{{.*}}, %[[VAL_13]]) {{.*}}: (!fir.ref<i8>, i32) -> i1
-    end subroutine 
-    
+    end subroutine
+
     ! CHECK-LABEL: func @_QMmax_testPdynamic_optional_weird(
     ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
     ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"},
@@ -123,9 +123,9 @@ module max_test
     ! CHECK:    fir.result %[[VAL_23]] : i32
     ! CHECK:  }
     ! CHECK:  fir.call @_FortranAioOutputInteger32(%{{.*}}, %[[VAL_24]]) {{.*}}: (!fir.ref<i8>, i32) -> i1
-    end subroutine 
+    end subroutine
     end module
-    
+
       use :: max_test
       integer :: a(4) = [1,12,23, 34]
       integer :: b(4) = [31,22,13, 4]

--- a/flang/test/Lower/Intrinsics/maxloc.f90
+++ b/flang/test/Lower/Intrinsics/maxloc.f90
@@ -18,7 +18,7 @@ subroutine maxloc_test(arr,res)
   ! CHECK-DAG: %[[a14:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
   ! CHECK-DAG: fir.freemem %[[a14]]
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPmaxloc_test2(
   ! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg2:.*]]: !fir.ref<i32>{{.*}}) {
   subroutine maxloc_test2(arr,res,d)
@@ -39,7 +39,7 @@ subroutine maxloc_test(arr,res)
   ! CHECK:  %[[a13:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
   ! CHECK:  fir.freemem %[[a13]]
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_maxloc_optional_scalar_mask(
   ! CHECK-SAME:  %[[VAL_0:[^:]+]]: !fir.ref<!fir.logical<4>>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.logical<4>>
@@ -65,7 +65,7 @@ subroutine maxloc_test(arr,res)
   ! CHECK:  %[[VAL_30:.*]] = fir.convert %[[VAL_14]] : (!fir.logical<4>) -> i1
   ! CHECK:  fir.call @_FortranAMaxlocInteger4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_29]], %[[VAL_30]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> ()
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_maxloc_optional_array_mask(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.logical<4>>

--- a/flang/test/Lower/Intrinsics/merge.f90
+++ b/flang/test/Lower/Intrinsics/merge.f90
@@ -9,7 +9,7 @@ logical :: mask
 merge_test = merge(o1, o2, mask)
 ! CHECK:  %[[a0:.*]]:2 = fir.unboxchar %[[arg2]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK: %[[a0_cast:.*]] = fir.convert %[[a0]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>>
-! CHECK:  %[[a1:.*]]:2 = fir.unboxchar %[[arg3]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index) 
+! CHECK:  %[[a1:.*]]:2 = fir.unboxchar %[[arg3]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK: %[[a1_cast:.*]] = fir.convert %[[a1]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>>
 ! CHECK: %[[a2:.*]] = fir.load %[[arg4]] : !fir.ref<!fir.logical<4>>
 ! CHECK: %[[a3:.*]] = fir.convert %[[a2]] : (!fir.logical<4>) -> i1

--- a/flang/test/Lower/Intrinsics/minloc.f90
+++ b/flang/test/Lower/Intrinsics/minloc.f90
@@ -18,7 +18,7 @@ subroutine minloc_test(arr,res)
   ! CHECK-DAG: %[[a14:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
   ! CHECK-DAG: fir.freemem %[[a14]]
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPminloc_test2(
   ! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg2:.*]]: !fir.ref<i32>
   subroutine minloc_test2(arr,res,d)
@@ -39,7 +39,7 @@ subroutine minloc_test(arr,res)
   ! CHECK:  %[[a13:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
   ! CHECK:  fir.freemem %[[a13]]
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_minloc_optional_scalar_mask(
   ! CHECK-SAME:  %[[VAL_0:[^:]+]]: !fir.ref<!fir.logical<4>>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.logical<4>>
@@ -65,7 +65,7 @@ subroutine minloc_test(arr,res)
   ! CHECK:  %[[VAL_30:.*]] = fir.convert %[[VAL_14]] : (!fir.logical<4>) -> i1
   ! CHECK:  fir.call @_FortranAMinlocInteger4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_29]], %[[VAL_30]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> ()
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_minloc_optional_array_mask(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.logical<4>>

--- a/flang/test/Lower/Intrinsics/modulo.f90
+++ b/flang/test/Lower/Intrinsics/modulo.f90
@@ -20,7 +20,7 @@ subroutine modulo_testr(r, a, p)
   ! ALL: fir.store %[[res]] to %[[arg0]] : !fir.ref<f64>
   r = modulo(a, p)
 end subroutine
-  
+
 ! ALL-LABEL: func @_QPmodulo_testi(
 ! ALL-SAME: %[[arg0:.*]]: !fir.ref<i64>{{.*}}, %[[arg1:.*]]: !fir.ref<i64>{{.*}}, %[[arg2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine modulo_testi(r, a, p)

--- a/flang/test/Lower/Intrinsics/nint.f90
+++ b/flang/test/Lower/Intrinsics/nint.f90
@@ -14,4 +14,3 @@ subroutine nint_test1(i, a)
     i = nint(a, 8)
     ! CHECK: fir.call @llvm.lround.i64.f64
   end subroutine
-  

--- a/flang/test/Lower/Intrinsics/not.f90
+++ b/flang/test/Lower/Intrinsics/not.f90
@@ -13,4 +13,3 @@ subroutine not_test
     ! CHECK: return
     destination = not(source)
   end subroutine
-  

--- a/flang/test/Lower/Intrinsics/pack.f90
+++ b/flang/test/Lower/Intrinsics/pack.f90
@@ -21,7 +21,7 @@ subroutine pack_test(a,m,v,r)
   ! CHECK:  %[[a13:.*]] = fir.box_addr %[[a11]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
   ! CHECK:  fir.freemem %[[a13]]
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_pack_optional(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
   subroutine test_pack_optional(vector, array, mask)

--- a/flang/test/Lower/Intrinsics/perror.f90
+++ b/flang/test/Lower/Intrinsics/perror.f90
@@ -11,13 +11,13 @@ subroutine test_perror()
   ! CHECK: %[[C10:.*]] = arith.constant 10 : index
   ! CHECK: %[[VAL_2:.*]] = fir.alloca !fir.char<1,10> {bindc_name = "string", uniq_name = "_QFtest_perrorEstring"}
   ! CHECK: %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] typeparams %[[C10]] {uniq_name = "_QFtest_perrorEstring"} : (!fir.ref<!fir.char<1,10>>, index) -> (!fir.ref<!fir.char<1,10>>, !fir.ref<!fir.char<1,10>>)
-  
+
   call perror(string)
   ! CHECK: %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#0 : (!fir.ref<!fir.char<1,10>>) -> !fir.box<!fir.char<1,10>>
   ! CHECK: %[[VAL_5:.*]] = fir.box_addr %[[VAL_4]] : (!fir.box<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,10>>
   ! CHECK: %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-  ! CHECK: fir.call @_FortranAPerror(%[[VAL_6]]) fastmath<contract> : (!fir.ref<i8>) -> () 
-  
+  ! CHECK: fir.call @_FortranAPerror(%[[VAL_6]]) fastmath<contract> : (!fir.ref<i8>) -> ()
+
   call perror("prefix")
   ! CHECK: %[[VAL_7:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,6>>
   ! CHECK: %[[C6:.*]] = arith.constant 6 : index
@@ -25,13 +25,13 @@ subroutine test_perror()
   ! CHECK: %[[VAL_9:.*]] = fir.embox %[[VAL_8]]#0 : (!fir.ref<!fir.char<1,6>>) -> !fir.box<!fir.char<1,6>>
   ! CHECK: %[[VAL_10:.*]] = fir.box_addr %[[VAL_9]] : (!fir.box<!fir.char<1,6>>) -> !fir.ref<!fir.char<1,6>>
   ! CHECK: %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,6>>) -> !fir.ref<i8>
-  ! CHECK: fir.call @_FortranAPerror(%[[VAL_11]]) fastmath<contract> : (!fir.ref<i8>) -> () 
-  
+  ! CHECK: fir.call @_FortranAPerror(%[[VAL_11]]) fastmath<contract> : (!fir.ref<i8>) -> ()
+
   call perror(one)
   ! CHECK: %[[VAL_12:.*]] = fir.embox %[[VAL_1]]#0 : (!fir.ref<!fir.char<1>>) -> !fir.box<!fir.char<1>>
   ! CHECK: %[[VAL_13:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.char<1>>) -> !fir.ref<!fir.char<1>>
   ! CHECK: %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<i8>
-  ! CHECK: fir.call @_FortranAPerror(%[[VAL_14]]) fastmath<contract> : (!fir.ref<i8>) -> () 
+  ! CHECK: fir.call @_FortranAPerror(%[[VAL_14]]) fastmath<contract> : (!fir.ref<i8>) -> ()
 end subroutine test_perror
 
 ! CHECK-LABEL: func @_QPtest_perror_unknown_length(

--- a/flang/test/Lower/Intrinsics/product.f90
+++ b/flang/test/Lower/Intrinsics/product.f90
@@ -111,7 +111,7 @@ real function product_test_optional_4(x, use_mask)
 real :: x(:)
 logical :: use_mask
 logical, allocatable :: mask(:)
-if (use_mask) then 
+if (use_mask) then
   allocate(mask(size(x, 1)))
   call set_mask(mask)
   ! CHECK: fir.call @_QPset_mask

--- a/flang/test/Lower/Intrinsics/reduce.f90
+++ b/flang/test/Lower/Intrinsics/reduce.f90
@@ -19,7 +19,7 @@ end type
 
   integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
   integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
-  
+
 
 contains
 
@@ -46,11 +46,11 @@ subroutine integer1(a, id, d1, d2)
   res = reduce(a, red_int1)
 
   res = reduce(a, red_int1, identity=id)
-  
+
   res = reduce(a, red_int1, identity=id, ordered = .true.)
 
   res = reduce(a, red_int1, [.true., .true., .false.])
-  
+
   res = reduce(a, red_int1_value)
 
   fptr => red_int1

--- a/flang/test/Lower/Intrinsics/reshape.f90
+++ b/flang/test/Lower/Intrinsics/reshape.f90
@@ -24,16 +24,16 @@ subroutine reshape_test(x, source, pd, sh, ord)
   ! CHECK-DAG:  %[[a18:.*]] = fir.box_addr %[[a15]] : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>) -> !fir.heap<!fir.array<?x?xi32>>
   ! CHECK-DAG:  fir.freemem %[[a18]]
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtest_reshape_optional(
   ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
   ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
   subroutine test_reshape_optional(pad, order, source, shape)
-    real, pointer :: pad(:, :) 
-    integer, pointer :: order(:) 
+    real, pointer :: pad(:, :)
+    integer, pointer :: order(:)
     real :: source(:, :, :)
-    integer :: shape(4) 
-    print *, reshape(source=source, shape=shape, pad=pad, order=order)  
+    integer :: shape(4)
+    print *, reshape(source=source, shape=shape, pad=pad, order=order)
   ! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
   ! CHECK:  %[[VAL_14:.*]] = fir.box_addr %[[VAL_13]] : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>) -> !fir.ptr<!fir.array<?x?xf32>>
   ! CHECK:  %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (!fir.ptr<!fir.array<?x?xf32>>) -> i64

--- a/flang/test/Lower/Intrinsics/scale.f90
+++ b/flang/test/Lower/Intrinsics/scale.f90
@@ -14,7 +14,7 @@ subroutine scale_test1(x, i)
   ! CHECK: %[[tmp:.*]] = fir.call @_FortranAScale4(%[[x_val]], %[[i_cast]]) {{.*}}: (f32, i64) -> f32
   ! CHECK: hlfir.assign %[[tmp]] to %[[res]]#0 : f32, !fir.ref<f32>
 end subroutine scale_test1
-  
+
 ! CHECK-LABEL: scale_test2
 subroutine scale_test2(x, i)
   real(kind=8) :: x, res

--- a/flang/test/Lower/Intrinsics/spread.f90
+++ b/flang/test/Lower/Intrinsics/spread.f90
@@ -30,7 +30,7 @@ subroutine spread_test(s,d,n,r)
   ! CHECK-DAG:  %[[a15:.*]] = fir.box_addr %[[a13]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
   ! CHECK:  fir.freemem %[[a15]]
 end subroutine
-  
+
 ! CHECK-LABEL: func @_QMspread_modPspread_test2(
 ! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg2:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg3:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}) {
 subroutine spread_test2(s,d,n,r)

--- a/flang/test/Lower/Intrinsics/sum.f90
+++ b/flang/test/Lower/Intrinsics/sum.f90
@@ -111,7 +111,7 @@ integer function sum_test_optional_4(x, use_mask)
 integer :: x(:)
 logical :: use_mask
 logical, allocatable :: mask(:)
-if (use_mask) then 
+if (use_mask) then
   allocate(mask(size(x, 1)))
   call set_mask(mask)
   ! CHECK: fir.call @_QPset_mask

--- a/flang/test/Lower/Intrinsics/system.f90
+++ b/flang/test/Lower/Intrinsics/system.f90
@@ -1,8 +1,8 @@
 ! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPall_args(
-! CHECK-SAME:    %[[commandArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "command"}, 
-! CHECK-SAME:    %[[exitstatArg:.*]]: !fir.ref<i32> {fir.bindc_name = "exitstat"}) { 
+! CHECK-SAME:    %[[commandArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "command"},
+! CHECK-SAME:    %[[exitstatArg:.*]]: !fir.ref<i32> {fir.bindc_name = "exitstat"}) {
 subroutine all_args(command, exitstat)
 CHARACTER(*) :: command
 INTEGER :: exitstat

--- a/flang/test/Lower/Intrinsics/transfer.f90
+++ b/flang/test/Lower/Intrinsics/transfer.f90
@@ -27,7 +27,7 @@ subroutine trans_test(store, word)
     real :: word
     store = transfer(word, store)
   end subroutine
-  
+
   ! CHECK-LABEL: func @_QPtrans_test2(
   ! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
   ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
@@ -69,13 +69,13 @@ subroutine trans_test(store, word)
   ! CHECK:         fir.freemem %[[VAL_25]]
   ! CHECK:         return
   ! CHECK:       }
-  
+
   subroutine trans_test2(store, word)
     integer :: store(3)
     real :: word
     store = transfer(word, store, 3)
   end subroutine
-  
+
   integer function trans_test3(p)
     ! CHECK-LABEL: func @_QPtrans_test3(
     ! CHECK-SAME:                       %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}) -> i32 {

--- a/flang/test/Lower/Intrinsics/unlink-sub.f90
+++ b/flang/test/Lower/Intrinsics/unlink-sub.f90
@@ -41,7 +41,7 @@ subroutine all_arguments(path, status)
     !CHECK:        %[[unlink_result:.*]] = fir.call @_FortranAUnlink(%[[path]], %[[path_len]], %[[src_path]], %[[line]])
     !CHECK-SAME:   : (!fir.ref<i8>, i64, !fir.ref<i8>, i32)
     !CHECK-SAME:   -> i32
-  
+
     !CHECK-DAG:    %[[status_i64:.*]] = fir.convert %[[status_decl]]#0 : (!fir.ref<i32>) -> i64
     !CHECK-DAG:    %[[c_null:.*]] = arith.constant 0 : i64
     !CHECK-DAG:    %[[cmp_result:.*]] = arith.cmpi ne, %[[status_i64]], %[[c_null]] : i64


### PR DESCRIPTION
Only the fortran source files in flang/test have been modified. The other files in the directory will be cleaned up in subsequent commits