### PR TITLE
[libc] implement inet_addr

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -945,6 +945,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # arpa/inet.h entrypoints
     libc.src.arpa.inet.htonl
     libc.src.arpa.inet.htons
+    libc.src.arpa.inet.inet_addr
     libc.src.arpa.inet.inet_aton
     libc.src.arpa.inet.ntohl
     libc.src.arpa.inet.ntohs

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1078,6 +1078,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # arpa/inet.h entrypoints
     libc.src.arpa.inet.htonl
     libc.src.arpa.inet.htons
+    libc.src.arpa.inet.inet_addr
     libc.src.arpa.inet.inet_aton
     libc.src.arpa.inet.ntohl
     libc.src.arpa.inet.ntohs

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1116,6 +1116,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # arpa/inet.h entrypoints
     libc.src.arpa.inet.htonl
     libc.src.arpa.inet.htons
+    libc.src.arpa.inet.inet_addr
     libc.src.arpa.inet.inet_aton
     libc.src.arpa.inet.ntohl
     libc.src.arpa.inet.ntohs

--- a/libc/include/arpa/inet.yaml
+++ b/libc/include/arpa/inet.yaml
@@ -3,6 +3,7 @@ header_template: inet.h.def
 macros: []
 types:
   - type_name: in_addr
+  - type_name: in_addr_t
 enums: []
 objects: []
 functions:
@@ -18,6 +19,12 @@ functions:
     return_type: uint16_t
     arguments:
       - type: uint16_t
+  - name: inet_addr
+    standards:
+      - POSIX
+    return_type: in_addr_t
+    arguments:
+      - type: const char *
   - name: inet_aton
     standards:
       - llvm_libc_ext

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -29,6 +29,7 @@
 
 #define INADDR_ANY __LLVM_LIBC_CAST(static_cast, in_addr_t, 0x00000000)
 #define INADDR_BROADCAST __LLVM_LIBC_CAST(static_cast, in_addr_t, 0xffffffff)
+#define INADDR_NONE __LLVM_LIBC_CAST(static_cast, in_addr_t, 0xffffffff)
 
 #define INET_ADDRSTRLEN 16
 #define INET6_ADDRSTRLEN 46

--- a/libc/src/arpa/inet/CMakeLists.txt
+++ b/libc/src/arpa/inet/CMakeLists.txt
@@ -36,6 +36,21 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  inet_addr
+  SRCS
+    inet_addr.cpp
+  HDRS
+    inet_addr.h
+  DEPENDS
+    libc.include.arpa_inet
+    libc.include.llvm-libc-macros.netinet_in_macros
+    libc.include.llvm-libc-types.in_addr
+    libc.include.llvm-libc-types.in_addr_t
+    libc.src.__support.common
+    libc.src.arpa.inet.inet_aton
+)
+
+add_entrypoint_object(
   ntohl
   SRCS
     ntohl.cpp

--- a/libc/src/arpa/inet/inet_addr.cpp
+++ b/libc/src/arpa/inet/inet_addr.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of inet_addr function ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/arpa/inet/inet_addr.h"
+#include "include/llvm-libc-macros/netinet-in-macros.h"
+#include "include/llvm-libc-types/in_addr.h"
+#include "include/llvm-libc-types/in_addr_t.h"
+#include "src/__support/common.h"
+#include "src/arpa/inet/inet_aton.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(in_addr_t, inet_addr, (const char *cp)) {
+  in_addr addr;
+  return inet_aton(cp, &addr) ? addr.s_addr : INADDR_NONE;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/arpa/inet/inet_addr.h
+++ b/libc/src/arpa/inet/inet_addr.h
@@ -1,0 +1,21 @@
+//===-- Implementation header of inet_addr ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_ARPA_INET_INET_ADDR_H
+#define LLVM_LIBC_SRC_ARPA_INET_INET_ADDR_H
+
+#include "include/llvm-libc-types/in_addr_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+in_addr_t inet_addr(const char *cp);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_ARPA_INET_INET_ADDR_H

--- a/libc/test/src/arpa/inet/CMakeLists.txt
+++ b/libc/test/src/arpa/inet/CMakeLists.txt
@@ -23,6 +23,17 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  inet_addr
+  SUITE
+    libc_arpa_inet_unittests
+  SRCS
+    inet_addr_test.cpp
+  DEPENDS
+    libc.src.arpa.inet.htonl
+    libc.src.arpa.inet.inet_addr
+)
+
+add_libc_unittest(
   inet_aton
   SUITE
     libc_arpa_inet_unittests

--- a/libc/test/src/arpa/inet/inet_addr_test.cpp
+++ b/libc/test/src/arpa/inet/inet_addr_test.cpp
@@ -1,0 +1,25 @@
+//===-- Unittests for inet_addr -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/arpa/inet/htonl.h"
+#include "src/arpa/inet/inet_addr.h"
+#include "test/UnitTest/Test.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+TEST(LlvmLibcInetAddr, ValidTest) {
+  ASSERT_EQ(htonl(0x7f010204), inet_addr("127.1.2.4"));
+  ASSERT_EQ(htonl(0x7f010004), inet_addr("127.1.4"));
+}
+
+TEST(LlvmLibcInetAddr, InvalidTest) {
+  ASSERT_EQ(htonl(0xffffffff), inet_addr(""));
+  ASSERT_EQ(htonl(0xffffffff), inet_addr("x"));
+}
+
+} // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This patch adds the posix function `inet_addr`. Since most of the parsing logic is delegated to `inet_aton`, I have only included some basic smoke tests for testing purposes.