### PR TITLE
[bazel] Fix LLDB :Host Build

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -550,6 +550,7 @@ cc_library(
             "include/lldb/Host/posix/*.h",
         ]),
     }),
+    features = ["-layering_check"],  # histedit.h breaks this.
     includes = ["include"],
     # TODO: Move this to Config library when https://github.com/bazelbuild/bazel/issues/21884 is fixed
     linkopts = select({
@@ -591,7 +592,6 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    features = ["-layering_check"], # histedit.h breaks this.
 )
 
 cc_headers_only(

--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -591,6 +591,7 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    features = ["-layering_check"], # histedit.h breaks this.
 )
 
 cc_headers_only(


### PR DESCRIPTION
On some systems (probably those with a more recent clang), building :Host errors out with a layering check violation due to the histedit.h system include. Opt it out of layering checks for now, similar to other targets that depend on non standard library system includes.