### PR TITLE
[Modules][Diagnostic] Improve diagnostics for stale module dependencies

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -71,6 +71,9 @@ def err_ast_file_not_found : Error<
 def err_ast_file_out_of_date : Error<
   "%select{PCH|module|precompiled}0 file '%1' is out of date and "
   "needs to be rebuilt%select{|: %3}2">, DefaultFatal;
+def err_ast_file_dependency_out_of_date : Error<
+  "%select{PCH|module|AST}0 file '%1' is out of date because "
+  "dependency '%2' has changed%select{|: %4}3">, DefaultFatal;
 def err_ast_file_invalid : Error<
   "file '%1' is not a valid %select{PCH|module|precompiled}0 file: %2">, DefaultFatal;
 def note_module_file_imported_by : Note<

--- a/clang/include/clang/Serialization/ModuleManager.h
+++ b/clang/include/clang/Serialization/ModuleManager.h
@@ -198,8 +198,11 @@ public:
     /// The module file is missing.
     Missing,
 
-    /// The module file is out-of-date.
-    OutOfDate
+    /// The importee module file is out-of-date.
+    ImporteeOutOfDate,
+
+    /// The importer file is out-of-date
+    ImporterOutOfDate
   };
 
   using ASTFileSignatureReader = ASTFileSignature (*)(StringRef);

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5128,7 +5128,7 @@ ASTReader::ReadASTCore(StringRef FileName,
         << ErrorStr;
     return Failure;
 
-  case ModuleManager::OutOfDate:
+  case ModuleManager::ImporteeOutOfDate:
     // We couldn't load the module file because it is out-of-date. If the
     // client can handle out-of-date, return it.
     if (ClientLoadCapabilities & ARR_OutOfDate)
@@ -5138,6 +5138,20 @@ ASTReader::ReadASTCore(StringRef FileName,
     Diag(diag::err_ast_file_out_of_date)
         << moduleKindForDiagnostic(Type) << FileName << !ErrorStr.empty()
         << ErrorStr;
+    return Failure;
+
+  case ModuleManager::ImporterOutOfDate:
+    // We couldn't load the module file because it is out-of-date. If the
+    // client can handle out-of-date, return it.
+    if (ClientLoadCapabilities & ARR_OutOfDate)
+      return OutOfDate;
+
+    // Otherwise, report that the importer is out of date because the dependency
+    // changed.
+    if (ImportedBy)
+      Diag(diag::err_ast_file_dependency_out_of_date)
+          << moduleKindForDiagnostic(ImportedBy->Kind) << ImportedBy->FileName
+          << FileName << !ErrorStr.empty() << StringRef(ErrorStr);
     return Failure;
   }
 

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -125,7 +125,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     ErrorStr = IgnoreModTime ? "module file has a different size than expected"
                              : "module file has a different size or "
                                "modification time than expected";
-    return OutOfDate;
+    return ImporterOutOfDate;
   }
 
   if (!Entry) {
@@ -159,7 +159,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     if (implicitModuleNamesMatch(Type, ModuleEntry, *Entry)) {
       // Check the stored signature.
       if (checkSignature(ModuleEntry->Signature, ExpectedSignature, ErrorStr))
-        return OutOfDate;
+        return ImporterOutOfDate;
 
       Module = ModuleEntry;
       updateModuleImports(*ModuleEntry, ImportedBy, ImportLoc);
@@ -198,7 +198,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     // Report that the module is out of date, since we tried (and failed) to
     // import it earlier.
     Entry->closeFile();
-    return OutOfDate;
+    return ImporteeOutOfDate;
   } else {
     // Get a buffer of the file and close the file descriptor when done.
     // The file is volatile because in a parallel build we expect multiple
@@ -226,7 +226,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
   // ReadSignature unless there's something to check though.
   if (ExpectedSignature && checkSignature(ReadSignature(NewModule->Data),
                                           ExpectedSignature, ErrorStr))
-    return OutOfDate;
+    return ImporterOutOfDate;
 
   // We're keeping this module.  Store it everywhere.
   Module = Modules[*Entry] = NewModule.get();

--- a/clang/test/Modules/invalid-module-dep.c
+++ b/clang/test/Modules/invalid-module-dep.c
@@ -37,7 +37,7 @@
 #include <A/A.h>
 #include <B/B.h> // expected-warning {{conflicts with imported file}} \
                  // expected-note {{imported by module 'B'}} \
-                 // expected-error {{out of date and needs to be rebuilt}}
+                 // expected-error {{is out of date because dependency}}
 
 //--- Sysroot/usr/include/A/module.modulemap
 module A [system] {


### PR DESCRIPTION
When a module becomes out of date because its dependency has changed, Clang previously reported that the dependency itself was `out of date and needs to be rebuilt`, even when the dependency had just been rebuilt. This was confusing because the real issue is that the importing module is stale due to the dependency change.

This patch introduces a new diagnostic that clearly indicates which module is out of date and which dependency has changed, making it easier for users to understand what needs to be rebuilt.

Before:
`module file 'A.pcm' is out of date and needs to be rebuilt`
          (even though A.pcm was just rebuilt)
After:
`module file 'B.pcm' is out of date because dependency 'A.pcm' has changed`