### PR TITLE
Add missing `LLVM_ABI` annotations

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1471,7 +1471,7 @@ public:
 
   /// If this value is normal and has an exact, normal, multiplicative inverse,
   /// store it in inv and return true.
-  bool getExactInverse(APFloat *Inv) const;
+  LLVM_ABI bool getExactInverse(APFloat *Inv) const;
 
   // If this is an exact power of two, return the exponent while ignoring the
   // sign bit. If it's not an exact power of 2, return INT_MIN

--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -164,7 +164,7 @@ public:
   VocabStorage() = default;
 
   /// Create a VocabStorage with pre-organized section data
-  VocabStorage(std::vector<std::vector<Embedding>> &&SectionData);
+  LLVM_ABI VocabStorage(std::vector<std::vector<Embedding>> &&SectionData);
 
   VocabStorage(VocabStorage &&) = default;
   VocabStorage &operator=(VocabStorage &&) = default;

--- a/llvm/include/llvm/AsmParser/AsmParserContext.h
+++ b/llvm/include/llvm/AsmParser/AsmParserContext.h
@@ -34,9 +34,12 @@ class AsmParserContext {
   DenseMap<Instruction *, FileLocRange> Instructions;
 
 public:
-  std::optional<FileLocRange> getFunctionLocation(const Function *) const;
-  std::optional<FileLocRange> getBlockLocation(const BasicBlock *) const;
-  std::optional<FileLocRange> getInstructionLocation(const Instruction *) const;
+  LLVM_ABI std::optional<FileLocRange>
+  getFunctionLocation(const Function *) const;
+  LLVM_ABI std::optional<FileLocRange>
+  getBlockLocation(const BasicBlock *) const;
+  LLVM_ABI std::optional<FileLocRange>
+  getInstructionLocation(const Instruction *) const;
   /// Get the function at the requested location range.
   /// If no single function occupies the queried range, or the record is
   /// missing, a nullptr is returned.

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -201,7 +201,7 @@ enum class RootParameterType : uint32_t {
 
 LLVM_ABI ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
 
-bool isValidParameterType(uint32_t V);
+LLVM_ABI_FOR_TEST bool isValidParameterType(uint32_t V);
 
 bool isValidRangeType(uint32_t V);
 

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -34,7 +34,7 @@ public:
   StringRef getKey() const { return Key; }
 
   CacheKey(const CASID &ID);
-  CacheKey(const ObjectProxy &Proxy);
+  LLVM_ABI_FOR_TEST CacheKey(const ObjectProxy &Proxy);
   CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
 
 private:
@@ -98,10 +98,11 @@ private:
 };
 
 /// Create an action cache in memory.
-std::unique_ptr<ActionCache> createInMemoryActionCache();
+LLVM_ABI std::unique_ptr<ActionCache> createInMemoryActionCache();
 
 /// Create an action cache on disk.
-Expected<std::unique_ptr<ActionCache>> createOnDiskActionCache(StringRef Path);
+LLVM_ABI Expected<std::unique_ptr<ActionCache>>
+createOnDiskActionCache(StringRef Path);
 
 } // end namespace llvm::cas
 

--- a/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
+++ b/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
@@ -18,6 +18,7 @@ class ObjectStore;
 
 /// Create on-disk \c ObjectStore and \c ActionCache instances based on
 /// \c ondisk::UnifiedOnDiskCache, with built-in hashing.
+LLVM_ABI
 Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
 createOnDiskUnifiedCASDatabases(StringRef Path);
 

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -70,7 +70,7 @@ public:
   }
 
   /// Return a printable string for CASID.
-  std::string toString() const;
+  LLVM_ABI std::string toString() const;
 
   ArrayRef<uint8_t> getHash() const {
     return arrayRefFromStringRef<uint8_t>(Hash);

--- a/llvm/include/llvm/CAS/MappedFileRegionArena.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionArena.h
@@ -61,7 +61,7 @@ public:
   /// that information can be stored before the header, like a file magic.
   /// \param NewFileConstructor is for constructing new files. It has exclusive
   /// access to the file. Must call \c initializeBumpPtr.
-  static Expected<MappedFileRegionArena>
+  LLVM_ABI_FOR_TEST static Expected<MappedFileRegionArena>
   create(const Twine &Path, uint64_t Capacity, uint64_t HeaderOffset,
          function_ref<Error(MappedFileRegionArena &)> NewFileConstructor);
 
@@ -81,7 +81,7 @@ public:
     return data() + *Offset;
   }
   /// Allocate, returning the offset from \a data() instead of a pointer.
-  Expected<int64_t> allocateOffset(uint64_t AllocSize);
+  LLVM_ABI_FOR_TEST Expected<int64_t> allocateOffset(uint64_t AllocSize);
 
   char *data() const { return Region.data(); }
   uint64_t size() const { return H->BumpPtr; }
@@ -106,7 +106,7 @@ private:
   // initialize header from offset.
   void initializeHeader(uint64_t HeaderOffset);
 
-  void destroyImpl();
+  LLVM_ABI_FOR_TEST void destroyImpl();
   void moveImpl(MappedFileRegionArena &RHS) {
     std::swap(Region, RHS.Region);
     std::swap(H, RHS.H);

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -179,7 +179,8 @@ protected:
 
 public:
   /// Helper functions to store object and returns a ObjectProxy.
-  Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs, StringRef Data);
+  LLVM_ABI_FOR_TEST Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs,
+                                                      StringRef Data);
 
   /// Store object from StringRef.
   Expected<ObjectRef> storeFromString(ArrayRef<ObjectRef> Refs,
@@ -205,10 +206,10 @@ public:
   static Error createUnknownObjectError(const CASID &ID);
 
   /// Create ObjectProxy from CASID. If the object doesn't exist, get an error.
-  Expected<ObjectProxy> getProxy(const CASID &ID);
+  LLVM_ABI Expected<ObjectProxy> getProxy(const CASID &ID);
   /// Create ObjectProxy from ObjectRef. If the object can't be loaded, get an
   /// error.
-  Expected<ObjectProxy> getProxy(ObjectRef Ref);
+  LLVM_ABI Expected<ObjectProxy> getProxy(ObjectRef Ref);
 
   /// \returns \c std::nullopt if the object is missing from the CAS.
   Expected<std::optional<ObjectProxy>> getProxyIfExists(ObjectRef Ref);
@@ -329,13 +330,14 @@ private:
 };
 
 /// Create an in memory CAS.
-std::unique_ptr<ObjectStore> createInMemoryCAS();
+LLVM_ABI std::unique_ptr<ObjectStore> createInMemoryCAS();
 
 /// \returns true if \c LLVM_ENABLE_ONDISK_CAS configuration was enabled.
 bool isOnDiskCASEnabled();
 
 /// Create a persistent on-disk path at \p Path.
-Expected<std::unique_ptr<ObjectStore>> createOnDiskCAS(const Twine &Path);
+LLVM_ABI Expected<std::unique_ptr<ObjectStore>>
+createOnDiskCAS(const Twine &Path);
 
 } // namespace cas
 } // namespace llvm

--- a/llvm/include/llvm/CAS/OnDiskDataAllocator.h
+++ b/llvm/include/llvm/CAS/OnDiskDataAllocator.h
@@ -57,32 +57,33 @@ public:
   /// Get the data of \p Size stored at the given \p Offset. Note the allocator
   /// doesn't keep track of the allocation size, thus \p Size doesn't need to
   /// match the size of allocation but needs to be smaller.
-  Expected<ArrayRef<char>> get(FileOffset Offset, size_t Size) const;
+  LLVM_ABI_FOR_TEST Expected<ArrayRef<char>> get(FileOffset Offset,
+                                                 size_t Size) const;
 
   /// Allocate at least \p Size with 8-byte alignment.
-  Expected<OnDiskPtr> allocate(size_t Size);
+  LLVM_ABI_FOR_TEST Expected<OnDiskPtr> allocate(size_t Size);
 
   /// \returns the buffer that was allocated at \p create time, with size
   /// \p UserHeaderSize.
   MutableArrayRef<uint8_t> getUserHeader() const;
 
-  size_t size() const;
-  size_t capacity() const;
+  LLVM_ABI_FOR_TEST size_t size() const;
+  LLVM_ABI_FOR_TEST size_t capacity() const;
 
-  static Expected<OnDiskDataAllocator>
+  LLVM_ABI_FOR_TEST static Expected<OnDiskDataAllocator>
   create(const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
          uint32_t UserHeaderSize = 0,
          function_ref<void(void *)> UserHeaderInit = nullptr);
 
-  OnDiskDataAllocator(OnDiskDataAllocator &&RHS);
-  OnDiskDataAllocator &operator=(OnDiskDataAllocator &&RHS);
+  LLVM_ABI_FOR_TEST OnDiskDataAllocator(OnDiskDataAllocator &&RHS);
+  LLVM_ABI_FOR_TEST OnDiskDataAllocator &operator=(OnDiskDataAllocator &&RHS);
 
   // No copy. Just call \a create() again.
   OnDiskDataAllocator(const OnDiskDataAllocator &) = delete;
   OnDiskDataAllocator &operator=(const OnDiskDataAllocator &) = delete;
 
-  ~OnDiskDataAllocator();
+  LLVM_ABI_FOR_TEST ~OnDiskDataAllocator();
 
 private:
   struct ImplType;

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -259,10 +259,11 @@ public:
   /// already a record for this object the operation is a no-op. \param ID the
   /// object ID to associate the data & references with. \param Refs references
   /// \param Data data buffer.
-  Error store(ObjectID ID, ArrayRef<ObjectID> Refs, ArrayRef<char> Data);
+  LLVM_ABI_FOR_TEST Error store(ObjectID ID, ArrayRef<ObjectID> Refs,
+                                ArrayRef<char> Data);
 
   /// \returns \p nullopt if the object associated with \p Ref does not exist.
-  Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
+  LLVM_ABI_FOR_TEST Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
 
   /// \returns the hash bytes digest for the object reference.
   ArrayRef<uint8_t> getDigest(ObjectID Ref) const {
@@ -272,12 +273,13 @@ public:
 
   /// Form a reference for the provided hash. The reference can be used as part
   /// of a CAS object even if it's not associated with an object yet.
-  Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
+  LLVM_ABI_FOR_TEST Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
 
   /// Get an existing reference to the object \p Digest.
   ///
   /// Returns \p nullopt if the object is not stored in this CAS.
-  std::optional<ObjectID> getExistingReference(ArrayRef<uint8_t> Digest);
+  LLVM_ABI_FOR_TEST std::optional<ObjectID>
+  getExistingReference(ArrayRef<uint8_t> Digest);
 
   /// Check whether the object associated with \p Ref is stored in the CAS.
   /// Note that this function will fault-in according to the policy.
@@ -290,7 +292,7 @@ public:
   }
 
   /// \returns the data part of the provided object handle.
-  ArrayRef<char> getObjectData(ObjectHandle Node) const;
+  LLVM_ABI_FOR_TEST ArrayRef<char> getObjectData(ObjectHandle Node) const;
 
   /// \returns the object referenced by the provided object handle.
   object_refs_range getObjectRefs(ObjectHandle Node) const {
@@ -302,7 +304,7 @@ public:
   ///
   /// NOTE: There's a possibility that the returned size is not including a
   /// large object if the process crashed right at the point of inserting it.
-  size_t getStorageSize() const;
+  LLVM_ABI_FOR_TEST size_t getStorageSize() const;
 
   /// \returns The precentage of space utilization of hard space limits.
   ///
@@ -347,12 +349,12 @@ public:
   /// \param Policy If \p UpstreamDB is provided, controls how nodes are copied
   /// to primary store. This is recorded at creation time and subsequent opens
   /// need to pass the same policy otherwise the \p open will fail.
-  static Expected<std::unique_ptr<OnDiskGraphDB>>
+  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<OnDiskGraphDB>>
   open(StringRef Path, StringRef HashName, unsigned HashByteSize,
        OnDiskGraphDB *UpstreamDB = nullptr,
        FaultInPolicy Policy = FaultInPolicy::FullTree);
 
-  ~OnDiskGraphDB();
+  LLVM_ABI_FOR_TEST ~OnDiskGraphDB();
 
 private:
   /// Forward declaration for a proxy for an ondisk index record.
@@ -365,8 +367,8 @@ private:
   };
 
   /// Check if object exists and if it is on upstream only.
-  Expected<ObjectPresence> getObjectPresence(ObjectID Ref,
-                                             bool CheckUpstream) const;
+  LLVM_ABI_FOR_TEST Expected<ObjectPresence>
+  getObjectPresence(ObjectID Ref, bool CheckUpstream) const;
 
   /// \returns true if object can be found in database.
   bool containsObject(ObjectID Ref, bool CheckUpstream) const {
@@ -418,7 +420,8 @@ private:
 
   static InternalRef makeInternalRef(FileOffset IndexOffset);
 
-  Expected<ArrayRef<uint8_t>> getDigest(InternalRef Ref) const;
+  LLVM_ABI_FOR_TEST Expected<ArrayRef<uint8_t>>
+  getDigest(InternalRef Ref) const;
 
   ArrayRef<uint8_t> getDigest(const IndexProxy &I) const;
 
@@ -427,7 +430,8 @@ private:
   IndexProxy
   getIndexProxyFromPointer(OnDiskTrieRawHashMap::ConstOnDiskPtr P) const;
 
-  InternalRefArrayRef getInternalRefs(ObjectHandle Node) const;
+  LLVM_ABI_FOR_TEST InternalRefArrayRef
+  getInternalRefs(ObjectHandle Node) const;
   /// \}
 
   /// Get the atomic variable that keeps track of the standalone data storage

--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -36,11 +36,13 @@ public:
   ///
   /// \returns the value associated with the \p Key. It may be different than
   /// \p Value if another value is already associated with this key.
-  Expected<ArrayRef<char>> put(ArrayRef<uint8_t> Key, ArrayRef<char> Value);
+  LLVM_ABI_FOR_TEST Expected<ArrayRef<char>> put(ArrayRef<uint8_t> Key,
+                                                 ArrayRef<char> Value);
 
   /// \returns the value associated with the \p Key, or \p std::nullopt if the
   /// key does not exist.
-  Expected<std::optional<ArrayRef<char>>> get(ArrayRef<uint8_t> Key);
+  LLVM_ABI_FOR_TEST Expected<std::optional<ArrayRef<char>>>
+  get(ArrayRef<uint8_t> Key);
 
   /// \returns Total size of stored data.
   size_t getStorageSize() const { return Cache.size(); }
@@ -64,7 +66,7 @@ public:
   /// \param UnifiedCache An optional UnifiedOnDiskCache that manages the size
   /// and lifetime of the CAS instance and it must owns current initializing
   /// KeyValueDB after initialized.
-  static Expected<std::unique_ptr<OnDiskKeyValueDB>>
+  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<OnDiskKeyValueDB>>
   open(StringRef Path, StringRef HashName, unsigned KeySize,
        StringRef ValueName, size_t ValueSize,
        UnifiedOnDiskCache *UnifiedCache = nullptr);
@@ -73,7 +75,7 @@ public:
       function_ref<Error(FileOffset Offset, ArrayRef<char> Data)>;
   /// Validate the storage with a callback \p CheckValue to check the stored
   /// value.
-  Error validate(CheckValueT CheckValue) const;
+  LLVM_ABI_FOR_TEST Error validate(CheckValueT CheckValue) const;
 
 private:
   OnDiskKeyValueDB(size_t ValueSize, OnDiskTrieRawHashMap Cache,

--- a/llvm/include/llvm/CAS/OnDiskTrieRawHashMap.h
+++ b/llvm/include/llvm/CAS/OnDiskTrieRawHashMap.h
@@ -83,7 +83,7 @@ public:
   /// Validate the trie data structure.
   ///
   /// Callback receives the file offset to the data entry and the data stored.
-  Error validate(
+  LLVM_ABI_FOR_TEST Error validate(
       function_ref<Error(FileOffset, ConstValueProxy)> RecordVerifier) const;
 
   /// Check the valid range of file offset for OnDiskTrieRawHashMap.
@@ -161,10 +161,11 @@ public:
   ///
   /// \returns pointer to the value if exists, otherwise returns a non-value
   /// pointer that evaluates to `false` when convert to boolean.
-  ConstOnDiskPtr find(ArrayRef<uint8_t> Hash) const;
+  LLVM_ABI_FOR_TEST ConstOnDiskPtr find(ArrayRef<uint8_t> Hash) const;
 
   /// Helper function to recover a pointer into the trie from file offset.
-  Expected<ConstOnDiskPtr> recoverFromFileOffset(FileOffset Offset) const;
+  LLVM_ABI_FOR_TEST Expected<ConstOnDiskPtr>
+  recoverFromFileOffset(FileOffset Offset) const;
 
   using LazyInsertOnConstructCB =
       function_ref<void(FileOffset TentativeOffset, ValueProxy TentativeValue)>;
@@ -186,9 +187,10 @@ public:
   /// The in-memory \a TrieRawHashMap uses LazyAtomicPointer to synchronize
   /// simultaneous writes, but that seems dangerous to use in a memory-mapped
   /// file in case a process crashes in the busy state.
-  Expected<OnDiskPtr> insertLazy(ArrayRef<uint8_t> Hash,
-                                 LazyInsertOnConstructCB OnConstruct = nullptr,
-                                 LazyInsertOnLeakCB OnLeak = nullptr);
+  LLVM_ABI_FOR_TEST Expected<OnDiskPtr>
+  insertLazy(ArrayRef<uint8_t> Hash,
+             LazyInsertOnConstructCB OnConstruct = nullptr,
+             LazyInsertOnLeakCB OnLeak = nullptr);
 
   Expected<OnDiskPtr> insert(const ConstValueProxy &Value) {
     return insertLazy(Value.Hash, [&](FileOffset, ValueProxy Allocated) {
@@ -198,8 +200,8 @@ public:
     });
   }
 
-  size_t size() const;
-  size_t capacity() const;
+  LLVM_ABI_FOR_TEST size_t size() const;
+  LLVM_ABI_FOR_TEST size_t capacity() const;
 
   /// Gets or creates a file at \p Path with a hash-mapped trie named \p
   /// TrieName. The hash size is \p NumHashBits (in bits) and the records store
@@ -213,16 +215,16 @@ public:
   /// configure the trie, if it doesn't already exist.
   ///
   /// \pre NumHashBits is a multiple of 8 (byte-aligned).
-  static Expected<OnDiskTrieRawHashMap>
+  LLVM_ABI_FOR_TEST static Expected<OnDiskTrieRawHashMap>
   create(const Twine &Path, const Twine &TrieName, size_t NumHashBits,
          uint64_t DataSize, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
          std::optional<size_t> NewTableNumRootBits = std::nullopt,
          std::optional<size_t> NewTableNumSubtrieBits = std::nullopt);
 
-  OnDiskTrieRawHashMap(OnDiskTrieRawHashMap &&RHS);
-  OnDiskTrieRawHashMap &operator=(OnDiskTrieRawHashMap &&RHS);
-  ~OnDiskTrieRawHashMap();
+  LLVM_ABI_FOR_TEST OnDiskTrieRawHashMap(OnDiskTrieRawHashMap &&RHS);
+  LLVM_ABI_FOR_TEST OnDiskTrieRawHashMap &operator=(OnDiskTrieRawHashMap &&RHS);
+  LLVM_ABI_FOR_TEST ~OnDiskTrieRawHashMap();
 
 private:
   struct ImplType;

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -58,7 +58,7 @@ public:
   /// \param FaultInPolicy Controls how nodes are copied to primary store. This
   /// is recorded at creation time and subsequent opens need to pass the same
   /// policy otherwise the \p open will fail.
-  static Expected<std::unique_ptr<UnifiedOnDiskCache>>
+  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<UnifiedOnDiskCache>>
   open(StringRef Path, std::optional<uint64_t> SizeLimit, StringRef HashName,
        unsigned HashByteSize,
        OnDiskGraphDB::FaultInPolicy FaultInPolicy =
@@ -99,20 +99,20 @@ public:
   /// \param CheckSizeLimit if true it will check whether the primary store has
   /// exceeded its intended size limit. If false the check is skipped even if a
   /// \p SizeLimit was passed to the \p open call.
-  Error close(bool CheckSizeLimit = true);
+  LLVM_ABI_FOR_TEST Error close(bool CheckSizeLimit = true);
 
   /// Set the size for limiting growth. This has an effect for when the instance
   /// is closed.
-  void setSizeLimit(std::optional<uint64_t> SizeLimit);
+  LLVM_ABI_FOR_TEST void setSizeLimit(std::optional<uint64_t> SizeLimit);
 
   /// \returns the storage size of the cache data.
-  uint64_t getStorageSize() const;
+  LLVM_ABI_FOR_TEST uint64_t getStorageSize() const;
 
   /// \returns whether the primary store has exceeded the intended size limit.
   /// This can return false even if the overall size of the opened directory is
   /// over the \p SizeLimit passed to \p open. To know whether garbage
   /// collection needs to be triggered or not, call \p needsGarbaseCollection.
-  bool hasExceededSizeLimit() const;
+  LLVM_ABI_FOR_TEST bool hasExceededSizeLimit() const;
 
   /// \returns whether there are unused data that can be deleted using a
   /// \p collectGarbage call.
@@ -127,18 +127,18 @@ public:
   ///
   /// It is recommended that garbage-collection is triggered concurrently in the
   /// background, so that it has minimal effect on the workload of the process.
-  static Error collectGarbage(StringRef Path);
+  LLVM_ABI_FOR_TEST static Error collectGarbage(StringRef Path);
 
   /// Remove unused data from the current UnifiedOnDiskCache.
   Error collectGarbage();
 
   /// Helper function to convert the value stored in KeyValueDB and ObjectID.
-  static ObjectID getObjectIDFromValue(ArrayRef<char> Value);
+  LLVM_ABI_FOR_TEST static ObjectID getObjectIDFromValue(ArrayRef<char> Value);
 
   using ValueBytes = std::array<char, sizeof(uint64_t)>;
-  static ValueBytes getValueFromObjectID(ObjectID ID);
+  LLVM_ABI_FOR_TEST static ValueBytes getValueFromObjectID(ObjectID ID);
 
-  ~UnifiedOnDiskCache();
+  LLVM_ABI_FOR_TEST ~UnifiedOnDiskCache();
 
 private:
   friend class OnDiskGraphDB;

--- a/llvm/include/llvm/CGData/StableFunctionMap.h
+++ b/llvm/include/llvm/CGData/StableFunctionMap.h
@@ -105,7 +105,7 @@ struct StableFunctionMap {
   using HashFuncsMapType = std::unordered_map<stable_hash, EntryStorage>;
 
   /// Get the HashToFuncs map for serialization.
-  const HashFuncsMapType &getFunctionMap() const;
+  LLVM_ABI_FOR_TEST const HashFuncsMapType &getFunctionMap() const;
 
   /// Get the NameToId vector for serialization.
   ArrayRef<std::string> getNames() const { return IdToName; }

--- a/llvm/include/llvm/CodeGen/MIR2Vec.h
+++ b/llvm/include/llvm/CodeGen/MIR2Vec.h
@@ -74,7 +74,7 @@ class MIREmbedder;
 class SymbolicMIREmbedder;
 
 LLVM_ABI extern llvm::cl::OptionCategory MIR2VecCategory;
-extern cl::opt<float> OpcWeight, CommonOperandWeight, RegOperandWeight;
+LLVM_ABI extern cl::opt<float> OpcWeight, CommonOperandWeight, RegOperandWeight;
 
 using Embedding = ir2vec::Embedding;
 using MachineInstEmbeddingsMap = DenseMap<const MachineInstr *, Embedding>;
@@ -211,14 +211,18 @@ class MIRVocabulary {
 
 public:
   /// Static method for extracting base opcode names (public for testing)
-  static std::string extractBaseOpcodeName(StringRef InstrName);
+  LLVM_ABI_FOR_TEST static std::string
+  extractBaseOpcodeName(StringRef InstrName);
 
   /// Get indices from opcode or operand names. These are public for testing.
   /// String based lookups are inefficient and should be avoided in general.
-  unsigned getCanonicalIndexForBaseName(StringRef BaseName) const;
-  unsigned getCanonicalIndexForOperandName(StringRef OperandName) const;
-  unsigned getCanonicalIndexForRegisterClass(StringRef RegName,
-                                             bool IsPhysical = true) const;
+  LLVM_ABI_FOR_TEST unsigned
+  getCanonicalIndexForBaseName(StringRef BaseName) const;
+  LLVM_ABI_FOR_TEST unsigned
+  getCanonicalIndexForOperandName(StringRef OperandName) const;
+  LLVM_ABI_FOR_TEST unsigned
+  getCanonicalIndexForRegisterClass(StringRef RegName,
+                                    bool IsPhysical = true) const;
 
   /// Get the string key for a vocabulary entry at the given position
   LLVM_ABI std::string getStringKey(unsigned Pos) const;
@@ -262,7 +266,7 @@ public:
   MIRVocabulary() = delete;
 
   /// Factory method to create MIRVocabulary from vocabulary map
-  static Expected<MIRVocabulary>
+  LLVM_ABI_FOR_TEST static Expected<MIRVocabulary>
   create(VocabMap &&OpcMap, VocabMap &&CommonOperandsMap, VocabMap &&PhyRegMap,
          VocabMap &&VirtRegMap, const TargetInstrInfo &TII,
          const TargetRegisterInfo &TRI, const MachineRegisterInfo &MRI);
@@ -349,7 +353,7 @@ private:
 
 public:
   SymbolicMIREmbedder(const MachineFunction &F, const MIRVocabulary &Vocab);
-  static std::unique_ptr<SymbolicMIREmbedder>
+  LLVM_ABI_FOR_TEST static std::unique_ptr<SymbolicMIREmbedder>
   create(const MachineFunction &MF, const MIRVocabulary &Vocab);
 };
 

--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -750,7 +750,7 @@ public:
   /// instructions, so the order should be validated no more than once after
   /// each ordering to ensure that transforms have the same algorithmic
   /// complexity when asserts are enabled as when they are disabled.
-  void validateInstrOrdering() const;
+  LLVM_ABI_FOR_TEST void validateInstrOrdering() const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -292,7 +292,7 @@ public:
   /// \return The name of the subcommand found. If no subcommand is found,
   /// this returns an empty StringRef. If multiple subcommands are found, the
   /// first one is returned.
-  StringRef getSubCommand(
+  LLVM_ABI_FOR_TEST StringRef getSubCommand(
       ArrayRef<OptTable::SubCommand> AllSubCommands,
       std::function<void(ArrayRef<StringRef>)> HandleMultipleSubcommands,
       std::function<void(ArrayRef<StringRef>)> HandleOtherPositionals) const;

--- a/llvm/include/llvm/SandboxIR/Argument.h
+++ b/llvm/include/llvm/SandboxIR/Argument.h
@@ -29,7 +29,7 @@ public:
     assert(isa<llvm::Argument>(Val) && "Expected Argument!");
   }
   void printAsOperand(raw_ostream &OS) const;
-  void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/BasicBlock.h
+++ b/llvm/include/llvm/SandboxIR/BasicBlock.h
@@ -104,7 +104,7 @@ public:
 
 #ifndef NDEBUG
   void verify() const final;
-  void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/Function.h
+++ b/llvm/include/llvm/SandboxIR/Function.h
@@ -73,8 +73,8 @@ public:
   void verify() const final {
     assert(isa<llvm::Function>(Val) && "Expected Function!");
   }
-  void dumpNameAndArgs(raw_ostream &OS) const;
-  void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI_FOR_TEST void dumpNameAndArgs(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/Pass.h
+++ b/llvm/include/llvm/SandboxIR/Pass.h
@@ -65,7 +65,7 @@ public:
     return OS;
   }
   virtual void print(raw_ostream &OS) const { OS << Name; }
-  LLVM_DUMP_METHOD virtual void dump() const;
+  LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD virtual void dump() const;
 #endif
   /// Similar to print() but adds a newline. Used for testing.
   virtual void printPipeline(raw_ostream &OS) const { OS << Name << "\n"; }

--- a/llvm/include/llvm/SandboxIR/Region.h
+++ b/llvm/include/llvm/SandboxIR/Region.h
@@ -169,10 +169,10 @@ public:
 
 #ifndef NDEBUG
   /// This is an expensive check, meant for testing.
-  bool operator==(const Region &Other) const;
+  LLVM_ABI_FOR_TEST bool operator==(const Region &Other) const;
   bool operator!=(const Region &other) const { return !(*this == other); }
 
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void dump(raw_ostream &OS) const;
   void dump() const;
   friend raw_ostream &operator<<(raw_ostream &OS, const Region &Rgn) {
     Rgn.dump(OS);

--- a/llvm/include/llvm/SandboxIR/Tracker.h
+++ b/llvm/include/llvm/SandboxIR/Tracker.h
@@ -107,10 +107,10 @@ public:
 
   /// Saves a snapshot of the current state. If there was any previous snapshot,
   /// it will be replaced with the new one.
-  void save();
+  LLVM_ABI_FOR_TEST void save();
 
   /// Checks current state against saved state, crashes if different.
-  void expectNoDiff();
+  LLVM_ABI_FOR_TEST void expectNoDiff();
 };
 
 #endif // NDEBUG

--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -62,7 +62,7 @@ public:
   }
   bool operator!=(const Use &Other) const { return !(*this == Other); }
 #ifndef NDEBUG
-  void dumpOS(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const;
   void dump() const;
 #endif // NDEBUG
 };

--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -81,7 +81,7 @@ public:
   StringRef suffix() const { return Pattern.take_back(SuffixSize); }
   // Returns the longest plain substring of the pattern between prefix and
   // suffix.
-  StringRef longest_substr() const;
+  LLVM_ABI_FOR_TEST StringRef longest_substr() const;
 
 private:
   StringRef Pattern;

--- a/llvm/include/llvm/Support/Jobserver.h
+++ b/llvm/include/llvm/Support/Jobserver.h
@@ -150,10 +150,10 @@ public:
   /// Returns the singleton instance of the JobserverClient.
   /// The instance is created on the first call to this function.
   /// Returns a nullptr if no jobserver is configured or an error occurs.
-  static JobserverClient *getInstance();
+  LLVM_ABI_FOR_TEST static JobserverClient *getInstance();
 
   /// Resets the singleton instance. For testing purposes only.
-  static void resetForTesting();
+  LLVM_ABI_FOR_TEST static void resetForTesting();
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Support/LSP/Logging.h
+++ b/llvm/include/llvm/Support/LSP/Logging.h
@@ -25,7 +25,7 @@ public:
   enum class Level { Debug, Info, Error };
 
   /// Set the severity level of the logger.
-  static void setLogLevel(Level LogLevel);
+  LLVM_ABI_FOR_TEST static void setLogLevel(Level LogLevel);
 
   /// Initiate a log message at various severity levels. These should be called
   /// after a call to `initialize`.
@@ -46,8 +46,8 @@ private:
   static Logger &get();
 
   /// Start a log message with the given severity level.
-  static void log(Level LogLevel, const char *Fmt,
-                  const llvm::formatv_object_base &Message);
+  LLVM_ABI_FOR_TEST static void log(Level LogLevel, const char *Fmt,
+                                    const llvm::formatv_object_base &Message);
 
   /// The minimum logging level. Messages with lower level are ignored.
   Level LogLevel = Level::Error;

--- a/llvm/include/llvm/Support/LSP/Protocol.h
+++ b/llvm/include/llvm/Support/LSP/Protocol.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_SUPPORT_LSP_PROTOCOL_H
 #define LLVM_SUPPORT_LSP_PROTOCOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/SourceMgr.h"
@@ -80,7 +81,7 @@ class LSPError : public llvm::ErrorInfo<LSPError> {
 public:
   std::string message;
   ErrorCode code;
-  static char ID;
+  LLVM_ABI_FOR_TEST static char ID;
 
   LSPError(std::string message, ErrorCode code)
       : message(std::move(message)), code(code) {}
@@ -145,9 +146,9 @@ private:
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const URIForFile &value);
-bool fromJSON(const llvm::json::Value &value, URIForFile &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const URIForFile &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                URIForFile &result, llvm::json::Path path);
 raw_ostream &operator<<(raw_ostream &os, const URIForFile &value);
 
 //===----------------------------------------------------------------------===//
@@ -171,8 +172,9 @@ struct ClientCapabilities {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ClientCapabilities &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ClientCapabilities &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ClientInfo
@@ -187,8 +189,8 @@ struct ClientInfo {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ClientInfo &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ClientInfo &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InitializeParams
@@ -201,8 +203,8 @@ enum class TraceLevel {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, TraceLevel &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TraceLevel &result, llvm::json::Path path);
 
 struct InitializeParams {
   /// The capabilities provided by the client (editor or tool).
@@ -216,8 +218,9 @@ struct InitializeParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, InitializeParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                InitializeParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InitializedParams
@@ -248,8 +251,9 @@ struct TextDocumentItem {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, TextDocumentItem &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentItem &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // TextDocumentIdentifier
@@ -261,9 +265,10 @@ struct TextDocumentIdentifier {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const TextDocumentIdentifier &value);
-bool fromJSON(const llvm::json::Value &value, TextDocumentIdentifier &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextDocumentIdentifier &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentIdentifier &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // VersionedTextDocumentIdentifier
@@ -277,9 +282,11 @@ struct VersionedTextDocumentIdentifier {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const VersionedTextDocumentIdentifier &value);
-bool fromJSON(const llvm::json::Value &value,
-              VersionedTextDocumentIdentifier &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value
+toJSON(const VersionedTextDocumentIdentifier &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                VersionedTextDocumentIdentifier &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // Position
@@ -327,9 +334,9 @@ struct Position {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, Position &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const Position &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                Position &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Position &value);
 raw_ostream &operator<<(raw_ostream &os, const Position &value);
 
 //===----------------------------------------------------------------------===//
@@ -380,9 +387,9 @@ struct Range {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, Range &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const Range &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value, Range &result,
+                                llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Range &value);
 raw_ostream &operator<<(raw_ostream &os, const Range &value);
 
 //===----------------------------------------------------------------------===//
@@ -415,9 +422,9 @@ struct Location {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, Location &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const Location &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                Location &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Location &value);
 raw_ostream &operator<<(raw_ostream &os, const Location &value);
 
 //===----------------------------------------------------------------------===//
@@ -433,8 +440,9 @@ struct TextDocumentPositionParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              TextDocumentPositionParams &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentPositionParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ReferenceParams
@@ -446,16 +454,17 @@ struct ReferenceContext {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ReferenceContext &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ReferenceContext &result,
+                                llvm::json::Path path);
 
 struct ReferenceParams : TextDocumentPositionParams {
   ReferenceContext context;
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ReferenceParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ReferenceParams &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidOpenTextDocumentParams
@@ -467,8 +476,9 @@ struct DidOpenTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, DidOpenTextDocumentParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DidOpenTextDocumentParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidCloseTextDocumentParams
@@ -480,8 +490,9 @@ struct DidCloseTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              DidCloseTextDocumentParams &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DidCloseTextDocumentParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidChangeTextDocumentParams
@@ -505,8 +516,9 @@ struct TextDocumentContentChangeEvent {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              TextDocumentContentChangeEvent &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentContentChangeEvent &result,
+                                llvm::json::Path path);
 
 struct DidChangeTextDocumentParams {
   /// The document that changed.
@@ -517,8 +529,9 @@ struct DidChangeTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              DidChangeTextDocumentParams &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DidChangeTextDocumentParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // MarkupContent
@@ -538,7 +551,7 @@ struct MarkupContent {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const MarkupContent &mc);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const MarkupContent &mc);
 
 //===----------------------------------------------------------------------===//
 // Hover
@@ -557,7 +570,7 @@ struct Hover {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const Hover &hover);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Hover &hover);
 
 //===----------------------------------------------------------------------===//
 // SymbolKind
@@ -632,7 +645,7 @@ struct DocumentSymbol {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const DocumentSymbol &symbol);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const DocumentSymbol &symbol);
 
 //===----------------------------------------------------------------------===//
 // DocumentSymbolParams
@@ -644,8 +657,9 @@ struct DocumentSymbolParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, DocumentSymbolParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DocumentSymbolParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DiagnosticRelatedInformation
@@ -666,9 +680,11 @@ struct DiagnosticRelatedInformation {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              DiagnosticRelatedInformation &result, llvm::json::Path path);
-llvm::json::Value toJSON(const DiagnosticRelatedInformation &info);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DiagnosticRelatedInformation &result,
+                                llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value
+toJSON(const DiagnosticRelatedInformation &info);
 
 //===----------------------------------------------------------------------===//
 // Diagnostic
@@ -690,9 +706,9 @@ enum class DiagnosticTag {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(DiagnosticTag tag);
-bool fromJSON(const llvm::json::Value &value, DiagnosticTag &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(DiagnosticTag tag);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DiagnosticTag &result, llvm::json::Path path);
 
 struct Diagnostic {
   /// The source range where the message applies.
@@ -724,9 +740,9 @@ struct Diagnostic {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const Diagnostic &diag);
-bool fromJSON(const llvm::json::Value &value, Diagnostic &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Diagnostic &diag);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                Diagnostic &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // PublishDiagnosticsParams
@@ -745,7 +761,8 @@ struct PublishDiagnosticsParams {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const PublishDiagnosticsParams &params);
+LLVM_ABI_FOR_TEST llvm::json::Value
+toJSON(const PublishDiagnosticsParams &params);
 
 //===----------------------------------------------------------------------===//
 // TextEdit
@@ -765,9 +782,9 @@ inline bool operator==(const TextEdit &lhs, const TextEdit &rhs) {
   return std::tie(lhs.newText, lhs.range) == std::tie(rhs.newText, rhs.range);
 }
 
-bool fromJSON(const llvm::json::Value &value, TextEdit &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const TextEdit &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextEdit &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextEdit &value);
 raw_ostream &operator<<(raw_ostream &os, const TextEdit &value);
 
 //===----------------------------------------------------------------------===//
@@ -803,16 +820,18 @@ enum class CompletionItemKind {
   Operator = 24,
   TypeParameter = 25,
 };
-bool fromJSON(const llvm::json::Value &value, CompletionItemKind &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionItemKind &result,
+                                llvm::json::Path path);
 
 constexpr auto kCompletionItemKindMin =
     static_cast<size_t>(CompletionItemKind::Text);
 constexpr auto kCompletionItemKindMax =
     static_cast<size_t>(CompletionItemKind::TypeParameter);
 using CompletionItemKindBitset = std::bitset<kCompletionItemKindMax + 1>;
-bool fromJSON(const llvm::json::Value &value, CompletionItemKindBitset &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionItemKindBitset &result,
+                                llvm::json::Path path);
 
 CompletionItemKind
 adjustKindToCapability(CompletionItemKind kind,
@@ -895,7 +914,7 @@ struct CompletionItem {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const CompletionItem &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionItem &value);
 raw_ostream &operator<<(raw_ostream &os, const CompletionItem &value);
 bool operator<(const CompletionItem &lhs, const CompletionItem &rhs);
 
@@ -914,7 +933,7 @@ struct CompletionList {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const CompletionList &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionList &value);
 
 //===----------------------------------------------------------------------===//
 // CompletionContext
@@ -943,8 +962,9 @@ struct CompletionContext {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CompletionContext &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionContext &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // CompletionParams
@@ -955,8 +975,9 @@ struct CompletionParams : TextDocumentPositionParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CompletionParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ParameterInformation
@@ -976,7 +997,7 @@ struct ParameterInformation {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const ParameterInformation &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const ParameterInformation &value);
 
 //===----------------------------------------------------------------------===//
 // SignatureInformation
@@ -995,7 +1016,7 @@ struct SignatureInformation {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const SignatureInformation &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureInformation &value);
 raw_ostream &operator<<(raw_ostream &os, const SignatureInformation &value);
 
 //===----------------------------------------------------------------------===//
@@ -1015,7 +1036,7 @@ struct SignatureHelp {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const SignatureHelp &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureHelp &value);
 
 //===----------------------------------------------------------------------===//
 // DocumentLinkParams
@@ -1028,8 +1049,9 @@ struct DocumentLinkParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, DocumentLinkParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DocumentLinkParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DocumentLink
@@ -1065,7 +1087,7 @@ struct DocumentLink {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const DocumentLink &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const DocumentLink &value);
 
 //===----------------------------------------------------------------------===//
 // InlayHintsParams
@@ -1081,8 +1103,9 @@ struct InlayHintsParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, InlayHintsParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                InlayHintsParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InlayHintKind
@@ -1142,7 +1165,7 @@ struct InlayHint {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const InlayHint &);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const InlayHint &);
 bool operator==(const InlayHint &lhs, const InlayHint &rhs);
 bool operator<(const InlayHint &lhs, const InlayHint &rhs);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, InlayHintKind value);
@@ -1168,8 +1191,9 @@ struct CodeActionContext {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CodeActionContext &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CodeActionContext &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // CodeActionParams
@@ -1187,8 +1211,9 @@ struct CodeActionParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CodeActionParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CodeActionParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // WorkspaceEdit
@@ -1203,9 +1228,9 @@ struct WorkspaceEdit {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, WorkspaceEdit &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const WorkspaceEdit &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                WorkspaceEdit &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const WorkspaceEdit &value);
 
 //===----------------------------------------------------------------------===//
 // CodeAction
@@ -1242,7 +1267,7 @@ struct CodeAction {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const CodeAction &);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CodeAction &);
 
 } // namespace lsp
 } // namespace llvm

--- a/llvm/include/llvm/Support/LSP/Transport.h
+++ b/llvm/include/llvm/Support/LSP/Transport.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/LSP/Logging.h"
@@ -81,8 +82,8 @@ public:
   bool hasError() const final { return ferror(In); }
   bool isEndOfInput() const final { return feof(In); }
 
-  LogicalResult readDelimitedMessage(std::string &Json) final;
-  LogicalResult readStandardMessage(std::string &Json) final;
+  LLVM_ABI_FOR_TEST LogicalResult readDelimitedMessage(std::string &Json) final;
+  LLVM_ABI_FOR_TEST LogicalResult readStandardMessage(std::string &Json) final;
 
 private:
   std::FILE *In;
@@ -103,12 +104,14 @@ public:
         PrettyOutput(PrettyOutput) {}
 
   /// The following methods are used to send a message to the LSP client.
-  void notify(StringRef Method, llvm::json::Value Params);
-  void call(StringRef Method, llvm::json::Value Params, llvm::json::Value Id);
-  void reply(llvm::json::Value Id, llvm::Expected<llvm::json::Value> Result);
+  LLVM_ABI_FOR_TEST void notify(StringRef Method, llvm::json::Value Params);
+  LLVM_ABI_FOR_TEST void call(StringRef Method, llvm::json::Value Params,
+                              llvm::json::Value Id);
+  LLVM_ABI_FOR_TEST void reply(llvm::json::Value Id,
+                               llvm::Expected<llvm::json::Value> Result);
 
   /// Start executing the JSON-RPC transport.
-  llvm::Error run(MessageHandler &Handler);
+  LLVM_ABI_FOR_TEST llvm::Error run(MessageHandler &Handler);
 
 private:
   /// Dispatches the given incoming json message to the message handler.

--- a/llvm/include/llvm/Support/VirtualOutputBackends.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackends.h
@@ -29,26 +29,26 @@
 namespace llvm::vfs {
 
 /// Create a backend that ignores all output.
-IntrusiveRefCntPtr<OutputBackend> makeNullOutputBackend();
+LLVM_ABI IntrusiveRefCntPtr<OutputBackend> makeNullOutputBackend();
 
 /// Make a backend where \a OutputBackend::createFile() forwards to
 /// \p UnderlyingBackend when \p Filter is true, and otherwise returns a
 /// \a NullOutput.
-IntrusiveRefCntPtr<OutputBackend> makeFilteringOutputBackend(
+LLVM_ABI IntrusiveRefCntPtr<OutputBackend> makeFilteringOutputBackend(
     IntrusiveRefCntPtr<OutputBackend> UnderlyingBackend,
     std::function<bool(StringRef, std::optional<OutputConfig>)> Filter);
 
 /// Create a backend that forwards \a OutputBackend::createFile() to both \p
 /// Backend1 and \p Backend2. Writing to such backend will create identical
 /// outputs using two different backends.
-IntrusiveRefCntPtr<OutputBackend>
+LLVM_ABI IntrusiveRefCntPtr<OutputBackend>
 makeMirroringOutputBackend(IntrusiveRefCntPtr<OutputBackend> Backend1,
                            IntrusiveRefCntPtr<OutputBackend> Backend2);
 
 /// A helper class for proxying another backend, with the default
 /// implementation to forward to the underlying backend.
 class ProxyOutputBackend : public OutputBackend {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 protected:
   // Require subclass to implement cloneImpl().

--- a/llvm/include/llvm/Support/VirtualOutputConfig.h
+++ b/llvm/include/llvm/Support/VirtualOutputConfig.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_SUPPORT_VIRTUALOUTPUTCONFIG_H
 #define LLVM_SUPPORT_VIRTUALOUTPUTCONFIG_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class raw_ostream;
@@ -34,7 +36,7 @@ struct EmptyBaseClass {};
 /// configuration flag is either \c true or \c false.
 struct OutputConfig : detail::EmptyBaseClass {
 public:
-  void print(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &OS) const;
   void dump() const;
 
 #define HANDLE_OUTPUT_CONFIG_FLAG(NAME, DEFAULT)                               \
@@ -59,7 +61,7 @@ public:
   /// Updates Text and CRLF flags based on \a sys::fs::OF_Text and \a
   /// sys::fs::OF_CRLF in \p Flags. Rejects CRLF without Text (calling
   /// \a setBinary()).
-  OutputConfig &setOpenFlags(const sys::fs::OpenFlags &Flags);
+  LLVM_ABI_FOR_TEST OutputConfig &setOpenFlags(const sys::fs::OpenFlags &Flags);
 
   constexpr OutputConfig()
       : EmptyBaseClass()
@@ -84,7 +86,8 @@ private:
 
 } // namespace vfs
 
-raw_ostream &operator<<(raw_ostream &OS, vfs::OutputConfig Config);
+LLVM_ABI_FOR_TEST raw_ostream &operator<<(raw_ostream &OS,
+                                          vfs::OutputConfig Config);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/VirtualOutputFile.h
+++ b/llvm/include/llvm/Support/VirtualOutputFile.h
@@ -27,10 +27,10 @@
 namespace llvm::vfs {
 
 class OutputFileImpl : public RTTIExtends<OutputFileImpl, RTTIRoot> {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   ~OutputFileImpl() override = default;
 
   virtual Error keep() = 0;
@@ -40,10 +40,10 @@ public:
 
 class NullOutputFileImpl final
     : public RTTIExtends<NullOutputFileImpl, OutputFileImpl> {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   Error keep() final { return Error::success(); }
   Error discard() final { return Error::success(); }
   raw_pwrite_stream &getOS() final { return OS; }

--- a/llvm/include/llvm/Support/raw_ostream_proxy.h
+++ b/llvm/include/llvm/Support/raw_ostream_proxy.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_RAW_OSTREAM_PROXY_H
 #define LLVM_SUPPORT_RAW_OSTREAM_PROXY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -111,7 +112,7 @@ protected:
 /// Non-owning proxy for a \a raw_ostream. Enables passing a stream into an
 /// API that takes ownership.
 class raw_ostream_proxy : public raw_ostream_proxy_adaptor<> {
-  void anchor() override;
+  LLVM_ABI_FOR_TEST void anchor() override;
 
 public:
   raw_ostream_proxy(raw_ostream &OS) : raw_ostream_proxy_adaptor<>(OS) {}
@@ -120,7 +121,7 @@ public:
 /// Non-owning proxy for a \a raw_pwrite_stream. Enables passing a stream
 /// into an API that takes ownership.
 class raw_pwrite_stream_proxy : public raw_pwrite_stream_proxy_adaptor<> {
-  void anchor() override;
+  LLVM_ABI_FOR_TEST void anchor() override;
 
 public:
   raw_pwrite_stream_proxy(raw_pwrite_stream &OS)

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdaterBulk.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdaterBulk.h
@@ -81,7 +81,7 @@ public:
 
   /// Rewrite all uses and simplify the inserted PHI nodes.
   /// Use this method to preserve behavior when replacing SSAUpdater.
-  void RewriteAndOptimizeAllUses(DominatorTree &DT);
+  LLVM_ABI_FOR_TEST void RewriteAndOptimizeAllUses(DominatorTree &DT);
 };
 
 } // end namespace llvm

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -29,7 +29,7 @@ Expected<std::optional<uint64_t>> getOverriddenMaxMappingSize();
 /// Set MaxMappingSize for ondisk CAS. This function is not thread-safe and
 /// should be set before creaing any ondisk CAS and does not affect CAS already
 /// created. Set value 0 to use default size.
-void setMaxMappingSize(uint64_t Size);
+LLVM_ABI_FOR_TEST void setMaxMappingSize(uint64_t Size);
 
 /// Whether to use a small file mapping for ondisk databases created in \p Path.
 ///

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -588,7 +588,7 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print this VPSingleDefRecipe to dbgs() (for debugging).
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD void dump() const;
 #endif
 };
 
@@ -3506,8 +3506,8 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
-  void print(raw_ostream &O, const Twine &Indent,
-             VPSlotTracker &SlotTracker) const override;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &O, const Twine &Indent,
+                               VPSlotTracker &SlotTracker) const override;
 #endif
 
   /// Returns the scalar type of the induction.
@@ -3606,8 +3606,8 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
-  void print(raw_ostream &O, const Twine &Indent,
-             VPSlotTracker &SlotTracker) const override;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &O, const Twine &Indent,
+                               VPSlotTracker &SlotTracker) const override;
 #endif
 };
 
@@ -4448,10 +4448,10 @@ public:
   void printLiveIns(raw_ostream &O) const;
 
   /// Print this VPlan to \p O.
-  void print(raw_ostream &O) const;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &O) const;
 
   /// Print this VPlan in DOT format to \p O.
-  void printDOT(raw_ostream &O) const;
+  LLVM_ABI_FOR_TEST void printDOT(raw_ostream &O) const;
 
   /// Dump the plan to stderr (for debugging).
   LLVM_DUMP_METHOD void dump() const;
@@ -4459,7 +4459,7 @@ public:
 
   /// Clone the current VPlan, update all VPValues of the new VPlan and cloned
   /// recipes to refer to the clones, and return it.
-  VPlan *duplicate();
+  LLVM_ABI_FOR_TEST VPlan *duplicate();
 
   /// Create a new VPBasicBlock with \p Name and containing \p Recipe if
   /// present. The returned block is owned by the VPlan and deleted once the

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -395,7 +395,7 @@ class VPSlotTracker {
   std::unique_ptr<ModuleSlotTracker> MST;
 
   void assignName(const VPValue *V);
-  void assignNames(const VPlan &Plan);
+  LLVM_ABI_FOR_TEST void assignNames(const VPlan &Plan);
   void assignNames(const VPBasicBlock *VPBB);
   std::string getName(const Value *V);
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -31,8 +31,8 @@ class VPBuilder;
 class VPRecipeBuilder;
 struct VFRange;
 
-extern cl::opt<bool> VerifyEachVPlan;
-extern cl::opt<bool> EnableWideActiveLaneMask;
+LLVM_ABI_FOR_TEST extern cl::opt<bool> VerifyEachVPlan;
+LLVM_ABI_FOR_TEST extern cl::opt<bool> EnableWideActiveLaneMask;
 
 struct VPlanTransforms {
   /// Helper to run a VPlan transform \p Transform on \p VPlan, forwarding extra
@@ -181,7 +181,7 @@ struct VPlanTransforms {
   /// Apply VPlan-to-VPlan optimizations to \p Plan, including induction recipe
   /// optimizations, dead recipe removal, replicate region optimizations and
   /// block merging.
-  static void optimize(VPlan &Plan);
+  LLVM_ABI_FOR_TEST static void optimize(VPlan &Plan);
 
   /// Wrap predicated VPReplicateRecipes with a mask operand in an if-then
   /// region block and remove the mask operand. Optimize the created regions by

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -10,6 +10,7 @@
 #define LLVM_TRANSFORMS_VECTORIZE_VPLANUTILS_H
 
 #include "VPlan.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class ScalarEvolution;
@@ -67,6 +68,7 @@ unsigned getVFScaleFactor(VPRecipeBase *R);
 /// generating the values for the comparison. The recipes are stored in
 /// \p Recipes, and recipes forming an address for a load are also added to
 /// \p GEPs.
+LLVM_ABI_FOR_TEST
 std::optional<VPValue *>
 getRecipesForUncountableExit(VPlan &Plan,
                              SmallVectorImpl<VPRecipeBase *> &Recipes,

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -199,7 +199,8 @@ public:
 typedef DenseMap<Value *, VPValue *> Value2VPValueTy;
 typedef DenseMap<VPValue *, Value *> VPValue2ValueTy;
 
-raw_ostream &operator<<(raw_ostream &OS, const VPRecipeBase &R);
+LLVM_ABI_FOR_TEST raw_ostream &operator<<(raw_ostream &OS,
+                                          const VPRecipeBase &R);
 
 /// This class augments VPValue with operands which provide the inverse def-use
 /// edges from VPValue's users to their defs.
@@ -437,7 +438,7 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Dump the VPDef to stderr (for debugging).
-  void dump() const;
+  LLVM_ABI_FOR_TEST void dump() const;
 
   /// Each concrete VPDef prints itself.
   virtual void print(raw_ostream &O, const Twine &Indent,


### PR DESCRIPTION
This patch updates various LLVM headers to properly add the `LLVM_ABI` and `LLVM_ABI_FOR_TEST` annotations to build LLVM as a DLL on Windows.

This effort is tracked in #109483.