### PR TITLE
[libc] move abs_timesout and monotonicity out of linux dir

### DIFF
--- a/libc/hdr/errno_macros.h
+++ b/libc/hdr/errno_macros.h
@@ -15,7 +15,7 @@
 #include <linux/errno.h>
 
 #include "include/llvm-libc-macros/error-number-macros.h"
-#elif __APPLE__
+#elif defined(__APPLE__)
 #include <sys/errno.h>
 #else // __APPLE__
 #include "include/llvm-libc-macros/generic-error-number-macros.h"

--- a/libc/hdr/errno_macros.h
+++ b/libc/hdr/errno_macros.h
@@ -15,7 +15,9 @@
 #include <linux/errno.h>
 
 #include "include/llvm-libc-macros/error-number-macros.h"
-#else // __linux__
+#elif __APPLE__
+#include <sys/errno.h>
+#else // __APPLE__
 #include "include/llvm-libc-macros/generic-error-number-macros.h"
 #endif
 

--- a/libc/include/errno.h.def
+++ b/libc/include/errno.h.def
@@ -21,7 +21,7 @@
 
 #include "llvm-libc-macros/linux/error-number-macros.h"
 
-#elif __APPLE__
+#elif defined(__APPLE__)
 
 #include <sys/errno.h>
 

--- a/libc/include/errno.h.def
+++ b/libc/include/errno.h.def
@@ -21,8 +21,14 @@
 
 #include "llvm-libc-macros/linux/error-number-macros.h"
 
-#else // __linux__
+#elif __APPLE__
+
+#include <sys/errno.h>
+
+#else // __APPLE__
+
 #include "llvm-libc-macros/generic-error-number-macros.h"
+
 #endif
 
 __BEGIN_C_DECLS

--- a/libc/src/__support/threads/linux/CMakeLists.txt
+++ b/libc/src/__support/threads/linux/CMakeLists.txt
@@ -21,7 +21,7 @@ add_header_library(
     libc.src.__support.CPP.atomic
     libc.src.__support.CPP.limits
     libc.src.__support.CPP.optional
-    libc.src.__support.time.linux.abs_timeout
+    libc.src.__support.time.abs_timeout
 )
 
 set(monotonicity_flags)
@@ -38,8 +38,8 @@ add_header_library(
   DEPENDS
     .futex_utils
     libc.src.__support.threads.sleep
-    libc.src.__support.time.linux.abs_timeout
-    libc.src.__support.time.linux.monotonicity
+    libc.src.__support.time.abs_timeout
+    libc.src.__support.time.monotonicity
     libc.src.__support.CPP.optional
     libc.hdr.types.pid_t
   COMPILE_OPTIONS

--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -16,7 +16,7 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/linux/futex_word.h"
-#include "src/__support/time/linux/abs_timeout.h"
+#include "src/__support/time/abs_timeout.h"
 #include <linux/errno.h>
 #include <linux/futex.h>
 

--- a/libc/src/__support/threads/linux/raw_mutex.h
+++ b/libc/src/__support/threads/linux/raw_mutex.h
@@ -24,7 +24,7 @@
 #endif
 
 #if LIBC_COPT_TIMEOUT_ENSURE_MONOTONICITY
-#include "src/__support/time/linux/monotonicity.h"
+#include "src/__support/time/monotonicity.h"
 #endif
 
 #ifndef LIBC_COPT_RAW_MUTEX_DEFAULT_SPIN_COUNT

--- a/libc/src/__support/threads/linux/raw_mutex.h
+++ b/libc/src/__support/threads/linux/raw_mutex.h
@@ -17,7 +17,7 @@
 #include "src/__support/threads/linux/futex_utils.h"
 #include "src/__support/threads/linux/futex_word.h"
 #include "src/__support/threads/sleep.h"
-#include "src/__support/time/linux/abs_timeout.h"
+#include "src/__support/time/abs_timeout.h"
 
 #ifndef LIBC_COPT_TIMEOUT_ENSURE_MONOTONICITY
 #define LIBC_COPT_TIMEOUT_ENSURE_MONOTONICITY 1

--- a/libc/src/__support/threads/linux/rwlock.h
+++ b/libc/src/__support/threads/linux/rwlock.h
@@ -35,7 +35,7 @@
 #endif
 
 #if LIBC_COPT_TIMEOUT_ENSURE_MONOTONICITY
-#include "src/__support/time/linux/monotonicity.h"
+#include "src/__support/time/monotonicity.h"
 #endif
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/__support/time/CMakeLists.txt
+++ b/libc/src/__support/time/CMakeLists.txt
@@ -37,3 +37,32 @@ if(TARGET libc.src.__support.time.${LIBC_TARGET_OS}.clock_settime)
       libc.src.__support.time.${LIBC_TARGET_OS}.clock_settime
   )
 endif()
+
+add_header_library(
+  abs_timeout
+  HDRS
+    abs_timeout.h
+  DEPENDS
+    libc.hdr.types.struct_timespec
+    libc.src.__support.time.units
+    libc.src.__support.CPP.expected
+)
+
+add_header_library(
+  clock_conversion
+  HDRS
+    clock_conversion.h
+  DEPENDS
+    .clock_gettime
+    libc.src.__support.time.units
+)
+
+add_header_library(
+  monotonicity
+  HDRS
+    monotonicity.h
+  DEPENDS
+    .clock_conversion
+    .abs_timeout
+    libc.hdr.time_macros
+)

--- a/libc/src/__support/time/CMakeLists.txt
+++ b/libc/src/__support/time/CMakeLists.txt
@@ -49,15 +49,6 @@ add_header_library(
 )
 
 add_header_library(
-  clock_conversion
-  HDRS
-    clock_conversion.h
-  DEPENDS
-    .clock_gettime
-    libc.src.__support.time.units
-)
-
-add_header_library(
   monotonicity
   HDRS
     monotonicity.h

--- a/libc/src/__support/time/abs_timeout.h
+++ b/libc/src/__support/time/abs_timeout.h
@@ -1,13 +1,13 @@
-//===--- Linux absolute timeout ---------------------------------*- C++ -*-===//
+//===--- absolute timeout ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_ABS_TIMEOUT_H
-#define LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_ABS_TIMEOUT_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_TIME_ABS_TIMEOUT_H
+#define LLVM_LIBC_SRC___SUPPORT_TIME_ABS_TIMEOUT_H
 
 #include "hdr/time_macros.h"
 #include "hdr/types/struct_timespec.h"
@@ -47,4 +47,4 @@ public:
 } // namespace internal
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_ABS_TIMEOUT_H
+#endif // LLVM_LIBC_SRC___SUPPORT_TIME_ABS_TIMEOUT_H

--- a/libc/src/__support/time/abs_timeout.h
+++ b/libc/src/__support/time/abs_timeout.h
@@ -1,10 +1,10 @@
-//===--- absolute timeout ---------------------------------*- C++ -*-===//
+//===--- absolute timeout ---------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_TIME_ABS_TIMEOUT_H
 #define LLVM_LIBC_SRC___SUPPORT_TIME_ABS_TIMEOUT_H

--- a/libc/src/__support/time/linux/CMakeLists.txt
+++ b/libc/src/__support/time/linux/CMakeLists.txt
@@ -28,24 +28,3 @@ add_object_library(
     libc.src.__support.error_or
     libc.src.__support.OSUtil.osutil
 )
-
-
-add_header_library(
-  abs_timeout
-  HDRS
-    abs_timeout.h
-  DEPENDS
-    libc.hdr.types.struct_timespec
-    libc.src.__support.time.units
-    libc.src.__support.CPP.expected
-)
-
-add_header_library(
-  monotonicity
-  HDRS
-    monotonicity.h
-  DEPENDS
-    .abs_timeout
-    libc.hdr.time_macros
-    libc.src.__support.time.clock_conversion
-)

--- a/libc/src/__support/time/monotonicity.h
+++ b/libc/src/__support/time/monotonicity.h
@@ -1,19 +1,19 @@
-//===--- timeout linux implementation ---------------------------*- C++ -*-===//
+//===--- timeout implementation ---------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_MONOTONICITY_H
-#define LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_MONOTONICITY_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_TIME_MONOTONICITY_H
+#define LLVM_LIBC_SRC___SUPPORT_TIME_MONOTONICITY_H
 
 #include "hdr/time_macros.h"
 #include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/time/abs_timeout.h"
 #include "src/__support/time/clock_conversion.h"
-#include "src/__support/time/linux/abs_timeout.h"
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 // This function is separated from abs_timeout.
@@ -41,4 +41,4 @@ LIBC_INLINE void ensure_monotonicity(AbsTimeout &timeout) {
 } // namespace internal
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_MONOTONICITY_H
+#endif // LLVM_LIBC_SRC___SUPPORT_TIME_MONOTONICITY_H

--- a/libc/src/__support/time/monotonicity.h
+++ b/libc/src/__support/time/monotonicity.h
@@ -1,10 +1,10 @@
-//===--- timeout implementation ---------------------------*- C++ -*-===//
+//===--- timeout implementation ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_TIME_MONOTONICITY_H
 #define LLVM_LIBC_SRC___SUPPORT_TIME_MONOTONICITY_H

--- a/libc/src/pthread/pthread_rwlock_clockwrlock.cpp
+++ b/libc/src/pthread/pthread_rwlock_clockwrlock.cpp
@@ -12,7 +12,7 @@
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/linux/rwlock.h"
-#include "src/__support/time/linux/abs_timeout.h"
+#include "src/__support/time/abs_timeout.h"
 
 #include <pthread.h>
 

--- a/libc/src/pthread/pthread_rwlock_timedrdlock.cpp
+++ b/libc/src/pthread/pthread_rwlock_timedrdlock.cpp
@@ -13,7 +13,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
 #include "src/__support/threads/linux/rwlock.h"
-#include "src/__support/time/linux/abs_timeout.h"
+#include "src/__support/time/abs_timeout.h"
 
 #include <pthread.h>
 

--- a/libc/src/pthread/pthread_rwlock_timedwrlock.cpp
+++ b/libc/src/pthread/pthread_rwlock_timedwrlock.cpp
@@ -13,7 +13,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
 #include "src/__support/threads/linux/rwlock.h"
-#include "src/__support/time/linux/abs_timeout.h"
+#include "src/__support/time/abs_timeout.h"
 
 #include <pthread.h>
 

--- a/libc/test/src/__support/time/linux/CMakeLists.txt
+++ b/libc/test/src/__support/time/linux/CMakeLists.txt
@@ -3,7 +3,7 @@ add_libc_test(
   SUITE libc-support-time-tests
   SRCS timeout_test.cpp
   DEPENDS
-    libc.src.__support.time.linux.abs_timeout
-    libc.src.__support.time.linux.monotonicity
+    libc.src.__support.time.abs_timeout
+    libc.src.__support.time.monotonicity
     libc.src.__support.CPP.expected
 )

--- a/libc/test/src/__support/time/linux/timeout_test.cpp
+++ b/libc/test/src/__support/time/linux/timeout_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/CPP/expected.h"
-#include "src/__support/time/linux/abs_timeout.h"
-#include "src/__support/time/linux/monotonicity.h"
+#include "src/__support/time/abs_timeout.h"
+#include "src/__support/time/monotonicity.h"
 #include "test/UnitTest/Test.h"
 
 template <class T, class E>


### PR DESCRIPTION
This patch moves abs_timeout and monotonicity out of the linux dir into common. Both of these functions depend on clock_gettime which is the actual os-dependent component. As other features in `__support/threads` may want to use these, it's better to share it in common.
