### PR TITLE
[lldb][ClangExpressionParser] Clean up ownership of members in ClangDiagnosticManagerAdapter

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -171,9 +171,9 @@ public:
       : m_options(opts), m_filename(filename) {
     m_options.ShowPresumedLoc = true;
     m_options.ShowLevel = false;
-    m_os = std::make_shared<llvm::raw_string_ostream>(m_output);
+    m_os = std::make_unique<llvm::raw_string_ostream>(m_output);
     m_passthrough =
-        std::make_shared<clang::TextDiagnosticPrinter>(*m_os, m_options);
+        std::make_unique<clang::TextDiagnosticPrinter>(*m_os, m_options);
   }
 
   void ResetManager(DiagnosticManager *manager = nullptr) {
@@ -315,11 +315,11 @@ public:
 private:
   DiagnosticManager *m_manager = nullptr;
   DiagnosticOptions m_options;
-  std::shared_ptr<clang::TextDiagnosticPrinter> m_passthrough;
-  /// Output stream of m_passthrough.
-  std::shared_ptr<llvm::raw_string_ostream> m_os;
   /// Output string filled by m_os.
   std::string m_output;
+  /// Output stream of m_passthrough.
+  std::unique_ptr<llvm::raw_string_ostream> m_os;
+  std::unique_ptr<clang::TextDiagnosticPrinter> m_passthrough;
   StringRef m_filename;
 };
 


### PR DESCRIPTION
This aligns `ClangDiagnosticManagerAdapter` with how we set up the diagnostics in `ClangModulesDeclVendor`. We fixed lifetime issues around the same kind of setup here: https://github.com/llvm/llvm-project/pull/167724

This class didn't suffer from the same lifetime issue because it used `shared_ptr`s. So the stream wasn't freed before `~TextDiagnosticPrinter` accessing it. But that begged the question of why these are `shared_ptr`s in the first place. This patch makes these `unique_ptr`s and fixes the destruction order that would now be an issue.