### PR TITLE
[libunwind] Fix build error because of wrong register size

### DIFF
--- a/libunwind/src/UnwindLevel1.c
+++ b/libunwind/src/UnwindLevel1.c
@@ -82,7 +82,7 @@
     void *shstkRegContext = __libunwind_shstk_get_registers((cursor));         \
     void *shstkJumpAddress = __libunwind_shstk_get_jump_target();              \
     __asm__ volatile("mov x0, %0\n\t"                                          \
-                     "mov x1, wzr\n\t"                                         \
+                     "mov x1, #0\n\t"                                         \
                      "br %1\n\t"                                               \
                      :                                                         \
                      : "r"(shstkRegContext), "r"(shstkJumpAddress)             \


### PR DESCRIPTION
This patch should fix an libunwind build failure that happens on Chromium's Android bots:

https://github.com/llvm/llvm-project/pull/165066#issuecomment-3521706265

The issue is that we're using the `wzr` register to move the value 0 in x1, but this is the 32-bit register.

To prevent this issue, we use an immediate instead of the zero registers.