### PR TITLE
[clang][BPF] Turn on AddressSanitizer pass

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1636,6 +1636,8 @@ SanitizerMask ToolChain::getSupportedSanitizers() const {
     Res |= SanitizerKind::ShadowCallStack;
   if (getTriple().isAArch64(64))
     Res |= SanitizerKind::MemTag;
+  if (getTriple().isBPF())
+    Res |= SanitizerKind::KernelAddress;
   return Res;
 }
 


### PR DESCRIPTION
The BPF LLVM target currently doesn't support turning on the AddressSanitizer pass, either for userspace ASAN or KASAN. Enable the KASAN option for the BPF target in anticipation of a KASAN implementation for BPF.