### PR TITLE
[RISCV][GISel] Fallback to SelectionDAG for vleff intrinsics.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -25418,8 +25418,10 @@ bool RISCVTargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
   if (auto *II = dyn_cast<IntrinsicInst>(&Inst)) {
     // Mark RVV intrinsic as supported.
     if (RISCVVIntrinsicsTable::getRISCVVIntrinsicInfo(II->getIntrinsicID())) {
-      // GISel doesn't support tuple types yet.
-      if (Inst.getType()->isRISCVVectorTupleTy())
+      // GISel doesn't support tuple types yet. It also doesn't suport returning
+      // a struct containing a scalable vector like vleff.
+      if (Inst.getType()->isRISCVVectorTupleTy() ||
+          Inst.getType()->isStructTy())
         return true;
 
       for (unsigned i = 0; i < II->arg_size(); ++i)

--- a/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-vleff.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-vleff.ll
@@ -1,0 +1,15 @@
+; RUN: not --crash llc -mtriple=riscv64 -mattr=+v -global-isel -stop-after=irtranslator \
+; RUN:   -verify-machineinstrs < %s 2>&1 | FileCheck %s
+
+; Intrinsics returning structs and extractvalue of scalable vector are not
+; supported yet.
+define <vscale x 1 x i64> @intrinsic_vleff_v_nxv1i64_nxv1i64(ptr %0, i64 %1, ptr %2) nounwind {
+entry:
+  %a = call { <vscale x 1 x i64>, i64 } @llvm.riscv.vleff.nxv1i64(<vscale x 1 x i64> poison, ptr %0, i64 %1)
+  %b = extractvalue { <vscale x 1 x i64>, i64 } %a, 0
+  %c = extractvalue { <vscale x 1 x i64>, i64 } %a, 1
+  store i64 %c, ptr %2
+  ret <vscale x 1 x i64> %b
+}
+
+; CHECK: LLVM ERROR: unable to translate instruction: call llvm.riscv.vleff.nxv1i64.i64.p0 (in function: intrinsic_vleff_v_nxv1i64_nxv1i64)

--- a/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-vleff.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-vleff.ll
@@ -1,5 +1,4 @@
-; RUN: not --crash llc -mtriple=riscv64 -mattr=+v -global-isel -stop-after=irtranslator \
-; RUN:   -verify-machineinstrs < %s 2>&1 | FileCheck %s
+; RUN: not --crash llc -global-isel -mtriple=riscv64 -mattr=+v -filetype=null %s 2>&1 | FileCheck %s
 
 ; Intrinsics returning structs and extractvalue of scalable vector are not
 ; supported yet.


### PR DESCRIPTION
Fixes #167618

Supporting this in GISel requires multiple changes to IRTranslator to support aggregate returns containing scalable vectors and non-scalable types. Falling back is the quickest way to fix the crash.