### PR TITLE
[libcxx] Fix xsgetn in basic_filebuf

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -310,13 +310,19 @@ protected:
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL streamsize xsgetn(char_type* __str, streamsize __len) override {
     if (__always_noconv_) {
-      const streamsize __n = std::min(this->egptr() - this->gptr(), __len);
+      const streamsize __n = std::min( this->egptr() - this->gptr(), __len);
       if (__n != 0) {
         traits_type::copy(__str, this->gptr(), __n);
         this->__gbump_ptrdiff(__n);
       }
-      if (__len - __n >= this->egptr() - this->eback())
-        return std::fread(__str + __n, sizeof(char_type), __len - __n, __file_);
+      const streamsize __remainder = __len - __n;
+      const streamsize __buffer_space = this->egptr() - this->eback();
+
+      if (__remainder >= __buffer_space)
+        return std::fread(__str + __n, sizeof(char_type), __remainder, __file_) + __n;
+      else if( __remainder > 0)
+        return basic_streambuf<_CharT, _Traits>::xsgetn(__str + __n, __remainder) + __n;
+      return __n;
     }
     return basic_streambuf<_CharT, _Traits>::xsgetn(__str, __len);
   }

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -310,17 +310,17 @@ protected:
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL streamsize xsgetn(char_type* __str, streamsize __len) override {
     if (__always_noconv_) {
-      const streamsize __n = std::min( this->egptr() - this->gptr(), __len);
+      const streamsize __n = std::min(this->egptr() - this->gptr(), __len);
       if (__n != 0) {
         traits_type::copy(__str, this->gptr(), __n);
         this->__gbump_ptrdiff(__n);
       }
-      const streamsize __remainder = __len - __n;
+      const streamsize __remainder    = __len - __n;
       const streamsize __buffer_space = this->egptr() - this->eback();
 
       if (__remainder >= __buffer_space)
         return std::fread(__str + __n, sizeof(char_type), __remainder, __file_) + __n;
-      else if( __remainder > 0)
+      else if (__remainder > 0)
         return basic_streambuf<_CharT, _Traits>::xsgetn(__str + __n, __remainder) + __n;
       return __n;
     }


### PR DESCRIPTION
The optimized version of xsgetn for basic_filebuf added in #165223 has
an issue where if the reads come from both the buffer and the
filesystem it returns the wrong number of characters. This patch should
address the issue.
