### PR TITLE
[AMDGPU] Fix Inefficient S_CSELECT_B64 Sequence

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -1389,10 +1389,10 @@ bool SIPeepholeSDWA::strengthReduceCSelect64(MachineFunction &MF) {
 
       BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(AMDGPU::S_CSELECT_B32),
               MustBeVREADFIRSTLANE->getOperand(0).getReg())
+          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx + 2).getImm())
           .addImm(
               MustBeVCNDMASK->getOperand((CSelectZeroOpIdx == 1 ? 2 : 1) + 2)
                   .getImm())
-          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx + 2).getImm())
           .addReg(AMDGPU::SCC, RegState::Implicit);
 
       MustBeVREADFIRSTLANE->eraseFromParent();

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -24,6 +24,7 @@
 #include "GCNSubtarget.h"
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include <optional>
@@ -66,6 +67,7 @@ private:
   MachineInstr *createSDWAVersion(MachineInstr &MI);
   bool convertToSDWA(MachineInstr &MI, const SDWAOperandsVector &SDWAOperands);
   void legalizeScalarOperands(MachineInstr &MI, const GCNSubtarget &ST) const;
+  bool strengthReduceCSelect64(MachineFunction &MF);
 
 public:
   bool run(MachineFunction &MF);
@@ -1359,6 +1361,40 @@ void SIPeepholeSDWA::legalizeScalarOperands(MachineInstr &MI,
   }
 }
 
+bool SIPeepholeSDWA::strengthReduceCSelect64(MachineFunction &MF) {
+  bool Changed = false;
+
+  for (MachineBasicBlock &MBB : MF)
+    for (MachineInstr &MI : make_early_inc_range(MBB)) {
+      if (MI.getOpcode() != AMDGPU::S_CSELECT_B64)
+        continue;
+
+      Register Reg = MI.getOperand(0).getReg();
+      MachineInstr *MustBeVCNDMASK = MRI->getOneNonDBGUser(Reg);
+      if (!MustBeVCNDMASK ||
+          MustBeVCNDMASK->getOpcode() != AMDGPU::V_CNDMASK_B32_e64 ||
+          !MustBeVCNDMASK->getOperand(1).isImm() ||
+          !MustBeVCNDMASK->getOperand(2).isImm())
+        continue;
+
+      MachineInstr *MustBeVREADFIRSTLANE =
+          MRI->getOneNonDBGUser(MustBeVCNDMASK->getOperand(0).getReg());
+      if (!MustBeVREADFIRSTLANE ||
+          MustBeVREADFIRSTLANE->getOpcode() != AMDGPU::V_READFIRSTLANE_B32)
+        continue;
+
+      BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(AMDGPU::S_CSELECT_B32),
+              MustBeVREADFIRSTLANE->getOperand(0).getReg())
+          .addImm(MI.getOperand(1).getImm())
+          .addImm(MI.getOperand(2).getImm())
+          .addReg(AMDGPU::SCC, RegState::Implicit);
+
+      MustBeVREADFIRSTLANE->eraseFromParent();
+    }
+
+  return Changed;
+}
+
 bool SIPeepholeSDWALegacy::runOnMachineFunction(MachineFunction &MF) {
   if (skipFunction(MF.getFunction()))
     return false;
@@ -1432,6 +1468,9 @@ bool SIPeepholeSDWA::run(MachineFunction &MF) {
         legalizeScalarOperands(*ConvertedInstructions.pop_back_val(), ST);
     } while (Changed);
   }
+
+  // Other target-specific SSA-form peephole optimizations
+  Ret |= strengthReduceCSelect64(MF);
 
   return Ret;
 }

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -1366,7 +1366,9 @@ bool SIPeepholeSDWA::strengthReduceCSelect64(MachineFunction &MF) {
 
   for (MachineBasicBlock &MBB : MF)
     for (MachineInstr &MI : make_early_inc_range(MBB)) {
-      if (MI.getOpcode() != AMDGPU::S_CSELECT_B64)
+      if (MI.getOpcode() != AMDGPU::S_CSELECT_B64 ||
+          !MI.getOperand(1).isImm() || !MI.getOperand(2).isImm() ||
+          (MI.getOperand(1).getImm() != 0 && MI.getOperand(2).getImm() != 0))
         continue;
 
       Register Reg = MI.getOperand(0).getReg();
@@ -1383,10 +1385,13 @@ bool SIPeepholeSDWA::strengthReduceCSelect64(MachineFunction &MF) {
           MustBeVREADFIRSTLANE->getOpcode() != AMDGPU::V_READFIRSTLANE_B32)
         continue;
 
+      unsigned CSelectZeroOpIdx = MI.getOperand(1).getImm() ? 2 : 1;
+
       BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(AMDGPU::S_CSELECT_B32),
               MustBeVREADFIRSTLANE->getOperand(0).getReg())
-          .addImm(MI.getOperand(1).getImm())
-          .addImm(MI.getOperand(2).getImm())
+          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx == 1 ? 2 : 1)
+                      .getImm())
+          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx).getImm())
           .addReg(AMDGPU::SCC, RegState::Implicit);
 
       MustBeVREADFIRSTLANE->eraseFromParent();

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -1368,6 +1368,7 @@ bool SIPeepholeSDWA::strengthReduceCSelect64(MachineFunction &MF) {
     for (MachineInstr &MI : make_early_inc_range(MBB)) {
       if (MI.getOpcode() != AMDGPU::S_CSELECT_B64 ||
           !MI.getOperand(1).isImm() || !MI.getOperand(2).isImm() ||
+          (MI.getOperand(1).getImm() != 0 && MI.getOperand(1).getImm() != -1) ||
           (MI.getOperand(1).getImm() != 0 && MI.getOperand(2).getImm() != 0))
         continue;
 

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -1389,9 +1389,10 @@ bool SIPeepholeSDWA::strengthReduceCSelect64(MachineFunction &MF) {
 
       BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(AMDGPU::S_CSELECT_B32),
               MustBeVREADFIRSTLANE->getOperand(0).getReg())
-          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx == 1 ? 2 : 1)
-                      .getImm())
-          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx).getImm())
+          .addImm(
+              MustBeVCNDMASK->getOperand((CSelectZeroOpIdx == 1 ? 2 : 1) + 2)
+                  .getImm())
+          .addImm(MustBeVCNDMASK->getOperand(CSelectZeroOpIdx + 2).getImm())
           .addReg(AMDGPU::SCC, RegState::Implicit);
 
       MustBeVREADFIRSTLANE->eraseFromParent();


### PR DESCRIPTION
This PR contains a peephole transformation to change this pattern:

s_cselect_b64 s[0:1], X!=0, 0
v_cndmask_b32_e64 v0, Z, Y, s[0:1]
v_readfirstlane_b32 s0, v0

To:

s_cselect_b32 s0, Y, Z
