### PR TITLE
[flang][runtime] Advance output record in specific case

### DIFF
--- a/flang-rt/include/flang-rt/runtime/connection.h
+++ b/flang-rt/include/flang-rt/runtime/connection.h
@@ -66,6 +66,14 @@ struct ConnectionState : public ConnectionAttributes {
   RT_API_ATTRS bool NeedAdvance(std::size_t width) const {
     return positionInRecord > 0 && width > RemainingSpaceInRecord();
   }
+  RT_API_ATTRS bool NeedHardAdvance(std::size_t width) const {
+    auto recl{recordLength};
+    if (!recl) {
+      recl = openRecl;
+    }
+    return recl && positionInRecord > 0 &&
+        static_cast<std::int64_t>(positionInRecord + width) > *recl;
+  }
   RT_API_ATTRS void HandleAbsolutePosition(std::int64_t n) {
     positionInRecord = (n < 0 ? 0 : n) + leftTabLimit.value_or(0);
   }

--- a/flang-rt/include/flang-rt/runtime/format-implementation.h
+++ b/flang-rt/include/flang-rt/runtime/format-implementation.h
@@ -430,6 +430,9 @@ RT_API_ATTRS int FormatControl<CONTEXT>::CueUpNextDataEdit(
       if constexpr (std::is_base_of_v<InputStatementState, CONTEXT>) {
         context.HandleRelativePosition(chars);
       } else {
+        if (context.GetConnectionState().NeedHardAdvance(chars)) {
+          context.AdvanceRecord();
+        }
         EmitAscii(context, format_ + start, chars);
       }
     } else if (ch == 'H') {
@@ -442,6 +445,9 @@ RT_API_ATTRS int FormatControl<CONTEXT>::CueUpNextDataEdit(
       if constexpr (std::is_base_of_v<InputStatementState, CONTEXT>) {
         context.HandleRelativePosition(static_cast<std::size_t>(*repeat));
       } else {
+        if (context.GetConnectionState().NeedHardAdvance(*repeat)) {
+          context.AdvanceRecord();
+        }
         EmitAscii(
             context, format_ + offset_, static_cast<std::size_t>(*repeat));
       }
@@ -487,6 +493,9 @@ RT_API_ATTRS int FormatControl<CONTEXT>::CueUpNextDataEdit(
     } else if (ch == '\t' || ch == '\v') {
       // Tabs (extension)
       // TODO: any other raw characters?
+      if (context.GetConnectionState().NeedHardAdvance(1)) {
+        context.AdvanceRecord();
+      }
       EmitAscii(context, format_ + offset_ - 1, 1);
     } else {
       ReportBadFormat(

--- a/flang-rt/include/flang-rt/runtime/io-error.h
+++ b/flang-rt/include/flang-rt/runtime/io-error.h
@@ -15,9 +15,9 @@
 #ifndef FLANG_RT_RUNTIME_IO_ERROR_H_
 #define FLANG_RT_RUNTIME_IO_ERROR_H_
 
+#include "iostat.h"
 #include "memory.h"
 #include "terminator.h"
-#include "flang/Runtime/iostat.h"
 #include <cinttypes>
 
 namespace Fortran::runtime::io {

--- a/flang-rt/include/flang-rt/runtime/iostat.h
+++ b/flang-rt/include/flang-rt/runtime/iostat.h
@@ -1,4 +1,4 @@
-//===-- include/flang/Runtime/iostat.h --------------------------*- C++ -*-===//
+//===-- include/flang-rt/runtime/iostat.h -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang-rt/lib/runtime/iostat.cpp
+++ b/flang-rt/lib/runtime/iostat.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "flang/Runtime/iostat.h"
+#include "flang-rt/runtime/iostat.h"
 
 namespace Fortran::runtime::io {
 RT_OFFLOAD_API_GROUP_BEGIN

--- a/flang/include/flang/Runtime/iostat-consts.h
+++ b/flang/include/flang/Runtime/iostat-consts.h
@@ -9,7 +9,6 @@
 #ifndef FORTRAN_RUNTIME_IOSTAT_CONSTS_H_
 #define FORTRAN_RUNTIME_IOSTAT_CONSTS_H_
 
-#include "flang/Common/api-attrs.h"
 #include "flang/Runtime/magic-numbers.h"
 
 namespace Fortran::runtime::io {


### PR DESCRIPTION
When a formatted WRITE takes place in a defined output subroutine called from a context in which record advancement is allowed, such as NAMELIST, the char-string-edit-descs in the format can trigger record advancement.

Also clean up confusing messiness lingering from the separation of iostat.h two headers in flang/.../Runtime.  iostat.h didn't need to be put into flang/.../Runtime since it's included only by flang-rt, and iostat-consts.h doesn't need one of its includes.

Fixes https://github.com/llvm/llvm-project/issues/167757.