### PR TITLE
[lldb][NFC] Mark ValueObject library with NO_PLUGIN_DEPENDENCIES

### DIFF
--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -58,6 +58,8 @@ add_lldb_library(lldbCommands NO_PLUGIN_DEPENDENCIES
     lldbUtility
     lldbValueObject
     lldbVersion
+  CLANG_LIBS
+    clangFrontend
   )
 
 add_dependencies(lldbCommands LLDBOptionsGen)

--- a/lldb/source/ValueObject/CMakeLists.txt
+++ b/lldb/source/ValueObject/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_lldb_library(lldbValueObject
+add_lldb_library(lldbValueObject NO_PLUGIN_DEPENDENCIES
   DILAST.cpp
   DILEval.cpp
   DILLexer.cpp
@@ -34,6 +34,4 @@ add_lldb_library(lldbValueObject
     lldbSymbol
     lldbTarget
     lldbUtility
-    lldbPluginCPlusPlusLanguage
-    lldbPluginObjCLanguage
   )


### PR DESCRIPTION
The ValueObject library doesn't actually depend on any plugins currently, but it links against the C++ and ObjC language plugins. I removed those and added NO_PLUGIN_DEPENDENCIES.

However, the build failed initally because the Commands library depends on clangFrontend and it was previously getting it transitively through ValueObject -> C++/ObjC Language -> clangFrontend. This makes the dependency more explicit.