### PR TITLE
[Flang][OpenMP] Fix defaultmap(none) being overly aggressive with symbol checks

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -3070,8 +3070,13 @@ void OmpAttributeVisitor::Post(const parser::Name &name) {
       // place for the types specified.
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         // If the variable has declare target applied to it (enter or link) it
-        // is exempt from defaultmap(none) restrictions
-        if (!symbol->GetUltimate().test(Symbol::Flag::OmpDeclareTarget)) {
+        // is exempt from defaultmap(none) restrictions.
+        // We also exempt procedures and named constants from defaultmap(none)
+        // checking.
+        if (!symbol->GetUltimate().test(Symbol::Flag::OmpDeclareTarget) &&
+            !(IsProcedure(*symbol) &&
+                !semantics::IsProcedurePointer(*symbol)) &&
+            !IsNamedConstant(*symbol)) {
           auto &dMap = GetContext().defaultMap;
           for (auto defaults : dMap) {
             if (defaults.second ==


### PR DESCRIPTION
Currently we're picking up and complaining about builtin (and procedure) symbols like null() when defaultmap(none) is set, so I've relaxed the restriction a bit to allow for procedures and named constants to bypass the restriction. It might be the case that we want to tighten it up again in certain aspects in the future.