### PR TITLE
[MLIR][LLVM] Debug info: import debug records directly

### DIFF
--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -282,8 +282,7 @@ public:
   /// after the function conversion has finished.
   void addDebugIntrinsic(llvm::CallInst *intrinsic);
 
-  /// Adds a debug intrinsics to the list of intrinsics that should be converted
-  /// after the function conversion has finished.
+  /// Similar to `addDebugIntrinsic`, but for debug records.
   void addDebugRecord(llvm::DbgRecord *dr);
 
   /// Converts the LLVM values for an intrinsic to mixed MLIR values and
@@ -344,22 +343,25 @@ private:
   /// Converts all debug intrinsics in `debugIntrinsics`. Assumes that the
   /// function containing the intrinsics has been fully converted to MLIR.
   LogicalResult processDebugIntrinsics();
-  /// Converts all debug intrinsics in `debugIntrinsics`. Assumes that the
-  /// function containing the intrinsics has been fully converted to MLIR.
+  /// Converts all debug records in `debugRecords`. Assumes that the
+  /// function containing the record has been fully converted to MLIR.
   LogicalResult processDebugRecords();
   /// Converts a single debug intrinsic.
   LogicalResult processDebugIntrinsic(llvm::DbgVariableIntrinsic *dbgIntr,
                                       DominanceInfo &domInfo);
-  /// Converts a single debug intrinsic.
+  /// Converts a single debug record.
   LogicalResult processDebugRecord(llvm::DbgRecord &dr, DominanceInfo &domInfo);
-  /// YYY
-  void processDebugVariableAndExpression(
+  /// Process arguments for declare/value operation insertion. `localVarAttr`
+  /// and `localExprAttr` are the attained attributes after importing the debug
+  /// variable and expressions. This also sets the builder insertion point to be
+  /// used by these operations.
+  void processDebugOpArgumentsAndInsertionPt(
       Location loc, DILocalVariableAttr &localVarAttr,
       DIExpressionAttr &localExprAttr, Value &locVal, bool hasArgList,
       bool isKillLocation,
       llvm::function_ref<FailureOr<Value>()> convertArgOperandToValue,
-      llvm::Value *llvmLocation,
-      llvm::PointerUnion<llvm::Value *, llvm::DILocalVariable *> llvmLocalVar,
+      llvm::Value *address,
+      llvm::PointerUnion<llvm::Value *, llvm::DILocalVariable *> variable,
       llvm::DIExpression *expression, DominanceInfo &domInfo);
   /// Converts LLMV IR asm inline call operand's attributes into an array of
   /// MLIR attributes to be utilized in `llvm.inline_asm`.
@@ -504,7 +506,7 @@ private:
   /// Function-local list of debug intrinsics that need to be imported after the
   /// function conversion has finished.
   SetVector<llvm::Instruction *> debugIntrinsics;
-  /// Function-local list of debug intrinsics that need to be imported after the
+  /// Function-local list of debug records that need to be imported after the
   /// function conversion has finished.
   SetVector<llvm::DbgRecord *> debugRecords;
   /// Mapping between LLVM alias scope and domain metadata nodes and

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -163,9 +163,10 @@ public:
   /// Converts `value` to a float attribute. Asserts if the matching fails.
   FloatAttr matchFloatAttr(llvm::Value *value);
 
-  /// Converts `value` to a local variable attribute. Asserts if the matching
-  /// fails.
-  DILocalVariableAttr matchLocalVariableAttr(llvm::Value *value);
+  /// Converts `valOrVariable` to a local variable attribute. Asserts if the
+  /// matching fails.
+  DILocalVariableAttr matchLocalVariableAttr(
+      llvm::PointerUnion<llvm::Value *, llvm::DILocalVariable *> valOrVariable);
 
   /// Converts `value` to a label attribute. Asserts if the matching fails.
   DILabelAttr matchLabelAttr(llvm::Value *value);
@@ -281,6 +282,10 @@ public:
   /// after the function conversion has finished.
   void addDebugIntrinsic(llvm::CallInst *intrinsic);
 
+  /// Adds a debug intrinsics to the list of intrinsics that should be converted
+  /// after the function conversion has finished.
+  void addDebugRecord(llvm::DbgRecord *dr);
+
   /// Converts the LLVM values for an intrinsic to mixed MLIR values and
   /// attributes for LLVM_IntrOpBase. Attributes correspond to LLVM immargs. The
   /// list `immArgPositions` contains the positions of immargs on the LLVM
@@ -339,9 +344,23 @@ private:
   /// Converts all debug intrinsics in `debugIntrinsics`. Assumes that the
   /// function containing the intrinsics has been fully converted to MLIR.
   LogicalResult processDebugIntrinsics();
+  /// Converts all debug intrinsics in `debugIntrinsics`. Assumes that the
+  /// function containing the intrinsics has been fully converted to MLIR.
+  LogicalResult processDebugRecords();
   /// Converts a single debug intrinsic.
   LogicalResult processDebugIntrinsic(llvm::DbgVariableIntrinsic *dbgIntr,
                                       DominanceInfo &domInfo);
+  /// Converts a single debug intrinsic.
+  LogicalResult processDebugRecord(llvm::DbgRecord &dr, DominanceInfo &domInfo);
+  /// YYY
+  void processDebugVariableAndExpression(
+      Location loc, DILocalVariableAttr &localVarAttr,
+      DIExpressionAttr &localExprAttr, Value &locVal, bool hasArgList,
+      bool isKillLocation,
+      llvm::function_ref<FailureOr<Value>()> convertArgOperandToValue,
+      llvm::Value *llvmLocation,
+      llvm::PointerUnion<llvm::Value *, llvm::DILocalVariable *> llvmLocalVar,
+      llvm::DIExpression *expression, DominanceInfo &domInfo);
   /// Converts LLMV IR asm inline call operand's attributes into an array of
   /// MLIR attributes to be utilized in `llvm.inline_asm`.
   ArrayAttr convertAsmInlineOperandAttrs(const llvm::CallBase &llvmCall);
@@ -485,6 +504,9 @@ private:
   /// Function-local list of debug intrinsics that need to be imported after the
   /// function conversion has finished.
   SetVector<llvm::Instruction *> debugIntrinsics;
+  /// Function-local list of debug intrinsics that need to be imported after the
+  /// function conversion has finished.
+  SetVector<llvm::DbgRecord *> debugRecords;
   /// Mapping between LLVM alias scope and domain metadata nodes and
   /// attributes in the LLVM dialect corresponding to these nodes.
   DenseMap<const llvm::MDNode *, Attribute> aliasScopeMapping;

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -283,7 +283,7 @@ public:
   void addDebugIntrinsic(llvm::CallInst *intrinsic);
 
   /// Similar to `addDebugIntrinsic`, but for debug records.
-  void addDebugRecord(llvm::DbgRecord *dr);
+  void addDebugRecord(llvm::DbgRecord *debugRecord);
 
   /// Converts the LLVM values for an intrinsic to mixed MLIR values and
   /// attributes for LLVM_IntrOpBase. Attributes correspond to LLVM immargs. The
@@ -350,15 +350,15 @@ private:
   LogicalResult processDebugIntrinsic(llvm::DbgVariableIntrinsic *dbgIntr,
                                       DominanceInfo &domInfo);
   /// Converts a single debug record.
-  LogicalResult processDebugRecord(llvm::DbgRecord &dr, DominanceInfo &domInfo);
+  LogicalResult processDebugRecord(llvm::DbgRecord &debugRecord,
+                                   DominanceInfo &domInfo);
   /// Process arguments for declare/value operation insertion. `localVarAttr`
   /// and `localExprAttr` are the attained attributes after importing the debug
   /// variable and expressions. This also sets the builder insertion point to be
   /// used by these operations.
-  void processDebugOpArgumentsAndInsertionPt(
-      Location loc, DILocalVariableAttr &localVarAttr,
-      DIExpressionAttr &localExprAttr, Value &locVal, bool hasArgList,
-      bool isKillLocation,
+  std::tuple<DILocalVariableAttr, DIExpressionAttr, Value>
+  processDebugOpArgumentsAndInsertionPt(
+      Location loc, bool hasArgList, bool isKillLocation,
       llvm::function_ref<FailureOr<Value>()> convertArgOperandToValue,
       llvm::Value *address,
       llvm::PointerUnion<llvm::Value *, llvm::DILocalVariable *> variable,

--- a/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
+++ b/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
@@ -30,10 +30,13 @@ void registerFromLLVMIRTranslation() {
       llvm::cl::desc("Emit expensive warnings during LLVM IR import "
                      "(discouraged: testing only!)"),
       llvm::cl::init(false));
-  static llvm::cl::opt<bool> disableNewDbgConversion(
-      "disable-newdbg-conversion",
-      llvm::cl::desc("Disable conversion from new debug info format during "
-                     "LLVM IR import (discouraged: WIP!)"),
+  static llvm::cl::opt<bool> convertDebugRecToIntrinsics(
+      "convert-debug-rec-to-intrinsics",
+      llvm::cl::desc("Change the input LLVM module to use old debug intrinsics "
+                     "instead of records "
+                     "via convertFromNewDbgValues, this happens "
+                     "before importing the debug information"
+                     "(discouraged: to be removed soon!)"),
       llvm::cl::init(false));
   static llvm::cl::opt<bool> dropDICompositeTypeElements(
       "drop-di-composite-type-elements",
@@ -75,7 +78,7 @@ void registerFromLLVMIRTranslation() {
           return nullptr;
 
         // Debug records are WIP in the LLVM IR translator.
-        if (!disableNewDbgConversion)
+        if (!convertDebugRecToIntrinsics)
           llvmModule->convertFromNewDbgValues();
 
         return translateLLVMIRToModule(

--- a/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
+++ b/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
@@ -77,7 +77,8 @@ void registerFromLLVMIRTranslation() {
         if (llvm::verifyModule(*llvmModule, &llvm::errs()))
           return nullptr;
 
-        // Debug records are WIP in the LLVM IR translator.
+        // Now that the translation supports importing debug records directly,
+        // make it the default, but allow the user to override to old behavior.
         if (!convertDebugRecToIntrinsics)
           llvmModule->convertFromNewDbgValues();
 

--- a/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
+++ b/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
@@ -30,6 +30,11 @@ void registerFromLLVMIRTranslation() {
       llvm::cl::desc("Emit expensive warnings during LLVM IR import "
                      "(discouraged: testing only!)"),
       llvm::cl::init(false));
+  static llvm::cl::opt<bool> disableNewDbgConversion(
+      "disable-newdbg-conversion",
+      llvm::cl::desc("Disable conversion from new debug info format during "
+                     "LLVM IR import (discouraged: WIP!)"),
+      llvm::cl::init(false));
   static llvm::cl::opt<bool> dropDICompositeTypeElements(
       "drop-di-composite-type-elements",
       llvm::cl::desc(
@@ -69,8 +74,9 @@ void registerFromLLVMIRTranslation() {
         if (llvm::verifyModule(*llvmModule, &llvm::errs()))
           return nullptr;
 
-        // Debug records are not currently supported in the LLVM IR translator.
-        llvmModule->convertFromNewDbgValues();
+        // Debug records are WIP in the LLVM IR translator.
+        if (!disableNewDbgConversion)
+          llvmModule->convertFromNewDbgValues();
 
         return translateLLVMIRToModule(
             std::move(llvmModule), context, emitExpensiveWarnings,

--- a/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
@@ -1,0 +1,94 @@
+; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -disable-newdbg-conversion -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
+; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
+
+; CHECK: @callee()
+define void @callee() {
+  ret void
+}
+
+define void @func_with_empty_named_info() {
+  call void @callee()
+  ret void
+}
+
+define void @func_no_debug() {
+  ret void
+}
+
+; CHECK: llvm.func @func_with_debug(%[[ARG0:.*]]: i64
+define void @func_with_debug(i64 %0) !dbg !3 {
+
+  ; CHECK: llvm.intr.dbg.value #di_local_variable = %[[ARG0]] : i64
+  ; CHECK: llvm.intr.dbg.value #di_local_variable1 #llvm.di_expression<[DW_OP_LLVM_fragment(0, 1)]> = %[[ARG0]] : i64
+  ; CHECK: %[[CST:.*]] = llvm.mlir.constant(1 : i32) : i32
+  ; CHECK: %[[ADDR:.*]] = llvm.alloca %[[CST]] x i64
+  ; CHECK: llvm.intr.dbg.declare #di_local_variable2 #llvm.di_expression<[DW_OP_deref, DW_OP_LLVM_convert(4, DW_ATE_signed)]> = %[[ADDR]] : !llvm.ptr
+  %2 = alloca i64, align 8, !dbg !19
+    #dbg_value(i64 %0, !20, !DIExpression(DW_OP_LLVM_fragment, 0, 1), !22)
+    #dbg_declare(ptr %2, !23, !DIExpression(DW_OP_deref, DW_OP_LLVM_convert, 4, DW_ATE_signed), !25)
+    #dbg_value(i64 %0, !26, !DIExpression(), !27)
+  call void @func_no_debug(), !dbg !28
+  call void @func_no_debug(), !dbg !28
+  call void @func_no_debug(), !dbg !29
+  call void @func_no_debug(), !dbg !30
+  call void @func_no_debug(), !dbg !30
+  call void @func_no_debug(), !dbg !31
+  call void @func_no_debug(), !dbg !32
+  %3 = add i64 %0, %0, !dbg !32
+  ret void, !dbg !37
+}
+
+define void @empty_types() !dbg !38 {
+  ret void, !dbg !44
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "MLIR", isOptimized: true, runtimeVersion: 0, splitDebugFilename: "test.dwo", emissionKind: FullDebug, nameTableKind: None)
+!1 = !DIFile(filename: "foo.mlir", directory: "/test/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "func_with_debug", linkageName: "func_with_debug", scope: !4, file: !1, line: 3, type: !6, scopeLine: 3, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!4 = !DINamespace(name: "nested", scope: !5)
+!5 = !DINamespace(name: "toplevel", scope: null, exportSymbols: true)
+!6 = !DISubroutineType(cc: DW_CC_normal, types: !7)
+!7 = !{null, !8, !9, !11, !12, !13, !16}
+!8 = !DIBasicType(name: "si64")
+!9 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !10, size: 64, align: 32, offset: 8, extraData: !10)
+!10 = !DIBasicType(name: "si32", size: 32, encoding: DW_ATE_signed)
+!11 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "named", baseType: !10)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !10, size: 64, align: 32, offset: 8, dwarfAddressSpace: 3)
+!13 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "composite", file: !1, line: 42, size: 64, align: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4)
+!16 = !DICompositeType(tag: DW_TAG_array_type, name: "array", file: !1, baseType: !8, flags: DIFlagVector, elements: !17)
+!17 = !{!18}
+!18 = !DISubrange(lowerBound: 0, upperBound: 4, stride: 1)
+!19 = !DILocation(line: 100, column: 12, scope: !3)
+!20 = !DILocalVariable(name: "arg", arg: 1, scope: !21, file: !1, line: 6, type: !8, align: 32)
+!21 = distinct !DILexicalBlockFile(scope: !3, file: !1, discriminator: 0)
+!22 = !DILocation(line: 103, column: 3, scope: !3)
+!23 = !DILocalVariable(name: "alloc", scope: !24)
+!24 = distinct !DILexicalBlock(scope: !3)
+!25 = !DILocation(line: 106, column: 3, scope: !3)
+!26 = !DILocalVariable(scope: !24)
+!27 = !DILocation(line: 109, column: 3, scope: !3)
+!28 = !DILocation(line: 1, column: 2, scope: !3)
+!29 = !DILocation(line: 10, column: 10, scope: !3)
+!30 = !DILocation(line: 5, column: 6, scope: !3)
+!31 = !DILocation(line: 1, column: 1, scope: !3)
+!32 = !DILocation(line: 2, column: 4, scope: !33, inlinedAt: !36)
+!33 = distinct !DISubprogram(name: "callee", scope: !13, file: !1, type: !34, spFlags: DISPFlagDefinition, unit: !0)
+!34 = !DISubroutineType(types: !35)
+!35 = !{!8, !8}
+!36 = !DILocation(line: 28, column: 5, scope: !3)
+!37 = !DILocation(line: 135, column: 3, scope: !3)
+!38 = distinct !DISubprogram(name: "empty_types", scope: !39, file: !1, type: !40, spFlags: DISPFlagDefinition, unit: !0, annotations: !42)
+!39 = !DIModule(scope: !1, name: "module", configMacros: "bar", includePath: "/", apinotes: "/", file: !1, line: 42, isDecl: true)
+!40 = !DISubroutineType(cc: DW_CC_normal, types: !41)
+!41 = !{}
+!42 = !{!43}
+!43 = !{!"foo", !"bar"}
+!44 = !DILocation(line: 140, column: 3, scope: !38)
+
+; ///// -----

--- a/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
@@ -1,4 +1,4 @@
-; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -disable-newdbg-conversion -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
+; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -convert-debug-rec-to-intrinsics -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
 ; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
 
 ; CHECK: @callee()

--- a/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
@@ -1,6 +1,10 @@
 ; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -convert-debug-rec-to-intrinsics -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
 ; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -emit-expensive-warnings -split-input-file %s 2>&1 | FileCheck %s
 
+; CHECK: #[[LOCAL_VAR0:.*]] = #llvm.di_local_variable<scope = #di_lexical_block>
+; CHECK: #[[LOCAL_VAR1:.*]] = #llvm.di_local_variable<scope = #di_lexical_block_file, name = "arg"
+; CHECK: #[[LOCAL_VAR2:.*]] = #llvm.di_local_variable<scope = #di_lexical_block, name = "alloc"
+
 ; CHECK: @callee()
 define void @callee() {
   ret void
@@ -18,11 +22,11 @@ define void @func_no_debug() {
 ; CHECK: llvm.func @func_with_debug(%[[ARG0:.*]]: i64
 define void @func_with_debug(i64 %0) !dbg !3 {
 
-  ; CHECK: llvm.intr.dbg.value #di_local_variable{{.*}} = %[[ARG0]] : i64
-  ; CHECK: llvm.intr.dbg.value #di_local_variable{{.*}} #llvm.di_expression<[DW_OP_LLVM_fragment(0, 1)]> = %[[ARG0]] : i64
+  ; CHECK: llvm.intr.dbg.value #[[LOCAL_VAR0]] = %[[ARG0]] : i64
+  ; CHECK: llvm.intr.dbg.value #[[LOCAL_VAR1]] #llvm.di_expression<[DW_OP_LLVM_fragment(0, 1)]> = %[[ARG0]] : i64
   ; CHECK: %[[CST:.*]] = llvm.mlir.constant(1 : i32) : i32
   ; CHECK: %[[ADDR:.*]] = llvm.alloca %[[CST]] x i64
-  ; CHECK: llvm.intr.dbg.declare #di_local_variable{{.*}} #llvm.di_expression<[DW_OP_deref, DW_OP_LLVM_convert(4, DW_ATE_signed)]> = %[[ADDR]] : !llvm.ptr
+  ; CHECK: llvm.intr.dbg.declare #[[LOCAL_VAR2]] #llvm.di_expression<[DW_OP_deref, DW_OP_LLVM_convert(4, DW_ATE_signed)]> = %[[ADDR]] : !llvm.ptr
   %2 = alloca i64, align 8, !dbg !19
     #dbg_value(i64 %0, !20, !DIExpression(DW_OP_LLVM_fragment, 0, 1), !22)
     #dbg_declare(ptr %2, !23, !DIExpression(DW_OP_deref, DW_OP_LLVM_convert, 4, DW_ATE_signed), !25)

--- a/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
@@ -18,22 +18,16 @@ define void @func_no_debug() {
 ; CHECK: llvm.func @func_with_debug(%[[ARG0:.*]]: i64
 define void @func_with_debug(i64 %0) !dbg !3 {
 
-  ; CHECK: llvm.intr.dbg.value #di_local_variable = %[[ARG0]] : i64
-  ; CHECK: llvm.intr.dbg.value #di_local_variable1 #llvm.di_expression<[DW_OP_LLVM_fragment(0, 1)]> = %[[ARG0]] : i64
+  ; CHECK: llvm.intr.dbg.value #di_local_variable{{.*}} = %[[ARG0]] : i64
+  ; CHECK: llvm.intr.dbg.value #di_local_variable{{.*}} #llvm.di_expression<[DW_OP_LLVM_fragment(0, 1)]> = %[[ARG0]] : i64
   ; CHECK: %[[CST:.*]] = llvm.mlir.constant(1 : i32) : i32
   ; CHECK: %[[ADDR:.*]] = llvm.alloca %[[CST]] x i64
-  ; CHECK: llvm.intr.dbg.declare #di_local_variable2 #llvm.di_expression<[DW_OP_deref, DW_OP_LLVM_convert(4, DW_ATE_signed)]> = %[[ADDR]] : !llvm.ptr
+  ; CHECK: llvm.intr.dbg.declare #di_local_variable{{.*}} #llvm.di_expression<[DW_OP_deref, DW_OP_LLVM_convert(4, DW_ATE_signed)]> = %[[ADDR]] : !llvm.ptr
   %2 = alloca i64, align 8, !dbg !19
     #dbg_value(i64 %0, !20, !DIExpression(DW_OP_LLVM_fragment, 0, 1), !22)
     #dbg_declare(ptr %2, !23, !DIExpression(DW_OP_deref, DW_OP_LLVM_convert, 4, DW_ATE_signed), !25)
     #dbg_value(i64 %0, !26, !DIExpression(), !27)
   call void @func_no_debug(), !dbg !28
-  call void @func_no_debug(), !dbg !28
-  call void @func_no_debug(), !dbg !29
-  call void @func_no_debug(), !dbg !30
-  call void @func_no_debug(), !dbg !30
-  call void @func_no_debug(), !dbg !31
-  call void @func_no_debug(), !dbg !32
   %3 = add i64 %0, %0, !dbg !32
   ret void, !dbg !37
 }
@@ -74,9 +68,6 @@ define void @empty_types() !dbg !38 {
 !26 = !DILocalVariable(scope: !24)
 !27 = !DILocation(line: 109, column: 3, scope: !3)
 !28 = !DILocation(line: 1, column: 2, scope: !3)
-!29 = !DILocation(line: 10, column: 10, scope: !3)
-!30 = !DILocation(line: 5, column: 6, scope: !3)
-!31 = !DILocation(line: 1, column: 1, scope: !3)
 !32 = !DILocation(line: 2, column: 4, scope: !33, inlinedAt: !36)
 !33 = distinct !DISubprogram(name: "callee", scope: !13, file: !1, type: !34, spFlags: DISPFlagDefinition, unit: !0)
 !34 = !DISubroutineType(types: !35)

--- a/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info-records.ll
@@ -90,5 +90,3 @@ define void @empty_types() !dbg !38 {
 !42 = !{!43}
 !43 = !{!"foo", !"bar"}
 !44 = !DILocation(line: 140, column: 3, scope: !38)
-
-; ///// -----


### PR DESCRIPTION
Effectively means we don't need to call into `llvmModule->convertFromNewDbgValues()` anymore. Added a flag to allow users to access the old behavior.