### PR TITLE
[clang-doc][NFC] Lift Mustache template generation from HTML

### DIFF
--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -14,6 +14,8 @@
 
 #include "Representation.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/Mustache.h"
 #include "llvm/Support/Registry.h"
 
 namespace clang {
@@ -27,10 +29,9 @@ public:
 
   // Write out the decl info for the objects in the given map in the specified
   // format.
-  virtual llvm::Error
-  generateDocs(StringRef RootDir,
-               llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-               const ClangDocContext &CDCtx) = 0;
+  virtual llvm::Error generateDocumentation(
+      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      const ClangDocContext &CDCtx, std::string DirName = "") = 0;
 
   // This function writes a file with the index previously constructed.
   // It can be overwritten by any of the inherited generators.
@@ -51,6 +52,85 @@ llvm::Expected<std::unique_ptr<Generator>>
 findGeneratorByName(llvm::StringRef Format);
 
 std::string getTagType(TagTypeKind AS);
+
+llvm::Error createFileOpenError(StringRef FileName, std::error_code EC);
+
+class MustacheTemplateFile {
+  llvm::BumpPtrAllocator Allocator;
+  llvm::StringSaver Saver;
+  llvm::mustache::MustacheContext Ctx;
+  llvm::mustache::Template T;
+  std::unique_ptr<llvm::MemoryBuffer> Buffer;
+
+public:
+  static Expected<std::unique_ptr<MustacheTemplateFile>>
+  createMustacheFile(StringRef FileName) {
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrError =
+        llvm::MemoryBuffer::getFile(FileName);
+    if (auto EC = BufferOrError.getError())
+      return createFileOpenError(FileName, EC);
+    return std::make_unique<MustacheTemplateFile>(
+        std::move(BufferOrError.get()));
+  }
+
+  llvm::Error registerPartialFile(StringRef Name, StringRef FileName) {
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrError =
+        llvm::MemoryBuffer::getFile(FileName);
+    if (auto EC = BufferOrError.getError())
+      return createFileOpenError(FileName, EC);
+
+    std::unique_ptr<llvm::MemoryBuffer> Buffer = std::move(BufferOrError.get());
+    StringRef FileContent = Buffer->getBuffer();
+    T.registerPartial(Name.str(), FileContent.str());
+    return llvm::Error::success();
+  }
+
+  void render(llvm::json::Value &V, raw_ostream &OS) { T.render(V, OS); }
+
+  MustacheTemplateFile(std::unique_ptr<llvm::MemoryBuffer> &&B)
+      : Saver(Allocator), Ctx(Allocator, Saver), T(B->getBuffer(), Ctx),
+        Buffer(std::move(B)) {}
+};
+
+struct MustacheGenerator : public Generator {
+  Expected<std::string> getInfoTypeStr(llvm::json::Object *Info,
+                                       StringRef Filename);
+
+  /// Used to find the relative path from the file to the format's docs root.
+  /// Mainly used for the HTML resource paths.
+  SmallString<128> getRelativePathToRoot(StringRef PathToFile,
+                                         StringRef DocsRootPath);
+  virtual ~MustacheGenerator() = default;
+
+  /// Initializes the template files from disk and calls setupTemplate to
+  /// register partials
+  virtual llvm::Error setupTemplateFiles(const ClangDocContext &CDCtx) = 0;
+
+  /// Populates templates with data from JSON and calls any specifics for the
+  /// format. For example, for HTML it will render the paths for CSS and JS.
+  virtual llvm::Error generateDocForJSON(llvm::json::Value &JSON,
+                                         llvm::raw_fd_ostream &OS,
+                                         const ClangDocContext &CDCtx,
+                                         StringRef ObjectTypeStr,
+                                         StringRef RelativeRootPath) = 0;
+
+  /// Registers partials to templates.
+  llvm::Error
+  setupTemplate(std::unique_ptr<MustacheTemplateFile> &Template,
+                StringRef TemplatePath,
+                std::vector<std::pair<StringRef, StringRef>> Partials);
+
+  /// \brief The main orchestrator for Mustache-based documentation.
+  ///
+  /// 1. Initializes templates files from disk by calling setupTemplateFiles.
+  /// 2. Calls the JSON generator to write JSON to disk.
+  /// 3. Iterates over the JSON files, recreates the directory structure from
+  /// JSON, and calls generateDocForJSON for each file.
+  /// 4. A file of the desired format is created.
+  llvm::Error generateDocumentation(
+      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      const clang::doc::ClangDocContext &CDCtx, std::string DirName) override;
+};
 
 // This anchor is used to force the linker to link in the generated object file
 // and thus register the generators.

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -897,9 +897,9 @@ class HTMLGenerator : public Generator {
 public:
   static const char *Format;
 
-  llvm::Error generateDocs(StringRef RootDir,
-                           llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                           const ClangDocContext &CDCtx) override;
+  llvm::Error generateDocumentation(
+      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      const ClangDocContext &CDCtx, std::string DirName) override;
   llvm::Error createResources(ClangDocContext &CDCtx) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
@@ -907,10 +907,9 @@ public:
 
 const char *HTMLGenerator::Format = "html";
 
-llvm::Error
-HTMLGenerator::generateDocs(StringRef RootDir,
-                            llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                            const ClangDocContext &CDCtx) {
+llvm::Error HTMLGenerator::generateDocumentation(
+    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    const ClangDocContext &CDCtx, std::string DirName) {
   // Track which directories we already tried to create.
   llvm::StringSet<> CreatedDirs;
 

--- a/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
@@ -16,10 +16,7 @@
 #include "Representation.h"
 #include "support/File.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/Mustache.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/TimeProfiler.h"
 
 using namespace llvm;
 using namespace llvm::json;
@@ -27,82 +24,30 @@ using namespace llvm::mustache;
 
 namespace clang {
 namespace doc {
-static Error generateDocForJSON(json::Value &JSON, StringRef Filename,
-                                StringRef Path, raw_fd_ostream &OS,
-                                const ClangDocContext &CDCtx,
-                                StringRef HTMLRootPath);
-
-static Error createFileOpenError(StringRef FileName, std::error_code EC) {
-  return createFileError("cannot open file " + FileName, EC);
-}
-
-class MustacheHTMLGenerator : public Generator {
-public:
-  static const char *Format;
-  Error generateDocs(StringRef RootDir,
-                     StringMap<std::unique_ptr<doc::Info>> Infos,
-                     const ClangDocContext &CDCtx) override;
-  Error createResources(ClangDocContext &CDCtx) override;
-  Error generateDocForInfo(Info *I, raw_ostream &OS,
-                           const ClangDocContext &CDCtx) override;
-};
-
-class MustacheTemplateFile {
-  BumpPtrAllocator Allocator;
-  StringSaver Saver;
-  MustacheContext Ctx;
-  Template T;
-  std::unique_ptr<MemoryBuffer> Buffer;
-
-public:
-  static Expected<std::unique_ptr<MustacheTemplateFile>>
-  createMustacheFile(StringRef FileName) {
-    ErrorOr<std::unique_ptr<MemoryBuffer>> BufferOrError =
-        MemoryBuffer::getFile(FileName);
-    if (auto EC = BufferOrError.getError())
-      return createFileOpenError(FileName, EC);
-    return std::make_unique<MustacheTemplateFile>(
-        std::move(BufferOrError.get()));
-  }
-
-  Error registerPartialFile(StringRef Name, StringRef FileName) {
-    ErrorOr<std::unique_ptr<MemoryBuffer>> BufferOrError =
-        MemoryBuffer::getFile(FileName);
-    if (auto EC = BufferOrError.getError())
-      return createFileOpenError(FileName, EC);
-
-    std::unique_ptr<MemoryBuffer> Buffer = std::move(BufferOrError.get());
-    StringRef FileContent = Buffer->getBuffer();
-    T.registerPartial(Name.str(), FileContent.str());
-    return Error::success();
-  }
-
-  void render(json::Value &V, raw_ostream &OS) { T.render(V, OS); }
-
-  MustacheTemplateFile(std::unique_ptr<MemoryBuffer> &&B)
-      : Saver(Allocator), Ctx(Allocator, Saver), T(B->getBuffer(), Ctx),
-        Buffer(std::move(B)) {}
-};
 
 static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
 
 static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
 
-static Error
-setupTemplate(std::unique_ptr<MustacheTemplateFile> &Template,
-              StringRef TemplatePath,
-              std::vector<std::pair<StringRef, StringRef>> Partials) {
-  auto T = MustacheTemplateFile::createMustacheFile(TemplatePath);
-  if (Error Err = T.takeError())
-    return Err;
-  Template = std::move(T.get());
-  for (const auto &[Name, FileName] : Partials)
-    if (auto Err = Template->registerPartialFile(Name, FileName))
-      return Err;
-  return Error::success();
-}
+class MustacheHTMLGenerator : public MustacheGenerator {
+public:
+  static const char *Format;
+  Error createResources(ClangDocContext &CDCtx) override;
+  Error generateDocForInfo(Info *I, raw_ostream &OS,
+                           const ClangDocContext &CDCtx) override;
+  Error setupTemplateFiles(const ClangDocContext &CDCtx) override;
+  Error generateDocForJSON(json::Value &JSON, raw_fd_ostream &OS,
+                           const ClangDocContext &CDCtx, StringRef ObjTypeStr,
+                           StringRef RelativeRootPath) override;
+  // Populates templates with CSS stylesheets, JS scripts paths.
+  Error setupTemplateResources(const ClangDocContext &CDCtx, json::Value &V,
+                               SmallString<128> RelativeRootPath);
+  llvm::Error generateDocumentation(
+      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      const ClangDocContext &CDCtx, std::string DirName) override;
+};
 
-static Error setupTemplateFiles(const clang::doc::ClangDocContext &CDCtx) {
+Error MustacheHTMLGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
   // Template files need to use the native path when they're opened,
   // but have to be used in POSIX style when used in HTML.
   auto ConvertToNative = [](std::string &&Path) -> std::string {
@@ -135,97 +80,17 @@ static Error setupTemplateFiles(const clang::doc::ClangDocContext &CDCtx) {
   return Error::success();
 }
 
-Error MustacheHTMLGenerator::generateDocs(
-    StringRef RootDir, StringMap<std::unique_ptr<doc::Info>> Infos,
-    const clang::doc::ClangDocContext &CDCtx) {
-  {
-    llvm::TimeTraceScope TS("Setup Templates");
-    if (auto Err = setupTemplateFiles(CDCtx))
-      return Err;
-  }
-
-  {
-    llvm::TimeTraceScope TS("Generate JSON for Mustache");
-    if (auto JSONGenerator = findGeneratorByName("json")) {
-      if (Error Err = JSONGenerator.get()->generateDocs(
-              RootDir, std::move(Infos), CDCtx))
-        return Err;
-    } else
-      return JSONGenerator.takeError();
-  }
-  SmallString<128> JSONPath;
-  sys::path::native(RootDir.str() + "/json", JSONPath);
-
-  {
-    llvm::TimeTraceScope TS("Iterate JSON files");
-    std::error_code EC;
-    sys::fs::recursive_directory_iterator JSONIter(JSONPath, EC);
-    std::vector<json::Value> JSONFiles;
-    JSONFiles.reserve(Infos.size());
-    if (EC)
-      return createStringError("Failed to create directory iterator.");
-
-    SmallString<128> HTMLDirPath(RootDir.str() + "/html");
-    if (auto EC = sys::fs::create_directories(HTMLDirPath))
-      return createFileError(HTMLDirPath, EC);
-    while (JSONIter != sys::fs::recursive_directory_iterator()) {
-      // create the same directory structure in the HTML dir
-      if (JSONIter->type() == sys::fs::file_type::directory_file) {
-        SmallString<128> HTMLClonedPath(JSONIter->path());
-        sys::path::replace_path_prefix(HTMLClonedPath, JSONPath, HTMLDirPath);
-        if (auto EC = sys::fs::create_directories(HTMLClonedPath))
-          return createFileError(HTMLClonedPath, EC);
-      }
-
-      if (EC)
-        return createFileError("Failed to iterate: " + JSONIter->path(), EC);
-
-      auto Path = StringRef(JSONIter->path());
-      if (!Path.ends_with(".json")) {
-        JSONIter.increment(EC);
-        continue;
-      }
-
-      auto File = MemoryBuffer::getFile(Path);
-      if (EC = File.getError(); EC)
-        // TODO: Buffer errors to report later, look into using Clang
-        // diagnostics.
-        llvm::errs() << "Failed to open file: " << Path << " " << EC.message()
-                     << '\n';
-
-      auto Parsed = json::parse((*File)->getBuffer());
-      if (!Parsed)
-        return Parsed.takeError();
-
-      std::error_code FileErr;
-      SmallString<128> HTMLFilePath(JSONIter->path());
-      sys::path::replace_path_prefix(HTMLFilePath, JSONPath, HTMLDirPath);
-      sys::path::replace_extension(HTMLFilePath, "html");
-      raw_fd_ostream InfoOS(HTMLFilePath, FileErr, sys::fs::OF_None);
-      if (FileErr)
-        return createFileOpenError(Path, FileErr);
-
-      if (Error Err =
-              generateDocForJSON(*Parsed, sys::path::stem(HTMLFilePath),
-                                 HTMLFilePath, InfoOS, CDCtx, HTMLDirPath))
-        return Err;
-      JSONIter.increment(EC);
-    }
-  }
-
-  return Error::success();
-}
-
-static Error setupTemplateValue(const ClangDocContext &CDCtx, json::Value &V,
-                                SmallString<128> RelativeHTMLPath) {
+Error MustacheHTMLGenerator::setupTemplateResources(
+    const ClangDocContext &CDCtx, json::Value &V,
+    SmallString<128> RelativeRootPath) {
   V.getAsObject()->insert({"ProjectName", CDCtx.ProjectName});
   json::Value StylesheetArr = Array();
-  sys::path::native(RelativeHTMLPath, sys::path::Style::posix);
+  sys::path::native(RelativeRootPath, sys::path::Style::posix);
 
   auto *SSA = StylesheetArr.getAsArray();
   SSA->reserve(CDCtx.UserStylesheets.size());
   for (const auto &FilePath : CDCtx.UserStylesheets) {
-    SmallString<128> StylesheetPath = RelativeHTMLPath;
+    SmallString<128> StylesheetPath = RelativeRootPath;
     sys::path::append(StylesheetPath, sys::path::Style::posix,
                       sys::path::filename(FilePath));
     SSA->emplace_back(StylesheetPath);
@@ -236,7 +101,7 @@ static Error setupTemplateValue(const ClangDocContext &CDCtx, json::Value &V,
   auto *SCA = ScriptArr.getAsArray();
   SCA->reserve(CDCtx.JsScripts.size());
   for (auto Script : CDCtx.JsScripts) {
-    SmallString<128> JsPath = RelativeHTMLPath;
+    SmallString<128> JsPath = RelativeRootPath;
     sys::path::append(JsPath, sys::path::Style::posix,
                       sys::path::filename(Script));
     SCA->emplace_back(JsPath);
@@ -245,31 +110,18 @@ static Error setupTemplateValue(const ClangDocContext &CDCtx, json::Value &V,
   return Error::success();
 }
 
-static Error generateDocForJSON(json::Value &JSON, StringRef Filename,
-                                StringRef Path, raw_fd_ostream &OS,
-                                const ClangDocContext &CDCtx,
-                                StringRef HTMLRootPath) {
-  auto StrValue = (*JSON.getAsObject())["InfoType"];
-  if (StrValue.kind() != json::Value::Kind::String)
-    return createStringError("JSON file '%s' does not contain key: 'InfoType'.",
-                             Filename.str().c_str());
-  auto ObjTypeStr = StrValue.getAsString();
-  if (!ObjTypeStr.has_value())
-    return createStringError(
-        "JSON file '%s' does not contain 'InfoType' field as a string.",
-        Filename.str().c_str());
-
-  SmallString<128> PathVec(Path);
-  // Remove filename, or else the relative path will have an extra "../"
-  sys::path::remove_filename(PathVec);
-  auto RelativeHTMLPath = computeRelativePath(HTMLRootPath, PathVec);
-  if (ObjTypeStr.value() == "namespace") {
-    if (auto Err = setupTemplateValue(CDCtx, JSON, RelativeHTMLPath))
+Error MustacheHTMLGenerator::generateDocForJSON(json::Value &JSON,
+                                                raw_fd_ostream &OS,
+                                                const ClangDocContext &CDCtx,
+                                                StringRef ObjTypeStr,
+                                                StringRef RelativeRootPath) {
+  if (ObjTypeStr == "namespace") {
+    if (auto Err = setupTemplateResources(CDCtx, JSON, RelativeRootPath))
       return Err;
     assert(NamespaceTemplate && "NamespaceTemplate is nullptr.");
     NamespaceTemplate->render(JSON, OS);
-  } else if (ObjTypeStr.value() == "record") {
-    if (auto Err = setupTemplateValue(CDCtx, JSON, RelativeHTMLPath))
+  } else if (ObjTypeStr == "record") {
+    if (auto Err = setupTemplateResources(CDCtx, JSON, RelativeRootPath))
       return Err;
     assert(RecordTemplate && "RecordTemplate is nullptr.");
     RecordTemplate->render(JSON, OS);
@@ -304,6 +156,13 @@ Error MustacheHTMLGenerator::createResources(ClangDocContext &CDCtx) {
     if (Error Err = copyFile(FilePath, ResourcePath))
       return Err;
   return Error::success();
+}
+
+Error MustacheHTMLGenerator::generateDocumentation(
+    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    const ClangDocContext &CDCtx, std::string DirName) {
+  return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
+                                                  CDCtx, "html");
 }
 
 const char *MustacheHTMLGenerator::Format = "mustache";

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -12,9 +12,10 @@ class JSONGenerator : public Generator {
 public:
   static const char *Format;
 
-  Error generateDocs(StringRef RootDir,
-                     llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                     const ClangDocContext &CDCtx) override;
+  Error generateDocumentation(StringRef RootDir,
+                              llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+                              const ClangDocContext &CDCtx,
+                              std::string DirName) override;
   Error createResources(ClangDocContext &CDCtx) override;
   Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                            const ClangDocContext &CDCtx) override;
@@ -589,9 +590,9 @@ static SmallString<16> determineFileName(Info *I, SmallString<128> &Path) {
   return FileName;
 }
 
-Error JSONGenerator::generateDocs(
+Error JSONGenerator::generateDocumentation(
     StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-    const ClangDocContext &CDCtx) {
+    const ClangDocContext &CDCtx, std::string DirName) {
   StringSet<> CreatedDirs;
   StringMap<std::vector<doc::Info *>> FileToInfos;
   for (const auto &Group : Infos) {

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -398,9 +398,9 @@ class MDGenerator : public Generator {
 public:
   static const char *Format;
 
-  llvm::Error generateDocs(StringRef RootDir,
-                           llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                           const ClangDocContext &CDCtx) override;
+  llvm::Error generateDocumentation(
+      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      const ClangDocContext &CDCtx, std::string DirName) override;
   llvm::Error createResources(ClangDocContext &CDCtx) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
@@ -408,10 +408,9 @@ public:
 
 const char *MDGenerator::Format = "md";
 
-llvm::Error
-MDGenerator::generateDocs(StringRef RootDir,
-                          llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                          const ClangDocContext &CDCtx) {
+llvm::Error MDGenerator::generateDocumentation(
+    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    const ClangDocContext &CDCtx, std::string DirName) {
   // Track which directories we already tried to create.
   llvm::StringSet<> CreatedDirs;
 

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -347,19 +347,18 @@ class YAMLGenerator : public Generator {
 public:
   static const char *Format;
 
-  llvm::Error generateDocs(StringRef RootDir,
-                           llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                           const ClangDocContext &CDCtx) override;
+  llvm::Error generateDocumentation(
+      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      const ClangDocContext &CDCtx, std::string DirName) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
 };
 
 const char *YAMLGenerator::Format = "yaml";
 
-llvm::Error
-YAMLGenerator::generateDocs(StringRef RootDir,
-                            llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
-                            const ClangDocContext &CDCtx) {
+llvm::Error YAMLGenerator::generateDocumentation(
+    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    const ClangDocContext &CDCtx, std::string DirName) {
   for (const auto &Group : Infos) {
     doc::Info *Info = Group.getValue().get();
 

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -438,7 +438,8 @@ Example usage for a project using a compile commands database:
     // Run the generator.
     llvm::outs() << "Generating docs...\n";
 
-    ExitOnErr(G->generateDocs(OutDirectory, std::move(USRToInfo), CDCtx));
+    ExitOnErr(
+        G->generateDocumentation(OutDirectory, std::move(USRToInfo), CDCtx));
     llvm::outs() << "Generating assets for docs...\n";
     ExitOnErr(G->createResources(CDCtx));
     llvm::timeTraceProfilerEnd();


### PR DESCRIPTION
To prepare for more backends to use Mustache templates, this patch lifts
the Mustache utilities from `HTMLMustacheGenerator.cpp` to
`Generators.h`. A MustacheGenerator interface is created to share code for
template creation.