### PR TITLE
[NFC][analyzer] Add missing documentation for `decodeValueOfObjCType`

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1667,7 +1667,7 @@ Warn on uses of the 'bzero' function.
 .. _security-insecureAPI-decodeValueOfObjCType:
 
 security.insecureAPI.decodeValueOfObjCType (C)
-"""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""""
 Warn on uses of the Objective-C method ``-decodeValueOfObjCType:at:``.
 
 .. code-block:: objc

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1679,9 +1679,7 @@ Warn on uses of the Objective-C method ``-decodeValueOfObjCType:at:``.
 
 This diagnostic is emitted only on Apple platforms where the safer
 ``-decodeValueOfObjCType:at:size:`` alternative is available
-(
-iOS 11+, macOS 10.13+, tvOS 11+, watchOS 4.0+
-).
+(iOS 11+, macOS 10.13+, tvOS 11+, watchOS 4.0+).
 
 .. _security-insecureAPI-getpw:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -198,7 +198,7 @@ as error. Specifically on x86/x86-64 target if the pointer address space is
 dereference is not defined as error. See `X86/X86-64 Language Extensions
 <https://clang.llvm.org/docs/LanguageExtensions.html#memory-references-to-specified-segments>`__
 for reference.
-	
+
 If the analyzer option ``suppress-dereferences-from-any-address-space`` is set
 to true (the default value), then this checker never reports dereference of
 pointers with a specified address space. If the option is set to false, then
@@ -1663,6 +1663,25 @@ Warn on uses of the 'bzero' function.
  void test() {
    bzero(ptr, n); // warn
  }
+
+.. _security-insecureAPI-decodeValueOfObjCType:
+
+security.insecureAPI.decodeValueOfObjCType (C)
+"""""""""""""""""""""""""""""""""""""""
+Warn on uses of the Objective-C method ``-decodeValueOfObjCType:at:``.
+
+.. code-block:: objc
+
+  void test(NSCoder *decoder) {
+    unsigned int x;
+    [decoder decodeValueOfObjCType:"I" at:&x]; // warn
+  }
+
+This diagnostic is emitted only on Apple platforms where the safer
+``-decodeValueOfObjCType:at:size:`` alternative is available
+(
+iOS 11+, macOS 10.13+, tvOS 11+, watchOS 4.0+
+).
 
 .. _security-insecureAPI-getpw:
 


### PR DESCRIPTION
This check is introduced in https://github.com/llvm/llvm-project/commit/b284005072122fe4af879725e3c8090009f89ca0, but the documentation seems missing from `checkers.rst`.