### PR TITLE
[ADT] Simplify SmallDenseMap::grow (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -1077,6 +1077,9 @@ private:
   }
 
   void deallocateBuckets() {
+    // Fast path to deallocateBuckets in case getLargeRep()->NumBuckets == 0,
+    // just like destroyAll.  This path is used to destruct zombie instances
+    // after moves.
     if (Small || getLargeRep()->NumBuckets == 0)
       return;
 


### PR DESCRIPTION
Without this patch, SmallDenseMap::grow has two separate code paths to
grow the bucket array.  The code path to handle the small mode has its
own traversal over the bucket array.  This patch simplifies this logic
as follows:

1. Allocate a temporary instance of SmallDenseMap.
2. Move valid key/value pairs to the temporary instance.
3. Move LargeRep to *this.

Remarks:

- This patch adds moveFromImpl to move key/value pairs.
  moveFromOldBuckets is updated to use the new helper function.

- This patch adds a private constructor to SmallDenseMap that takes an
  exact number of buckets, accompanied by tag ExactBucketCount.

- This patch adds a fast path to deallocateBuckets in case
  getLargeRep()->NumBuckets == 0, just like destroyAll.  This path is
  used to destruct zombie instances after moves.

- In somewhat rare cases, we "grow" from the small mode to the small
  mode when there are many tombstones in the inline storage.  This is
  handled with another call to moveFrom.
