### PR TITLE
[clang] Use DenseMap::keys (NFC)

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
+++ b/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
@@ -131,7 +131,7 @@ public:
                      << " on StorageLocation " << this << " of type "
                      << getType() << "\n";
         llvm::dbgs() << "Existing children:\n";
-        for ([[maybe_unused]] auto [Field, Loc] : Children) {
+        for (const auto &Field : Children.keys()) {
           llvm::dbgs() << Field->getNameAsString() << "\n";
         }
       }

--- a/clang/lib/Analysis/FlowSensitive/ASTOps.cpp
+++ b/clang/lib/Analysis/FlowSensitive/ASTOps.cpp
@@ -81,7 +81,7 @@ bool containsSameFields(const FieldSet &Fields,
                         const RecordStorageLocation::FieldToLoc &FieldLocs) {
   if (Fields.size() != FieldLocs.size())
     return false;
-  for ([[maybe_unused]] auto [Field, Loc] : FieldLocs)
+  for (const auto &Field : FieldLocs.keys())
     if (!Fields.contains(cast_or_null<FieldDecl>(Field)))
       return false;
   return true;


### PR DESCRIPTION
With DenseMap::keys, we don't need to use [[maybe_unused]].
