### PR TITLE
[InstrRef] Consistently use MLocTracker::getLocID() before calling lookupOrTrackRegister

### DIFF
--- a/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
+++ b/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
@@ -955,7 +955,7 @@ TEST_F(InstrRefLDVTest, MLocSingleBlock) {
   // Add a new register to be tracked, and insert it into the transfer function
   // as a copy. The output of $rax should be the live-in value of $rsp.
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
   TransferFunc[0].insert({RspLoc, ValueIDNum(0, 1, RspLoc)});
   TransferFunc[0].insert({RaxLoc, ValueIDNum(0, 0, RspLoc)});
   initValueArray(MInLocs, 1, 2);
@@ -980,7 +980,7 @@ TEST_F(InstrRefLDVTest, MLocDiamondBlocks) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(4, 2);
 
@@ -1194,7 +1194,7 @@ TEST_F(InstrRefLDVTest, MLocSimpleLoop) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(3, 2);
 
@@ -1292,7 +1292,7 @@ TEST_F(InstrRefLDVTest, MLocNestedLoop) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(5, 2);
 
@@ -1493,7 +1493,7 @@ TEST_F(InstrRefLDVTest, MLocNoDominatingLoop) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(5, 2);
 
@@ -1648,7 +1648,7 @@ TEST_F(InstrRefLDVTest, MLocBadlyNestedLoops) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(5, 2);
 
@@ -1780,7 +1780,7 @@ TEST_F(InstrRefLDVTest, pickVPHILocDiamond) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(4, 2);
 
@@ -1976,7 +1976,7 @@ TEST_F(InstrRefLDVTest, pickVPHILocLoops) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(3, 2);
 
@@ -2104,9 +2104,9 @@ TEST_F(InstrRefLDVTest, pickVPHILocBadlyNestedLoops) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
   Register RBX = getRegByName("RBX");
-  LocIdx RbxLoc = MTracker->lookupOrTrackRegister(RBX);
+  LocIdx RbxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RBX));
 
   auto [MInLocs, MOutLocs] = allocValueTables(5, 3);
 
@@ -2256,7 +2256,7 @@ TEST_F(InstrRefLDVTest, vlocJoinDiamond) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  MTracker->lookupOrTrackRegister(RAX);
+  MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   DbgOpID LiveInRspID = DbgOpID(false, 0);
   DbgOpID LiveInRaxID = DbgOpID(false, 1);
@@ -2440,7 +2440,7 @@ TEST_F(InstrRefLDVTest, vlocJoinLoops) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  MTracker->lookupOrTrackRegister(RAX);
+  MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   DbgOpID LiveInRspID = DbgOpID(false, 0);
   DbgOpID LiveInRaxID = DbgOpID(false, 1);
@@ -2538,9 +2538,9 @@ TEST_F(InstrRefLDVTest, vlocJoinBadlyNestedLoops) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  MTracker->lookupOrTrackRegister(RAX);
+  MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
   Register RBX = getRegByName("RBX");
-  MTracker->lookupOrTrackRegister(RBX);
+  MTracker->lookupOrTrackRegister(MTracker->getLocID(RBX));
 
   DbgOpID LiveInRspID = DbgOpID(false, 0);
   DbgOpID LiveInRaxID = DbgOpID(false, 1);
@@ -2678,7 +2678,7 @@ TEST_F(InstrRefLDVTest, VLocDiamondBlocks) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   unsigned EntryBlk = 0, RetBlk = 3;
 
@@ -2896,7 +2896,7 @@ TEST_F(InstrRefLDVTest, VLocSimpleLoop) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   unsigned EntryBlk = 0, LoopBlk = 1;
 
@@ -3175,7 +3175,7 @@ TEST_F(InstrRefLDVTest, VLocNestedLoop) {
   ASSERT_TRUE(MTracker->getNumLocs() == 1);
   LocIdx RspLoc(0);
   Register RAX = getRegByName("RAX");
-  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(RAX);
+  LocIdx RaxLoc = MTracker->lookupOrTrackRegister(MTracker->getLocID(RAX));
 
   unsigned EntryBlk = 0, Loop1Blk = 1, Loop2Blk = 2;
 


### PR DESCRIPTION
The LocID for registers is just the register ID. The getLocID function is supposed to hide this detail, but it wasn't being used consistently.

This avoids a bunch of implicit casts from Register or MCRegister to unsigned.