### PR TITLE
[libcxx] [doc] Update the docs about LIBCXX_ENABLE_FILESYSTEM

### DIFF
--- a/libcxx/docs/VendorDocumentation.rst
+++ b/libcxx/docs/VendorDocumentation.rst
@@ -162,10 +162,10 @@ General purpose options
 
 .. option:: LIBCXX_ENABLE_FILESYSTEM:BOOL
 
-   **Default**: ``ON`` except on Windows when using MSVC.
+   **Default**: ``ON``
 
    This option can be used to enable or disable the filesystem components on
-   platforms that may not support them. For example on Windows when using MSVC.
+   platforms that may not support them.
 
 .. option:: LIBCXX_ENABLE_WIDE_CHARACTERS:BOOL
 


### PR DESCRIPTION
Since 1939eb3dc2330af6fb9609a7c3bd5276e127c9ce, std::filesystem is enabled by default in MSVC builds too.