### PR TITLE
[libcxx] [doc] Document the supported target versions of Windows

### DIFF
--- a/libcxx/docs/VendorDocumentation.rst
+++ b/libcxx/docs/VendorDocumentation.rst
@@ -376,6 +376,12 @@ newer (19.14) is required.
 
 Libc++ also supports being built with clang targeting MinGW environments.
 
+Libc++ supports Windows 7 or newer. However, the minimum runtime version
+of the build is determined by the ``_WIN32_WINNT`` define, which in many
+SDKs defaults to the latest version. To build a version that runs on an
+older version, define e.g. ``_WIN32_WINNT=0x601`` while building libc++,
+to target Windows 7.
+
 CMake + Visual Studio
 ---------------------
 

--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -147,7 +147,7 @@ macOS 10.13+          i386, x86_64, arm64
 FreeBSD 12+           i386, x86_64, arm
 Linux                 i386, x86_64, arm, arm64  Only glibc-2.24 and later and no other libc is officially supported
 Android 5.0+          i386, x86_64, arm, arm64
-Windows               i386, x86_64, arm64       Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
+Windows 7+            i386, x86_64, arm64       Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
 AIX 7.2TL5+           powerpc, powerpc64
 Embedded (picolibc)   arm
 ===================== ========================= ============================


### PR DESCRIPTION
The llvm-mingw toolchains defaults to `_WIN32_WINNT=0x601`, so this configuration is covered by our CI build matrix.