### PR TITLE
[libunwind] Faster handling of frames with missed FDE records.

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -1813,11 +1813,11 @@ bool UnwindCursor<A, R>::getInfoFromDwarfSection(
       // Add to cache (to make next lookup faster) if we had no hint
       // and there was no index.
       if (!foundInCache && (fdeSectionOffsetHint == 0)) {
-  #if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
+#if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
         if (sects.dwarf_index_section == 0)
-  #endif
-        DwarfFDECache<A>::add(sects.dso_base, fdeInfo.pcStart, fdeInfo.pcEnd,
-                              fdeInfo.fdeStart);
+#endif
+          DwarfFDECache<A>::add(sects.dso_base, fdeInfo.pcStart, fdeInfo.pcEnd,
+                                fdeInfo.fdeStart);
       }
       return true;
     }

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -1787,9 +1787,26 @@ bool UnwindCursor<A, R>::getInfoFromDwarfSection(
   }
   if (!foundFDE) {
     // Still not found, do full scan of __eh_frame section.
-    foundFDE = CFI_Parser<A>::findFDE(_addressSpace, pc, sects.dwarf_section,
-                                      sects.dwarf_section_length, 0,
-                                      &fdeInfo, &cieInfo);
+    // But only if __eh_frame_hdr is absent or empty.
+    // We assume that both sections have the same data, and don't want to waste
+    // time for long scan for absent addresses.
+    bool hasEHHeaderData = false;
+#if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
+    if ((sects.dwarf_index_section != 0)) {
+      typename EHHeaderParser<A>::EHHeaderInfo hdrInfo;
+      const pint_t ehHdrStart = sects.dwarf_index_section;
+      const pint_t ehHdrEnd = ehHdrStart + sects.dwarf_index_section_length;
+      if (EHHeaderParser<A>::decodeEHHdr(_addressSpace, ehHdrStart, ehHdrEnd,
+                                         hdrInfo)) {
+        hasEHHeaderData = (hdrInfo.fde_count != 0);
+      }
+    }
+#endif
+    if (!hasEHHeaderData) {
+      foundFDE = CFI_Parser<A>::findFDE(_addressSpace, pc, sects.dwarf_section,
+                                        sects.dwarf_section_length, 0, &fdeInfo,
+                                        &cieInfo);
+    }
   }
   if (foundFDE) {
     if (getInfoFromFdeCie(fdeInfo, cieInfo, pc, sects.dso_base)) {


### PR DESCRIPTION
Some stack may have frames with missing FDE records, for example, when they implemented in assembly and author did not provide frame information manually.
In that case any attempt to unwind such stack will result in potentially long linear .eh_frame section scan.
This patch adds assumption that if .eh_frame_hdr section is present and not empty, then any frame must be present in it and we can skip long linear scan of .eh_frame section.