### PR TITLE
[lli] Honor --jit-linker-kind=rtdyld on platforms that default to jitlink

### DIFF
--- a/llvm/test/ExecutionEngine/OrcLazy/debug-objects.ll
+++ b/llvm/test/ExecutionEngine/OrcLazy/debug-objects.ll
@@ -34,14 +34,19 @@
 ;
 ; RUN: lli --jit-linker=rtdyld --orc-lazy-debug=jit-debug-objects %s | \
 ; RUN:                              llvm-objdump --section-headers - | \
-; RUN:                              FileCheck --check-prefix=CHECK_LOAD_ADDR %s
+; RUN:                              FileCheck --check-prefix=CHECK_RTDYLD %s
+;
+; CHECK_RTDYLD:      .ltext
+; CHECK_RTDYLD-NOT:  0000000000000000
+; CHECK_RTDYLD-SAME: TEXT
+;
 ; RUN: lli --jit-linker=jitlink --orc-lazy-debug=jit-debug-objects %s | \
 ; RUN:                               llvm-objdump --section-headers - | \
-; RUN:                               FileCheck --check-prefix=CHECK_LOAD_ADDR %s
+; RUN:                               FileCheck --check-prefix=CHECK_JITLINK %s
 ;
-; CHECK_LOAD_ADDR:      .text
-; CHECK_LOAD_ADDR-NOT:  0000000000000000
-; CHECK_LOAD_ADDR-SAME: TEXT
+; CHECK_JITLINK:      .text
+; CHECK_JITLINK-NOT:  0000000000000000
+; CHECK_JITLINK-SAME: TEXT
 
 define i32 @main() !dbg !3 {
 entry:

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -1021,17 +1021,25 @@ static int runOrcJIT(const char *ProgName) {
     llvm_unreachable("Unrecognized platform value");
   }
 
-  std::unique_ptr<orc::ExecutorProcessControl> EPC = nullptr;
-  if (JITLinker == JITLinkerKind::JITLink) {
-    EPC = ExitOnErr(orc::SelfExecutorProcessControl::Create(
-        std::make_shared<orc::SymbolStringPool>()));
-
+  switch (JITLinker) {
+  case JITLinkerKind::JITLink:
     Builder.getJITTargetMachineBuilder()
         ->setRelocationModel(Reloc::PIC_)
         .setCodeModel(CodeModel::Small);
     Builder.setObjectLinkingLayerCreator([&](orc::ExecutionSession &ES) {
       return std::make_unique<orc::ObjectLinkingLayer>(ES);
     });
+    break;
+  case JITLinkerKind::RuntimeDyld:
+    Builder.setObjectLinkingLayerCreator([&](orc::ExecutionSession &ES) {
+      return std::make_unique<orc::RTDyldObjectLinkingLayer>(ES, [](const MemoryBuffer &) {
+        return std::make_unique<SectionMemoryManager>();
+      });
+    });
+    break;
+  case JITLinkerKind::Default:
+    // Let LLJITBuilder decide
+    break;
   }
 
   auto J = ExitOnErr(Builder.create());
@@ -1161,18 +1169,10 @@ static int runOrcJIT(const char *ProgName) {
   }
 
   // Resolve and run the main function.
+  using MainFnTy = int(int, char *[]);
   auto MainAddr = ExitOnErr(J->lookup(EntryFunc));
-  int Result;
-
-  if (EPC) {
-    // ExecutorProcessControl-based execution with JITLink.
-    Result = ExitOnErr(EPC->runAsMain(MainAddr, InputArgv));
-  } else {
-    // Manual in-process execution with RuntimeDyld.
-    using MainFnTy = int(int, char *[]);
-    auto MainFn = MainAddr.toPtr<MainFnTy *>();
-    Result = orc::runAsMain(MainFn, InputArgv, StringRef(InputFile));
-  }
+  auto MainFn = MainAddr.toPtr<MainFnTy *>();
+  int Result = orc::runAsMain(MainFn, InputArgv, StringRef(InputFile));
 
   // Wait for -entry-point threads.
   for (auto &AltEntryThread : AltEntryThreads)

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -1032,9 +1032,10 @@ static int runOrcJIT(const char *ProgName) {
     break;
   case JITLinkerKind::RuntimeDyld:
     Builder.setObjectLinkingLayerCreator([&](orc::ExecutionSession &ES) {
-      return std::make_unique<orc::RTDyldObjectLinkingLayer>(ES, [](const MemoryBuffer &) {
-        return std::make_unique<SectionMemoryManager>();
-      });
+      return std::make_unique<orc::RTDyldObjectLinkingLayer>(
+          ES, [](const MemoryBuffer &) {
+            return std::make_unique<SectionMemoryManager>();
+          });
     });
     break;
   case JITLinkerKind::Default:


### PR DESCRIPTION
So far, the setting enforced only jitlink but not rtdyld. We get better test coverage now that we honor both cases. We drop EPC-based execution on the way, because with ORC lli always executes in-process.