### PR TITLE
[Clang][Sema] properly remove qualifiers in __is_pointer_interconvertible_base_of

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -15607,8 +15607,8 @@ bool Sema::IsLayoutCompatible(QualType T1, QualType T2) const {
 
 bool Sema::IsPointerInterconvertibleBaseOf(const TypeSourceInfo *Base,
                                            const TypeSourceInfo *Derived) {
-  QualType BaseT = Base->getType()->getCanonicalTypeUnqualified();
-  QualType DerivedT = Derived->getType()->getCanonicalTypeUnqualified();
+  QualType BaseT = Base->getType().getUnqualifiedType();
+  QualType DerivedT = Derived->getType().getUnqualifiedType();
 
   if (BaseT->isStructureOrClassType() && DerivedT->isStructureOrClassType() &&
       getASTContext().hasSameType(BaseT, DerivedT))

--- a/clang/test/Sema/pointer-interconvertible-template-param.cpp
+++ b/clang/test/Sema/pointer-interconvertible-template-param.cpp
@@ -1,0 +1,22 @@
+// RUN: %clangxx %s -o %t
+// RUN: %t | FileCheck %s
+
+#include <iostream>
+
+class A {};
+class B : public A {};
+
+template <class _Base, class _Derived>
+inline constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
+
+int main() {
+    // CHECK: 1
+    std::cout << __is_pointer_interconvertible_base_of(const A, A) << std::endl;
+    // CHECK-NEXT: 1
+    std::cout << is_pointer_interconvertible_base_of_v<const A, A> << std::endl;
+
+    // CHECK-NEXT: 1
+    std::cout << __is_pointer_interconvertible_base_of(const A, B) << std::endl;
+    // CHECK-NEXT: 1
+    std::cout << is_pointer_interconvertible_base_of_v<const A, B> << std::endl;
+}


### PR DESCRIPTION
getCanonicalTypeUnqualified() doesn't actually remove cv qualifiers if the type is a SubstTemplateTypeParmType. Use getUnqualifiedType() instead, which does.