### PR TITLE
[PDB][NativeSession] Use better error code for invalid format

### DIFF
--- a/llvm/unittests/DebugInfo/PDB/NativeSessionTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/NativeSessionTest.cpp
@@ -40,6 +40,18 @@ TEST(NativeSessionTest, TestCreateFromExe) {
   ASSERT_THAT_ERROR(std::move(E), Succeeded());
 }
 
+TEST(NativeSessionTest, TestInvalidPdbMagicError) {
+  SmallString<128> InputsDir = unittest::getInputFileDirectory(TestMainArgv0);
+  llvm::sys::path::append(InputsDir, "SimpleTest.cpp");
+  std::string CppPath{InputsDir};
+  std::unique_ptr<IPDBSession> S;
+
+  Error E = NativeSession::createFromPdbPath(CppPath, S);
+  const char *FormatErr = "The record is in an unexpected format. "
+                          "The input file did not contain the pdb file magic.";
+  ASSERT_THAT_ERROR(std::move(E), FailedWithMessage(FormatErr));
+}
+
 TEST(NativeSessionTest, TestSetLoadAddress) {
   std::unique_ptr<IPDBSession> S;
   Error E = pdb::loadDataForEXE(PDB_ReaderType::Native, getExePath(), S);


### PR DESCRIPTION
Replaces the default "Success" std::error_code with a more meaningful one if  `Magic != file_magic::pdb`.