### PR TITLE
Revert "[lldb][NFC] Mark ValueObject library with NO_PLUGIN_DEPENDENCIES"

### DIFF
--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -58,8 +58,6 @@ add_lldb_library(lldbCommands NO_PLUGIN_DEPENDENCIES
     lldbUtility
     lldbValueObject
     lldbVersion
-  CLANG_LIBS
-    clangFrontend
   )
 
 add_dependencies(lldbCommands LLDBOptionsGen)

--- a/lldb/source/ValueObject/CMakeLists.txt
+++ b/lldb/source/ValueObject/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_lldb_library(lldbValueObject NO_PLUGIN_DEPENDENCIES
+add_lldb_library(lldbValueObject
   DILAST.cpp
   DILEval.cpp
   DILLexer.cpp
@@ -34,4 +34,6 @@ add_lldb_library(lldbValueObject NO_PLUGIN_DEPENDENCIES
     lldbSymbol
     lldbTarget
     lldbUtility
+    lldbPluginCPlusPlusLanguage
+    lldbPluginObjCLanguage
   )


### PR DESCRIPTION
Reverts llvm/llvm-project#167794

This breaks a build with BUILD_SHARED_LIBS=ON:

/usr/bin/ld: lib/liblldbCommands.a(CommandObjectTarget.cpp.o): undefined reference to symbol '_ZN5clang22PCHContainerOperationsC1Ev

Fixing that issue leads to similar failures due to different symbols.