### PR TITLE
[clang][C23] Allow NaN in constant evaluation

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -222,6 +222,8 @@ C23 Feature Support
   the same translation unit but from different types.
 - ``-MG`` now silences the "file not found" errors with ``#embed`` when
   scanning for dependencies and encountering an unknown file. #GH165632
+- Allow NaN in constant expression evaluation to maintain consistency with
+  GCC in behavior, even though it's an undefined behavior. #GH161806
 
 Non-comprehensive list of changes in this release
 -------------------------------------------------

--- a/clang/test/AST/const-nan.c
+++ b/clang/test/AST/const-nan.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -std=c23 -triple i386-linux %s -fsyntax-only -verify
+// RUN: %clang_cc1 -std=c23 -emit-llvm -triple i386-linux %s -o - | FileCheck %s
+
+// expected-no-diagnostics
+
+// CHECK: @[[CONST:.*]] = private unnamed_addr constant [1 x float] [float 0x7FF8000000000000], align 4
+// CHECK: @[[F_X:.*]] = internal global float 0x7FF8000000000000, align 4
+#pragma STDC FENV_ACCESS ON
+void f(void)
+{
+  // CHECK: %[[V:.*]] = alloca double, align 8
+  // CHECK: %[[W:.*]] = alloca [1 x float], align 4
+  // CHECK: %[[Y:.*]] = alloca float, align 4
+  // CHECK: %[[Z:.*]] = alloca double, align 8
+
+  // CHECK: store double 0x7FF8000000000000, ptr %[[V]], align 8
+  constexpr double v = 0.0/0.0; // does not raise an exception
+
+  // CHECK: call void @llvm.memcpy.p0.p0.i32(ptr align 4 %[[W]], ptr align 4 @[[CONST]], i32 4, i1 false)
+  float w[] = { 0.0f/0.0f }; // raises an exception
+
+  // F_X
+  static float x = 0.0f/0.0f; // does not raise an exception
+
+  // CHECK: %[[DIV:.*]] = call float @llvm.experimental.constrained.fdiv.f32(float 0.000000e+00, float 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  // CHECK: store float %[[DIV]], ptr %[[Y]], align 4
+  float y = 0.0f/0.0f; // raises an exception
+
+  // CHECK: %[[DIV1:.*]] = call double @llvm.experimental.constrained.fdiv.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  // CHECK: store double %[[DIV1]], ptr %[[Z]], align 8
+  double z = 0.0/0.0; // raises an exception
+}


### PR DESCRIPTION
Allow NaN in constant evaluation even if it's undefined behavior in C mode.

Fixes https://github.com/llvm/llvm-project/issues/161806.