### PR TITLE
[offload] defer "---> olInit" trace message

### DIFF
--- a/offload/tools/offload-tblgen/EntryPointGen.cpp
+++ b/offload/tools/offload-tblgen/EntryPointGen.cpp
@@ -102,9 +102,8 @@ static void EmitEntryPointFunc(const FunctionRec &F, raw_ostream &OS) {
   // Emit post-call prints
   OS << TAB_1 "if (llvm::offload::isTracingEnabled()) {\n";
   // postponed pre-call print for olInit
-  if (F.getName() == "olInit") {
+  if (F.getName() == "olInit")
     OS << formatv(TAB_2 "llvm::errs() << \"---> {0}\";\n", F.getName());
-  }
 
   if (F.getParams().size() > 0) {
     OS << formatv(TAB_2 "{0} Params = {{", F.getParamStructName());

--- a/offload/tools/offload-tblgen/EntryPointGen.cpp
+++ b/offload/tools/offload-tblgen/EntryPointGen.cpp
@@ -83,13 +83,15 @@ static void EmitEntryPointFunc(const FunctionRec &F, raw_ostream &OS) {
   OS << ") {\n";
 
   // Check offload is initialized
-  if (F.getName() != "olInit")
+  if (F.getName() != "olInit") {
     OS << "if (!llvm::offload::isOffloadInitialized()) return &UninitError;";
 
-  // Emit pre-call prints
-  OS << TAB_1 "if (llvm::offload::isTracingEnabled()) {\n";
-  OS << formatv(TAB_2 "llvm::errs() << \"---> {0}\";\n", F.getName());
-  OS << TAB_1 "}\n\n";
+    // Emit pre-call prints
+    // Postpone pre-calls for olInit as tracing requires liboffload to be initialized
+    OS << TAB_1 "if (llvm::offload::isTracingEnabled()) {\n";
+    OS << formatv(TAB_2 "llvm::errs() << \"---> {0}\";\n", F.getName());
+    OS << TAB_1 "}\n\n";
+  }
 
   // Perform actual function call to the validation wrapper
   ParamNameList = ParamNameList.substr(0, ParamNameList.size() - 2);
@@ -99,6 +101,11 @@ static void EmitEntryPointFunc(const FunctionRec &F, raw_ostream &OS) {
 
   // Emit post-call prints
   OS << TAB_1 "if (llvm::offload::isTracingEnabled()) {\n";
+  // postponed pre-call print for olInit
+  if (F.getName() == "olInit") {
+    OS << formatv(TAB_2 "llvm::errs() << \"---> {0}\";\n", F.getName());
+  }
+
   if (F.getParams().size() > 0) {
     OS << formatv(TAB_2 "{0} Params = {{", F.getParamStructName());
     for (const auto &Param : F.getParams()) {


### PR DESCRIPTION
Tracing requires liboffload to be initialized, so calling isTracingEnabled() before olInit always returns false. This caused the first trace log to look like:
```
-> OL_SUCCESS
```
instead of:
```
---> olInit() -> OL_SUCCESS
```
This patch moves the pre-call trace print for olInit so it is emitted only after initialization.

It would be possible to add extra logic to detect whether liboffload is already initialized and only postpone the first pre-call print, but this would add unnecessary complexity, especially since this is tablegen code. The difference would matter only in the unlikely case of a crash during a second olInit call.