### PR TITLE
[CodeGen] Hide SparseSet<LiveRegUnit> behind a typedef (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineTraceMetrics.h
+++ b/llvm/include/llvm/CodeGen/MachineTraceMetrics.h
@@ -83,6 +83,8 @@ struct LiveRegUnit {
   LiveRegUnit(unsigned RU) : RegUnit(RU) {}
 };
 
+using LiveRegUnitSet = SparseSet<LiveRegUnit>;
+
 /// Strategies for selecting traces.
 enum class MachineTraceStrategy {
   /// Select the trace through a block that has the fewest instructions.
@@ -381,15 +383,14 @@ public:
 
     /// Updates the depth of an machine instruction, given RegUnits.
     void updateDepth(TraceBlockInfo &TBI, const MachineInstr&,
-                     SparseSet<LiveRegUnit> &RegUnits);
+                     LiveRegUnitSet &RegUnits);
     void updateDepth(const MachineBasicBlock *, const MachineInstr&,
-                     SparseSet<LiveRegUnit> &RegUnits);
+                     LiveRegUnitSet &RegUnits);
 
     /// Updates the depth of the instructions from Start to End.
     void updateDepths(MachineBasicBlock::iterator Start,
                       MachineBasicBlock::iterator End,
-                      SparseSet<LiveRegUnit> &RegUnits);
-
+                      LiveRegUnitSet &RegUnits);
   };
 
   /// Get the trace ensemble representing the given trace selection strategy.

--- a/llvm/include/llvm/CodeGen/MachineTraceMetrics.h
+++ b/llvm/include/llvm/CodeGen/MachineTraceMetrics.h
@@ -382,9 +382,9 @@ public:
     Trace getTrace(const MachineBasicBlock *MBB);
 
     /// Updates the depth of an machine instruction, given RegUnits.
-    void updateDepth(TraceBlockInfo &TBI, const MachineInstr&,
+    void updateDepth(TraceBlockInfo &TBI, const MachineInstr &,
                      LiveRegUnitSet &RegUnits);
-    void updateDepth(const MachineBasicBlock *, const MachineInstr&,
+    void updateDepth(const MachineBasicBlock *, const MachineInstr &,
                      LiveRegUnitSet &RegUnits);
 
     /// Updates the depth of the instructions from Start to End.

--- a/llvm/lib/CodeGen/MachineCombiner.cpp
+++ b/llvm/lib/CodeGen/MachineCombiner.cpp
@@ -482,9 +482,8 @@ insertDeleteInstructions(MachineBasicBlock *MBB, MachineInstr &MI,
                          SmallVectorImpl<MachineInstr *> &InsInstrs,
                          SmallVectorImpl<MachineInstr *> &DelInstrs,
                          MachineTraceMetrics::Ensemble *TraceEnsemble,
-                         SparseSet<LiveRegUnit> &RegUnits,
-                         const TargetInstrInfo *TII, unsigned Pattern,
-                         bool IncrementalUpdate) {
+                         LiveRegUnitSet &RegUnits, const TargetInstrInfo *TII,
+                         unsigned Pattern, bool IncrementalUpdate) {
   // If we want to fix up some placeholder for some target, do it now.
   // We need this because in genAlternativeCodeSequence, we have not decided the
   // better pattern InsInstrs or DelInstrs, so we don't want generate some
@@ -565,7 +564,7 @@ bool MachineCombiner::combineInstructions(MachineBasicBlock *MBB) {
   if (!TraceEnsemble)
     TraceEnsemble = Traces->getEnsemble(TII->getMachineCombinerTraceStrategy());
 
-  SparseSet<LiveRegUnit> RegUnits;
+  LiveRegUnitSet RegUnits;
   RegUnits.setUniverse(TRI->getNumRegUnits());
 
   bool OptForSize = llvm::shouldOptimizeForSize(MBB, PSI, MBFI);

--- a/llvm/lib/CodeGen/MachineTraceMetrics.cpp
+++ b/llvm/lib/CodeGen/MachineTraceMetrics.cpp
@@ -737,7 +737,7 @@ static void getPHIDeps(const MachineInstr &UseMI,
 // tracking set when scanning instructions downwards.
 static void updatePhysDepsDownwards(const MachineInstr *UseMI,
                                     SmallVectorImpl<DataDep> &Deps,
-                                    SparseSet<LiveRegUnit> &RegUnits,
+                                    LiveRegUnitSet &RegUnits,
                                     const TargetRegisterInfo *TRI) {
   SmallVector<MCRegister, 8> Kills;
   SmallVector<unsigned, 8> LiveDefOps;
@@ -758,7 +758,7 @@ static void updatePhysDepsDownwards(const MachineInstr *UseMI,
     if (!MO.readsReg())
       continue;
     for (MCRegUnit Unit : TRI->regunits(Reg)) {
-      SparseSet<LiveRegUnit>::iterator I = RegUnits.find(Unit);
+      LiveRegUnitSet::iterator I = RegUnits.find(Unit);
       if (I == RegUnits.end())
         continue;
       Deps.push_back(DataDep(I->MI, I->Op, MO.getOperandNo()));
@@ -813,9 +813,9 @@ computeCrossBlockCriticalPath(const TraceBlockInfo &TBI) {
   return MaxLen;
 }
 
-void MachineTraceMetrics::Ensemble::
-updateDepth(MachineTraceMetrics::TraceBlockInfo &TBI, const MachineInstr &UseMI,
-            SparseSet<LiveRegUnit> &RegUnits) {
+void MachineTraceMetrics::Ensemble::updateDepth(TraceBlockInfo &TBI,
+                                                const MachineInstr &UseMI,
+                                                LiveRegUnitSet &RegUnits) {
   SmallVector<DataDep, 8> Deps;
   // Collect all data dependencies.
   if (UseMI.isPHI())
@@ -852,16 +852,15 @@ updateDepth(MachineTraceMetrics::TraceBlockInfo &TBI, const MachineInstr &UseMI,
   }
 }
 
-void MachineTraceMetrics::Ensemble::
-updateDepth(const MachineBasicBlock *MBB, const MachineInstr &UseMI,
-            SparseSet<LiveRegUnit> &RegUnits) {
+void MachineTraceMetrics::Ensemble::updateDepth(const MachineBasicBlock *MBB,
+                                                const MachineInstr &UseMI,
+                                                LiveRegUnitSet &RegUnits) {
   updateDepth(BlockInfo[MBB->getNumber()], UseMI, RegUnits);
 }
 
-void MachineTraceMetrics::Ensemble::
-updateDepths(MachineBasicBlock::iterator Start,
-             MachineBasicBlock::iterator End,
-             SparseSet<LiveRegUnit> &RegUnits) {
+void MachineTraceMetrics::Ensemble::updateDepths(
+    MachineBasicBlock::iterator Start, MachineBasicBlock::iterator End,
+    LiveRegUnitSet &RegUnits) {
     for (; Start != End; Start++)
       updateDepth(Start->getParent(), *Start, RegUnits);
 }
@@ -887,7 +886,7 @@ computeInstrDepths(const MachineBasicBlock *MBB) {
   // in the trace. We should track any live-out physregs that were defined in
   // the trace. This is quite rare in SSA form, typically created by CSE
   // hoisting a compare.
-  SparseSet<LiveRegUnit> RegUnits;
+  LiveRegUnitSet RegUnits;
   RegUnits.setUniverse(MTM.TRI->getNumRegUnits());
 
   // Go through trace blocks in top-down order, stopping after the center block.
@@ -925,7 +924,7 @@ computeInstrDepths(const MachineBasicBlock *MBB) {
 // Return the issue height of MI after considering any live regunits.
 // Height is the issue height computed from virtual register dependencies alone.
 static unsigned updatePhysDepsUpwards(const MachineInstr &MI, unsigned Height,
-                                      SparseSet<LiveRegUnit> &RegUnits,
+                                      LiveRegUnitSet &RegUnits,
                                       const TargetSchedModel &SchedModel,
                                       const TargetInstrInfo *TII,
                                       const TargetRegisterInfo *TRI) {
@@ -944,7 +943,7 @@ static unsigned updatePhysDepsUpwards(const MachineInstr &MI, unsigned Height,
     // This is a def of Reg. Remove corresponding entries from RegUnits, and
     // update MI Height to consider the physreg dependencies.
     for (MCRegUnit Unit : TRI->regunits(Reg.asMCReg())) {
-      SparseSet<LiveRegUnit>::iterator I = RegUnits.find(Unit);
+      LiveRegUnitSet::iterator I = RegUnits.find(Unit);
       if (I == RegUnits.end())
         continue;
       unsigned DepHeight = I->Cycle;
@@ -1048,7 +1047,7 @@ computeInstrHeights(const MachineBasicBlock *MBB) {
 
   // For physregs, the def isn't known when we see the use.
   // Instead, keep track of the highest use of each regunit.
-  SparseSet<LiveRegUnit> RegUnits;
+  LiveRegUnitSet RegUnits;
   RegUnits.setUniverse(MTM.TRI->getNumRegUnits());
 
   // If the bottom of the trace was already precomputed, initialize heights

--- a/llvm/lib/CodeGen/MachineTraceMetrics.cpp
+++ b/llvm/lib/CodeGen/MachineTraceMetrics.cpp
@@ -861,8 +861,8 @@ void MachineTraceMetrics::Ensemble::updateDepth(const MachineBasicBlock *MBB,
 void MachineTraceMetrics::Ensemble::updateDepths(
     MachineBasicBlock::iterator Start, MachineBasicBlock::iterator End,
     LiveRegUnitSet &RegUnits) {
-    for (; Start != End; Start++)
-      updateDepth(Start->getParent(), *Start, RegUnits);
+  for (; Start != End; Start++)
+    updateDepth(Start->getParent(), *Start, RegUnits);
 }
 
 /// Compute instruction depths for all instructions above or in MBB in its


### PR DESCRIPTION
So that changing the type of the container (planned in a future patch) is less intrusive.
