### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (5 of N)

### DIFF
--- a/flang/test/Lower/OpenACC/Todo/do-loops-to-acc-loops-todo.f90
+++ b/flang/test/Lower/OpenACC/Todo/do-loops-to-acc-loops-todo.f90
@@ -72,9 +72,9 @@ subroutine nested_loop_with_inner_goto()
   integer :: ii = 0, jj = 0
   integer, parameter :: nn = 3
   real, dimension(nn, nn) :: aa
-  
+
   aa = -1
-  
+
   ! Nested loop with goto from inner loop - unstructured control flow is not converted.
   !$acc kernels
   do ii = 1, nn

--- a/flang/test/Lower/OpenACC/acc-atomic-capture.f90
+++ b/flang/test/Lower/OpenACC/acc-atomic-capture.f90
@@ -36,7 +36,7 @@ program acc_atomic_capture_test
 !CHECK: }
 
     !$acc atomic capture
-        y = x * y 
+        y = x * y
         x = y
     !$acc end atomic
 
@@ -53,8 +53,8 @@ program acc_atomic_capture_test
 
     !$acc atomic capture
         x = y
-        y = 2 * 10 + (8 - x) 
-    !$acc end atomic 
+        y = 2 * 10 + (8 - x)
+    !$acc end atomic
 end program
 
 
@@ -123,8 +123,8 @@ end subroutine
 ! CHECK: }
 
 subroutine capture_with_convert_i32_to_f64()
-  real(8) :: x 
-  integer :: v, u 
+  real(8) :: x
+  integer :: v, u
   x = 1.0
   v = 0
   u = 1

--- a/flang/test/Lower/OpenACC/acc-atomic-update-array.f90
+++ b/flang/test/Lower/OpenACC/acc-atomic-update-array.f90
@@ -5,7 +5,7 @@ subroutine atomic_update_array1(r, n, x)
   integer :: n
   real :: r(n), x
   integer :: i
-   
+
   !$acc data copy(r)
 
   !$acc parallel loop
@@ -51,7 +51,7 @@ subroutine atomic_write_array1(r, n, x)
   implicit none
   integer :: n
   real :: r(n), x
-  
+
   !$acc atomic write
   x = r(n)
 end subroutine
@@ -61,7 +61,7 @@ end subroutine
 ! CHECK: %[[DECL_X:.*]]:2 = hlfir.declare %[[ARG2]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFatomic_write_array1Ex"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
 ! CHECK: %[[DECL_R:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFatomic_write_array1Er"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
 ! CHECK: %[[DES:.*]] = hlfir.designate %[[DECL_R]]#0 (%{{.*}})  : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
-! CHECK: %[[LOAD:.*]] = fir.load %[[DES]] : !fir.ref<f32> 
+! CHECK: %[[LOAD:.*]] = fir.load %[[DES]] : !fir.ref<f32>
 ! CHECK: acc.atomic.write %[[DECL_X]]#0 = %[[LOAD]] : !fir.ref<f32>, f32
 
 subroutine atomic_capture_array1(r, n, x, y)

--- a/flang/test/Lower/OpenACC/acc-atomic-update.f90
+++ b/flang/test/Lower/OpenACC/acc-atomic-update.f90
@@ -42,7 +42,7 @@ program acc_atomic_update_test
 !CHECK: }
 
     !$acc atomic update
-        a = a + b 
+        a = a + b
 
 !CHECK: {{.*}} = arith.constant 1 : i32
 !CHECK: acc.atomic.update %[[Y_DECL]]#0 : !fir.ref<i32> {
@@ -56,10 +56,10 @@ program acc_atomic_update_test
 !CHECK:    %[[RESULT:.*]] = arith.muli %[[LOADED_X]], %[[ARG]] : i32
 !CHECK:    acc.yield %[[RESULT]] : i32
 !CHECK:  }
-    !$acc atomic 
+    !$acc atomic
         y = y + 1
     !$acc atomic update
-        z = x * z 
+        z = x * z
 
 !CHECK:  %[[C1_VAL:.*]] = arith.constant 1 : i32
 !CHECK:  acc.atomic.update %[[I1_DECL]]#0 : !fir.ref<i8> {

--- a/flang/test/Lower/OpenACC/acc-bounds.f90
+++ b/flang/test/Lower/OpenACC/acc-bounds.f90
@@ -114,7 +114,7 @@ contains
     !$acc data attach(a)
     !$acc end data
   end subroutine
-  
+
 ! CHECK-LABEL: func.func @_QMopenacc_boundsPacc_optional_data(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "a", fir.optional}) {
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional, pointer>, uniq_name = "_QMopenacc_boundsFacc_optional_dataEa"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)

--- a/flang/test/Lower/OpenACC/acc-host-data.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data.f90
@@ -26,7 +26,7 @@ subroutine acc_host_data()
 ! CHECK: acc.host_data dataOperands(%[[DA0]], %[[DA1]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
 ! CHECK: } attributes {ifPresent}
 
-  !$acc host_data use_device(a) if_present 
+  !$acc host_data use_device(a) if_present
   !$acc end host_data
 ! CHECK: acc.host_data dataOperands(%{{.*}}{{.*}} : !fir.ref<!fir.array<10xf32>>{{.*}}) {
 ! CHECK: } attributes {ifPresent}

--- a/flang/test/Lower/OpenACC/acc-loop-exit.f90
+++ b/flang/test/Lower/OpenACC/acc-loop-exit.f90
@@ -11,7 +11,7 @@ subroutine sub1(x, a)
   end do
 
   i = 2
-end 
+end
 
 ! CHECK-LABEL: func.func @_QPsub1
 ! CHECK: %[[A:.*]]:2 = hlfir.declare %arg1 dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFsub1Ea"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
@@ -20,9 +20,9 @@ end
 ! CHECK:   %[[I:.*]]:2 = hlfir.declare %{{[0-9]+}} {uniq_name = "_QFsub1Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: ^bb{{.*}}:
 ! CHECK: ^bb{{.*}}:
-! CHECK:   %[[LOAD_I:.*]] = fir.load %[[I]]#0 : !fir.ref<i32> 
-! CHECK:   %[[LOAD_I:.*]] = fir.load %[[I]]#0 : !fir.ref<i32> 
-! CHECK:   %[[LOAD_A:.*]] = fir.load %[[A]]#0 : !fir.ref<i32> 
+! CHECK:   %[[LOAD_I:.*]] = fir.load %[[I]]#0 : !fir.ref<i32>
+! CHECK:   %[[LOAD_I:.*]] = fir.load %[[I]]#0 : !fir.ref<i32>
+! CHECK:   %[[LOAD_A:.*]] = fir.load %[[A]]#0 : !fir.ref<i32>
 ! CHECK:   %[[CMP:.*]] = arith.cmpi eq, %[[LOAD_I]], %[[LOAD_A]] : i32
 ! CHECK:   cf.cond_br %[[CMP]], ^[[EARLY_RET:.*]], ^[[NO_RET:.*]]
 ! CHECK: ^[[EARLY_RET]]:

--- a/flang/test/Lower/OpenACC/acc-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-loop.f90
@@ -376,8 +376,8 @@ end subroutine
 ! CHECK-SAME: %[[ARG_J:.*]]: !fir.ref<i32> {fir.bindc_name = "j"}
 ! CHECK-SAME: %[[ARG_K:.*]]: !fir.ref<i32> {fir.bindc_name = "k"}
 ! CHECK: %[[DC_I:.*]]:2 = hlfir.declare %[[ARG_I]] dummy_scope %0
-! CHECK: %[[DC_J:.*]]:2 = hlfir.declare %[[ARG_J]] dummy_scope %0 
-! CHECK: %[[DC_K:.*]]:2 = hlfir.declare %[[ARG_K]] dummy_scope %0 
+! CHECK: %[[DC_J:.*]]:2 = hlfir.declare %[[ARG_J]] dummy_scope %0
+! CHECK: %[[DC_K:.*]]:2 = hlfir.declare %[[ARG_K]] dummy_scope %0
 ! CHECK: acc.parallel combined(loop)
 ! CHECK: %[[P_I:.*]] = acc.private varPtr(%[[DC_I]]#0 : !fir.ref<i32>) -> !fir.ref<i32> {implicit = true, name = "i"}
 ! CHECK: %[[P_J:.*]] = acc.private varPtr(%[[DC_J]]#0 : !fir.ref<i32>) -> !fir.ref<i32> {implicit = true, name = "j"}

--- a/flang/test/Lower/OpenACC/acc-private.f90
+++ b/flang/test/Lower/OpenACC/acc-private.f90
@@ -195,8 +195,8 @@
 ! CHECK-LABEL: acc.firstprivate.recipe @firstprivatization_ref_i32 : !fir.ref<i32> init {
 ! CHECK: ^bb0(%{{.*}}: !fir.ref<i32>):
 ! CHECK:   %[[ALLOCA:.*]] = fir.alloca i32
-! CHECK:   %[[DECLARE:.*]]:2 = hlfir.declare %[[ALLOCA]] {uniq_name = "acc.private.init"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>) 
-! CHECK:   acc.yield %[[DECLARE]]#0 : !fir.ref<i32> 
+! CHECK:   %[[DECLARE:.*]]:2 = hlfir.declare %[[ALLOCA]] {uniq_name = "acc.private.init"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:   acc.yield %[[DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: } copy {
 ! CHECK: ^bb0(%[[SRC:.*]]: !fir.ref<i32>, %[[DST:.*]]: !fir.ref<i32>):
 ! CHECK:   %[[VALUE:.*]] = fir.load %[[SRC]] : !fir.ref<i32>
@@ -223,8 +223,8 @@
 ! CHECK-LABEL: acc.private.recipe @privatization_ref_i32 : !fir.ref<i32> init {
 ! CHECK: ^bb0(%{{.*}}: !fir.ref<i32>):
 ! CHECK:   %[[ALLOCA:.*]] = fir.alloca i32
-! CHECK:   %[[DECLARE:.*]]:2 = hlfir.declare %[[ALLOCA]] {uniq_name = "acc.private.init"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>) 
-! CHECK:   acc.yield %[[DECLARE]]#0 : !fir.ref<i32> 
+! CHECK:   %[[DECLARE:.*]]:2 = hlfir.declare %[[ALLOCA]] {uniq_name = "acc.private.init"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:   acc.yield %[[DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: }
 
 program acc_private

--- a/flang/test/Lower/OpenACC/acc-routine-named.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-named.f90
@@ -14,7 +14,7 @@ contains
   subroutine acc1()
   end subroutine
 
-! CHECK-LABEL: func.func @_QMacc_routinesPacc1() 
+! CHECK-LABEL: func.func @_QMacc_routinesPacc1()
 ! CHECK-SAME:attributes {acc.routine_info = #acc.routine_info<[@[[r1]]]>}
 
   subroutine acc2()

--- a/flang/test/Lower/OpenACC/acc-routine.f90
+++ b/flang/test/Lower/OpenACC/acc-routine.f90
@@ -127,13 +127,13 @@ subroutine acc_routine16()
 end subroutine
 
 subroutine acc_routine17()
-  !$acc routine device_type(host) worker dtype(multicore) vector 
+  !$acc routine device_type(host) worker dtype(multicore) vector
 end subroutine
 
 subroutine acc_routine18()
-  !$acc routine device_type(host) bind(acc_routine17) dtype(multicore) bind(acc_routine16) 
+  !$acc routine device_type(host) bind(acc_routine17) dtype(multicore) bind(acc_routine16)
 end subroutine
 
 subroutine acc_routine19()
-  !$acc routine device_type(host,default) bind(acc_routine17) dtype(multicore) bind(acc_routine16) 
+  !$acc routine device_type(host,default) bind(acc_routine17) dtype(multicore) bind(acc_routine16)
 end subroutine

--- a/flang/test/Lower/OpenACC/acc-routine02.f90
+++ b/flang/test/Lower/OpenACC/acc-routine02.f90
@@ -17,4 +17,4 @@ end program
 
 ! CHECK-LABEL: acc.routine @acc_routine_0 func(@_QPsub1)
 
-! CHECK: func.func @_QPsub1(%ar{{.*}}: !fir.ref<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.ref<i32> {fir.bindc_name = "n"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>} 
+! CHECK: func.func @_QPsub1(%ar{{.*}}: !fir.ref<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.ref<i32> {fir.bindc_name = "n"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}

--- a/flang/test/Lower/OpenACC/acc-routine03.f90
+++ b/flang/test/Lower/OpenACC/acc-routine03.f90
@@ -20,7 +20,7 @@ interface
     !$acc routine worker bind(sub2)
     real :: a(:)
   end subroutine
- 
+
   subroutine sub2(a)
     !$acc routine worker nohost
     real :: a(:)

--- a/flang/test/Lower/OpenACC/acc-routine04.f90
+++ b/flang/test/Lower/OpenACC/acc-routine04.f90
@@ -14,17 +14,17 @@ end module
 
 program test_acc_routine
   use dummy_mod
-  
+
   !$acc routine(sub2) seq
-  
+
   implicit none
-  
+
   integer :: i
 
 contains
   subroutine sub2()
   end subroutine
-  
+
 end program
 
 ! CHECK: acc.routine @acc_routine_1 func(@_QFPsub2) seq

--- a/flang/test/Lower/OpenACC/acc-shutdown.f90
+++ b/flang/test/Lower/OpenACC/acc-shutdown.f90
@@ -23,9 +23,9 @@ subroutine acc_shutdown
 
   !$acc shutdown device_num(1) device_type(default, nvidia)
 !CHECK: [[DEVNUM:%.*]] = arith.constant 1 : i32
-!CHECK: acc.shutdown device_num([[DEVNUM]] : i32) attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]} 
+!CHECK: acc.shutdown device_num([[DEVNUM]] : i32) attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]}
 
   !$acc shutdown device_type(default) device_type(nvidia)
-!CHECK: acc.shutdown attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]} 
+!CHECK: acc.shutdown attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]}
 
 end subroutine acc_shutdown

--- a/flang/test/Lower/OpenACC/acc-terminator.f90
+++ b/flang/test/Lower/OpenACC/acc-terminator.f90
@@ -17,7 +17,7 @@ program main
     !$acc data copyin(a(:,:,i),b(:,:,i),c(:,:,i)) copyout(c2(:,:,i))
 
     !$acc host_data use_device(a(:,:,i),b(:,:,i),c(:,:,i))
-    
+
     !$acc end host_data
 
     if ( stat .ne. 0 ) then

--- a/flang/test/Lower/OpenACC/acc-use-device.f90
+++ b/flang/test/Lower/OpenACC/acc-use-device.f90
@@ -9,7 +9,7 @@ subroutine test()
 ! CHECK: %[[A0:.*]] = fir.alloca !fir.array<?xf64>, %{{.*}} {bindc_name = "b", uniq_name = "_QFtestEb"}
 ! CHECK: %[[A1:.*]] = fir.shape_shift {{.*}} : (index, index) -> !fir.shapeshift<1>
 ! CHECK: %[[A:.*]]:2 = hlfir.declare %[[A0]](%[[A1]]) {uniq_name = "_QFtestEb"} : (!fir.ref<!fir.array<?xf64>>, !fir.shapeshift<1>) -> (!fir.box<!fir.array<?xf64>>, !fir.ref<!fir.array<?xf64>>)
-  
+
   !$acc data copy(b)
 ! CHECK: %[[B:.*]] = acc.copyin var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) -> !fir.box<!fir.array<?xf64>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
 ! CHECK: acc.data dataOperands(%[[B]] : !fir.box<!fir.array<?xf64>>) {
@@ -23,7 +23,7 @@ subroutine test()
 ! CHECK: fir.call @_QPvadd(%[[A]]#1) fastmath<contract> : (!fir.ref<!fir.array<?xf64>>) -> ()
   !$acc end data
 ! CHECK: acc.copyout accVar(%[[B]] : !fir.box<!fir.array<?xf64>>) to var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-end 
+end
 
 ! Test for allocatable, pointer and assumed-shape variables appearing in use_device clause.
 subroutine test2(a, b, c)

--- a/flang/test/Lower/OpenACC/locations.f90
+++ b/flang/test/Lower/OpenACC/locations.f90
@@ -114,7 +114,7 @@ module acc_locations
   subroutine atomic_read_loc()
     integer(4) :: x
     integer(8) :: y
-  
+
     !$acc atomic read
     y = x
   end
@@ -123,10 +123,10 @@ module acc_locations
   subroutine atomic_capture_loc()
     implicit none
     integer :: k, v, i
-  
+
     k = 1
     v = 0
-  
+
     !$acc atomic capture
     v = k
     k = (i + 1) * 3.14
@@ -142,13 +142,13 @@ module acc_locations
   subroutine atomic_update_loc()
     implicit none
     integer :: x, y, z
-    
-    !$acc atomic 
+
+    !$acc atomic
     y = y + 1
 ! CHECK: acc.atomic.update %{{.*}} : !fir.ref<i32> {
 ! CHECK: ^bb0(%{{.*}}: i32 loc("{{.*}}locations.f90":142:3)):
 ! CHECK: } loc("{{.*}}locations.f90":142:3)
-    
+
     !$acc atomic update
     z = x * z
   end subroutine
@@ -183,5 +183,3 @@ module acc_locations
     !CHECK-SAME:  loc("{{.*}}locations.f90":181:11)
   end subroutine
 end module
-
-


### PR DESCRIPTION
Only the fortran source files in flang/test/Lower/OpenACC have been modified. The other files in flang/test will be cleaned up in subsequent commits