### PR TITLE
[NFC][TableGen] Remove `close` member from various CodeGenHelpers

### DIFF
--- a/llvm/include/llvm/TableGen/CodeGenHelpers.h
+++ b/llvm/include/llvm/TableGen/CodeGenHelpers.h
@@ -33,25 +33,17 @@ public:
       OS << "#undef " << Name << "\n";
     OS << "\n";
   }
-  ~IfDefEmitter() { close(); }
-
-  // Explicit function to close the ifdef scopes.
-  void close() {
-    if (Closed)
-      return;
-
+  ~IfDefEmitter() {
     OS << "\n";
     if (LateUndef)
       OS << "#undef " << Name << "\n";
     OS << "#endif // " << Name << "\n\n";
-    Closed = true;
   }
 
 private:
   std::string Name;
   raw_ostream &OS;
   bool LateUndef;
-  bool Closed = false;
 };
 
 // Simple RAII helper for emitting header include guard (ifndef-define-endif).
@@ -62,20 +54,11 @@ public:
     OS << "#ifndef " << Name << "\n"
        << "#define " << Name << "\n\n";
   }
-  ~IncludeGuardEmitter() { close(); }
-
-  // Explicit function to close the ifdef scopes.
-  void close() {
-    if (Closed)
-      return;
-    OS << "\n#endif // " << Name << "\n\n";
-    Closed = true;
-  }
+  ~IncludeGuardEmitter() { OS << "\n#endif // " << Name << "\n\n"; }
 
 private:
   std::string Name;
   raw_ostream &OS;
-  bool Closed = false;
 };
 
 // Simple RAII helper for emitting namespace scope. Name can be a single
@@ -89,15 +72,9 @@ public:
       OS << "namespace " << Name << " {\n\n";
   }
 
-  ~NamespaceEmitter() { close(); }
-
-  // Explicit function to close the namespace scopes.
-  void close() {
-    if (Closed)
-      return;
+  ~NamespaceEmitter() {
     if (!Name.empty())
       OS << "\n} // namespace " << Name << "\n";
-    Closed = true;
   }
 
 private:
@@ -114,7 +91,6 @@ private:
   }
   std::string Name;
   raw_ostream &OS;
-  bool Closed = false;
 };
 
 } // end namespace llvm

--- a/mlir/tools/mlir-tblgen/EnumsGen.cpp
+++ b/mlir/tools/mlir-tblgen/EnumsGen.cpp
@@ -702,41 +702,45 @@ static void emitEnumDecl(const Record &enumDef, raw_ostream &os) {
   StringRef underlyingToSymFnName = enumInfo.getUnderlyingToSymbolFnName();
   auto enumerants = enumInfo.getAllCases();
 
-  llvm::NamespaceEmitter ns(os, cppNamespace);
+  {
+    llvm::NamespaceEmitter ns(os, cppNamespace);
 
-  // Emit the enum class definition
-  emitEnumClass(enumDef, enumName, underlyingType, description, enumerants, os);
+    // Emit the enum class definition
+    emitEnumClass(enumDef, enumName, underlyingType, description, enumerants,
+                  os);
 
-  // Emit conversion function declarations
-  if (llvm::all_of(enumerants, [](EnumCase enumerant) {
-        return enumerant.getValue() >= 0;
-      })) {
-    os << formatv(
-        "::std::optional<{0}> {1}({2});\n", enumName, underlyingToSymFnName,
-        underlyingType.empty() ? std::string("unsigned") : underlyingType);
-  }
-  os << formatv("{2} {1}({0});\n", enumName, symToStrFnName, symToStrFnRetType);
-  os << formatv("::std::optional<{0}> {1}(::llvm::StringRef);\n", enumName,
-                strToSymFnName);
+    // Emit conversion function declarations
+    if (llvm::all_of(enumerants, [](EnumCase enumerant) {
+          return enumerant.getValue() >= 0;
+        })) {
+      os << formatv(
+          "::std::optional<{0}> {1}({2});\n", enumName, underlyingToSymFnName,
+          underlyingType.empty() ? std::string("unsigned") : underlyingType);
+    }
+    os << formatv("{2} {1}({0});\n", enumName, symToStrFnName,
+                  symToStrFnRetType);
+    os << formatv("::std::optional<{0}> {1}(::llvm::StringRef);\n", enumName,
+                  strToSymFnName);
 
-  if (enumInfo.isBitEnum()) {
-    emitOperators(enumDef, os);
-  } else {
-    emitMaxValueFn(enumDef, os);
-  }
+    if (enumInfo.isBitEnum()) {
+      emitOperators(enumDef, os);
+    } else {
+      emitMaxValueFn(enumDef, os);
+    }
 
-  // Generate a generic `stringifyEnum` function that forwards to the method
-  // specified by the user.
-  const char *const stringifyEnumStr = R"(
+    // Generate a generic `stringifyEnum` function that forwards to the method
+    // specified by the user.
+    const char *const stringifyEnumStr = R"(
 inline {0} stringifyEnum({1} enumValue) {{
   return {2}(enumValue);
 }
 )";
-  os << formatv(stringifyEnumStr, symToStrFnRetType, enumName, symToStrFnName);
+    os << formatv(stringifyEnumStr, symToStrFnRetType, enumName,
+                  symToStrFnName);
 
-  // Generate a generic `symbolizeEnum` function that forwards to the method
-  // specified by the user.
-  const char *const symbolizeEnumStr = R"(
+    // Generate a generic `symbolizeEnum` function that forwards to the method
+    // specified by the user.
+    const char *const symbolizeEnumStr = R"(
 template <typename EnumType>
 ::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
 
@@ -745,9 +749,9 @@ inline ::std::optional<{0}> symbolizeEnum<{0}>(::llvm::StringRef str) {
   return {1}(str);
 }
 )";
-  os << formatv(symbolizeEnumStr, enumName, strToSymFnName);
+    os << formatv(symbolizeEnumStr, enumName, strToSymFnName);
 
-  const char *const attrClassDecl = R"(
+    const char *const attrClassDecl = R"(
 class {1} : public ::mlir::{2} {
 public:
   using ValueType = {0};
@@ -757,13 +761,12 @@ public:
   {0} getValue() const;
 };
 )";
-  if (enumInfo.genSpecializedAttr()) {
-    StringRef attrClassName = enumInfo.getSpecializedAttrClassName();
-    StringRef baseAttrClassName = "IntegerAttr";
-    os << formatv(attrClassDecl, enumName, attrClassName, baseAttrClassName);
-  }
-
-  ns.close();
+    if (enumInfo.genSpecializedAttr()) {
+      StringRef attrClassName = enumInfo.getSpecializedAttrClassName();
+      StringRef baseAttrClassName = "IntegerAttr";
+      os << formatv(attrClassDecl, enumName, attrClassName, baseAttrClassName);
+    }
+  } // close `ns`.
 
   // Generate a generic parser and printer for the enum.
   std::string qualName =


### PR DESCRIPTION
Always rely on local scopes to enforce the lifetime of these helper objects and by extension where the "closing" of various C++ code constructs happens.