### PR TITLE
[lldb][NFC] Simplify code in UnwindAssemblyInstruction

### DIFF
--- a/lldb/include/lldb/Core/Disassembler.h
+++ b/lldb/include/lldb/Core/Disassembler.h
@@ -297,6 +297,10 @@ public:
 
   lldb::InstructionSP GetInstructionAtIndex(size_t idx) const;
 
+  llvm::ArrayRef<lldb::InstructionSP> Instructions() const {
+    return m_instructions;
+  }
+
   /// Get the instruction at the given address.
   ///
   /// \return

--- a/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
@@ -134,8 +134,8 @@ bool UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly(
     return unwind_plan.GetRowCount() > 0;
   }
 
-  Instruction *inst = inst_list.GetInstructionAtIndex(0).get();
-  const lldb::addr_t base_addr = inst->GetAddress().GetFileAddress();
+  Instruction &first_inst = *inst_list.GetInstructionAtIndex(0).get();
+  const lldb::addr_t base_addr = first_inst.GetAddress().GetFileAddress();
 
   // Map for storing the unwind state at a given offset. When we see a forward
   // branch we add a new entry to this map with the actual unwind plan row and
@@ -161,7 +161,7 @@ bool UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly(
     m_curr_row_modified = false;
     m_forward_branch_offset = 0;
 
-    inst = inst_list.GetInstructionAtIndex(idx).get();
+    Instruction *inst = inst_list.GetInstructionAtIndex(idx).get();
     if (!inst)
       continue;
     DumpInstToLog(log, *inst, inst_list);

--- a/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
@@ -144,7 +144,7 @@ bool UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly(
              "Unwind row for the function entry missing");
       --it; // Move it to the row corresponding to the current offset
 
-      // If the offset of m_curr_row don't match with the offset we see in
+      // If the offset of m_state.row doesn't match with the offset we see in
       // saved_unwind_states then we have to update current unwind state to
       // the saved values. It is happening after we processed an epilogue and a
       // return to caller instruction.


### PR DESCRIPTION
This is a series of patches aimed at simplifying the main loop in UnwindAssemblyInstruction.
In a future PR, I would like to fix a bug whereby a mid function epilogue causes the unwinder to produce incorrect results, and these changes will make the fix easier to follow.

While this does pollute the git blame a bit, this code hasn't changed in close to ten years, and even the latest changes were already of a reformatting nature. As such, I believe this is acceptable.

Please look at each commit individually.