### PR TITLE
[utils] don't warn when setting rlimit fails on Solaris

### DIFF
--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -137,10 +137,11 @@ class Run(object):
                     "Raised process limit from %d to %d" % (soft_limit, desired_limit)
                 )
         except Exception as ex:
-            # Warn, unless this is Windows, z/OS, or Cygwin in which case this is expected.
+            # Warn, unless this is Windows, z/OS, Solaris or Cygwin in which case this is expected.
             if (
                 os.name != "nt"
                 and platform.system() != "OS/390"
+                and platform.system() != "SunOS"
                 and platform.sys.platform != "cygwin"
             ):
                 self.lit_config.warning("Failed to raise process limit: %s" % ex)


### PR DESCRIPTION
Solaris doesn't define RLIMIT_NPROC, so this is expected to fail there. This fixes a test failure in llvm/utils/lit/tests/verbosity.py on Solaris due to this unexpected warning being included in the lit output.