### PR TITLE
Re-land [lldb][NFC] Mark ValueObject library with NO_PLUGIN_DEPENDENCIES

### DIFF
--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -58,6 +58,9 @@ add_lldb_library(lldbCommands NO_PLUGIN_DEPENDENCIES
     lldbUtility
     lldbValueObject
     lldbVersion
+  CLANG_LIBS
+    clangFrontend
+    clangSerialization
   )
 
 add_dependencies(lldbCommands LLDBOptionsGen)

--- a/lldb/source/Expression/CMakeLists.txt
+++ b/lldb/source/Expression/CMakeLists.txt
@@ -24,6 +24,7 @@ add_lldb_library(lldbExpression NO_PLUGIN_DEPENDENCIES
 
   LINK_COMPONENTS
     Core
+    DebugInfoDWARF
     ExecutionEngine
     Support
   LINK_LIBS

--- a/lldb/source/ValueObject/CMakeLists.txt
+++ b/lldb/source/ValueObject/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_lldb_library(lldbValueObject
+add_lldb_library(lldbValueObject NO_PLUGIN_DEPENDENCIES
   DILAST.cpp
   DILEval.cpp
   DILLexer.cpp
@@ -34,6 +34,4 @@ add_lldb_library(lldbValueObject
     lldbSymbol
     lldbTarget
     lldbUtility
-    lldbPluginCPlusPlusLanguage
-    lldbPluginObjCLanguage
   )

--- a/lldb/source/Version/CMakeLists.txt
+++ b/lldb/source/Version/CMakeLists.txt
@@ -40,4 +40,7 @@ add_lldb_library(lldbVersion NO_PLUGIN_DEPENDENCIES
   ADDITIONAL_HEADERS
     ${version_inc}
     ${vcs_version_inc}
+
+  CLANG_LIBS
+    clangBasic
 )


### PR DESCRIPTION
This is a fixed version of #167886.

The build previously failed with `BUILD_SHARED_LIBS=ON`. After trying that locally, I uncovered a few other instances of lldb non-plugin libraries depending on clang transitively through lldbValueObject, so I added the correct clang libraries to their dependencies.