### PR TITLE
[clang-tidy][NFC] Add clang-format option to insert newline at EOF

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: LLVM
 QualifierAlignment: Left
 LineEnding: LF
+InsertNewlineAtEOF: true


### PR DESCRIPTION
As it appears, all our files already follow it.
Adding this for future PR with new checks