### PR TITLE
[CIR][NFC] Add missing code markers for Dtor_VectorDeleting

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -709,8 +709,8 @@ void CIRGenFunction::emitCXXDeleteExpr(const CXXDeleteExpr *e) {
   ptr = ptr.withElementType(builder, convertTypeForMem(deleteTy));
 
   if (e->isArrayForm() &&
-      cgm.getContext().getTargetInfo().emitVectorDeletingDtors(
-          cgm.getContext().getLangOpts())) {
+      cgm.getASTContext().getTargetInfo().emitVectorDeletingDtors(
+          cgm.getASTContext().getLangOpts())) {
     cgm.errorNYI(e->getSourceRange(),
                  "emitCXXDeleteExpr: emitVectorDeletingDtors");
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -708,6 +708,13 @@ void CIRGenFunction::emitCXXDeleteExpr(const CXXDeleteExpr *e) {
   deleteTy = getContext().getBaseElementType(deleteTy);
   ptr = ptr.withElementType(builder, convertTypeForMem(deleteTy));
 
+  if (e->isArrayForm() &&
+      cgm.getContext().getTargetInfo().emitVectorDeletingDtors(
+          cgm.getContext().getLangOpts())) {
+    cgm.errorNYI(e->getSourceRange(),
+                 "emitCXXDeleteExpr: emitVectorDeletingDtors");
+  }
+
   if (e->isArrayForm()) {
     assert(!cir::MissingFeatures::deleteArray());
     cgm.errorNYI(e->getSourceRange(), "emitCXXDeleteExpr: array delete");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -738,7 +738,9 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
   // outside of the function-try-block, which means it's always
   // possible to delegate the destructor body to the complete
   // destructor.  Do so.
-  if (dtorType == Dtor_Deleting) {
+  if (dtorType == Dtor_Deleting || dtorType == Dtor_VectorDeleting) {
+    if (cxxStructorImplicitParamValue && dtorType == Dtor_VectorDeleting)
+      cgm.errorNYI(dtor->getSourceRange(), "emitConditionalArrayDtorCall");
     RunCleanupsScope dtorEpilogue(*this);
     enterDtorCleanups(dtor, Dtor_Deleting);
     if (haveInsertPoint()) {
@@ -771,6 +773,7 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
   case Dtor_Comdat:
     llvm_unreachable("not expecting a COMDAT");
   case Dtor_Deleting:
+  case Dtor_VectorDeleting:
     llvm_unreachable("already handled deleting case");
 
   case Dtor_Complete:


### PR DESCRIPTION
This adds some minimal code to mark locations where handling is needed for Dtor_VectorDeleting type dtors, which were added in https://github.com/llvm/llvm-project/pull/165598

This is not a comprehensive mark-up of the missing code, as some code will be needed in places where the surrounding function has larger missing pieces in CIR currently.

This fixes a warning for an uncovered switch case that was causing CI builds to fail.