### PR TITLE
[RFC] [IR] Modules can make filtered range to iterate function definitions only

### DIFF
--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -712,11 +712,11 @@ public:
 
   /// Get an iterator range over all function definitions (excluding
   /// declarations).
-  auto function_definitions() {
+  auto getFunctionDefs() {
     return make_filter_range(functions(),
                              [](Function &F) { return !F.isDeclaration(); });
   }
-  auto function_definitions() const {
+  auto getFunctionDefs() const {
     return make_filter_range(
         functions(), [](const Function &F) { return !F.isDeclaration(); });
   }

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -710,6 +710,17 @@ public:
     return make_range(begin(), end());
   }
 
+  /// Get an iterator range over all function definitions (excluding
+  /// declarations).
+  auto function_definitions() {
+    return make_filter_range(functions(),
+                             [](Function &F) { return !F.isDeclaration(); });
+  }
+  auto function_definitions() const {
+    return make_filter_range(
+        functions(), [](const Function &F) { return !F.isDeclaration(); });
+  }
+
 /// @}
 /// @name Alias Iteration
 /// @{

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -395,7 +395,7 @@ public:
   /// FIXME: Use --target option to get target info directly, avoiding the need
   /// to parse machine functions for pre-training operations.
   bool initializeVocabularyForLayout(const Module &M) {
-    for (const Function &F : M.function_definitions()) {
+    for (const Function &F : M.getFunctionDefs()) {
 
       MachineFunction *MF = MMI.getMachineFunction(F);
       if (!MF)
@@ -429,7 +429,7 @@ public:
     std::string Relationships;
     raw_string_ostream RelOS(Relationships);
 
-    for (const Function &F : M.function_definitions()) {
+    for (const Function &F : M.getFunctionDefs()) {
 
       MachineFunction *MF = MMI.getMachineFunction(F);
       if (!MF) {
@@ -528,7 +528,7 @@ public:
       return;
     }
 
-    for (const Function &F : M.function_definitions()) {
+    for (const Function &F : M.getFunctionDefs()) {
 
       MachineFunction *MF = MMI.getMachineFunction(F);
       if (!MF) {

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -395,9 +395,7 @@ public:
   /// FIXME: Use --target option to get target info directly, avoiding the need
   /// to parse machine functions for pre-training operations.
   bool initializeVocabularyForLayout(const Module &M) {
-    for (const Function &F : M) {
-      if (F.isDeclaration())
-        continue;
+    for (const Function &F : M.function_definitions()) {
 
       MachineFunction *MF = MMI.getMachineFunction(F);
       if (!MF)
@@ -431,9 +429,7 @@ public:
     std::string Relationships;
     raw_string_ostream RelOS(Relationships);
 
-    for (const Function &F : M) {
-      if (F.isDeclaration())
-        continue;
+    for (const Function &F : M.function_definitions()) {
 
       MachineFunction *MF = MMI.getMachineFunction(F);
       if (!MF) {
@@ -532,9 +528,7 @@ public:
       return;
     }
 
-    for (const Function &F : M) {
-      if (F.isDeclaration())
-        continue;
+    for (const Function &F : M.function_definitions()) {
 
       MachineFunction *MF = MMI.getMachineFunction(F);
       if (!MF) {

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -433,4 +433,82 @@ define void @Foo2() {
   ASSERT_EQ(M2Str, M1Print);
 }
 
+TEST(ModuleTest, FunctionDefinitions) {
+  // Test function_definitions() method which returns only functions with bodies
+  LLVMContext Context;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(R"(
+declare void @Decl1()
+declare void @Decl2()
+
+define void @Def1() {
+  ret void
+}
+
+define void @Def2() {
+  ret void
+}
+
+declare void @Decl3()
+
+define void @Def3() {
+  ret void
+}
+)",
+                                                  Err, Context);
+  ASSERT_TRUE(M);
+
+  // Count total functions (should be 6: 3 declarations + 3 definitions)
+  size_t TotalFunctions = 0;
+  for (Function &F : *M) {
+    (void)F;
+    ++TotalFunctions;
+  }
+  EXPECT_EQ(TotalFunctions, 6u);
+
+  // Count function definitions only (should be 3)
+  size_t DefinitionCount = 0;
+  for (Function &F : M->function_definitions()) {
+    EXPECT_FALSE(F.isDeclaration());
+    ++DefinitionCount;
+  }
+  EXPECT_EQ(DefinitionCount, 3u);
+
+  // Verify the names of the definitions
+  auto DefRange = M->function_definitions();
+  auto It = DefRange.begin();
+  EXPECT_EQ(It->getName(), "Def1");
+  ++It;
+  EXPECT_EQ(It->getName(), "Def2");
+  ++It;
+  EXPECT_EQ(It->getName(), "Def3");
+  ++It;
+  EXPECT_EQ(It, DefRange.end());
+}
+
+TEST(ModuleTest, FunctionDefinitionsEmpty) {
+  // Test function_definitions() with no definitions (only declarations)
+  LLVMContext Context;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(R"(
+declare void @Decl1()
+declare void @Decl2()
+declare void @Decl3()
+)",
+                                                  Err, Context);
+  ASSERT_TRUE(M);
+
+  // Should have functions
+  EXPECT_FALSE(M->empty());
+  EXPECT_EQ(M->size(), 3u);
+
+  // But no definitions
+  size_t DefinitionCount = 0;
+  for (Function &F : M->function_definitions()) {
+    (void)F;
+    ++DefinitionCount;
+  }
+  EXPECT_EQ(DefinitionCount, 0u);
+}
+
 } // end namespace

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -434,7 +434,7 @@ define void @Foo2() {
 }
 
 TEST(ModuleTest, FunctionDefinitions) {
-  // Test function_definitions() method which returns only functions with bodies
+  // Test getFunctionDefs() method which returns only functions with bodies
   LLVMContext Context;
   SMDiagnostic Err;
   std::unique_ptr<Module> M = parseAssemblyString(R"(
@@ -468,14 +468,14 @@ define void @Def3() {
 
   // Count function definitions only (should be 3)
   size_t DefinitionCount = 0;
-  for (Function &F : M->function_definitions()) {
+  for (Function &F : M->getFunctionDefs()) {
     EXPECT_FALSE(F.isDeclaration());
     ++DefinitionCount;
   }
   EXPECT_EQ(DefinitionCount, 3u);
 
   // Verify the names of the definitions
-  auto DefRange = M->function_definitions();
+  auto DefRange = M->getFunctionDefs();
   auto It = DefRange.begin();
   EXPECT_EQ(It->getName(), "Def1");
   ++It;
@@ -487,7 +487,7 @@ define void @Def3() {
 }
 
 TEST(ModuleTest, FunctionDefinitionsEmpty) {
-  // Test function_definitions() with no definitions (only declarations)
+  // Test getFunctionDefs() with no definitions (only declarations)
   LLVMContext Context;
   SMDiagnostic Err;
   std::unique_ptr<Module> M = parseAssemblyString(R"(
@@ -504,7 +504,7 @@ declare void @Decl3()
 
   // But no definitions
   size_t DefinitionCount = 0;
-  for (Function &F : M->function_definitions()) {
+  for (Function &F : M->getFunctionDefs()) {
     (void)F;
     ++DefinitionCount;
   }


### PR DESCRIPTION
We often wish to iterate over all function definitions in a module for transformations.
Such API doesn't exists yet, so what people normally used is to iterate over all functions and skip the declarations:

```cpp
for (auto& F: M) {
    if (F.isDeclaration()) continue;
}
```

A regex search of the following pattern shows 100+ hits inside llvm, let along other patterns, e.g. collect all definitions in a module into a worklist.

```
for \(.*F.*\).*\n.*if \(F.isDeclaration\(\)\).*\n.*continue;
```

This pattern is verbose and hard to review in a long loop. 
As an alternative, this patch provides a new API that iterates over definitions only. 

Tests:

1. Added unit test
2. Touching @svkeerthy 's tool (also to show the cleanness of the new API).

Note: `function_definitions` seems a bit long, I'm open to suggestions to other names.