### PR TITLE
[RegAllocGreedy] Use MCRegister instead of MCPhysReg. NFC

### DIFF
--- a/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -1225,12 +1225,11 @@ MCRegister RAGreedy::tryRegionSplit(const LiveInterval &VirtReg,
   return doRegionSplit(VirtReg, BestCand, HasCompact, NewVRegs);
 }
 
-unsigned
-RAGreedy::calculateRegionSplitCostAroundReg(MCPhysReg PhysReg,
-                                            AllocationOrder &Order,
-                                            BlockFrequency &BestCost,
-                                            unsigned &NumCands,
-                                            unsigned &BestCand) {
+unsigned RAGreedy::calculateRegionSplitCostAroundReg(MCRegister PhysReg,
+                                                     AllocationOrder &Order,
+                                                     BlockFrequency &BestCost,
+                                                     unsigned &NumCands,
+                                                     unsigned &BestCand) {
   // Discard bad candidates before we run out of interference cache cursors.
   // This will only affect register classes with a lot of registers (>32).
   if (NumCands == IntfCache.getMaxCursors()) {
@@ -1309,7 +1308,7 @@ unsigned RAGreedy::calculateRegionSplitCost(const LiveInterval &VirtReg,
                                             unsigned &NumCands,
                                             bool IgnoreCSR) {
   unsigned BestCand = NoCand;
-  for (MCPhysReg PhysReg : Order) {
+  for (MCRegister PhysReg : Order) {
     assert(PhysReg);
     if (IgnoreCSR && EvictAdvisor->isUnusedCalleeSavedReg(PhysReg))
       continue;
@@ -1363,7 +1362,7 @@ MCRegister RAGreedy::doRegionSplit(const LiveInterval &VirtReg,
 
 // VirtReg has a physical Hint, this function tries to split VirtReg around
 // Hint if we can place new COPY instructions in cold blocks.
-bool RAGreedy::trySplitAroundHintReg(MCPhysReg Hint,
+bool RAGreedy::trySplitAroundHintReg(MCRegister Hint,
                                      const LiveInterval &VirtReg,
                                      SmallVectorImpl<Register> &NewVRegs,
                                      AllocationOrder &Order) {
@@ -1427,8 +1426,7 @@ bool RAGreedy::trySplitAroundHintReg(MCPhysReg Hint,
 
     MCRegister OtherPhysReg =
         OtherReg.isPhysical() ? OtherReg.asMCReg() : VRM->getPhys(OtherReg);
-    MCRegister ThisHint =
-        SubReg ? TRI->getSubReg(Hint, SubReg) : MCRegister(Hint);
+    MCRegister ThisHint = SubReg ? TRI->getSubReg(Hint, SubReg) : Hint;
     if (OtherPhysReg == ThisHint)
       Cost += MBFI->getBlockFreq(Instr.getParent());
   }
@@ -1822,7 +1820,7 @@ MCRegister RAGreedy::tryLocalSplit(const LiveInterval &VirtReg,
       (1.0f / MBFI->getEntryFreq().getFrequency());
   SmallVector<float, 8> GapWeight;
 
-  for (MCPhysReg PhysReg : Order) {
+  for (MCRegister PhysReg : Order) {
     assert(PhysReg);
     // Keep track of the largest spill weight that would need to be evicted in
     // order to make use of PhysReg between UseSlots[I] and UseSlots[I + 1].

--- a/llvm/lib/CodeGen/RegAllocGreedy.h
+++ b/llvm/lib/CodeGen/RegAllocGreedy.h
@@ -336,7 +336,7 @@ private:
   MCRegister tryRegionSplit(const LiveInterval &, AllocationOrder &,
                             SmallVectorImpl<Register> &);
   /// Calculate cost of region splitting around the specified register.
-  unsigned calculateRegionSplitCostAroundReg(MCPhysReg PhysReg,
+  unsigned calculateRegionSplitCostAroundReg(MCRegister PhysReg,
                                              AllocationOrder &Order,
                                              BlockFrequency &BestCost,
                                              unsigned &NumCands,
@@ -351,7 +351,7 @@ private:
                            bool HasCompact,
                            SmallVectorImpl<Register> &NewVRegs);
   /// Try to split VirtReg around physical Hint register.
-  bool trySplitAroundHintReg(MCPhysReg Hint, const LiveInterval &VirtReg,
+  bool trySplitAroundHintReg(MCRegister Hint, const LiveInterval &VirtReg,
                              SmallVectorImpl<Register> &NewVRegs,
                              AllocationOrder &Order);
   /// Check other options before using a callee-saved register for the first


### PR DESCRIPTION
Removes some implicit casts from MCRegister to unsigned.