### PR TITLE
[libc++] Fix the locale base API on Linux with musl

### DIFF
--- a/libcxx/include/__locale_dir/support/linux.h
+++ b/libcxx/include/__locale_dir/support/linux.h
@@ -83,15 +83,30 @@ inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t& __loc) {
 // Strtonum functions
 //
 inline _LIBCPP_HIDE_FROM_ABI float __strtof(const char* __nptr, char** __endptr, __locale_t __loc) {
+#if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
   return ::strtof_l(__nptr, __endptr, __loc);
+#else
+  (void)__loc;
+  return ::strtof(__nptr, __endptr);
+#endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI double __strtod(const char* __nptr, char** __endptr, __locale_t __loc) {
+#if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
   return ::strtod_l(__nptr, __endptr, __loc);
+#else
+  (void)__loc;
+  return ::strtod(__nptr, __endptr);
+#endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI long double __strtold(const char* __nptr, char** __endptr, __locale_t __loc) {
+#if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
   return ::strtold_l(__nptr, __endptr, __loc);
+#else
+  (void)__loc;
+  return ::strtold(__nptr, __endptr);
+#endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI long long __strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {


### PR DESCRIPTION
# Patch Notes

## Details

[libc++] - minor refactor - Handle the same guards used by musl libc to conditionally compile the 'Strtonum functions'.
 * Closes GHI llvm/llvm-project#167977

### Affected Versions
- **llvm-project**: Versions **<= 21.1.5** (other versions may also be impacted)
- **Platforms**: Primarily **Linux** with **musl's libc**
- **Subprojects**: **libcxxabi**, **libcxx**

---

## Context

This pull request addresses an issue encountered when building **libcxx** with certain configurations (`-D_LIBCPP_HAS_MUSL_LIBC` & `-D__linux__`) that lack the `_GNU_SOURCE` definition. Specifically, this issue arises if the system **musl libc** is built with `_BSD_SOURCE` instead of `_GNU_SOURCE`. The resultant configuration leads to problems with the "Strtonum functions" in the file [libcxx/include/__locale_dir/support/linux.h](https://github.com/llvm/llvm-project/tree/master/libcxx/include/__locale_dir/support/linux.h), affecting the following functions:

- `__strtof`
- `__strtod`
- `__strtold`

**Error messages displayed include**:
```console
error: no member named 'strtof_l' in the global namespace
```
```console
error: no member named 'strtod_l' in the global namespace
```
```console
error: no member named 'strtold_l' in the global namespace
```

For more insight, relevant code can be accessed [here](https://github.com/llvm/llvm-project/blob/79cd1b7a25cdbf42c7234999ae9bc51db30af1f0/libcxx/include/__locale_dir/support/linux.h#L85-L95).

---

### Suggested Fix

The resolution involves implementing conditional compilation guards that align with those utilized by **musl libc**. This is in line with existing practices for functions like `__strtoll` and `__strtoull`, as seen in [libcxx/include/__locale_dir/support/linux.h](https://github.com/llvm/llvm-project/tree/master/libcxx/include/__locale_dir/support/linux.h). The proposed changes to the functions are outlined below:

```diff
  //
  // Strtonum functions
  //
  inline _LIBCPP_HIDE_FROM_ABI float __strtof(const char* __nptr, char** __endptr, __locale_t __loc) {
+ #if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
    return ::strtof_l(__nptr, __endptr, __loc);
+ #else
+   (void)__loc;
+   return ::strtof(__nptr, __endptr);
+ #endif
  }

  inline _LIBCPP_HIDE_FROM_ABI double __strtod(const char* __nptr, char** __endptr, __locale_t __loc) {
+ #if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
    return ::strtod_l(__nptr, __endptr, __loc);
+ #else
+   (void)__loc;
+   return ::strtod(__nptr, __endptr);
+ #endif
  }

  inline _LIBCPP_HIDE_FROM_ABI long double __strtold(const char* __nptr, char** __endptr, __locale_t __loc) {
+ #if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
    return ::strtod_l(__nptr, __endptr, __loc);
+ #else
+   (void)__loc;
+   return ::strtold(__nptr, __endptr);
+ #endif
  }
```

> [!NOTE]
>  The musl development team may consider it a defect not to check for `defined(_GNU_SOURCE)`. However, given the musl implementation (version circa **v1.2.5**), it discards the `__loc` argument even if `defined(_GNU_SOURCE)` is present, while omitting `strto*_l` functions entirely without it. Therefore, an optimized approach might be to omit the `|| defined(_GNU_SOURCE)` condition, as it currently holds no effect unless musl's implementation changes in future versions.
> However this implementation has opted for 'correctness' in defined behavior. This should help ensure no regression is introduced for other configurations.

---

### References / See Also

For further investigation, see additional details in GHI llvm/llvm-project#167977


---

cc: @ldionne (Please Review)