### PR TITLE
[Windows] Adjust exported symbols to filter out profile symbols

### DIFF
--- a/llvm/utils/extract_symbols.py
+++ b/llvm/utils/extract_symbols.py
@@ -123,6 +123,9 @@ def should_keep_microsoft_symbol(symbol, calling_convention_decoration):
         and (symbol.startswith("?Head@") or symbol.startswith("?Tail@"))
     ):
         return symbol
+    # Skip symbols added by the compiler with -fprofile-generate.
+    elif symbol.startswith("__prof"):
+        return None
     # Keep mangled llvm:: and clang:: function symbols. How we detect these is a
     # bit of a mess and imprecise, but that avoids having to completely demangle
     # the symbol name. The outermost namespace is at the end of the identifier


### PR DESCRIPTION
When building Clang for Windows with clang-cl with -fprofile-generate and LLVM_EXPORT_SYMBOLS_FOR_PLUGINS, the build fails with
  lld-link: error: too many exported symbols (got 76137, max 65535)

Removing the symbols generated from the use of that flag removes about 13K symbols.