### PR TITLE
DeclareRuntimeLibcalls: Use RuntimeLibraryAnalysis

### DIFF
--- a/llvm/include/llvm/Analysis/RuntimeLibcallInfo.h
+++ b/llvm/include/llvm/Analysis/RuntimeLibcallInfo.h
@@ -31,7 +31,7 @@ private:
   friend AnalysisInfoMixin<RuntimeLibraryAnalysis>;
   LLVM_ABI static AnalysisKey Key;
 
-  RTLIB::RuntimeLibcallsInfo LibcallsInfo;
+  std::optional<RTLIB::RuntimeLibcallsInfo> LibcallsInfo;
 };
 
 class LLVM_ABI RuntimeLibraryInfoWrapper : public ImmutablePass {

--- a/llvm/lib/Analysis/RuntimeLibcallInfo.cpp
+++ b/llvm/lib/Analysis/RuntimeLibcallInfo.cpp
@@ -15,7 +15,9 @@ AnalysisKey RuntimeLibraryAnalysis::Key;
 
 RTLIB::RuntimeLibcallsInfo
 RuntimeLibraryAnalysis::run(const Module &M, ModuleAnalysisManager &) {
-  return RTLIB::RuntimeLibcallsInfo(M);
+  if (!LibcallsInfo)
+    LibcallsInfo = RTLIB::RuntimeLibcallsInfo(M);
+  return *LibcallsInfo;
 }
 
 INITIALIZE_PASS(RuntimeLibraryInfoWrapper, "runtime-library-info",

--- a/llvm/lib/Transforms/Utils/DeclareRuntimeLibcalls.cpp
+++ b/llvm/lib/Transforms/Utils/DeclareRuntimeLibcalls.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/DeclareRuntimeLibcalls.h"
+#include "llvm/Analysis/RuntimeLibcallInfo.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/RuntimeLibcalls.h"
 
@@ -49,7 +50,9 @@ static void mergeAttributes(LLVMContext &Ctx, const Module &M,
 
 PreservedAnalyses DeclareRuntimeLibcallsPass::run(Module &M,
                                                   ModuleAnalysisManager &MAM) {
-  RTLIB::RuntimeLibcallsInfo RTLCI(M.getTargetTriple());
+  const RTLIB::RuntimeLibcallsInfo &RTLCI =
+      MAM.getResult<RuntimeLibraryAnalysis>(M);
+
   LLVMContext &Ctx = M.getContext();
   const DataLayout &DL = M.getDataLayout();
   const Triple &TT = M.getTargetTriple();

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/codegen-opt-flags.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/codegen-opt-flags.ll
@@ -1,0 +1,17 @@
+; REQUIRES: arm-registered-target
+
+; Make sure that codegen flags work to change the set of libcalls
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=arm-none-linux-gnueabi -float-abi=hard -exception-model=sjlj -meabi=4 < %s | FileCheck %s
+
+; Depends on -exception-model
+; CHECK: declare arm_aapcs_vfpcc void @_Unwind_SjLj_Register(...)
+; CHECK: declare arm_aapcs_vfpcc void @_Unwind_SjLj_Resume(...)
+; CHECK: declare arm_aapcs_vfpcc void @_Unwind_SjLj_Unregister(...)
+
+; Calling convention depends on -float-abi
+; CHECK: declare arm_aapcs_vfpcc void @__addtf3(...)
+
+; memclr functions depend on -meabi
+; CHECK: declare arm_aapcscc void @__aeabi_memclr(...)
+; CHECK: declare arm_aapcscc void @__aeabi_memclr4(...)
+; CHECK: declare arm_aapcscc void @__aeabi_memclr8(...)

--- a/llvm/tools/opt/NewPMDriver.cpp
+++ b/llvm/tools/opt/NewPMDriver.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/RuntimeLibcallInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/Config/llvm-config.h"
@@ -351,9 +352,9 @@ static void registerEPCallbacks(PassBuilder &PB) {
 
 bool llvm::runPassPipeline(
     StringRef Arg0, Module &M, TargetMachine *TM, TargetLibraryInfoImpl *TLII,
-    ToolOutputFile *Out, ToolOutputFile *ThinLTOLinkOut,
-    ToolOutputFile *OptRemarkFile, StringRef PassPipeline,
-    ArrayRef<PassPlugin> PassPlugins,
+    RTLIB::RuntimeLibcallsInfo &RTLCI, ToolOutputFile *Out,
+    ToolOutputFile *ThinLTOLinkOut, ToolOutputFile *OptRemarkFile,
+    StringRef PassPipeline, ArrayRef<PassPlugin> PassPlugins,
     ArrayRef<std::function<void(PassBuilder &)>> PassBuilderCallbacks,
     OutputKind OK, VerifierKind VK, bool ShouldPreserveAssemblyUseListOrder,
     bool ShouldPreserveBitcodeUseListOrder, bool EmitSummaryIndex,
@@ -416,6 +417,7 @@ bool llvm::runPassPipeline(
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager CGAM;
   ModuleAnalysisManager MAM;
+  MAM.registerPass([&] { return RuntimeLibraryAnalysis(std::move(RTLCI)); });
 
   PassInstrumentationCallbacks PIC;
   PrintPassOptions PrintPassOpts;

--- a/llvm/tools/opt/NewPMDriver.h
+++ b/llvm/tools/opt/NewPMDriver.h
@@ -31,6 +31,10 @@ class TargetMachine;
 class ToolOutputFile;
 class TargetLibraryInfoImpl;
 
+namespace RTLIB {
+struct RuntimeLibcallsInfo;
+}
+
 extern cl::opt<bool> DebugifyEach;
 extern cl::opt<std::string> DebugifyExport;
 
@@ -67,9 +71,9 @@ void printPasses(raw_ostream &OS);
 /// nullptr.
 bool runPassPipeline(
     StringRef Arg0, Module &M, TargetMachine *TM, TargetLibraryInfoImpl *TLII,
-    ToolOutputFile *Out, ToolOutputFile *ThinLinkOut,
-    ToolOutputFile *OptRemarkFile, StringRef PassPipeline,
-    ArrayRef<PassPlugin> PassPlugins,
+    RTLIB::RuntimeLibcallsInfo &RTLCI, ToolOutputFile *Out,
+    ToolOutputFile *ThinLinkOut, ToolOutputFile *OptRemarkFile,
+    StringRef PassPipeline, ArrayRef<PassPlugin> PassPlugins,
     ArrayRef<std::function<void(PassBuilder &)>> PassBuilderCallbacks,
     opt_tool::OutputKind OK, opt_tool::VerifierKind VK,
     bool ShouldPreserveAssemblyUseListOrder,

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Analysis/CallGraphSCCPass.h"
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Analysis/RegionPass.h"
+#include "llvm/Analysis/RuntimeLibcallInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/AsmParser/Parser.h"
@@ -672,6 +673,11 @@ optMain(int argc, char **argv,
   // Add an appropriate TargetLibraryInfo pass for the module's triple.
   TargetLibraryInfoImpl TLII(ModuleTriple);
 
+  // FIXME: Get ABI name from MCOptions
+  RTLIB::RuntimeLibcallsInfo RTLCI(ModuleTriple, codegen::getExceptionModel(),
+                                   codegen::getFloatABIForCalls(),
+                                   codegen::getEABIVersion());
+
   // The -disable-simplify-libcalls flag actually disables all builtin optzns.
   if (DisableSimplifyLibCalls)
     TLII.disableAllFunctions();
@@ -746,7 +752,7 @@ optMain(int argc, char **argv,
     // string. Hand off the rest of the functionality to the new code for that
     // layer.
     if (!runPassPipeline(
-            argv[0], *M, TM.get(), &TLII, Out.get(), ThinLinkOut.get(),
+            argv[0], *M, TM.get(), &TLII, RTLCI, Out.get(), ThinLinkOut.get(),
             RemarksFile.get(), Pipeline, PluginList, PassBuilderCallbacks, OK,
             VK, /* ShouldPreserveAssemblyUseListOrder */ false,
             /* ShouldPreserveBitcodeUseListOrder */ true, EmitSummaryIndex,


### PR DESCRIPTION
Also add boilerplate to have a live instance when running
opt configured from CommandFlags / TargetOptions.