### PR TITLE
[clang][bytecode] Print field descriptor in Pointer::print()

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -830,6 +830,9 @@ private:
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Pointer &P) {
   P.print(OS);
+  OS << ' ';
+  if (const Descriptor *D = P.getFieldDesc())
+    D->dump(OS);
   return OS;
 }
 


### PR DESCRIPTION
This is almost always useful information and ::print() is debug-only code.