### PR TITLE
[ADT] Fix a memory leak in SmallDenseMap

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -1122,6 +1122,7 @@ private:
       Tmp.Small = false;
       Tmp.getLargeRep()->NumBuckets = 0;
     } else {
+      deallocateBuckets();
       Small = false;
       NumTombstones = 0;
       *getLargeRep() = std::move(*Tmp.getLargeRep());


### PR DESCRIPTION
Tmp.moveFrom(*this); about 10 lines above leaves *this in a zombie
state with a bucket array still allocated.  This patch fixes the
memory leak by calling deallocateBuckets().
