### PR TITLE
[MC] Remove a redundant cast (NFC)

### DIFF
--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -570,8 +570,7 @@ void MachObjectWriter::bindIndirectSymbols(MCAssembler &Asm) {
     //
     // FIXME: Do not hardcode.
     if (Asm.registerSymbol(*ISD.Symbol))
-      static_cast<MCSymbolMachO *>(ISD.Symbol)
-          ->setReferenceTypeUndefinedLazy(true);
+      ISD.Symbol->setReferenceTypeUndefinedLazy(true);
   }
 }
 


### PR DESCRIPTION
ISD.Symbol is already of type MCSymbolMachO *.

Identified with readability-redundant-casting.
