### PR TITLE
[Hexagon] Remove redundant declarations (NFC)

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonQFPOptimizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonQFPOptimizer.cpp
@@ -112,11 +112,6 @@ const std::map<unsigned short, unsigned short> QFPInstMap{
     {Hexagon::V6_vneg_qf16_hf, Hexagon::V6_vneg_qf16_qf16}};
 } // namespace
 
-namespace llvm {
-FunctionPass *createHexagonQFPOptimizer();
-void initializeHexagonQFPOptimizerPass(PassRegistry &);
-} // namespace llvm
-
 namespace {
 struct HexagonQFPOptimizer : public MachineFunctionPass {
 public:


### PR DESCRIPTION
These functions are declared in Hexagon.h.

Identified with readability-redundant-declaration.
