### PR TITLE
[Basic] Remove a redundant std::string::c_str (NFC)

### DIFF
--- a/clang/lib/Basic/Targets/SystemZ.cpp
+++ b/clang/lib/Basic/Targets/SystemZ.cpp
@@ -205,7 +205,7 @@ void SystemZTargetInfo::getTargetDefines(const LangOptions &Opts,
     Librel |= V.getSubminor().value_or(0);
     Str += llvm::utohexstr(Librel);
 
-    Builder.defineMacro("__TARGET_LIB__", Str.c_str());
+    Builder.defineMacro("__TARGET_LIB__", Str);
   }
 }
 


### PR DESCRIPTION
defineMacro takes Twine, which can be constructed from
const std::string &.

Identified with readability-redundant-string-cstr.
