### PR TITLE
[BOLT][print] Add option '--print-only-file' (NFC)

### DIFF
--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -139,6 +139,9 @@ private:
   void handleRelocation(const object::SectionRef &RelocatedSection,
                         const RelocationRef &Rel);
 
+  /// Collect functions that are specified to be bumped.
+  void selectFunctionsToPrint();
+
   /// Mark functions that are not meant for processing as ignored.
   void selectFunctionsToProcess();
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -61,6 +61,8 @@ extern cl::OptionCategory BoltOptCategory;
 
 extern cl::opt<bool> EnableBAT;
 extern cl::opt<bool> Instrument;
+extern cl::list<std::string> PrintOnly;
+extern cl::opt<std::string> PrintOnlyFile;
 extern cl::opt<bool> StrictMode;
 extern cl::opt<bool> UpdateDebugSections;
 extern cl::opt<unsigned> Verbosity;
@@ -130,14 +132,6 @@ static cl::opt<bool>
 PrintDynoStatsOnly("print-dyno-stats-only",
   cl::desc("while printing functions output dyno-stats and skip instructions"),
   cl::init(false),
-  cl::Hidden,
-  cl::cat(BoltCategory));
-
-static cl::list<std::string>
-PrintOnly("print-only",
-  cl::CommaSeparated,
-  cl::desc("list of functions to print"),
-  cl::value_desc("func1,func2,func3,..."),
   cl::Hidden,
   cl::cat(BoltCategory));
 

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -245,6 +245,16 @@ cl::opt<bool> PrintCacheMetrics(
     cl::desc("calculate and print various metrics for instruction cache"),
     cl::cat(BoltOptCategory));
 
+cl::list<std::string> PrintOnly("print-only", cl::CommaSeparated,
+                                cl::desc("list of functions to print"),
+                                cl::value_desc("func1,func2,func3,..."),
+                                cl::Hidden, cl::cat(BoltCategory));
+
+cl::opt<std::string>
+    PrintOnlyFile("print-only-file",
+                  cl::desc("file with list of functions to print"), cl::Hidden,
+                  cl::cat(BoltCategory));
+
 cl::opt<bool> PrintSections("print-sections",
                             cl::desc("print all registered sections"),
                             cl::Hidden, cl::cat(BoltCategory));

--- a/bolt/test/print-only.test
+++ b/bolt/test/print-only.test
@@ -1,0 +1,25 @@
+# Verify if `--print-only` and `--print-only-files` work fine.
+
+# REQURIES: system-linux
+
+# RUN: %clang %cflags -x c %p/Inputs/bolt_icf.cpp -o %t -Wl,-q
+# RUN: llvm-bolt %t -o %t.bolt --icf=none --print-cfg \
+# RUN:     --print-only=foo.*,bar.*,main.* 2>&1 | FileCheck %s
+
+# RUN: echo "bar.*" > %t.pof
+# RUN: echo "main.*" >> %t.pof
+# RUN: llvm-bolt %t -o %t.bolt --icf=none --print-cfg \
+# RUN:     --print-only=foo.* --print-only-file=%t.pof \
+# RUN:     2>&1 | FileCheck %s
+
+# RUN: echo "foo.*" >> %t.pof
+# RUN: llvm-bolt %t -o %t.bolt --icf=none --print-cfg \
+# RUN:     --print-only-file=%t.pof 2>&1 | FileCheck %s
+
+# CHECK-NOT: Binary Function "fiz" after building cfg
+# CHECK-NOT: Binary Function "faz" after building cfg
+# CHECK-NOT: Binary Function "zip" after building cfg
+# CHECK-NOT: Binary Function "zap" after building cfg
+# CHECK: Binary Function "foo" after building cfg
+# CHECK: Binary Function "bar" after building cfg
+# CHECK: Binary Function "main" after building cfg

--- a/bolt/test/print-only.test
+++ b/bolt/test/print-only.test
@@ -1,6 +1,6 @@
 # Verify if `--print-only` and `--print-only-files` work fine.
 
-# REQURIES: system-linux
+# REQUIRES: system-linux
 
 # RUN: %clang %cflags -x c %p/Inputs/bolt_icf.cpp -o %t -Wl,-q
 # RUN: llvm-bolt %t -o %t.bolt --icf=none --print-cfg \


### PR DESCRIPTION
With this option we can pass to BOLT names of functions to be printed through a file instead of specifying those functions all on command line.