### PR TITLE
[Clang][ThreadSafety] Contextualize FieldDecl references in thread sa…

### DIFF
--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -394,6 +394,13 @@ til::SExpr *SExprBuilder::translateDeclRefExpr(const DeclRefExpr *DRE,
   if (const auto *VarD = dyn_cast<VarDecl>(VD))
     return translateVariable(VarD, Ctx);
 
+  if (const auto *FD = dyn_cast<FieldDecl>(VD)) {
+    if (Ctx && Ctx->SelfArg) {
+      til::SExpr *E = new (Arena) til::SApply(SelfVar);
+      return new (Arena) til::Project(E, FD);
+    }
+  }
+
   // For non-local variables, treat it as a reference to a named object.
   return new (Arena) til::LiteralPtr(VD);
 }

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -3590,14 +3590,10 @@ void requireDecl(RelockableScope &scope) {
 struct foo
 {
   Mutex mu;
-  // expected-note@+1{{see attribute on parameter here}}
   void require(RelockableScope &scope EXCLUSIVE_LOCKS_REQUIRED(mu));
   void callRequire(){
     RelockableScope scope(&mu);
-    // TODO: False positive due to incorrect parsing of parameter attribute arguments.
     require(scope);
-    // expected-warning@-1{{calling function 'require' requires holding mutex 'mu' exclusively}}
-    // expected-warning@-2{{mutex managed by 'scope' is 'mu' instead of 'mu'}}
   }
 };
 


### PR DESCRIPTION
…fety attribute arguments

This enables the thread safety handler to handle field references appropriately in attribute arguments by creating proper TIL representations for `FieldDecl` references in `translateDeclRefExpr`. Earlier, the analyzer treated the reference to the field name `mu` without the context required for it to match on `this->mu`, which led to a false positive in clang/test/SemaCXX/warn-thread-safety-analysis.cpp. That false positive is resolved with the changes made here.

I noticed this while working on [PR#167048](https://github.com/llvm/llvm-project/pull/167048), when the added Clang spelling for `guarded_by` was failing to emulate the functionality of the corresponding GNU spelling due to the above reason.