### PR TITLE
[RDF] RegisterRef/RegisterId improvements. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -116,7 +116,7 @@ public:
 
   constexpr unsigned asMaskIdx() const {
     assert(isMask());
-    return toMaskIdx(Reg);
+    return Reg & ~MaskFlag;
   }
 
   constexpr operator bool() const {
@@ -138,11 +138,6 @@ public:
 
   static constexpr RegisterId toMaskId(unsigned Idx) { return Idx | MaskFlag; }
 
-  static constexpr unsigned toMaskIdx(RegisterId Id) {
-    assert(isMaskId(Id));
-    return Id & ~MaskFlag;
-  }
-
   bool operator<(RegisterRef) const = delete;
   bool operator==(RegisterRef) const = delete;
   bool operator!=(RegisterRef) const = delete;
@@ -157,7 +152,7 @@ struct PhysicalRegisterInfo {
   }
 
   const uint32_t *getRegMaskBits(RegisterId R) const {
-    return RegMasks.get(RegisterRef::toMaskIdx(R));
+    return RegMasks.get(RegisterRef(R).asMaskIdx());
   }
 
   bool alias(RegisterRef RA, RegisterRef RB) const;
@@ -170,7 +165,7 @@ struct PhysicalRegisterInfo {
   }
 
   const BitVector &getMaskUnits(RegisterId MaskId) const {
-    return MaskInfos[RegisterRef::toMaskIdx(MaskId)].Units;
+    return MaskInfos[RegisterRef(MaskId).asMaskIdx()].Units;
   }
 
   std::set<RegisterId> getUnits(RegisterRef RR) const;

--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -87,8 +87,8 @@ private:
 
 struct RegisterRef {
 private:
-  static constexpr unsigned MaskFlag = 1u << 30;
-  static constexpr unsigned UnitFlag = 1u << 31;
+  static constexpr RegisterId MaskFlag = 1u << 30;
+  static constexpr RegisterId UnitFlag = 1u << 31;
 
 public:
   RegisterId Reg = 0;
@@ -114,7 +114,7 @@ public:
     return Reg & ~UnitFlag;
   }
 
-  constexpr unsigned getMaskIdx() const {
+  constexpr unsigned asMaskIdx() const {
     assert(isMask());
     return toMaskIdx(Reg);
   }

--- a/llvm/lib/CodeGen/RDFGraph.cpp
+++ b/llvm/lib/CodeGen/RDFGraph.cpp
@@ -1827,7 +1827,7 @@ bool DataFlowGraph::hasUntrackedRef(Stmt S, bool IgnoreReserved) const {
   for (Ref R : S.Addr->members(*this)) {
     Ops.push_back(&R.Addr->getOp());
     RegisterRef RR = R.Addr->getRegRef(*this);
-    if (IgnoreReserved && RR.isReg() && ReservedRegs[RR.idx()])
+    if (IgnoreReserved && RR.isReg() && ReservedRegs[RR.asMCReg().id()])
       continue;
     if (!isTracked(RR))
       return true;

--- a/llvm/lib/CodeGen/RDFRegisters.cpp
+++ b/llvm/lib/CodeGen/RDFRegisters.cpp
@@ -126,13 +126,10 @@ std::set<RegisterId> PhysicalRegisterInfo::getAliasSet(RegisterId Reg) const {
 std::set<RegisterId> PhysicalRegisterInfo::getUnits(RegisterRef RR) const {
   std::set<RegisterId> Units;
 
-  if (RR.Reg == 0)
-    return Units; // Empty
-
   if (RR.isReg()) {
     if (RR.Mask.none())
       return Units; // Empty
-    for (MCRegUnitMaskIterator UM(RR.idx(), &TRI); UM.isValid(); ++UM) {
+    for (MCRegUnitMaskIterator UM(RR.asMCReg(), &TRI); UM.isValid(); ++UM) {
       auto [U, M] = *UM;
       if ((M & RR.Mask).any())
         Units.insert(U);
@@ -142,7 +139,7 @@ std::set<RegisterId> PhysicalRegisterInfo::getUnits(RegisterRef RR) const {
 
   assert(RR.isMask());
   unsigned NumRegs = TRI.getNumRegs();
-  const uint32_t *MB = getRegMaskBits(RR.idx());
+  const uint32_t *MB = getRegMaskBits(RR.Reg);
   for (unsigned I = 0, E = (NumRegs + 31) / 32; I != E; ++I) {
     uint32_t C = ~MB[I]; // Clobbered regs
     if (I == 0)          // Reg 0 should be ignored
@@ -162,12 +159,12 @@ std::set<RegisterId> PhysicalRegisterInfo::getUnits(RegisterRef RR) const {
   return Units;
 }
 
-RegisterRef PhysicalRegisterInfo::mapTo(RegisterRef RR, unsigned R) const {
+RegisterRef PhysicalRegisterInfo::mapTo(RegisterRef RR, RegisterId R) const {
   if (RR.Reg == R)
     return RR;
-  if (unsigned Idx = TRI.getSubRegIndex(R, RR.Reg))
+  if (unsigned Idx = TRI.getSubRegIndex(RegisterRef(R).asMCReg(), RR.asMCReg()))
     return RegisterRef(R, TRI.composeSubRegIndexLaneMask(Idx, RR.Mask));
-  if (unsigned Idx = TRI.getSubRegIndex(RR.Reg, R)) {
+  if (unsigned Idx = TRI.getSubRegIndex(RR.asMCReg(), RegisterRef(R).asMCReg())) {
     const RegInfo &RI = RegInfos[R];
     LaneBitmask RCM =
         RI.RegClass ? RI.RegClass->LaneMask : LaneBitmask::getAll();
@@ -187,8 +184,8 @@ bool PhysicalRegisterInfo::equal_to(RegisterRef A, RegisterRef B) const {
     return A.Mask == B.Mask;
 
   // Compare reg units lexicographically.
-  MCRegUnitMaskIterator AI(A.Reg, &getTRI());
-  MCRegUnitMaskIterator BI(B.Reg, &getTRI());
+  MCRegUnitMaskIterator AI(A.asMCReg(), &getTRI());
+  MCRegUnitMaskIterator BI(B.asMCReg(), &getTRI());
   while (AI.isValid() && BI.isValid()) {
     auto [AReg, AMask] = *AI;
     auto [BReg, BMask] = *BI;
@@ -225,8 +222,8 @@ bool PhysicalRegisterInfo::less(RegisterRef A, RegisterRef B) const {
     return A.Reg < B.Reg;
 
   // Compare reg units lexicographically.
-  llvm::MCRegUnitMaskIterator AI(A.Reg, &getTRI());
-  llvm::MCRegUnitMaskIterator BI(B.Reg, &getTRI());
+  llvm::MCRegUnitMaskIterator AI(A.asMCReg(), &getTRI());
+  llvm::MCRegUnitMaskIterator BI(B.asMCReg(), &getTRI());
   while (AI.isValid() && BI.isValid()) {
     auto [AReg, AMask] = *AI;
     auto [BReg, BMask] = *BI;
@@ -252,18 +249,17 @@ bool PhysicalRegisterInfo::less(RegisterRef A, RegisterRef B) const {
 }
 
 void PhysicalRegisterInfo::print(raw_ostream &OS, RegisterRef A) const {
-  if (A.Reg == 0 || A.isReg()) {
-    if (0 < A.idx() && A.idx() < TRI.getNumRegs())
-      OS << TRI.getName(A.idx());
+  if (A.isReg()) {
+    MCRegister Reg = A.asMCReg();
+    if (Reg && Reg.id() < TRI.getNumRegs())
+      OS << TRI.getName(Reg);
     else
-      OS << printReg(A.idx(), &TRI);
+      OS << printReg(Reg, &TRI);
     OS << PrintLaneMaskShort(A.Mask);
   } else if (A.isUnit()) {
-    OS << printRegUnit(A.idx(), &TRI);
+    OS << printRegUnit(A.asMCRegUnit(), &TRI);
   } else {
-    assert(A.isMask());
-    // RegMask SS flag is preserved by idx().
-    unsigned Idx = Register(A.idx()).stackSlotIndex();
+    unsigned Idx = A.getMaskIdx();
     const char *Fmt = Idx < 0x10000 ? "%04x" : "%08x";
     OS << "M#" << format(Fmt, Idx);
   }
@@ -280,7 +276,7 @@ bool RegisterAggr::hasAliasOf(RegisterRef RR) const {
   if (RR.isMask())
     return Units.anyCommon(PRI.getMaskUnits(RR.Reg));
 
-  for (MCRegUnitMaskIterator U(RR.Reg, &PRI.getTRI()); U.isValid(); ++U) {
+  for (MCRegUnitMaskIterator U(RR.asMCReg(), &PRI.getTRI()); U.isValid(); ++U) {
     auto [Unit, LaneMask] = *U;
     if ((LaneMask & RR.Mask).any())
       if (Units.test(Unit))
@@ -295,7 +291,7 @@ bool RegisterAggr::hasCoverOf(RegisterRef RR) const {
     return T.reset(Units).none();
   }
 
-  for (MCRegUnitMaskIterator U(RR.Reg, &PRI.getTRI()); U.isValid(); ++U) {
+  for (MCRegUnitMaskIterator U(RR.asMCReg(), &PRI.getTRI()); U.isValid(); ++U) {
     auto [Unit, LaneMask] = *U;
     if ((LaneMask & RR.Mask).any())
       if (!Units.test(Unit))
@@ -310,7 +306,7 @@ RegisterAggr &RegisterAggr::insert(RegisterRef RR) {
     return *this;
   }
 
-  for (MCRegUnitMaskIterator U(RR.Reg, &PRI.getTRI()); U.isValid(); ++U) {
+  for (MCRegUnitMaskIterator U(RR.asMCReg(), &PRI.getTRI()); U.isValid(); ++U) {
     auto [Unit, LaneMask] = *U;
     if ((LaneMask & RR.Mask).any())
       Units.set(Unit);

--- a/llvm/lib/CodeGen/RDFRegisters.cpp
+++ b/llvm/lib/CodeGen/RDFRegisters.cpp
@@ -164,7 +164,8 @@ RegisterRef PhysicalRegisterInfo::mapTo(RegisterRef RR, RegisterId R) const {
     return RR;
   if (unsigned Idx = TRI.getSubRegIndex(RegisterRef(R).asMCReg(), RR.asMCReg()))
     return RegisterRef(R, TRI.composeSubRegIndexLaneMask(Idx, RR.Mask));
-  if (unsigned Idx = TRI.getSubRegIndex(RR.asMCReg(), RegisterRef(R).asMCReg())) {
+  if (unsigned Idx =
+          TRI.getSubRegIndex(RR.asMCReg(), RegisterRef(R).asMCReg())) {
     const RegInfo &RI = RegInfos[R];
     LaneBitmask RCM =
         RI.RegClass ? RI.RegClass->LaneMask : LaneBitmask::getAll();

--- a/llvm/lib/CodeGen/RDFRegisters.cpp
+++ b/llvm/lib/CodeGen/RDFRegisters.cpp
@@ -260,7 +260,7 @@ void PhysicalRegisterInfo::print(raw_ostream &OS, RegisterRef A) const {
   } else if (A.isUnit()) {
     OS << printRegUnit(A.asMCRegUnit(), &TRI);
   } else {
-    unsigned Idx = A.getMaskIdx();
+    unsigned Idx = A.asMaskIdx();
     const char *Fmt = Idx < 0x10000 ? "%04x" : "%08x";
     OS << "M#" << format(Fmt, Idx);
   }


### PR DESCRIPTION
RegisterId can represent a physical register, a MCRegUnit, or
an index into a side structure that stores register masks. These 3
types were encoded by using the physical reg, stack slot, and
virtual register encoding partitions from the Register class.
This encoding scheme alias wasn't well contained so
Register::index2StackSlot and Register::stackSlotIndex appeared
in multiple places.

This patch gives RegisterRef its own encoding defines and separates
it from Register.

I've removed the generic idx() method in favor of getAsMCReg(),
getAsMCRegUnit(), and getMaskIdx() for some degree of type safety.

Some places used the RegisterId field of RegisterRef directly as a
register. Those have been updated to use getAsMCReg.
    
Some special cases for RegisterId 0 have been removed as it can
be treated like a MCRegister by existing code.
    
I think I want to rename the Reg field of RegisterRef to Id, but
I'll do that in another patch.
    
Additionally, callers of the RegisterRef constructor need to be
audited for implicit conversions from Register/MCRegister
to unsigned.