### PR TITLE
[analyzer] Fix crash in Z3 SMTConv when negating a boolean expression (#165779)

### DIFF
--- a/clang/test/Analysis/z3-unarysymexpr.c
+++ b/clang/test/Analysis/z3-unarysymexpr.c
@@ -47,3 +47,11 @@ int z3_crash2(int a) {
     return *d; // expected-warning{{Dereference of undefined pointer value}}
   return 0;
 }
+
+// Refer to issue 165779
+void z3_crash3(long a) {
+  if (~-(5 && a)) {
+    long *c;
+    *c; // expected-warning{{Dereference of undefined pointer value (loaded from variable 'c')}}
+  }
+}


### PR DESCRIPTION
Refer to #158276 for previous hotfix.

In Z3, boolean expressions are incompatible with bitvec operators. However, C expressions like `-(5 && a)` will generate such symbolic expressions, which will be further used as an integer. To be compatible with such usages, this fix converts such expressions to integer using the existing `fromCast`.