### PR TITLE
[AMDGPU] Removal of language sensitive option for _Float16 and half( 'e') handling

### DIFF
--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -43,7 +43,6 @@
 //  SJ -> sigjmp_buf
 //  K -> ucontext_t
 //  p -> pid_t
-//  e -> _Float16 for HIP/C++ and __fp16 for OpenCL
 //  . -> "...".  This may only occur at the end of the function list.
 //
 // Types may be prefixed with the following modifiers:

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12402,12 +12402,8 @@ static QualType DecodeTypeFromStr(const char *&Str, const ASTContext &Context,
 
   // Read the base type.
   switch (*Str++) {
-  default: llvm_unreachable("Unknown builtin type letter!");
-  case 'e':
-    assert(HowLong == 0 && !Signed && !Unsigned &&
-           "Bad modifiers used with 'e'!");
-    Type = Context.getLangOpts().OpenCL ? Context.HalfTy : Context.Float16Ty;
-    break;
+  default:
+    llvm_unreachable("Unknown builtin type letter!");
   case 'x':
     assert(HowLong == 0 && !Signed && !Unsigned &&
            "Bad modifiers used with 'x'!");


### PR DESCRIPTION
Removing the 'e' handling for the amdgcn builtins as we decided to use _Float16 for both HIP/C++ and OpenCL 