### PR TITLE
[ARM] Cleanup unused ARMbrcond. NFC

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
@@ -4057,14 +4057,8 @@ void ARMDAGToDAGISel::Select(SDNode *N) {
   case ARMISD::BRCOND: {
     // Pattern: (ARMbrcond:void (bb:Other):$dst, (imm:i32):$cc)
     // Emits: (Bcc:void (bb:Other):$dst, (imm:i32):$cc)
-    // Pattern complexity = 6  cost = 1  size = 0
-
-    // Pattern: (ARMbrcond:void (bb:Other):$dst, (imm:i32):$cc)
-    // Emits: (tBcc:void (bb:Other):$dst, (imm:i32):$cc)
-    // Pattern complexity = 6  cost = 1  size = 0
-
-    // Pattern: (ARMbrcond:void (bb:Other):$dst, (imm:i32):$cc)
-    // Emits: (t2Bcc:void (bb:Other):$dst, (imm:i32):$cc)
+    //    or: (tBcc:void (bb:Other):$dst, (imm:i32):$cc)
+    //    or: (t2Bcc:void (bb:Other):$dst, (imm:i32):$cc)
     // Pattern complexity = 6  cost = 1  size = 0
 
     unsigned Opc = Subtarget->isThumb() ?

--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -40,12 +40,6 @@ def SDT_ARMCMov : SDTypeProfile<1, 4, [
   SDTCisVT<4, FlagsVT>,    // in flags
 ]>;
 
-def SDT_ARMBrcond : SDTypeProfile<0, 2, [
-  SDTCisVT<0, OtherVT>,    // target basic block
-  SDTCisVT<1, CondCodeVT>, // condition code
-  SDTCisVT<2, FlagsVT>,    // in flags
-]>;
-
 def SDT_ARMBrJT    : SDTypeProfile<0, 2,
                                   [SDTCisPtrTy<0>, SDTCisVT<1, i32>]>;
 
@@ -193,8 +187,6 @@ def ARMcmov          : SDNode<"ARMISD::CMOV", SDT_ARMCMov>;
 def ARMssat   : SDNode<"ARMISD::SSAT", SDTIntSatNoShOp, []>;
 
 def ARMusat   : SDNode<"ARMISD::USAT", SDTIntSatNoShOp, []>;
-
-def ARMbrcond        : SDNode<"ARMISD::BRCOND", SDT_ARMBrcond, [SDNPHasChain]>;
 
 def ARMbrjt          : SDNode<"ARMISD::BR_JT", SDT_ARMBrJT,
                               [SDNPHasChain]>;
@@ -2596,11 +2588,8 @@ def : ARMPat<(ARMcall_pred GPRnoip:$func), (BLX_pred_noip $func)>,
 
 
 let isBranch = 1, isTerminator = 1 in {
-  // FIXME: should be able to write a pattern for ARMBrcond, but can't use
-  // a two-value operand where a dag node expects two operands. :(
   def Bcc : ABI<0b1010, (outs), (ins arm_br_target:$target),
-               IIC_Br, "b", "\t$target",
-               [/*(ARMbrcond bb:$target, imm:$cc, CCR:$ccr)*/]>,
+               IIC_Br, "b", "\t$target", []>,
                Sched<[WriteBr]>  {
     bits<24> target;
     let Inst{23-0} = target;

--- a/llvm/lib/Target/ARM/ARMInstrThumb.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb.td
@@ -624,12 +624,9 @@ let isBranch = 1, isTerminator = 1, isBarrier = 1 in {
   }
 }
 
-// FIXME: should be able to write a pattern for ARMBrcond, but can't use
-// a two-value operand where a dag node expects two operands. :(
 let isBranch = 1, isTerminator = 1 in
   def tBcc : T1I<(outs), (ins thumb_bcc_target:$target, pred:$p), IIC_Br,
-                 "b${p}\t$target",
-                 [/*(ARMbrcond bb:$target, imm:$cc)*/]>,
+                 "b${p}\t$target", []>,
              T1BranchCond<{1,1,0,1}>, Sched<[WriteBr]> {
   bits<4> p;
   bits<8> target;

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -4027,12 +4027,9 @@ def t2TBH : T2I<(outs), (ins (addrmode_tbh $Rn, $Rm):$addr), IIC_Br,
 
 } // isBranch, isTerminator, isBarrier
 
-// FIXME: should be able to write a pattern for ARMBrcond, but can't use
-// a two-value operand where a dag node expects ", "two operands. :(
 let isBranch = 1, isTerminator = 1 in
 def t2Bcc : T2I<(outs), (ins brtarget:$target), IIC_Br,
-                "b", ".w\t$target",
-                [/*(ARMbrcond bb:$target, imm:$cc)*/]>, Sched<[WriteBr]> {
+                "b", ".w\t$target", []>, Sched<[WriteBr]> {
   let Inst{31-27} = 0b11110;
   let Inst{15-14} = 0b10;
   let Inst{12} = 0;


### PR DESCRIPTION
This tablegen pattern is unused, and it looks like the code to emit ARMbrcond in DAG2DAG has a few other optimizations for CBZ and low overhead loops. Remove the old, unused patterns and out of data FIXMEs.