### PR TITLE
[Clang] Add #pragma clang deprecated_header

### DIFF
--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -666,6 +666,11 @@ def warn_pragma_deprecated_macro_use :
   ExtWarn<"macro %0 has been marked as deprecated%select{|: %2}1">,
   InGroup<DeprecatedPragma>;
 
+// - #pragma depcreated_header
+def warn_pragma_deprecated_header : Warning<
+  "header is deprecated%select{|: %1}0">,
+  InGroup<Deprecated>;
+
 // - #pragma clang restrict_expansion(...)
 def warn_pragma_restrict_expansion_macro_use :
   ExtWarn<"macro %0 has been marked as unsafe for use in headers"

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -2943,6 +2943,7 @@ public:
   void HandlePragmaMark(Token &MarkTok);
   void HandlePragmaPoison();
   void HandlePragmaSystemHeader(Token &SysHeaderTok);
+  void HandlePragmaDeprecatedHeader(Token &Tok, std::string DeprecationMessage);
   void HandlePragmaDependency(Token &DependencyTok);
   void HandlePragmaPushMacro(Token &Tok);
   void HandlePragmaPopMacro(Token &Tok);

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2509,6 +2509,15 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
       Action = TrackGMFState.inGMF() ? Import : Skip;
     else
       Action = (ModuleToImport && !getLangOpts().CompilingPCH) ? Import : Skip;
+
+    // If we're not entering the header, it might have been marked deprecated
+    // the first time it was included.
+    if (auto MaybeMessage = HeaderInfo.getHeaderDeprecationMessage(*File);
+        MaybeMessage) {
+      std::string_view Message = *MaybeMessage;
+      Diag(FilenameTok, diag::warn_pragma_deprecated_header)
+          << !Message.empty() << Message;
+    }
   }
 
   // Check for circular inclusion of the main file.

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -490,6 +490,18 @@ bool Preprocessor::HandleEndOfFile(Token &Result, bool isEndOfMacro) {
             SourceMgr.getFileEntryForID(CurPPLexer->getFileID())))
       FoundPCHThroughHeader = true;
 
+    if (CurPPLexer) {
+      if (OptionalFileEntryRef File = CurPPLexer->getFileEntry()) {
+        if (auto MaybeMessage = HeaderInfo.getHeaderDeprecationMessage(*File);
+            MaybeMessage) {
+          std::string_view Message = *MaybeMessage;
+          Diag(SourceMgr.getIncludeLoc(CurPPLexer->getFileID()),
+               diag::warn_pragma_deprecated_header)
+              << !Message.empty() << Message;
+        }
+      }
+    }
+
     // We're done with the #included file.
     RemoveTopOfLexerStack();
 

--- a/clang/test/Lexer/deprecated-header-msg.h
+++ b/clang/test/Lexer/deprecated-header-msg.h
@@ -1,0 +1,6 @@
+#ifndef DEPRECATED_HEADER_MSG_H
+#define DEPRECATED_HEADER_MSG_H
+
+#pragma clang deprecated_header("This is a shitty header")
+
+#endif // DEPRECATED_HEADER_MSG_H

--- a/clang/test/Lexer/deprecated-header.c
+++ b/clang/test/Lexer/deprecated-header.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -Wdeprecated %s -fsyntax-only -verify -Wunknown-pragmas -Wextra-tokens
+
+#pragma clang deprecated_header( // expected-error {{expected string literal in #pragma clang deprecated_header}}
+#pragma clang deprecated_header() // expected-error {{expected string literal in #pragma clang deprecated_header}}
+#pragma clang deprecated_header("" // expected-error {{expected )}}
+#pragma clang deprecated_header something // expected-warning {{extra tokens at end of #pragma clang deprecated_header directive}}
+#pragma clang deprecated_header("") something // expected-warning {{extra tokens at end of #pragma clang deprecated_header directive}}
+
+#include "deprecated-header.h" // expected-warning {{header is deprecated}}
+#include "deprecated-header.h" // expected-warning {{header is deprecated}}
+
+#include "deprecated-header-msg.h" // expected-warning {{header is deprecated: This is a shitty header}}
+#include "deprecated-header-msg.h" // expected-warning {{header is deprecated: This is a shitty header}}

--- a/clang/test/Lexer/deprecated-header.h
+++ b/clang/test/Lexer/deprecated-header.h
@@ -1,0 +1,6 @@
+#ifndef DEPRECATED_HEADER_H
+#define DEPRECATED_HEADER_H
+
+#pragma clang deprecated_header
+
+#endif // DEPRECATED_HEADER_H


### PR DESCRIPTION
This pragma allows marking headers as deprecated, which significantly improves the diagnostics issued compared to the traditional

```
#if defined(__DEPRECATED) && __DEPRECATED
#  warning This header is deprecated
#endif
```

Specifically, the warning is issued at the place the header is included instead inside the header. This allows suppressing the warning more locally if required. Using the pragma also moves the diagnostic into `-Wdeprecated`, which is a much more sensible warning group than `-W#warning`. `-Wno-deprecated` _in the command line_ would suppress the above diagnostic, but we don't tell users.
