### PR TITLE
[llvm][Triple] Add libc-less variants of some environments

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -808,6 +808,8 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         else if (Target.getEnvironment() == llvm::Triple::Musl ||
                  Target.getEnvironment() == llvm::Triple::MuslABI64)
           Target.setEnvironment(llvm::Triple::MuslABIN32);
+        else
+          Target.setEnvironment(llvm::Triple::ABIN32);
       } else if (ABIName == "64") {
         Target = Target.get64BitArchVariant();
         if (Target.getEnvironment() == llvm::Triple::GNU ||
@@ -817,6 +819,8 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         else if (Target.getEnvironment() == llvm::Triple::Musl ||
                  Target.getEnvironment() == llvm::Triple::MuslABIN32)
           Target.setEnvironment(llvm::Triple::MuslABI64);
+        else
+          Target.setEnvironment(llvm::Triple::ABI64);
       }
     }
   }

--- a/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
@@ -102,9 +102,11 @@ StringRef loongarch::getLoongArchABI(const Driver &D, const ArgList &Args,
   // Honor the explicit ABI modifier suffix in triple's environment part if
   // present, falling back to {ILP32,LP64}D otherwise.
   switch (Triple.getEnvironment()) {
+  case llvm::Triple::SF:
   case llvm::Triple::GNUSF:
   case llvm::Triple::MuslSF:
     return IsLA32 ? "ilp32s" : "lp64s";
+  case llvm::Triple::F32:
   case llvm::Triple::GNUF32:
   case llvm::Triple::MuslF32:
     return IsLA32 ? "ilp32f" : "lp64f";

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -107,10 +107,12 @@ std::string Linux::getMultiarchTriple(const Driver &D,
     switch (TargetEnvironment) {
     default:
       return TargetTriple.str();
+    case llvm::Triple::SF:
     case llvm::Triple::GNUSF:
     case llvm::Triple::MuslSF:
       FPFlavor = "sf";
       break;
+    case llvm::Triple::F32:
     case llvm::Triple::GNUF32:
     case llvm::Triple::MuslF32:
       FPFlavor = "f32";

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -253,6 +253,14 @@ public:
   enum EnvironmentType {
     UnknownEnvironment,
 
+    ABIN32,
+    ABI64,
+    EABI,
+    EABIHF,
+    F32,
+    SF,
+    X32,
+
     GNU,
     GNUT64,
     GNUABIN32,
@@ -266,10 +274,7 @@ public:
     GNUSF,
     GNUX32,
     GNUILP32,
-    CODE16,
-    EABI,
-    EABIHF,
-    Android,
+
     Musl,
     MuslABIN32,
     MuslABI64,
@@ -279,12 +284,16 @@ public:
     MuslSF,
     MuslX32,
     MuslWALI,
+
+    Android,
+    CODE16,
     LLVM,
 
     MSVC,
     Itanium,
     Cygnus,
     CoreCLR,
+
     Simulator, // Simulator variants of other systems, e.g., Apple's iOS
     MacABI,    // Mac Catalyst variant of Apple's iOS deployment target.
 
@@ -1157,13 +1166,15 @@ public:
   // Tests whether the target is N32.
   bool isABIN32() const {
     EnvironmentType Env = getEnvironment();
-    return Env == Triple::GNUABIN32 || Env == Triple::MuslABIN32;
+    return Env == Triple::GNUABIN32 || Env == Triple::MuslABIN32 ||
+           Env == Triple::ABIN32;
   }
 
   /// Tests whether the target is X32.
   bool isX32() const {
     EnvironmentType Env = getEnvironment();
-    return Env == Triple::GNUX32 || Env == Triple::MuslX32;
+    return Env == Triple::GNUX32 || Env == Triple::MuslX32 ||
+           Env == Triple::X32;
   }
 
   /// Tests whether the target is eBPF.

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchBaseInfo.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchBaseInfo.cpp
@@ -55,10 +55,12 @@ static ABI getTripleABI(const Triple &TT) {
   case llvm::Triple::EnvironmentType::UnknownEnvironment:
     TripleABI = ABI_Unknown;
     break;
+  case llvm::Triple::EnvironmentType::SF:
   case llvm::Triple::EnvironmentType::GNUSF:
   case llvm::Triple::EnvironmentType::MuslSF:
     TripleABI = Is64Bit ? ABI_LP64S : ABI_ILP32S;
     break;
+  case llvm::Triple::EnvironmentType::F32:
   case llvm::Triple::EnvironmentType::GNUF32:
   case llvm::Triple::EnvironmentType::MuslF32:
     TripleABI = Is64Bit ? ABI_LP64F : ABI_ILP32F;

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -345,8 +345,18 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   case CODE16: return "code16";
   case CoreCLR: return "coreclr";
   case Cygnus: return "cygnus";
+  case ABIN32:
+    return "abin32";
+  case ABI64:
+    return "abi64";
   case EABI: return "eabi";
   case EABIHF: return "eabihf";
+  case F32:
+    return "f32";
+  case SF:
+    return "sf";
+  case X32:
+    return "x32";
   case GNU: return "gnu";
   case GNUT64: return "gnut64";
   case GNUABI64: return "gnuabi64";
@@ -747,8 +757,13 @@ static Triple::OSType parseOS(StringRef OSName) {
 
 static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
   return StringSwitch<Triple::EnvironmentType>(EnvironmentName)
+      .StartsWith("abin32", Triple::ABIN32)
+      .StartsWith("abi64", Triple::ABI64)
       .StartsWith("eabihf", Triple::EABIHF)
       .StartsWith("eabi", Triple::EABI)
+      .StartsWith("f32", Triple::F32)
+      .StartsWith("sf", Triple::SF)
+      .StartsWith("x32", Triple::X32)
       .StartsWith("gnuabin32", Triple::GNUABIN32)
       .StartsWith("gnuabi64", Triple::GNUABI64)
       .StartsWith("gnueabihft64", Triple::GNUEABIHFT64)

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -121,6 +121,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::MuslX32, T.getEnvironment());
 
+  T = Triple("x86_64-pc-linux-x32");
+  EXPECT_EQ(Triple::x86_64, T.getArch());
+  EXPECT_EQ(Triple::PC, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::X32, T.getEnvironment());
+
   T = Triple("x86_64-pc-hurd-gnu");
   EXPECT_EQ(Triple::x86_64, T.getArch());
   EXPECT_EQ(Triple::PC, T.getVendor());
@@ -728,11 +734,23 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::MuslF32, T.getEnvironment());
 
+  T = Triple("loongarch32-unknown-linux-f32");
+  EXPECT_EQ(Triple::loongarch32, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::F32, T.getEnvironment());
+
   T = Triple("loongarch32-unknown-linux-muslsf");
   EXPECT_EQ(Triple::loongarch32, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::MuslSF, T.getEnvironment());
+
+  T = Triple("loongarch32-unknown-linux-sf");
+  EXPECT_EQ(Triple::loongarch32, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::SF, T.getEnvironment());
 
   T = Triple("loongarch64-unknown-linux");
   EXPECT_EQ(Triple::loongarch64, T.getArch());
@@ -924,6 +942,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::GNUABI64, T.getEnvironment());
   EXPECT_EQ(Triple::MipsSubArch_r6, T.getSubArch());
 
+  T = Triple("mips64-unknown-linux-abi64");
+  EXPECT_EQ(Triple::mips64, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::ABI64, T.getEnvironment());
+
   T = Triple("mips64el-unknown-linux-gnuabin32");
   EXPECT_EQ(Triple::mips64el, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
@@ -1084,6 +1108,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::MuslABIN32, T.getEnvironment());
   EXPECT_EQ(Triple::MipsSubArch_r6, T.getSubArch());
+
+  T = Triple("mips64-unknown-linux-abin32");
+  EXPECT_EQ(Triple::mips64, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::ABIN32, T.getEnvironment());
 
   T = Triple("mipsel-unknown-linux-musl");
   EXPECT_EQ(Triple::mipsel, T.getArch());


### PR DESCRIPTION
In Zig, building libc-less binaries is a first-class use case. As such, we would like to have environment names that indicate the ABI but without implying anything about libc. This is in line with the existing `EABI` and `EABIHF` environments.