### PR TITLE
[clang-tidy][docs][NFC] Enforce 80 characters limit (4/4)

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/mpi/buffer-deref.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/mpi/buffer-deref.rst
@@ -5,9 +5,10 @@ mpi-buffer-deref
 
 This check verifies if a buffer passed to an MPI (Message Passing Interface)
 function is sufficiently dereferenced. Buffers should be passed as a single
-pointer or array. As MPI function signatures specify ``void *`` for their buffer
-types, insufficiently dereferenced buffers can be passed, like for example as
-double pointers or multidimensional arrays, without a compiler warning emitted.
+pointer or array. As MPI function signatures specify ``void *`` for their
+buffer types, insufficiently dereferenced buffers can be passed, like for
+example as double pointers or multidimensional arrays, without a compiler
+warning emitted.
 
 Examples:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/mpi/type-mismatch.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/mpi/type-mismatch.rst
@@ -3,10 +3,11 @@
 mpi-type-mismatch
 =================
 
-This check verifies if buffer type and MPI (Message Passing Interface) datatype
-pairs match for used MPI functions. All MPI datatypes defined by the MPI
-standard (3.1) are verified by this check. User defined typedefs, custom MPI
-datatypes and null pointer constants are skipped, in the course of verification.
+This check verifies if buffer type and MPI (Message Passing Interface)
+datatype pairs match for used MPI functions. All MPI datatypes defined
+by the MPI standard (3.1) are verified by this check. User defined typedefs,
+custom MPI datatypes and null pointer constants are skipped, in the course
+of verification.
 
 Example:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.rst
@@ -3,11 +3,11 @@
 objc-forbidden-subclassing
 ==========================
 
-Finds Objective-C classes which are subclasses of classes which are not designed
-to be subclassed.
+Finds Objective-C classes which are subclasses of classes which are
+not designed to be subclassed.
 
-By default, includes a list of Objective-C classes which are publicly documented
-as not supporting subclassing.
+By default, includes a list of Objective-C classes which are publicly
+documented as not supporting subclassing.
 
 .. note::
 

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/nsdate-formatter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/nsdate-formatter.rst
@@ -17,8 +17,7 @@ format specifier:
 
    * | **Example 1:** Input Date: `29 December 2014` ;
      | Format String: `yyyy-ww`;
-     | Output string: `2014-01` (Wrong because it’s not
-     | the first week of 2014)
+     | Output string: `2014-01` (Wrong because it’s not the first week of 2014)
 
    * | **Example 2:** Input Date: `29 December 2014` ;
      | Format String: `dd-MM-yyyy (ww-YYYY)`;
@@ -27,27 +26,27 @@ format specifier:
 #. F without ee/EE : Numeric day of week in a month without actual day.
 
    * | **Example:** Input Date: `29 December 2014` ; Format String: `F-MM`;
-     | Output string: `5-12` (Wrong because it reads as
-     | *5th ___ of Dec* in English)
+     | Output string: `5-12` (Wrong because it reads as *5th ___ of Dec* in
+     | English)
 
 #. F without MM : Numeric day of week in a month without month.
 
    * | **Example:** Input Date: `29 December 2014` ; Format String: `F-EE`
-     | Output string: `5-Mon` (Wrong because it reads as
-     | *5th Mon of ___* in English)
+     | Output string: `5-Mon` (Wrong because it reads as *5th Mon of ___* in
+     | English)
 
 #. WW without MM : Week of the month without the month.
 
    * | **Example:** Input Date: `29 December 2014` ; Format String: `WW-yyyy`
-     | Output string: `05-2014` (Wrong because it reads as
-     | *5th Week of ___* in English)
+     | Output string: `05-2014` (Wrong because it reads as *5th Week of ___* in
+     | English)
 
 #. YYYY + QQ : Week year specified with quarter of normal year
    (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-QQ`
-     | Output string: `2015-04` (Wrong because it’s not
-     | the 4th quarter of 2015)
+     | Output string: `2015-04` (Wrong because it’s not the 4th quarter of
+     | 2015)
 
    * | **Example 2:** Input Date: `29 December 2014` ;
      | Format String: `ww-YYYY (QQ-yyyy)`
@@ -57,8 +56,7 @@ format specifier:
    (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-MM`
-     | Output string: `2015-12` (Wrong because it’s not
-     | the 12th month of 2015)
+     | Output string: `2015-12` (Wrong because it’s not the 12th month of 2015)
 
    * | **Example 2:** Input Date: `29 December 2014` ;
      | Format String: `ww-YYYY (MM-yyyy)`
@@ -68,8 +66,7 @@ format specifier:
    (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-DD`
-     | Output string: `2015-363` (Wrong because it’s not
-     | the 363rd day of 2015)
+     | Output string: `2015-363` (Wrong because it’s not the 363rd day of 2015)
 
    * | **Example 2:** Input Date: `29 December 2014` ;
      | Format String: `ww-YYYY (DD-yyyy)`
@@ -79,8 +76,7 @@ format specifier:
    (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-WW`
-     | Output string: `2015-05` (Wrong because it’s not
-     | the 5th week of 2015)
+     | Output string: `2015-05` (Wrong because it’s not the 5th week of 2015)
 
    * | **Example 2:** Input Date: `29 December 2014` ;
      | Format String: `ww-YYYY (WW-MM-yyyy)`
@@ -91,8 +87,8 @@ format specifier:
 
    * | **Example 1:** Input Date: `29 December 2014` ;
      | Format String: `YYYY-ww-F-EE`
-     | Output string: `2015-01-5-Mon` (Wrong because it’s not
-     | the 5th Monday of January in 2015)
+     | Output string: `2015-01-5-Mon` (Wrong because it’s not the 5th Monday of
+     | January in 2015)
 
    * | **Example 2:** Input Date: `29 December 2014` ;
      | Format String: `ww-YYYY (F-EE-MM-yyyy)`

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/nsdate-formatter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/nsdate-formatter.rst
@@ -3,71 +3,97 @@
 objc-nsdate-formatter
 =====================
 
-When ``NSDateFormatter`` is used to convert an ``NSDate`` type to a ``String`` type, the user
-can specify a custom format string. Certain format specifiers are undesirable
-despite being legal. See http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns for all legal date patterns.
+When ``NSDateFormatter`` is used to convert an ``NSDate`` type to a ``String``
+type, the user can specify a custom format string. Certain format specifiers
+are undesirable despite being legal.
+See http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
+for all legal date patterns.
 
-This checker reports as warnings the following string patterns in a date format specifier:
+This checker reports as warnings the following string patterns in a date
+format specifier:
 
-#. yyyy + ww : Calendar year specified with week of a week year (unless YYYY is also specified).
+#. yyyy + ww : Calendar year specified with week of a week year
+   (unless YYYY is also specified).
 
-   * | **Example 1:** Input Date: `29 December 2014` ; Format String: `yyyy-ww`;
-     | Output string: `2014-01` (Wrong because it’s not the first week of 2014)
+   * | **Example 1:** Input Date: `29 December 2014` ;
+     | Format String: `yyyy-ww`;
+     | Output string: `2014-01` (Wrong because it’s not
+     | the first week of 2014)
 
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `dd-MM-yyyy (ww-YYYY)`;
+   * | **Example 2:** Input Date: `29 December 2014` ;
+     | Format String: `dd-MM-yyyy (ww-YYYY)`;
      | Output string: `29-12-2014 (01-2015)` (This is correct)
 
 #. F without ee/EE : Numeric day of week in a month without actual day.
 
    * | **Example:** Input Date: `29 December 2014` ; Format String: `F-MM`;
-     | Output string: `5-12` (Wrong because it reads as *5th ___ of Dec* in English)
+     | Output string: `5-12` (Wrong because it reads as
+     | *5th ___ of Dec* in English)
 
 #. F without MM : Numeric day of week in a month without month.
 
    * | **Example:** Input Date: `29 December 2014` ; Format String: `F-EE`
-     | Output string: `5-Mon` (Wrong because it reads as *5th Mon of ___* in English)
+     | Output string: `5-Mon` (Wrong because it reads as
+     | *5th Mon of ___* in English)
 
 #. WW without MM : Week of the month without the month.
 
    * | **Example:** Input Date: `29 December 2014` ; Format String: `WW-yyyy`
-     | Output string: `05-2014` (Wrong because it reads as *5th Week of ___* in English)
+     | Output string: `05-2014` (Wrong because it reads as
+     | *5th Week of ___* in English)
 
-#. YYYY + QQ : Week year specified with quarter of normal year (unless yyyy is also specified).
+#. YYYY + QQ : Week year specified with quarter of normal year
+   (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-QQ`
-     | Output string: `2015-04` (Wrong because it’s not the 4th quarter of 2015)
+     | Output string: `2015-04` (Wrong because it’s not
+     | the 4th quarter of 2015)
 
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (QQ-yyyy)`
+   * | **Example 2:** Input Date: `29 December 2014` ;
+     | Format String: `ww-YYYY (QQ-yyyy)`
      | Output string: `01-2015 (04-2014)` (This is correct)
 
-#. YYYY + MM :  Week year specified with Month of a calendar year (unless yyyy is also specified).
+#. YYYY + MM :  Week year specified with Month of a calendar year
+   (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-MM`
-     | Output string: `2015-12` (Wrong because it’s not the 12th month of 2015)
+     | Output string: `2015-12` (Wrong because it’s not
+     | the 12th month of 2015)
 
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (MM-yyyy)`
+   * | **Example 2:** Input Date: `29 December 2014` ;
+     | Format String: `ww-YYYY (MM-yyyy)`
      | Output string: `01-2015 (12-2014)` (This is correct)
 
-#. YYYY + DD : Week year with day of a calendar year (unless yyyy is also specified).
+#. YYYY + DD : Week year with day of a calendar year
+   (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-DD`
-     | Output string: `2015-363` (Wrong because it’s not the 363rd day of 2015)
+     | Output string: `2015-363` (Wrong because it’s not
+     | the 363rd day of 2015)
 
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (DD-yyyy)`
+   * | **Example 2:** Input Date: `29 December 2014` ;
+     | Format String: `ww-YYYY (DD-yyyy)`
      | Output string: `01-2015 (363-2014)` (This is correct)
 
-#. YYYY + WW : Week year with week of a calendar year (unless yyyy is also specified).
+#. YYYY + WW : Week year with week of a calendar year
+   (unless yyyy is also specified).
 
    * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-WW`
-     | Output string: `2015-05` (Wrong because it’s not the 5th week of 2015)
+     | Output string: `2015-05` (Wrong because it’s not
+     | the 5th week of 2015)
 
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (WW-MM-yyyy)`
+   * | **Example 2:** Input Date: `29 December 2014` ;
+     | Format String: `ww-YYYY (WW-MM-yyyy)`
      | Output string: `01-2015 (05-12-2014)` (This is correct)
 
-#. YYYY + F : Week year with day of week in a calendar month (unless yyyy is also specified).
+#. YYYY + F : Week year with day of week in a calendar month
+   (unless yyyy is also specified).
 
-   * | **Example 1:** Input Date: `29 December 2014` ; Format String: `YYYY-ww-F-EE`
-     | Output string: `2015-01-5-Mon` (Wrong because it’s not the 5th Monday of January in 2015)
+   * | **Example 1:** Input Date: `29 December 2014` ;
+     | Format String: `YYYY-ww-F-EE`
+     | Output string: `2015-01-5-Mon` (Wrong because it’s not
+     | the 5th Monday of January in 2015)
 
-   * | **Example 2:** Input Date: `29 December 2014` ; Format String: `ww-YYYY (F-EE-MM-yyyy)`
+   * | **Example 2:** Input Date: `29 December 2014` ;
+     | Format String: `ww-YYYY (F-EE-MM-yyyy)`
      | Output string: `01-2015 (5-Mon-12-2014)` (This is correct)

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/property-declaration.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/property-declaration.rst
@@ -23,8 +23,8 @@ The check will only fix 'CamelCase' to 'camelCase'. In some other cases we will
 only provide warning messages since the property name could be complicated.
 Users will need to come up with a proper name by their own.
 
-This check also accepts special acronyms as prefixes or suffixes. Such prefixes or suffixes
-will suppress the Lower Camel Case check according to the guide:
+This check also accepts special acronyms as prefixes or suffixes. Such prefixes
+or suffixes will suppress the Lower Camel Case check according to the guide:
 https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingBasics.html#//apple_ref/doc/uid/20001281-1002931-BBCFHEAB
 
 For a full list of well-known acronyms:

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/no-int-to-ptr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/no-int-to-ptr.rst
@@ -7,8 +7,8 @@ Diagnoses every integer to pointer cast.
 
 While casting an (integral) pointer to an integer is obvious - you just get
 the integral value of the pointer, casting an integer to an (integral) pointer
-is deceivingly different. While you will get a pointer with that integral value,
-if you got that integral value via a pointer-to-integer cast originally,
+is deceivingly different. While you will get a pointer with that integral
+value, if you got that integral value via a pointer-to-integer cast originally,
 the new pointer will lack the provenance information from the original pointer.
 
 So while (integral) pointer to integer casts are effectively no-ops,

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-swap.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-swap.rst
@@ -3,11 +3,11 @@
 performance-noexcept-swap
 =========================
 
-The check flags user-defined swap and iter_swap functions not marked with ``noexcept`` or
-marked with ``noexcept(expr)`` where ``expr`` evaluates to ``false``
-(but is not a ``false`` literal itself).
+The check flags user-defined swap and iter_swap functions not marked with
+``noexcept`` or marked with ``noexcept(expr)`` where ``expr`` evaluates to
+``false`` (but is not a ``false`` literal itself).
 
-When a swap or iter_swap function is marked as ``noexcept``, it assures the compiler that
-no exceptions will be thrown during the swapping of two objects, which allows
-the compiler to perform certain optimizations such as omitting exception
-handling code.
+When a swap or iter_swap function is marked as ``noexcept``, it assures the
+compiler that no exceptions will be thrown during the swapping of two objects,
+which allows the compiler to perform certain optimizations such as omitting
+exception handling code.

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
@@ -9,8 +9,8 @@ const reference.
 
 The check is only applied if it is safe to replace the copy by a const
 reference. This is the case when the variable is const qualified or when it is
-only used as a const, i.e. only const methods or operators are invoked on it, or
-it is used as const reference or value argument in constructors or function
+only used as a const, i.e. only const methods or operators are invoked on it,
+or it is used as const reference or value argument in constructors or function
 calls.
 
 Example:

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/simd-intrinsics.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/simd-intrinsics.rst
@@ -19,18 +19,18 @@ objects.
 Otherwise, it just complains the intrinsics are non-portable (and there are
 `P0214`_ alternatives).
 
-Many architectures provide SIMD operations (e.g. x86 SSE/AVX, Power AltiVec/VSX,
-ARM NEON). It is common that SIMD code implementing the same algorithm, is
-written in multiple target-dispatching pieces to optimize for different
-architectures or micro-architectures.
+Many architectures provide SIMD operations (e.g. x86 SSE/AVX, Power
+AltiVec/VSX, ARM NEON). It is common that SIMD code implementing the same
+algorithm, is written in multiple target-dispatching pieces to optimize for
+different architectures or micro-architectures.
 
 The C++ standard proposal `P0214`_ and its extensions cover many common SIMD
 operations. By migrating from target-dependent intrinsics to `P0214`_
-operations, the SIMD code can be simplified and pieces for different targets can
-be unified.
+operations, the SIMD code can be simplified and pieces for different targets
+can be unified.
 
-Refer to `P0214`_ for introduction and motivation for the data-parallel standard
-library.
+Refer to `P0214`_ for introduction and motivation for the data-parallel
+standard library.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/std-allocator-const.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/std-allocator-const.rst
@@ -9,11 +9,11 @@ elements). These are not allowed in standard C++, and should usually be
 
 Per C++ ``[allocator.requirements.general]``: "T is any cv-unqualified object
 type", ``std::allocator<const T>`` is undefined. Many standard containers use
-``std::allocator`` by default and therefore their ``const T`` instantiations are
-undefined.
+``std::allocator`` by default and therefore their ``const T`` instantiations
+are undefined.
 
-libc++ defines ``std::allocator<const T>`` as an extension which will be removed
-in the future.
+libc++ defines ``std::allocator<const T>`` as an extension which will be
+removed in the future.
 
 libstdc++ and MSVC do not support ``std::allocator<const T>``:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/template-virtual-member-function.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/template-virtual-member-function.rst
@@ -3,16 +3,17 @@
 portability-template-virtual-member-function
 ============================================
 
-Finds cases when an uninstantiated virtual member function in a template class causes
-cross-compiler incompatibility.
+Finds cases when an uninstantiated virtual member function in a template class
+causes cross-compiler incompatibility.
 
-Upon instantiating a template class, non-virtual member functions don't have to be
-instantiated unless they are used. Virtual member function instantiation on the other hand
-is unspecified and depends on the implementation of the compiler.
+Upon instantiating a template class, non-virtual member functions don't have
+to be instantiated unless they are used. Virtual member function instantiation
+on the other hand is unspecified and depends on the implementation of the
+compiler.
 
-In the following snippets the virtual member function is not instantiated by GCC and Clang,
-but it is instantiated by MSVC, so while the snippet is accepted by the former compilers,
-it is rejected by the latter.
+In the following snippets the virtual member function is not instantiated by
+GCC and Clang, but it is instantiated by MSVC, so while the snippet is accepted
+by the former compilers, it is rejected by the latter.
 
 .. code:: c++
 
@@ -32,6 +33,7 @@ it is rejected by the latter.
         return 0;
     }
 
-Cross-platform projects that need to support MSVC on Windows might see compiler errors
-because certain virtual member functions are instantiated, which are not instantiated
-by other compilers on other platforms. This check highlights such virtual member functions.
+Cross-platform projects that need to support MSVC on Windows might see compiler
+errors because certain virtual member functions are instantiated, which are not
+instantiated by other compilers on other platforms. This check highlights such
+virtual member functions.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-contains.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-contains.rst
@@ -30,5 +30,5 @@ Initial expression                      Result
 
 This check will apply to any class that has a ``contains`` method, notably
 including ``std::set``, ``std::unordered_set``, ``std::map``, and
-``std::unordered_map`` as of C++20, and ``std::string`` and ``std::string_view``
-as of C++23.
+``std::unordered_map`` as of C++20, and ``std::string`` and
+``std::string_view`` as of C++23.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
@@ -6,11 +6,11 @@ readability-container-data-pointer
 Finds cases where code could use ``data()`` rather than the address of the
 element at index 0 in a container. This pattern is commonly used to materialize
 a pointer to the backing data of a container. ``std::vector`` and
-``std::string`` provide a ``data()`` accessor to retrieve the data pointer which
-should be preferred.
+``std::string`` provide a ``data()`` accessor to retrieve the data pointer
+which should be preferred.
 
-This also ensures that in the case that the container is empty, the data pointer
-access does not perform an errant memory access.
+This also ensures that in the case that the container is empty, the data
+pointer access does not perform an errant memory access.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/convert-member-functions-to-static.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/convert-member-functions-to-static.rst
@@ -10,5 +10,6 @@ After applying modifications as suggested by the check, running the check again
 might find more opportunities to mark member functions ``static``.
 
 After making a member function ``static``, you might want to run the check
-:doc:`readability-static-accessed-through-instance <../readability/static-accessed-through-instance>` to replace calls like
+:doc:`readability-static-accessed-through-instance
+<../readability/static-accessed-through-instance>` to replace calls like
 ``Instance.method()`` by ``Class::method()``.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/delete-null-pointer.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/delete-null-pointer.rst
@@ -3,7 +3,8 @@
 readability-delete-null-pointer
 ===============================
 
-Checks the ``if`` statements where a pointer's existence is checked and then deletes the pointer.
+Checks the ``if`` statements where a pointer's existence is checked and
+then deletes the pointer.
 The check is unnecessary as deleting a null pointer has no effect.
 
 .. code:: c++

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/else-after-return.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/else-after-return.rst
@@ -9,7 +9,8 @@ Early exit is one of the suggested enforcements of that. Please do not use
 ``else`` or ``else if`` after something that interrupts control flow - like
 ``return``, ``break``, ``continue``, ``throw``.
 
-The following piece of code illustrates how the check works. This piece of code:
+The following piece of code illustrates how the check works.
+This piece of code:
 
 .. code-block:: c++
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.rst
@@ -68,8 +68,8 @@ Nesting level
 ^^^^^^^^^^^^^
 
 While by itself the nesting level does not change the function's Cognitive
-Complexity metric, it is tracked, and is used by the next, third building block.
-The following structures increase the nesting level (by `1`):
+Complexity metric, it is tracked, and is used by the next, third building
+block. The following structures increase the nesting level (by `1`):
 
 * Conditional operators:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.rst
@@ -16,7 +16,8 @@ The following options are described below:
  - :option:`MinimumVariableNameLength`, :option:`IgnoredVariableNames`
  - :option:`MinimumParameterNameLength`, :option:`IgnoredParameterNames`
  - :option:`MinimumLoopCounterNameLength`, :option:`IgnoredLoopCounterNames`
- - :option:`MinimumExceptionNameLength`, :option:`IgnoredExceptionVariableNames`
+ - :option:`MinimumExceptionNameLength`,
+   :option:`IgnoredExceptionVariableNames`
 
 .. option:: MinimumVariableNameLength
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -31,12 +31,13 @@ The naming of virtual methods is reported where they occur in the base class,
 but not where they are overridden, as it can't be fixed locally there.
 This also applies for pseudo-override patterns like CRTP.
 
-``Leading_upper_snake_case`` is a naming convention where the first word is capitalized
-followed by lower case word(s) separated by underscore(s) '_'. Examples include:
-`Cap_snake_case`, `Cobra_case`, `Foo_bar_baz`, and `Master_copy_8gb`.
+``Leading_upper_snake_case`` is a naming convention where the first word is
+capitalized followed by lower case word(s) separated by underscore(s) '_'.
+Examples include: `Cap_snake_case`, `Cobra_case`, `Foo_bar_baz`,
+and `Master_copy_8gb`.
 
-Hungarian notation can be customized using different *HungarianPrefix* settings.
-The options and their corresponding values are:
+Hungarian notation can be customized using different *HungarianPrefix*
+settings. The options and their corresponding values are:
 
  - ``Off`` - the default setting
  - ``On`` - example: ``int iVariable``
@@ -57,62 +58,164 @@ The available options are summarized below:
 
 **Specific options**
 
- - :option:`AbstractClassCase`, :option:`AbstractClassPrefix`, :option:`AbstractClassSuffix`, :option:`AbstractClassIgnoredRegexp`, :option:`AbstractClassHungarianPrefix`
- - :option:`ClassCase`, :option:`ClassPrefix`, :option:`ClassSuffix`, :option:`ClassIgnoredRegexp`, :option:`ClassHungarianPrefix`
- - :option:`ClassConstexprCase`, :option:`ClassConstexprPrefix`, :option:`ClassConstexprSuffix`, :option:`ClassConstexprIgnoredRegexp`, :option:`ClassConstexprHungarianPrefix`
- - :option:`ClassConstantCase`, :option:`ClassConstantPrefix`, :option:`ClassConstantSuffix`, :option:`ClassConstantIgnoredRegexp`, :option:`ClassConstantHungarianPrefix`
- - :option:`ClassMemberCase`, :option:`ClassMemberPrefix`, :option:`ClassMemberSuffix`, :option:`ClassMemberIgnoredRegexp`, :option:`ClassMemberHungarianPrefix`
- - :option:`ClassMethodCase`, :option:`ClassMethodPrefix`, :option:`ClassMethodSuffix`, :option:`ClassMethodIgnoredRegexp`
- - :option:`ConceptCase`, :option:`ConceptPrefix`, :option:`ConceptSuffix`, :option:`ConceptIgnoredRegexp`
- - :option:`ConstantCase`, :option:`ConstantPrefix`, :option:`ConstantSuffix`, :option:`ConstantIgnoredRegexp`, :option:`ConstantHungarianPrefix`
- - :option:`ConstantMemberCase`, :option:`ConstantMemberPrefix`, :option:`ConstantMemberSuffix`, :option:`ConstantMemberIgnoredRegexp`, :option:`ConstantMemberHungarianPrefix`
- - :option:`ConstantParameterCase`, :option:`ConstantParameterPrefix`, :option:`ConstantParameterSuffix`, :option:`ConstantParameterIgnoredRegexp`, :option:`ConstantParameterHungarianPrefix`
- - :option:`ConstantPointerParameterCase`, :option:`ConstantPointerParameterPrefix`, :option:`ConstantPointerParameterSuffix`, :option:`ConstantPointerParameterIgnoredRegexp`, :option:`ConstantPointerParameterHungarianPrefix`
- - :option:`ConstexprFunctionCase`, :option:`ConstexprFunctionPrefix`, :option:`ConstexprFunctionSuffix`, :option:`ConstexprFunctionIgnoredRegexp`
- - :option:`ConstexprMethodCase`, :option:`ConstexprMethodPrefix`, :option:`ConstexprMethodSuffix`, :option:`ConstexprMethodIgnoredRegexp`
- - :option:`ConstexprVariableCase`, :option:`ConstexprVariablePrefix`, :option:`ConstexprVariableSuffix`, :option:`ConstexprVariableIgnoredRegexp`, :option:`ConstexprVariableHungarianPrefix`
- - :option:`EnumCase`, :option:`EnumPrefix`, :option:`EnumSuffix`, :option:`EnumIgnoredRegexp`
- - :option:`EnumConstantCase`, :option:`EnumConstantPrefix`, :option:`EnumConstantSuffix`, :option:`EnumConstantIgnoredRegexp`, :option:`EnumConstantHungarianPrefix`
- - :option:`FunctionCase`, :option:`FunctionPrefix`, :option:`FunctionSuffix`, :option:`FunctionIgnoredRegexp`
- - :option:`GlobalConstexprVariableCase`, :option:`GlobalConstexprVariablePrefix`, :option:`GlobalConstexprVariableSuffix`, :option:`GlobalConstexprVariableIgnoredRegexp`, :option:`GlobalConstexprVariableHungarianPrefix`
- - :option:`GlobalConstantCase`, :option:`GlobalConstantPrefix`, :option:`GlobalConstantSuffix`, :option:`GlobalConstantIgnoredRegexp`, :option:`GlobalConstantHungarianPrefix`
- - :option:`GlobalConstantPointerCase`, :option:`GlobalConstantPointerPrefix`, :option:`GlobalConstantPointerSuffix`, :option:`GlobalConstantPointerIgnoredRegexp`, :option:`GlobalConstantPointerHungarianPrefix`
- - :option:`GlobalFunctionCase`, :option:`GlobalFunctionPrefix`, :option:`GlobalFunctionSuffix`, :option:`GlobalFunctionIgnoredRegexp`
- - :option:`GlobalPointerCase`, :option:`GlobalPointerPrefix`, :option:`GlobalPointerSuffix`, :option:`GlobalPointerIgnoredRegexp`, :option:`GlobalPointerHungarianPrefix`
- - :option:`GlobalVariableCase`, :option:`GlobalVariablePrefix`, :option:`GlobalVariableSuffix`, :option:`GlobalVariableIgnoredRegexp`, :option:`GlobalVariableHungarianPrefix`
- - :option:`InlineNamespaceCase`, :option:`InlineNamespacePrefix`, :option:`InlineNamespaceSuffix`, :option:`InlineNamespaceIgnoredRegexp`
- - :option:`LocalConstexprVariableCase`, :option:`LocalConstexprVariablePrefix`, :option:`LocalConstexprVariableSuffix`, :option:`LocalConstexprVariableIgnoredRegexp`, :option:`LocalConstexprVariableHungarianPrefix`
- - :option:`LocalConstantCase`, :option:`LocalConstantPrefix`, :option:`LocalConstantSuffix`, :option:`LocalConstantIgnoredRegexp`, :option:`LocalConstantHungarianPrefix`
- - :option:`LocalConstantPointerCase`, :option:`LocalConstantPointerPrefix`, :option:`LocalConstantPointerSuffix`, :option:`LocalConstantPointerIgnoredRegexp`, :option:`LocalConstantPointerHungarianPrefix`
- - :option:`LocalPointerCase`, :option:`LocalPointerPrefix`, :option:`LocalPointerSuffix`, :option:`LocalPointerIgnoredRegexp`, :option:`LocalPointerHungarianPrefix`
- - :option:`LocalVariableCase`, :option:`LocalVariablePrefix`, :option:`LocalVariableSuffix`, :option:`LocalVariableIgnoredRegexp`, :option:`LocalVariableHungarianPrefix`
- - :option:`MacroDefinitionCase`, :option:`MacroDefinitionPrefix`, :option:`MacroDefinitionSuffix`, :option:`MacroDefinitionIgnoredRegexp`
- - :option:`MemberCase`, :option:`MemberPrefix`, :option:`MemberSuffix`, :option:`MemberIgnoredRegexp`, :option:`MemberHungarianPrefix`
- - :option:`MethodCase`, :option:`MethodPrefix`, :option:`MethodSuffix`, :option:`MethodIgnoredRegexp`
- - :option:`NamespaceCase`, :option:`NamespacePrefix`, :option:`NamespaceSuffix`, :option:`NamespaceIgnoredRegexp`
- - :option:`ParameterCase`, :option:`ParameterPrefix`, :option:`ParameterSuffix`, :option:`ParameterIgnoredRegexp`, :option:`ParameterHungarianPrefix`
- - :option:`ParameterPackCase`, :option:`ParameterPackPrefix`, :option:`ParameterPackSuffix`, :option:`ParameterPackIgnoredRegexp`
- - :option:`PointerParameterCase`, :option:`PointerParameterPrefix`, :option:`PointerParameterSuffix`, :option:`PointerParameterIgnoredRegexp`, :option:`PointerParameterHungarianPrefix`
- - :option:`PrivateMemberCase`, :option:`PrivateMemberPrefix`, :option:`PrivateMemberSuffix`, :option:`PrivateMemberIgnoredRegexp`, :option:`PrivateMemberHungarianPrefix`
- - :option:`PrivateMethodCase`, :option:`PrivateMethodPrefix`, :option:`PrivateMethodSuffix`, :option:`PrivateMethodIgnoredRegexp`
- - :option:`ProtectedMemberCase`, :option:`ProtectedMemberPrefix`, :option:`ProtectedMemberSuffix`, :option:`ProtectedMemberIgnoredRegexp`, :option:`ProtectedMemberHungarianPrefix`
- - :option:`ProtectedMethodCase`, :option:`ProtectedMethodPrefix`, :option:`ProtectedMethodSuffix`, :option:`ProtectedMethodIgnoredRegexp`
- - :option:`PublicMemberCase`, :option:`PublicMemberPrefix`, :option:`PublicMemberSuffix`, :option:`PublicMemberIgnoredRegexp`, :option:`PublicMemberHungarianPrefix`
- - :option:`PublicMethodCase`, :option:`PublicMethodPrefix`, :option:`PublicMethodSuffix`, :option:`PublicMethodIgnoredRegexp`
- - :option:`ScopedEnumConstantCase`, :option:`ScopedEnumConstantPrefix`, :option:`ScopedEnumConstantSuffix`, :option:`ScopedEnumConstantIgnoredRegexp`
- - :option:`StaticConstexprVariableCase`, :option:`StaticConstexprVariablePrefix`, :option:`StaticConstexprVariableSuffix`, :option:`StaticConstexprVariableIgnoredRegexp`, :option:`StaticConstexprVariableHungarianPrefix`
- - :option:`StaticConstantCase`, :option:`StaticConstantPrefix`, :option:`StaticConstantSuffix`, :option:`StaticConstantIgnoredRegexp`, :option:`StaticConstantHungarianPrefix`
- - :option:`StaticVariableCase`, :option:`StaticVariablePrefix`, :option:`StaticVariableSuffix`, :option:`StaticVariableIgnoredRegexp`, :option:`StaticVariableHungarianPrefix`
- - :option:`StructCase`, :option:`StructPrefix`, :option:`StructSuffix`, :option:`StructIgnoredRegexp`
- - :option:`TemplateParameterCase`, :option:`TemplateParameterPrefix`, :option:`TemplateParameterSuffix`, :option:`TemplateParameterIgnoredRegexp`
- - :option:`TemplateTemplateParameterCase`, :option:`TemplateTemplateParameterPrefix`, :option:`TemplateTemplateParameterSuffix`, :option:`TemplateTemplateParameterIgnoredRegexp`
- - :option:`TypeAliasCase`, :option:`TypeAliasPrefix`, :option:`TypeAliasSuffix`, :option:`TypeAliasIgnoredRegexp`
- - :option:`TypedefCase`, :option:`TypedefPrefix`, :option:`TypedefSuffix`, :option:`TypedefIgnoredRegexp`
- - :option:`TypeTemplateParameterCase`, :option:`TypeTemplateParameterPrefix`, :option:`TypeTemplateParameterSuffix`, :option:`TypeTemplateParameterIgnoredRegexp`
- - :option:`UnionCase`, :option:`UnionPrefix`, :option:`UnionSuffix`, :option:`UnionIgnoredRegexp`
- - :option:`ValueTemplateParameterCase`, :option:`ValueTemplateParameterPrefix`, :option:`ValueTemplateParameterSuffix`, :option:`ValueTemplateParameterIgnoredRegexp`
- - :option:`VariableCase`, :option:`VariablePrefix`, :option:`VariableSuffix`, :option:`VariableIgnoredRegexp`, :option:`VariableHungarianPrefix`
- - :option:`VirtualMethodCase`, :option:`VirtualMethodPrefix`, :option:`VirtualMethodSuffix`, :option:`VirtualMethodIgnoredRegexp`
+ - :option:`AbstractClassCase`, :option:`AbstractClassPrefix`,
+   :option:`AbstractClassSuffix`, :option:`AbstractClassIgnoredRegexp`,
+   :option:`AbstractClassHungarianPrefix`
+ - :option:`ClassCase`, :option:`ClassPrefix`, :option:`ClassSuffix`,
+   :option:`ClassIgnoredRegexp`, :option:`ClassHungarianPrefix`
+ - :option:`ClassConstexprCase`, :option:`ClassConstexprPrefix`,
+   :option:`ClassConstexprSuffix`, :option:`ClassConstexprIgnoredRegexp`,
+   :option:`ClassConstexprHungarianPrefix`
+ - :option:`ClassConstantCase`, :option:`ClassConstantPrefix`,
+   :option:`ClassConstantSuffix`, :option:`ClassConstantIgnoredRegexp`,
+   :option:`ClassConstantHungarianPrefix`
+ - :option:`ClassMemberCase`, :option:`ClassMemberPrefix`,
+   :option:`ClassMemberSuffix`, :option:`ClassMemberIgnoredRegexp`,
+   :option:`ClassMemberHungarianPrefix`
+ - :option:`ClassMethodCase`, :option:`ClassMethodPrefix`,
+   :option:`ClassMethodSuffix`, :option:`ClassMethodIgnoredRegexp`
+ - :option:`ConceptCase`, :option:`ConceptPrefix`, :option:`ConceptSuffix`,
+   :option:`ConceptIgnoredRegexp`
+ - :option:`ConstantCase`, :option:`ConstantPrefix`, :option:`ConstantSuffix`,
+   :option:`ConstantIgnoredRegexp`, :option:`ConstantHungarianPrefix`
+ - :option:`ConstantMemberCase`, :option:`ConstantMemberPrefix`,
+   :option:`ConstantMemberSuffix`, :option:`ConstantMemberIgnoredRegexp`,
+   :option:`ConstantMemberHungarianPrefix`
+ - :option:`ConstantParameterCase`, :option:`ConstantParameterPrefix`,
+   :option:`ConstantParameterSuffix`, :option:`ConstantParameterIgnoredRegexp`,
+   :option:`ConstantParameterHungarianPrefix`
+ - :option:`ConstantPointerParameterCase`,
+   :option:`ConstantPointerParameterPrefix`,
+   :option:`ConstantPointerParameterSuffix`,
+   :option:`ConstantPointerParameterIgnoredRegexp`,
+   :option:`ConstantPointerParameterHungarianPrefix`
+ - :option:`ConstexprFunctionCase`, :option:`ConstexprFunctionPrefix`,
+   :option:`ConstexprFunctionSuffix`, :option:`ConstexprFunctionIgnoredRegexp`
+ - :option:`ConstexprMethodCase`, :option:`ConstexprMethodPrefix`,
+   :option:`ConstexprMethodSuffix`, :option:`ConstexprMethodIgnoredRegexp`
+ - :option:`ConstexprVariableCase`, :option:`ConstexprVariablePrefix`,
+   :option:`ConstexprVariableSuffix`, :option:`ConstexprVariableIgnoredRegexp`,
+   :option:`ConstexprVariableHungarianPrefix`
+ - :option:`EnumCase`, :option:`EnumPrefix`, :option:`EnumSuffix`,
+   :option:`EnumIgnoredRegexp`
+ - :option:`EnumConstantCase`, :option:`EnumConstantPrefix`,
+   :option:`EnumConstantSuffix`, :option:`EnumConstantIgnoredRegexp`,
+   :option:`EnumConstantHungarianPrefix`
+ - :option:`FunctionCase`, :option:`FunctionPrefix`, :option:`FunctionSuffix`,
+   :option:`FunctionIgnoredRegexp`
+ - :option:`GlobalConstexprVariableCase`,
+   :option:`GlobalConstexprVariablePrefix`,
+   :option:`GlobalConstexprVariableSuffix`,
+   :option:`GlobalConstexprVariableIgnoredRegexp`,
+   :option:`GlobalConstexprVariableHungarianPrefix`
+ - :option:`GlobalConstantCase`, :option:`GlobalConstantPrefix`,
+   :option:`GlobalConstantSuffix`, :option:`GlobalConstantIgnoredRegexp`,
+   :option:`GlobalConstantHungarianPrefix`
+ - :option:`GlobalConstantPointerCase`,
+   :option:`GlobalConstantPointerPrefix`,
+   :option:`GlobalConstantPointerSuffix`,
+   :option:`GlobalConstantPointerIgnoredRegexp`,
+   :option:`GlobalConstantPointerHungarianPrefix`
+ - :option:`GlobalFunctionCase`, :option:`GlobalFunctionPrefix`,
+   :option:`GlobalFunctionSuffix`, :option:`GlobalFunctionIgnoredRegexp`
+ - :option:`GlobalPointerCase`, :option:`GlobalPointerPrefix`,
+   :option:`GlobalPointerSuffix`, :option:`GlobalPointerIgnoredRegexp`,
+   :option:`GlobalPointerHungarianPrefix`
+ - :option:`GlobalVariableCase`, :option:`GlobalVariablePrefix`,
+   :option:`GlobalVariableSuffix`, :option:`GlobalVariableIgnoredRegexp`,
+   :option:`GlobalVariableHungarianPrefix`
+ - :option:`InlineNamespaceCase`, :option:`InlineNamespacePrefix`,
+   :option:`InlineNamespaceSuffix`, :option:`InlineNamespaceIgnoredRegexp`
+ - :option:`LocalConstexprVariableCase`,
+   :option:`LocalConstexprVariablePrefix`,
+   :option:`LocalConstexprVariableSuffix`,
+   :option:`LocalConstexprVariableIgnoredRegexp`,
+   :option:`LocalConstexprVariableHungarianPrefix`
+ - :option:`LocalConstantCase`, :option:`LocalConstantPrefix`,
+   :option:`LocalConstantSuffix`, :option:`LocalConstantIgnoredRegexp`,
+   :option:`LocalConstantHungarianPrefix`
+ - :option:`LocalConstantPointerCase`,
+   :option:`LocalConstantPointerPrefix`,
+   :option:`LocalConstantPointerSuffix`,
+   :option:`LocalConstantPointerIgnoredRegexp`,
+   :option:`LocalConstantPointerHungarianPrefix`
+ - :option:`LocalPointerCase`, :option:`LocalPointerPrefix`,
+   :option:`LocalPointerSuffix`, :option:`LocalPointerIgnoredRegexp`,
+   :option:`LocalPointerHungarianPrefix`
+ - :option:`LocalVariableCase`, :option:`LocalVariablePrefix`,
+   :option:`LocalVariableSuffix`, :option:`LocalVariableIgnoredRegexp`,
+   :option:`LocalVariableHungarianPrefix`
+ - :option:`MacroDefinitionCase`, :option:`MacroDefinitionPrefix`,
+   :option:`MacroDefinitionSuffix`, :option:`MacroDefinitionIgnoredRegexp`
+ - :option:`MemberCase`, :option:`MemberPrefix`, :option:`MemberSuffix`,
+   :option:`MemberIgnoredRegexp`, :option:`MemberHungarianPrefix`
+ - :option:`MethodCase`, :option:`MethodPrefix`, :option:`MethodSuffix`,
+   :option:`MethodIgnoredRegexp`
+ - :option:`NamespaceCase`, :option:`NamespacePrefix`,
+   :option:`NamespaceSuffix`, :option:`NamespaceIgnoredRegexp`
+ - :option:`ParameterCase`, :option:`ParameterPrefix`,
+   :option:`ParameterSuffix`, :option:`ParameterIgnoredRegexp`,
+   :option:`ParameterHungarianPrefix`
+ - :option:`ParameterPackCase`, :option:`ParameterPackPrefix`,
+   :option:`ParameterPackSuffix`, :option:`ParameterPackIgnoredRegexp`
+ - :option:`PointerParameterCase`, :option:`PointerParameterPrefix`,
+   :option:`PointerParameterSuffix`, :option:`PointerParameterIgnoredRegexp`,
+   :option:`PointerParameterHungarianPrefix`
+ - :option:`PrivateMemberCase`, :option:`PrivateMemberPrefix`,
+   :option:`PrivateMemberSuffix`, :option:`PrivateMemberIgnoredRegexp`,
+   :option:`PrivateMemberHungarianPrefix`
+ - :option:`PrivateMethodCase`, :option:`PrivateMethodPrefix`,
+   :option:`PrivateMethodSuffix`, :option:`PrivateMethodIgnoredRegexp`
+ - :option:`ProtectedMemberCase`, :option:`ProtectedMemberPrefix`,
+   :option:`ProtectedMemberSuffix`, :option:`ProtectedMemberIgnoredRegexp`,
+   :option:`ProtectedMemberHungarianPrefix`
+ - :option:`ProtectedMethodCase`, :option:`ProtectedMethodPrefix`,
+   :option:`ProtectedMethodSuffix`, :option:`ProtectedMethodIgnoredRegexp`
+ - :option:`PublicMemberCase`, :option:`PublicMemberPrefix`,
+   :option:`PublicMemberSuffix`, :option:`PublicMemberIgnoredRegexp`,
+   :option:`PublicMemberHungarianPrefix`
+ - :option:`PublicMethodCase`, :option:`PublicMethodPrefix`,
+   :option:`PublicMethodSuffix`, :option:`PublicMethodIgnoredRegexp`
+ - :option:`ScopedEnumConstantCase`, :option:`ScopedEnumConstantPrefix`,
+   :option:`ScopedEnumConstantSuffix`,
+   :option:`ScopedEnumConstantIgnoredRegexp`
+ - :option:`StaticConstexprVariableCase`,
+   :option:`StaticConstexprVariablePrefix`,
+   :option:`StaticConstexprVariableSuffix`,
+   :option:`StaticConstexprVariableIgnoredRegexp`,
+   :option:`StaticConstexprVariableHungarianPrefix`
+ - :option:`StaticConstantCase`, :option:`StaticConstantPrefix`,
+   :option:`StaticConstantSuffix`, :option:`StaticConstantIgnoredRegexp`,
+   :option:`StaticConstantHungarianPrefix`
+ - :option:`StaticVariableCase`, :option:`StaticVariablePrefix`,
+   :option:`StaticVariableSuffix`, :option:`StaticVariableIgnoredRegexp`,
+   :option:`StaticVariableHungarianPrefix`
+ - :option:`StructCase`, :option:`StructPrefix`, :option:`StructSuffix`,
+   :option:`StructIgnoredRegexp`
+ - :option:`TemplateParameterCase`, :option:`TemplateParameterPrefix`,
+   :option:`TemplateParameterSuffix`, :option:`TemplateParameterIgnoredRegexp`
+ - :option:`TemplateTemplateParameterCase`,
+   :option:`TemplateTemplateParameterPrefix`,
+   :option:`TemplateTemplateParameterSuffix`,
+   :option:`TemplateTemplateParameterIgnoredRegexp`
+ - :option:`TypeAliasCase`, :option:`TypeAliasPrefix`,
+   :option:`TypeAliasSuffix`, :option:`TypeAliasIgnoredRegexp`
+ - :option:`TypedefCase`, :option:`TypedefPrefix`, :option:`TypedefSuffix`,
+   :option:`TypedefIgnoredRegexp`
+ - :option:`TypeTemplateParameterCase`,
+   :option:`TypeTemplateParameterPrefix`,
+   :option:`TypeTemplateParameterSuffix`,
+   :option:`TypeTemplateParameterIgnoredRegexp`
+ - :option:`UnionCase`, :option:`UnionPrefix`, :option:`UnionSuffix`,
+   :option:`UnionIgnoredRegexp`
+ - :option:`ValueTemplateParameterCase`,
+   :option:`ValueTemplateParameterPrefix`,
+   :option:`ValueTemplateParameterSuffix`,
+   :option:`ValueTemplateParameterIgnoredRegexp`
+ - :option:`VariableCase`, :option:`VariablePrefix`, :option:`VariableSuffix`,
+   :option:`VariableIgnoredRegexp`, :option:`VariableHungarianPrefix`
+ - :option:`VirtualMethodCase`, :option:`VirtualMethodPrefix`,
+   :option:`VirtualMethodSuffix`, :option:`VirtualMethodIgnoredRegexp`
 
 
 Options description
@@ -1608,8 +1711,8 @@ After:
 
     #define pre_my_macro_definition_post
 
-Note: This will not warn on builtin macros or macros defined on the command line
-using the ``-D`` flag.
+Note: This will not warn on builtin macros or macros defined on the
+command line using the ``-D`` flag.
 
 .. option:: MemberCase
 
@@ -2804,44 +2907,45 @@ distinguished as the given name. The first character of the given name can be
 capitalized to separate it from the type indicators (see also CamelCase).
 Otherwise the case of this character denotes scope.
 
-The following table is the default mapping table of Hungarian Notation which
-maps Decl to its prefix string. You can also have your own style in config file.
+The following table is the default mapping table of Hungarian Notation
+which maps Decl to its prefix string. You can also have your own style
+in config file.
 
-================= ============== ====================== ============== ============== ==============
-Primitive Type                                                         Microsoft Type
------------------ -------------- ---------------------- -------------- -------------- --------------
-    Type          Prefix         Type                   Prefix         Type           Prefix
-================= ============== ====================== ============== ============== ==============
-int8_t            i8             signed int             si             BOOL           b
-int16_t           i16            signed short           ss             BOOLEAN        b
-int32_t           i32            signed short int       ssi            BYTE           by
-int64_t           i64            signed long long int   slli           CHAR           c
-uint8_t           u8             signed long long       sll            UCHAR          uc
-uint16_t          u16            signed long int        sli            SHORT          s
-uint32_t          u32            signed long            sl             USHORT         us
-uint64_t          u64            signed                 s              WORD           w
-char8_t           c8             unsigned long long int ulli           DWORD          dw
-char16_t          c16            unsigned long long     ull            DWORD32        dw32
-char32_t          c32            unsigned long int      uli            DWORD64        dw64
-float             f              unsigned long          ul             LONG           l
-double            d              unsigned short int     usi            ULONG          ul
-char              c              unsigned short         us             ULONG32        ul32
-bool              b              unsigned int           ui             ULONG64        ul64
-_Bool             b              unsigned char          uc             ULONGLONG      ull
-int               i              unsigned               u              HANDLE         h
-size_t            n              long long int          lli            INT            i
-short             s              long double            ld             INT8           i8
-signed            i              long long              ll             INT16          i16
-unsigned          u              long int               li             INT32          i32
-long              l              long                   l              INT64          i64
-long long         ll             ptrdiff_t              p              UINT           ui
-unsigned long     ul             void                   *none*         UINT8          u8
-long double       ld                                                   UINT16         u16
-ptrdiff_t         p                                                    UINT32         u32
-wchar_t           wc                                                   UINT64         u64
-short int         si                                                   PVOID          p
-short             s
-================= ============== ====================== ============== ============== ==============
+============== ======== ====================== ======== ============== ========
+Primitive Type                                          Microsoft Type
+-------------- -------- ---------------------- -------- -------------- --------
+    Type       Prefix   Type                   Prefix   Type           Prefix
+============== ======== ====================== ======== ============== ========
+int8_t         i8       signed int             si       BOOL           b
+int16_t        i16      signed short           ss       BOOLEAN        b
+int32_t        i32      signed short int       ssi      BYTE           by
+int64_t        i64      signed long long int   slli     CHAR           c
+uint8_t        u8       signed long long       sll      UCHAR          uc
+uint16_t       u16      signed long int        sli      SHORT          s
+uint32_t       u32      signed long            sl       USHORT         us
+uint64_t       u64      signed                 s        WORD           w
+char8_t        c8       unsigned long long int ulli     DWORD          dw
+char16_t       c16      unsigned long long     ull      DWORD32        dw32
+char32_t       c32      unsigned long int      uli      DWORD64        dw64
+float          f        unsigned long          ul       LONG           l
+double         d        unsigned short int     usi      ULONG          ul
+char           c        unsigned short         us       ULONG32        ul32
+bool           b        unsigned int           ui       ULONG64        ul64
+_Bool          b        unsigned char          uc       ULONGLONG      ull
+int            i        unsigned               u        HANDLE         h
+size_t         n        long long int          lli      INT            i
+short          s        long double            ld       INT8           i8
+signed         i        long long              ll       INT16          i16
+unsigned       u        long int               li       INT32          i32
+long           l        long                   l        INT64          i64
+long long      ll       ptrdiff_t              p        UINT           ui
+unsigned long  ul       void                   *none*   UINT8          u8
+long double    ld                                       UINT16         u16
+ptrdiff_t      p                                        UINT32         u32
+wchar_t        wc                                       UINT64         u64
+short int      si                                       PVOID          p
+short          s
+============== ======== ====================== ======== ============== ========
 
 **There are more trivial options for Hungarian Notation:**
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -4,9 +4,9 @@ readability-implicit-bool-conversion
 ====================================
 
 This check can be used to find implicit conversions between built-in types and
-booleans. Depending on use case, it may simply help with readability of the code,
-or in some cases, point to potential bugs which remain unnoticed due to implicit
-conversions.
+booleans. Depending on use case, it may simply help with readability of the
+code, or in some cases, point to potential bugs which remain unnoticed due to
+implicit conversions.
 
 The following is a real-world example of bug which was hiding behind implicit
 ``bool`` conversion:

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/make-member-function-const.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/make-member-function-const.rst
@@ -37,7 +37,8 @@ In addition, this check ignores functions that
 * are templated or part of a class template
 * have an empty body
 * do not (implicitly) use ``this`` at all
-  (see :doc:`readability-convert-member-functions-to-static <../readability/convert-member-functions-to-static>`).
+  (see :doc:`readability-convert-member-functions-to-static
+  <../readability/convert-member-functions-to-static>`).
 
 The following real-world examples will be preserved by the check:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.rst
@@ -3,15 +3,16 @@
 readability-math-missing-parentheses
 ====================================
 
-Check for missing parentheses in mathematical expressions that involve operators
-of different priorities.
+Check for missing parentheses in mathematical expressions that involve
+operators of different priorities.
 
 Parentheses in mathematical expressions clarify the order
-of operations, especially with different-priority operators. Lengthy or multiline
-expressions can obscure this order, leading to coding errors. IDEs can aid clarity
-by highlighting parentheses. Explicitly using parentheses also clarifies what the
-developer had in mind when writing the expression. Ensuring their presence reduces
-ambiguity and errors, promoting clearer and more maintainable code.
+of operations, especially with different-priority operators. Lengthy or
+multiline expressions can obscure this order, leading to coding errors.
+IDEs can aid clarity by highlighting parentheses. Explicitly using parentheses
+also clarifies what the developer had in mind when writing the expression.
+Ensuring their presence reduces ambiguity and errors, promoting clearer and
+more maintainable code.
 
 Before:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/named-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/named-parameter.rst
@@ -10,8 +10,9 @@ Guide:
 
 https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions
 
-All parameters should have the same name in both the function declaration and definition.
-If a parameter is not utilized, its name can be commented out in a function definition.
+All parameters should have the same name in both the function declaration and
+definition. If a parameter is not utilized, its name can be commented out in a
+function definition.
 
 .. code-block:: c++
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/operators-representation.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/operators-representation.rst
@@ -69,9 +69,10 @@ To configure check to enforce Alternative Token Representation for all
 operators set options to
 `and;and_eq;bitand;bitor;compl;not;not_eq;or;or_eq;xor;xor_eq`.
 
-Developers do not need to enforce all operators, and can mix the representations
-as desired by specifying a semicolon-separated list of both traditional and
-alternative tokens in the configuration, such as `and;||;not`.
+Developers do not need to enforce all operators, and can mix the
+representations as desired by specifying a semicolon-separated list of
+both traditional and alternative tokens in the configuration,
+such as `and;||;not`.
 
 .. option:: BinaryOperators
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-casting.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-casting.rst
@@ -18,9 +18,9 @@ In this example, the ``static_cast<int>(value)`` is redundant, as it performs
 a cast from an ``int`` to another ``int``.
 
 Casting operations involving constructor conversions, user-defined conversions,
-functional casts, type-dependent casts, casts between distinct type aliases that
-refer to the same underlying type, as well as bitfield-related casts and casts
-directly from lvalue to rvalue, are all disregarded by the check.
+functional casts, type-dependent casts, casts between distinct type aliases
+that refer to the same underlying type, as well as bitfield-related casts and
+casts directly from lvalue to rvalue, are all disregarded by the check.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-control-flow.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-control-flow.rst
@@ -4,7 +4,8 @@ readability-redundant-control-flow
 ==================================
 
 This check looks for procedures (functions returning no value) with ``return``
-statements at the end of the function. Such ``return`` statements are redundant.
+statements at the end of the function. Such ``return`` statements are
+redundant.
 
 Loop statements (``for``, ``while``, ``do while``) are checked for redundant
 ``continue`` statements at the end of the loop body.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.rst
@@ -4,7 +4,8 @@ readability-redundant-string-cstr
 =================================
 
 
-Finds unnecessary calls to ``std::string::c_str()`` and ``std::string::data()``.
+Finds unnecessary calls to ``std::string::c_str()`` and
+``std::string::data()``.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/reference-to-constructed-temporary.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/reference-to-constructed-temporary.rst
@@ -23,10 +23,10 @@ Examples of problematic code include:
 In the first example, a ``const std::string&`` reference variable ``str`` is
 assigned a temporary object created by the ``std::string("hello")``
 constructor. In the second example, a ``const Point&`` reference variable ``p``
-is assigned an object that is constructed from an initializer list ``{ 1, 2 }``.
-Both of these examples extend the lifetime of the temporary object to the
-lifetime of the reference variable, which can make it difficult to reason about
-and may lead to subtle bugs or misunderstanding.
+is assigned an object that is constructed from an initializer list
+``{ 1, 2 }``. Both of these examples extend the lifetime of the temporary
+object to the lifetime of the reference variable, which can make it difficult
+to reason about and may lead to subtle bugs or misunderstanding.
 
 To avoid these issues, it is recommended to change the reference variable to a
 (``const``) value variable.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
@@ -76,8 +76,9 @@ Examples:
      becomes ``return (i & 1) != 0;``
 
   6. Given ``struct X { explicit operator bool(); };``, and an instance ``x``
-     of ``struct X``, the conditional return ``if (x) return true;
-     return false;`` becomes ``return static_cast<bool>(x);``
+     of ``struct X``, the conditional return
+     ``if (x) return true; return false;``
+     becomes ``return static_cast<bool>(x);``
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
@@ -75,9 +75,9 @@ Examples:
      an implicit conversion of an integer quantity ``i & 1`` to ``bool`` and
      becomes ``return (i & 1) != 0;``
 
-  6. Given ``struct X { explicit operator bool(); };``, and an instance ``x`` of
-     ``struct X``, the conditional return ``if (x) return true; return false;``
-     becomes ``return static_cast<bool>(x);``
+  6. Given ``struct X { explicit operator bool(); };``, and an instance ``x``
+     of ``struct X``, the conditional return ``if (x) return true;
+     return false;`` becomes ``return static_cast<bool>(x);``
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/string-compare.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/string-compare.rst
@@ -8,11 +8,11 @@ Finds string comparisons using the compare method.
 A common mistake is to use the string's ``compare`` method instead of using the
 equality or inequality operators. The compare method is intended for sorting
 functions and thus returns a negative number, a positive number or
-zero depending on the lexicographical relationship between the strings compared.
-If an equality or inequality check can suffice, that is recommended. This is
-recommended to avoid the risk of incorrect interpretation of the return value
-and to simplify the code. The string equality and inequality operators can
-also be faster than the ``compare`` method due to early termination.
+zero depending on the lexicographical relationship between the strings
+compared. If an equality or inequality check can suffice, that is recommended.
+This is recommended to avoid the risk of incorrect interpretation of the return
+value and to simplify the code. The string equality and inequality operators
+can also be faster than the ``compare`` method due to early termination.
 
 Example
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/suspicious-call-argument.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/suspicious-call-argument.rst
@@ -235,8 +235,8 @@ Parameter names are the identifiers as written in the source code.
 Argument names are:
 
   * If a variable is passed, the variable's name.
-  * If a subsequent function call's return value is used as argument, the called
-    function's name.
+  * If a subsequent function call's return value is used as argument, the
+    called function's name.
   * Otherwise, empty string.
 
 Empty argument or parameter names are ignored by the heuristics.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/uppercase-literal-suffix.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/uppercase-literal-suffix.rst
@@ -10,8 +10,8 @@ By default, only the suffixes that begin with ``l`` (``l``, ``ll``, ``lu``,
 `hicpp-uppercase-literal-suffix` redirects here as an alias for this check.
 
 Detects when the integral literal or floating point (decimal or hexadecimal)
-literal has a non-uppercase suffix and provides a fix-it hint with the uppercase
-suffix.
+literal has a non-uppercase suffix and provides a fix-it hint with the
+uppercase suffix.
 
 All valid combinations of suffixes are supported.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/use-anyofallof.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/use-anyofallof.rst
@@ -3,9 +3,9 @@
 readability-use-anyofallof
 ==========================
 
-Finds range-based for loops that can be replaced by a call to ``std::any_of`` or
-``std::all_of``. In C++20 mode, suggests ``std::ranges::any_of`` or
-``std::ranges::all_of``.
+Finds range-based for loops that can be replaced by a call to
+``std::any_of`` or ``std::all_of``. In C++20 mode, suggests
+``std::ranges::any_of`` or ``std::ranges::all_of``.
 
 Example:
 


### PR DESCRIPTION
Fix documentation in `mpi`, `objc`, `openmp`, `performance`, `portability`, `readability` and `zircon`.

This is part of the codebase cleanup described in https://github.com/llvm/llvm-project/issues/167098