### PR TITLE
[clang][bytecode] Adjust pointers when moving them

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBlock.cpp
+++ b/clang/lib/AST/ByteCode/InterpBlock.cpp
@@ -102,12 +102,21 @@ bool Block::hasPointer(const Pointer *P) const {
 
 void Block::movePointersTo(Block *B) {
   assert(B != this);
+  unsigned MDDiff = static_cast<int>(B->Desc->getMetadataSize()) -
+                    static_cast<int>(Desc->getMetadataSize());
 
   while (Pointers) {
     Pointer *P = Pointers;
 
     this->removePointer(P);
     P->BS.Pointee = B;
+
+    // If the metadata size changed between the two blocks, move the pointer
+    // base/offset. Realistically, this should only happen when we move pointers
+    // from a dummy pointer to a global one.
+    P->BS.Base += MDDiff;
+    P->Offset += MDDiff;
+
     B->addPointer(P);
   }
   assert(!this->hasPointers());

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -33,6 +33,7 @@ Pointer::Pointer(Block *Pointee, uint64_t BaseAndOffset)
 Pointer::Pointer(Block *Pointee, unsigned Base, uint64_t Offset)
     : Offset(Offset), StorageKind(Storage::Block) {
   assert((Base == RootPtrMark || Base % alignof(void *) == 0) && "wrong base");
+  assert(Base >= Pointee->getDescriptor()->getMetadataSize());
 
   BS = {Pointee, Base, nullptr, nullptr};
 

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -398,3 +398,24 @@ namespace PointerCast {
                                           // expected-note {{cast that performs the conversions of a reinterpret_cast}}
   };
 }
+
+namespace DummyToGlobalBlockMove {
+  struct Baz {
+    unsigned int n;
+  };
+
+  struct AP {
+    const AP *p;
+    const Baz *lp;
+  };
+
+  class Bar {
+  public:
+    static Baz _m[];
+    static const AP m;
+  };
+
+  const AP Bar::m = {0, &Bar::_m[0]};
+  Baz Bar::_m[] = {{0}};
+  const AP m = {&Bar ::m};
+}


### PR DESCRIPTION
When calling Block::movePointersTo(), the two blocks might have different metadata sizes, which causes the final pointer to be incorrect and point to garbage. Adjust the pointer base and offset accordingly.

Fixes https://github.com/llvm/llvm-project/issues/168018