### PR TITLE
[InstSimplify] Fix crash when optimizing minmax with bitcast constant vectors

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6985,6 +6985,10 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
           // VectorShuffle instruction, which is not allowed in simplifyBinOp.
           OptResult = MinMaxOptResult::UseEither;
           for (unsigned i = 0; i != ElemCount.getFixedValue(); ++i) {
+            if (!C->getAggregateElement(i)) {
+              OptResult = MinMaxOptResult::CannotOptimize;
+              break;
+            }
             auto ElemResult = OptimizeConstMinMax(C->getAggregateElement(i),
                                                   IID, Call, &NewConst);
             if (ElemResult == MinMaxOptResult::CannotOptimize ||

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6985,12 +6985,12 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
           // VectorShuffle instruction, which is not allowed in simplifyBinOp.
           OptResult = MinMaxOptResult::UseEither;
           for (unsigned i = 0; i != ElemCount.getFixedValue(); ++i) {
-            if (!C->getAggregateElement(i)) {
+            auto *Elt = C->getAggregateElement(i);
+            if (!Elt) {
               OptResult = MinMaxOptResult::CannotOptimize;
               break;
             }
-            auto ElemResult = OptimizeConstMinMax(C->getAggregateElement(i),
-                                                  IID, Call, &NewConst);
+            auto ElemResult = OptimizeConstMinMax(Elt, IID, Call, &NewConst);
             if (ElemResult == MinMaxOptResult::CannotOptimize ||
                 (ElemResult != OptResult &&
                  OptResult != MinMaxOptResult::UseEither &&


### PR DESCRIPTION
When simplifying min/max intrinsics with fixed-size vector constants,
InstructionSimplify attempts to optimize element-wise. However,
getAggregateElement() can return null for certain constant expressions
like bitcasts, leading to a null pointer dereference.

This patch adds a check to bail out of the optimization when
getAggregateElement() returns null, preventing the crash while
maintaining correct behavior for normal constant vectors.

Fixes crash with patterns like:
  call <2 x half> @llvm.minnum.v2f16(<2 x half> %x,
                                     <2 x half> bitcast (<1 x i32> <i32 N> to <2 x half>))