### PR TITLE
[llvm][ARM] Allow MOVT and MOVW on the offset between two labels

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -428,7 +428,7 @@ unsigned ARMAsmBackend::adjustFixupValue(const MCAssembler &Asm,
   // signed 16bit range.
   if ((Kind == ARM::fixup_arm_movw_lo16 || Kind == ARM::fixup_arm_movt_hi16 ||
        Kind == ARM::fixup_t2_movw_lo16 || Kind == ARM::fixup_t2_movt_hi16) &&
-      !Target.isAbsolute() && (Addend < minIntN(16) || Addend > maxIntN(16))) {
+      !IsResolved && (Addend < minIntN(16) || Addend > maxIntN(16))) {
     Ctx.reportError(Fixup.getLoc(), "Relocation Not In Range");
     return 0;
   }

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -428,7 +428,7 @@ unsigned ARMAsmBackend::adjustFixupValue(const MCAssembler &Asm,
   // signed 16bit range.
   if ((Kind == ARM::fixup_arm_movw_lo16 || Kind == ARM::fixup_arm_movt_hi16 ||
        Kind == ARM::fixup_t2_movw_lo16 || Kind == ARM::fixup_t2_movt_hi16) &&
-      (Addend < minIntN(16) || Addend > maxIntN(16))) {
+      !Target.isAbsolute() && (Addend < minIntN(16) || Addend > maxIntN(16))) {
     Ctx.reportError(Fixup.getLoc(), "Relocation Not In Range");
     return 0;
   }

--- a/llvm/test/MC/ARM/arm-movt-movw-absolute-pass.s
+++ b/llvm/test/MC/ARM/arm-movt-movw-absolute-pass.s
@@ -1,14 +1,9 @@
-@RUN: llvm-mc -triple armv7-eabi -filetype obj -o - %s 2>&1 | FileCheck %s
+@RUN: llvm-mc -triple armv7-eabi -filetype obj %s -o - | llvm-objdump -d --triple armv7-eabi - | FileCheck %s
 
-    .text
 a:
     movw    r1, #:lower16:b - a + 65536
     movt    r1, #:upper16:b - a + 65536
 b:
 
-@CHECK-NOT: error: Relocation Not In Range
-@CHECK-NOT: movw    r1, #:lower16:b - a + 65536
-@CHECK-NOT: ^
-@CHECK-NOT: error: Relocation Not In Range
-@CHECK-NOT: movt    r1, #:upper16:b - a + 65536
-@CHECK-NOT: ^
+@CHECK: 0: e3001008 movw r1, #0x8
+@CHECK: 4: e3401001 movt r1, #0x1

--- a/llvm/test/MC/ARM/arm-movt-movw-absolute-pass.s
+++ b/llvm/test/MC/ARM/arm-movt-movw-absolute-pass.s
@@ -1,0 +1,14 @@
+@RUN: llvm-mc -triple armv7-eabi -filetype obj -o - %s 2>&1 | FileCheck %s
+
+    .text
+a:
+    movw    r1, #:lower16:b - a + 65536
+    movt    r1, #:upper16:b - a + 65536
+b:
+
+@CHECK-NOT: error: Relocation Not In Range
+@CHECK-NOT: movw    r1, #:lower16:b - a + 65536
+@CHECK-NOT: ^
+@CHECK-NOT: error: Relocation Not In Range
+@CHECK-NOT: movt    r1, #:upper16:b - a + 65536
+@CHECK-NOT: ^


### PR DESCRIPTION
In this case, the value is a constant, not an addend to a relocation.
So the "Relocation Not In Range" error must not be triggered.

Regression from PR #112877
Fixes #132322