### PR TITLE
[flang][AIX] add use of the variables (NFC)

### DIFF
--- a/flang/test/Lower/derived-types-bindc.f90
+++ b/flang/test/Lower/derived-types-bindc.f90
@@ -41,4 +41,10 @@ subroutine s1()
   end type
   type(t4) :: xt4
 ! CHECK-DAG: %_QFs1Tt4 = type <{ i16, [2 x i8], { double, double }, [1 x i8], [3 x i8] }>
+
+  xt0%x2 = 1.
+  xt1%x2 = 1.
+  xt2%x2 = 1.
+  xt3%x2 = (1., 1.)
+  xt4%x2 = (1., 1.)
 end subroutine s1


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/bf3b704c60cc521b79ec54bd57fcf72368178a52, the type definition is no longer generated without using the variables. This patch is to add the use of the derived type variables.