### PR TITLE
[libc] Allow user-defined LIBC_ASSERT macro.

### DIFF
--- a/libc/src/__support/libc_assert.h
+++ b/libc/src/__support/libc_assert.h
@@ -14,9 +14,11 @@
 // The build is configured to just use the public <assert.h> API
 // for libc's internal assertions.
 
+#ifndef LIBC_ASSERT
 #include <assert.h>
 
 #define LIBC_ASSERT(COND) assert(COND)
+#endif // LIBC_ASSERT
 
 #else // Not LIBC_COPT_USE_C_ASSERT
 


### PR DESCRIPTION
By only defining it if LIBC_ASSERT macro is not defined.

Fixes https://github.com/llvm/llvm-project/issues/162392