### PR TITLE
[flang-rt] Fix TypeCategory for quad-precision COMPLEX

### DIFF
--- a/flang-rt/lib/runtime/type-code.cpp
+++ b/flang-rt/lib/runtime/type-code.cpp
@@ -92,7 +92,7 @@ RT_API_ATTRS TypeCode::TypeCode(TypeCategory f, int kind) {
       raw_ = CFI_type_extended_double_Complex;
       break;
     case 16:
-      raw_ = CFI_type_long_double_Complex;
+      raw_ = CFI_type_float128_Complex;
       break;
     }
     break;

--- a/flang-rt/unittests/Runtime/CMakeLists.txt
+++ b/flang-rt/unittests/Runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ add_flangrt_unittest(RuntimeTests
   Time.cpp
   TemporaryStack.cpp
   Transformational.cpp
+  TypeCode.cpp
 
   LINK_LIBS
     flang_rt.runtime.unittest

--- a/flang-rt/unittests/Runtime/TypeCode.cpp
+++ b/flang-rt/unittests/Runtime/TypeCode.cpp
@@ -1,0 +1,43 @@
+//===-- unittests/Runtime/TypeCode.cpp --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+#include "flang-rt/runtime/type-code.h"
+
+using namespace Fortran::runtime;
+using namespace Fortran::common;
+
+TEST(TypeCode, ComplexTypes) {
+  // Test all Complex type kinds to ensure they map correctly
+  struct ComplexTypeMapping {
+    int kind;
+    Fortran::ISO::CFI_type_t expectedType;
+  };
+
+  ComplexTypeMapping mappings[] = {
+      {2, CFI_type_half_float_Complex},
+      {3, CFI_type_bfloat_Complex},
+      {4, CFI_type_float_Complex},
+      {8, CFI_type_double_Complex},
+      {10, CFI_type_extended_double_Complex},
+      {16, CFI_type_float128_Complex},
+  };
+
+  for (const auto &mapping : mappings) {
+    TypeCode tc(TypeCategory::Complex, mapping.kind);
+    EXPECT_EQ(tc.raw(), mapping.expectedType)
+        << "Complex kind " << mapping.kind << " should map to CFI type "
+        << mapping.expectedType;
+    EXPECT_TRUE(tc.IsComplex());
+
+    auto categoryAndKind = tc.GetCategoryAndKind();
+    ASSERT_TRUE(categoryAndKind.has_value());
+    EXPECT_EQ(categoryAndKind->first, TypeCategory::Complex);
+    EXPECT_EQ(categoryAndKind->second, mapping.kind);
+  }
+}


### PR DESCRIPTION
Modify the TypeCategory for quad-precision COMPLEX to CFI_type_float128_Complex so it matches the TypeCode returned by SELECT TYPE lowering.

Fixes #134565