### PR TITLE
[Clang][Sema] Emit diagnostic for __builtin_vectorelements(<SVEType>) when SVE is not available.

### DIFF
--- a/clang/include/clang/Sema/SemaARM.h
+++ b/clang/include/clang/Sema/SemaARM.h
@@ -96,6 +96,9 @@ public:
   bool checkTargetClonesAttr(SmallVectorImpl<StringRef> &Params,
                              SmallVectorImpl<SourceLocation> &Locs,
                              SmallVectorImpl<SmallString<64>> &NewParams);
+  bool checkSVETypeSupport(QualType Ty, SourceLocation Loc,
+                           const FunctionDecl *FD,
+                           const llvm::StringMap<bool> &FeatureMap);
 };
 
 SemaARM::ArmStreamingType getArmStreamingFnType(const FunctionDecl *FD);

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2254,16 +2254,10 @@ void Sema::checkTypeSupport(QualType Ty, SourceLocation Loc, ValueDecl *D) {
     }
 
     // Don't allow SVE types in functions without a SVE target.
-    if (Ty->isSVESizelessBuiltinType() && FD && !FD->getType().isNull()) {
+    if (Ty->isSVESizelessBuiltinType() && FD) {
       llvm::StringMap<bool> CallerFeatureMap;
       Context.getFunctionFeatureMap(CallerFeatureMap, FD);
-      if (!Builtin::evaluateRequiredTargetFeatures("sve", CallerFeatureMap)) {
-        if (!Builtin::evaluateRequiredTargetFeatures("sme", CallerFeatureMap))
-          Diag(Loc, diag::err_sve_vector_in_non_sve_target) << Ty;
-        else if (!IsArmStreamingFunction(FD,
-                                         /*IncludeLocallyStreaming=*/true))
-          Diag(Loc, diag::err_sve_vector_in_non_streaming_function) << Ty;
-      }
+      ARM().checkSVETypeSupport(Ty, Loc, FD, CallerFeatureMap);
     }
 
     if (auto *VT = Ty->getAs<VectorType>();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9125,20 +9125,10 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     const FunctionDecl *FD = cast<FunctionDecl>(CurContext);
     llvm::StringMap<bool> CallerFeatureMap;
     Context.getFunctionFeatureMap(CallerFeatureMap, FD);
-
-    if (!Builtin::evaluateRequiredTargetFeatures("sve", CallerFeatureMap)) {
-      if (!Builtin::evaluateRequiredTargetFeatures("sme", CallerFeatureMap)) {
-        Diag(NewVD->getLocation(), diag::err_sve_vector_in_non_sve_target) << T;
-        NewVD->setInvalidDecl();
-        return;
-      } else if (!IsArmStreamingFunction(FD,
-                                         /*IncludeLocallyStreaming=*/true)) {
-        Diag(NewVD->getLocation(),
-             diag::err_sve_vector_in_non_streaming_function)
-            << T;
-        NewVD->setInvalidDecl();
-        return;
-      }
+    if (ARM().checkSVETypeSupport(T, NewVD->getLocation(), FD,
+                                  CallerFeatureMap)) {
+      NewVD->setInvalidDecl();
+      return;
     }
   }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -4189,6 +4189,14 @@ static bool CheckVectorElementsTraitOperandType(Sema &S, QualType T,
            << ""
            << "__builtin_vectorelements" << T << ArgRange;
 
+  if (auto *FD = dyn_cast<FunctionDecl>(S.CurContext)) {
+    if (T->isSVESizelessBuiltinType()) {
+      llvm::StringMap<bool> CallerFeatureMap;
+      S.Context.getFunctionFeatureMap(CallerFeatureMap, FD);
+      return S.ARM().checkSVETypeSupport(T, Loc, FD, CallerFeatureMap);
+    }
+  }
+
   return false;
 }
 

--- a/clang/test/Sema/AArch64/builtin_vectorelements.c
+++ b/clang/test/Sema/AArch64/builtin_vectorelements.c
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -fsyntax-only -verify %s
+// REQUIRES: aarch64-registered-target
+
+#include <arm_sve.h>
+
+__attribute__((target("sve")))
+long test_builtin_vectorelements_sve(void) {
+  return __builtin_vectorelements(svuint8_t);
+}
+
+__attribute__((target("sve2p1")))
+long test_builtin_vectorelements_sve2p1(void) {
+  return __builtin_vectorelements(svuint8_t);
+}
+
+long test_builtin_vectorelements_no_sve(void) {
+  // expected-error@+1 {{SVE vector type 'svuint8_t' (aka '__SVUint8_t') cannot be used in a target without sve}}
+  return __builtin_vectorelements(svuint8_t);
+}
+
+__attribute__((target("sme")))
+long test_builtin_vectorelements_sme_streaming(void) __arm_streaming {
+  return __builtin_vectorelements(svuint8_t);
+}
+
+__attribute__((target("sme2p1")))
+long test_builtin_vectorelements_sme2p1_streaming(void) __arm_streaming {
+  return __builtin_vectorelements(svuint8_t);
+}
+
+__attribute__((target("sme")))
+long test_builtin_vectorelements_sme(void) {
+  // expected-error@+1 {{SVE vector type 'svuint8_t' (aka '__SVUint8_t') cannot be used in a non-streaming function}}
+  return __builtin_vectorelements(svuint8_t);
+}
+
+__attribute__((target("sve,sme")))
+long test_builtin_vectorelements_sve_sme_streaming_compatible(void) __arm_streaming_compatible {
+  return __builtin_vectorelements(svuint8_t);
+}
+
+__attribute__((target("sme")))
+long test_builtin_vectorelements_sme_streaming_compatible(void) __arm_streaming_compatible {
+  // expected-error@+1 {{SVE vector type 'svuint8_t' (aka '__SVUint8_t') cannot be used in a non-streaming function}}
+  return __builtin_vectorelements(svuint8_t);
+}


### PR DESCRIPTION
As is done for other targets, I've moved the target type checking code into SemaARM and migrated existing uses.

Fixes https://github.com/llvm/llvm-project/issues/155736