### PR TITLE
[docs] Fix invalid header length in llvm-ir2vec.rst

### DIFF
--- a/llvm/docs/CommandGuide/llvm-ir2vec.rst
+++ b/llvm/docs/CommandGuide/llvm-ir2vec.rst
@@ -1,5 +1,5 @@
 llvm-ir2vec - IR2Vec and MIR2Vec Embedding Generation Tool
-===========================================================
+==========================================================
 
 .. program:: llvm-ir2vec
 

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -273,7 +273,8 @@ def process_rst(name):
 
         if len(header) != len(title):
             print(
-                "error: invalid header in %r (does not match title)" % file_subpath,
+                "error: invalid header length in %r (does not match length of title)"
+                % file_subpath,
                 file=sys.stderr,
             )
         if " - " not in title:


### PR DESCRIPTION
This also improves the error message to be more clear for folks who
haven't used a lot of rst.
