### PR TITLE
[Clang][OpenMP] Bug fix Default clause variable category

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -1364,15 +1364,15 @@ DSAStackTy::DSAVarData DSAStackTy::getDSA(const_iterator &Iter,
   DefaultDataSharingAttributes IterDA = Iter->DefaultAttr;
   switch (Iter->DefaultVCAttr) {
   case DSA_VC_aggregate:
-    if (!VD->getType()->isAggregateType())
+    if (!D->getType()->isAggregateType())
       IterDA = DSA_none;
     break;
   case DSA_VC_pointer:
-    if (!VD->getType()->isPointerType())
+    if (!D->getType()->isPointerType())
       IterDA = DSA_none;
     break;
   case DSA_VC_scalar:
-    if (!VD->getType()->isScalarType())
+    if (!D->getType()->isScalarType())
       IterDA = DSA_none;
     break;
   case DSA_VC_all:

--- a/clang/test/OpenMP/parallel_default_variableCategory_codegen.cpp
+++ b/clang/test/OpenMP/parallel_default_variableCategory_codegen.cpp
@@ -1,0 +1,91 @@
+// RUN: %clangxx -Xclang -verify -Wno-vla -fopenmp -fopenmp-version=60 -x c++ -S -emit-llvm %s -o - | FileCheck %s
+// expected-no-diagnostics
+#ifndef HEADER
+#define HEADER
+
+int global;
+#define VECTOR_SIZE 4
+
+int main (int argc, char **argv) {
+  int i,n;
+  int x;
+
+  n = VECTOR_SIZE;
+
+  #pragma omp parallel masked firstprivate(x) num_threads(2)
+  {
+     int *xPtr = nullptr;
+     // scalar
+     #pragma omp task default(shared:scalar)
+     {
+       xPtr = &x;
+     }
+     #pragma omp taskwait
+
+     // pointer
+     #pragma omp task default(shared:pointer) shared(x)
+     {
+       xPtr = &x;
+     }
+     #pragma omp taskwait
+  }
+
+  int *aggregate[VECTOR_SIZE] = {0,0,0,0};
+  
+  #pragma omp parallel masked num_threads(2)
+  {
+     // aggregate
+     #pragma omp task default(shared:aggregate)
+     for(i=0;i<n;i++) {
+       aggregate[i] = &x;
+     }
+     #pragma omp taskwait
+
+     #pragma omp task default(shared:aggregate) shared(x)
+     for(i=0;i<n;i++) {
+       aggregate[i] = &x;
+     }
+     #pragma omp taskwait
+
+     // all
+     #pragma omp task default(shared:all)
+     for(i=0;i<n;i++) {
+       aggregate[i] = &x;
+     }
+     #pragma omp taskwait
+  }
+}
+
+#endif
+
+// CHECK-LABEL: define {{.*}}main.omp_outlined{{.*}}
+// CHECK-NEXT:  entry:
+// CHECK: %x.addr = alloca{{.*}}
+// CHECK: %xPtr = alloca{{.*}}
+// CHECK: store ptr null, ptr %xPtr{{.*}}
+// CHECK: store ptr %xPtr{{.*}}
+// CHECK: store ptr %x.addr{{.*}}
+// CHECK-NEXT:  {{.*}}call{{.*}}__kmpc_omp_task_alloc{{.*}}
+// CHECK: ret void
+//
+// CHECK: define {{.*}}main.omp_outlined{{.*}}
+// CHECK-NEXT:  entry:
+// CHECK-DAG: %i.addr = alloca{{.*}}
+// CHECK-DAG:  %n.addr = alloca{{.*}}
+// CHECK-DAG:  %aggregate.addr = alloca{{.*}}
+// CHECK-DAG:  %x.addr = alloca{{.*}}
+// CHECK: [[TMP0:%.*]] = load{{.*}}%i.addr{{.*}}
+// CHECK-NEXT:  [[TMP1:%.*]] = load{{.*}}%n.addr{{.*}}
+// CHECK-NEXT:  [[TMP2:%.*]] = load{{.*}}%aggregate.addr{{.*}}
+// CHECK-NEXT:  [[TMP3:%.*]] = load{{.*}}%x.addr{{.*}}
+// CHECK: store ptr [[TMP2]]{{.*}}
+// CHECK-NEXT:  {{.*}}call{{.*}}__kmpc_omp_task_alloc{{.*}}
+// CHECK: store ptr [[TMP2]]{{.*}}
+// CHECK: store ptr [[TMP3]]{{.*}}
+// CHECK-NEXT:  {{.*}}call{{.*}}__kmpc_omp_task_alloc{{.*}}
+// CHECK: store ptr [[TMP0]]{{.*}}
+// CHECK: store ptr [[TMP1]]{{.*}}
+// CHECK: store ptr [[TMP2]]{{.*}}
+// CHECK: store ptr [[TMP3]]{{.*}}
+// CHECK-NEXT:  {{.*}}call{{.*}}__kmpc_omp_task_alloc{{.*}}
+// CHECK: ret void


### PR DESCRIPTION
Same changes as in fix for [165276](https://github.com/llvm/llvm-project/pull/165276) except for remove unnecessary <vector> include in test to restore Ubuntu build.
This is not needed as allocatable modifier is not applicable to the default clause in C/C++.