### PR TITLE
[flang][acc] Add missing dependency on MLIROpenACCUtils

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
@@ -15,4 +15,5 @@ add_flang_library(FIROpenACCTransforms
   MLIRIR
   MLIRPass
   MLIROpenACCDialect
+  MLIROpenACCUtils
 )


### PR DESCRIPTION
FIROpenACCTransforms needs to link against MLIROpenACCUtils; otherwise, linking will fail:
`undefined reference to `mlir::acc::isValidSymbolUse`