### PR TITLE
[VE] TableGen-erate SDNode descriptions

### DIFF
--- a/llvm/lib/Target/VE/CMakeLists.txt
+++ b/llvm/lib/Target/VE/CMakeLists.txt
@@ -9,6 +9,7 @@ tablegen(LLVM VEGenMCCodeEmitter.inc -gen-emitter)
 tablegen(LLVM VEGenAsmWriter.inc -gen-asm-writer)
 tablegen(LLVM VEGenAsmMatcher.inc -gen-asm-matcher)
 tablegen(LLVM VEGenDAGISel.inc -gen-dag-isel)
+tablegen(LLVM VEGenSDNodeInfo.inc -gen-sd-node-info)
 tablegen(LLVM VEGenSubtargetInfo.inc -gen-subtarget)
 tablegen(LLVM VEGenCallingConv.inc -gen-callingconv)
 add_public_tablegen_target(VECommonTableGen)
@@ -24,6 +25,7 @@ add_llvm_target(VECodeGen
   VEMachineFunctionInfo.cpp
   VEMCInstLower.cpp
   VERegisterInfo.cpp
+  VESelectionDAGInfo.cpp
   VESubtarget.cpp
   VETargetMachine.cpp
   VVPISelLowering.cpp

--- a/llvm/lib/Target/VE/VECustomDAG.cpp
+++ b/llvm/lib/Target/VE/VECustomDAG.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "VECustomDAG.h"
+#include "VESelectionDAGInfo.h"
 
 #ifndef DEBUG_TYPE
 #define DEBUG_TYPE "vecustomdag"

--- a/llvm/lib/Target/VE/VEISelDAGToDAG.cpp
+++ b/llvm/lib/Target/VE/VEISelDAGToDAG.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "VE.h"
+#include "VESelectionDAGInfo.h"
 #include "VETargetMachine.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
 #include "llvm/Support/ErrorHandling.h"

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -17,6 +17,7 @@
 #include "VEInstrBuilder.h"
 #include "VEMachineFunctionInfo.h"
 #include "VERegisterInfo.h"
+#include "VESelectionDAGInfo.h"
 #include "VETargetMachine.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/CodeGen/CallingConvLower.h"
@@ -912,47 +913,6 @@ VETargetLowering::VETargetLowering(const TargetMachine &TM,
   setMinStackArgumentAlignment(Align(8));
 
   computeRegisterProperties(Subtarget->getRegisterInfo());
-}
-
-const char *VETargetLowering::getTargetNodeName(unsigned Opcode) const {
-#define TARGET_NODE_CASE(NAME)                                                 \
-  case VEISD::NAME:                                                            \
-    return "VEISD::" #NAME;
-  switch ((VEISD::NodeType)Opcode) {
-  case VEISD::FIRST_NUMBER:
-    break;
-    TARGET_NODE_CASE(CMPI)
-    TARGET_NODE_CASE(CMPU)
-    TARGET_NODE_CASE(CMPF)
-    TARGET_NODE_CASE(CMPQ)
-    TARGET_NODE_CASE(CMOV)
-    TARGET_NODE_CASE(CALL)
-    TARGET_NODE_CASE(EH_SJLJ_LONGJMP)
-    TARGET_NODE_CASE(EH_SJLJ_SETJMP)
-    TARGET_NODE_CASE(EH_SJLJ_SETUP_DISPATCH)
-    TARGET_NODE_CASE(GETFUNPLT)
-    TARGET_NODE_CASE(GETSTACKTOP)
-    TARGET_NODE_CASE(GETTLSADDR)
-    TARGET_NODE_CASE(GLOBAL_BASE_REG)
-    TARGET_NODE_CASE(Hi)
-    TARGET_NODE_CASE(Lo)
-    TARGET_NODE_CASE(RET_GLUE)
-    TARGET_NODE_CASE(TS1AM)
-    TARGET_NODE_CASE(VEC_UNPACK_LO)
-    TARGET_NODE_CASE(VEC_UNPACK_HI)
-    TARGET_NODE_CASE(VEC_PACK)
-    TARGET_NODE_CASE(VEC_BROADCAST)
-    TARGET_NODE_CASE(REPL_I32)
-    TARGET_NODE_CASE(REPL_F32)
-
-    TARGET_NODE_CASE(LEGALAVL)
-
-    // Register the VVP_* SDNodes.
-#define ADD_VVP_OP(VVP_NAME, ...) TARGET_NODE_CASE(VVP_NAME)
-#include "VVPNodes.def"
-  }
-#undef TARGET_NODE_CASE
-  return nullptr;
 }
 
 EVT VETargetLowering::getSetCCResultType(const DataLayout &, LLVMContext &,

--- a/llvm/lib/Target/VE/VEISelLowering.h
+++ b/llvm/lib/Target/VE/VEISelLowering.h
@@ -20,51 +20,6 @@
 namespace llvm {
 class VESubtarget;
 
-namespace VEISD {
-enum NodeType : unsigned {
-  FIRST_NUMBER = ISD::BUILTIN_OP_END,
-
-  CMPI, // Compare between two signed integer values.
-  CMPU, // Compare between two unsigned integer values.
-  CMPF, // Compare between two floating-point values.
-  CMPQ, // Compare between two quad floating-point values.
-  CMOV, // Select between two values using the result of comparison.
-
-  CALL,                   // A call instruction.
-  EH_SJLJ_LONGJMP,        // SjLj exception handling longjmp.
-  EH_SJLJ_SETJMP,         // SjLj exception handling setjmp.
-  EH_SJLJ_SETUP_DISPATCH, // SjLj exception handling setup_dispatch.
-  GETFUNPLT,              // Load function address through %plt insturction.
-  GETTLSADDR,             // Load address for TLS access.
-  GETSTACKTOP,            // Retrieve address of stack top (first address of
-                          // locals and temporaries).
-  GLOBAL_BASE_REG,        // Global base reg for PIC.
-  Hi,                     // Hi/Lo operations, typically on a global address.
-  Lo,                     // Hi/Lo operations, typically on a global address.
-  RET_GLUE,               // Return with a flag operand.
-  TS1AM,                  // A TS1AM instruction used for 1/2 bytes swap.
-  VEC_UNPACK_LO,          // unpack the lo v256 slice of a packed v512 vector.
-  VEC_UNPACK_HI,          // unpack the hi v256 slice of a packed v512 vector.
-                          //    0: v512 vector, 1: AVL
-  VEC_PACK,               // pack a lo and a hi vector into one v512 vector
-                          //    0: v256 lo vector, 1: v256 hi vector, 2: AVL
-
-  VEC_BROADCAST, // A vector broadcast instruction.
-                 //   0: scalar value, 1: VL
-  REPL_I32,
-  REPL_F32, // Replicate subregister to other half.
-
-  // Annotation as a wrapper. LEGALAVL(VL) means that VL refers to 64bit of
-  // data, whereas the raw EVL coming in from VP nodes always refers to number
-  // of elements, regardless of their size.
-  LEGALAVL,
-
-// VVP_* nodes.
-#define ADD_VVP_OP(VVP_NAME, ...) VVP_NAME,
-#include "VVPNodes.def"
-};
-}
-
 /// Convert a DAG integer condition code to a VE ICC condition.
 inline static VECC::CondCode intCondCode2Icc(ISD::CondCode CC) {
   switch (CC) {
@@ -167,7 +122,6 @@ class VETargetLowering : public TargetLowering {
 public:
   VETargetLowering(const TargetMachine &TM, const VESubtarget &STI);
 
-  const char *getTargetNodeName(unsigned Opcode) const override;
   MVT getScalarShiftAmountTy(const DataLayout &, EVT) const override {
     return MVT::i32;
   }

--- a/llvm/lib/Target/VE/VESelectionDAGInfo.cpp
+++ b/llvm/lib/Target/VE/VESelectionDAGInfo.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "VESelectionDAGInfo.h"
+
+#define GET_SDNODE_DESC
+#include "VEGenSDNodeInfo.inc"
+
+using namespace llvm;
+
+VESelectionDAGInfo::VESelectionDAGInfo()
+    : SelectionDAGGenTargetInfo(VEGenSDNodeInfo) {}
+
+VESelectionDAGInfo::~VESelectionDAGInfo() = default;
+
+const char *VESelectionDAGInfo::getTargetNodeName(unsigned Opcode) const {
+#define TARGET_NODE_CASE(NAME)                                                 \
+  case VEISD::NAME:                                                            \
+    return "VEISD::" #NAME;
+
+  switch (static_cast<VEISD::NodeType>(Opcode)) {
+    TARGET_NODE_CASE(GLOBAL_BASE_REG)
+    TARGET_NODE_CASE(LEGALAVL)
+  }
+#undef TARGET_NODE_CASE
+
+  return SelectionDAGGenTargetInfo::getTargetNodeName(Opcode);
+}
+
+void VESelectionDAGInfo::verifyTargetNode(const SelectionDAG &DAG,
+                                          const SDNode *N) const {
+  switch (N->getOpcode()) {
+  case VEISD::GETSTACKTOP:
+    // result #0 has invalid type; expected ch, got i64
+    return;
+  }
+
+  SelectionDAGGenTargetInfo::verifyTargetNode(DAG, N);
+}

--- a/llvm/lib/Target/VE/VESelectionDAGInfo.h
+++ b/llvm/lib/Target/VE/VESelectionDAGInfo.h
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_VE_VESELECTIONDAGINFO_H
+#define LLVM_LIB_TARGET_VE_VESELECTIONDAGINFO_H
+
+#include "llvm/CodeGen/SelectionDAGTargetInfo.h"
+
+#define GET_SDNODE_ENUM
+#include "VEGenSDNodeInfo.inc"
+
+namespace llvm {
+namespace VEISD {
+
+enum NodeType : unsigned {
+  GLOBAL_BASE_REG = GENERATED_OPCODE_END, // Global base reg for PIC.
+
+  // Annotation as a wrapper. LEGALAVL(VL) means that VL refers to 64bit of
+  // data, whereas the raw EVL coming in from VP nodes always refers to number
+  // of elements, regardless of their size.
+  LEGALAVL,
+};
+
+} // namespace VEISD
+
+class VESelectionDAGInfo : public SelectionDAGGenTargetInfo {
+public:
+  VESelectionDAGInfo();
+
+  ~VESelectionDAGInfo() override;
+
+  const char *getTargetNodeName(unsigned Opcode) const override;
+
+  void verifyTargetNode(const SelectionDAG &DAG,
+                        const SDNode *N) const override;
+};
+
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_VE_VESELECTIONDAGINFO_H

--- a/llvm/lib/Target/VE/VESubtarget.cpp
+++ b/llvm/lib/Target/VE/VESubtarget.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "VESubtarget.h"
+#include "VESelectionDAGInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 
 using namespace llvm;
@@ -43,7 +44,15 @@ VESubtarget::VESubtarget(const Triple &TT, const std::string &CPU,
                          const std::string &FS, const TargetMachine &TM)
     : VEGenSubtargetInfo(TT, CPU, /*TuneCPU=*/CPU, FS), TargetTriple(TT),
       InstrInfo(initializeSubtargetDependencies(CPU, FS)), TLInfo(TM, *this),
-      FrameLowering(*this) {}
+      FrameLowering(*this) {
+  TSInfo = std::make_unique<VESelectionDAGInfo>();
+}
+
+VESubtarget::~VESubtarget() = default;
+
+const SelectionDAGTargetInfo *VESubtarget::getSelectionDAGInfo() const {
+  return TSInfo.get();
+}
 
 uint64_t VESubtarget::getAdjustedFrameSize(uint64_t FrameSize) const {
   // Calculate adjusted frame size by adding the size of RSA frame,

--- a/llvm/lib/Target/VE/VESubtarget.h
+++ b/llvm/lib/Target/VE/VESubtarget.h
@@ -16,7 +16,6 @@
 #include "VEFrameLowering.h"
 #include "VEISelLowering.h"
 #include "VEInstrInfo.h"
-#include "llvm/CodeGen/SelectionDAGTargetInfo.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
@@ -41,12 +40,14 @@ class VESubtarget : public VEGenSubtargetInfo {
 
   VEInstrInfo InstrInfo;
   VETargetLowering TLInfo;
-  SelectionDAGTargetInfo TSInfo;
+  std::unique_ptr<const SelectionDAGTargetInfo> TSInfo;
   VEFrameLowering FrameLowering;
 
 public:
   VESubtarget(const Triple &TT, const std::string &CPU, const std::string &FS,
               const TargetMachine &TM);
+
+  ~VESubtarget() override;
 
   const VEInstrInfo *getInstrInfo() const override { return &InstrInfo; }
   const VEFrameLowering *getFrameLowering() const override {
@@ -56,9 +57,8 @@ public:
     return &InstrInfo.getRegisterInfo();
   }
   const VETargetLowering *getTargetLowering() const override { return &TLInfo; }
-  const SelectionDAGTargetInfo *getSelectionDAGInfo() const override {
-    return &TSInfo;
-  }
+
+  const SelectionDAGTargetInfo *getSelectionDAGInfo() const override;
 
   bool enableMachineScheduler() const override;
 

--- a/llvm/lib/Target/VE/VVPISelLowering.cpp
+++ b/llvm/lib/Target/VE/VVPISelLowering.cpp
@@ -13,6 +13,7 @@
 
 #include "VECustomDAG.h"
 #include "VEISelLowering.h"
+#include "VESelectionDAGInfo.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
This allows SDNodes to be validated against their expected type profiles
and reduces the number of changes required to add a new node.

There is a couple of nodes that are missing description and one node fails validation.

Part of #119709.
