### PR TITLE
Don't check frame base as varies if registers are available from targets.

### DIFF
--- a/llvm/test/DebugInfo/dwarfdump-dwp-str-offsets-64.yaml
+++ b/llvm/test/DebugInfo/dwarfdump-dwp-str-offsets-64.yaml
@@ -20,8 +20,7 @@
 # CHECK:      0x0000001a:   DW_TAG_subprogram
 # CHECK-NEXT:                 DW_AT_low_pc    (indexed (00000000) address = <unresolved>)
 # CHECK-NEXT:                 DW_AT_high_pc   (0x0000000f)
-# CHECK-NEXT:                 DW_AT_frame_base        (DW_OP_reg6 RBP)
-# CHECK-NEXT:                 DW_AT_name      ("main")
+# CHECK:                      DW_AT_name      ("main")
 # CHECK-NEXT:                 DW_AT_decl_file (0x00)
 # CHECK-NEXT:                 DW_AT_decl_line (1)
 # CHECK-NEXT:                 DW_AT_type      (0x00000029 "int")


### PR DESCRIPTION
Fixes a buildbot issue stemming from https://github.com/llvm/llvm-project/pull/167986