### PR TITLE
[clang-tidy][NFC] Reformat code and set 'KeepEmptyLines' to false

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -2,3 +2,7 @@ BasedOnStyle: LLVM
 QualifierAlignment: Left
 LineEnding: LF
 InsertNewlineAtEOF: true
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: false

--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -1,8 +1,8 @@
 BasedOnStyle: LLVM
-QualifierAlignment: Left
-LineEnding: LF
 InsertNewlineAtEOF: true
 KeepEmptyLines:
   AtEndOfFile: false
   AtStartOfBlock: false
   AtStartOfFile: false
+LineEnding: LF
+QualifierAlignment: Left

--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -819,7 +819,6 @@ void ClangTidyDiagnosticConsumer::removeDuplicatedDiagnosticsOfAliasCheckers() {
           (*Inserted.first)->Message.Fix;
 
       if (CandidateFix != ExistingFix) {
-
         // In case of a conflict, don't suggest any fix-it.
         ExistingError.Message.Fix.clear();
         ExistingError.Notes.emplace_back(

--- a/clang-tools-extra/clang-tidy/altera/KernelNameRestrictionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/KernelNameRestrictionCheck.cpp
@@ -74,7 +74,6 @@ bool KernelNameRestrictionPPCallbacks::fileNameIsRestricted(
 }
 
 void KernelNameRestrictionPPCallbacks::EndOfMainFile() {
-
   // Check main file for restricted names.
   OptionalFileEntryRef Entry = SM.getFileEntryRefForID(SM.getMainFileID());
   const StringRef FileName = llvm::sys::path::filename(Entry->getName());

--- a/clang-tools-extra/clang-tidy/boost/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/boost/UseRangesCheck.cpp
@@ -201,7 +201,6 @@ private:
 } // namespace
 
 utils::UseRangesCheck::ReplacerMap UseRangesCheck::getReplacerMap() const {
-
   ReplacerMap Results;
   static const Signature SingleSig = {{0}};
   static const Signature TwoSig = {{0}, {2}};

--- a/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
@@ -117,7 +117,6 @@ void BranchCloneCheck::registerMatchers(MatchFinder *Finder) {
 ///
 static bool isIdenticalStmt(const ASTContext &Ctx, const Stmt *Stmt1,
                             const Stmt *Stmt2, bool IgnoreSideEffects) {
-
   if (!Stmt1 || !Stmt2)
     return !Stmt1 && !Stmt2;
 

--- a/clang-tools-extra/clang-tidy/bugprone/ComparePointerToMemberVirtualFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ComparePointerToMemberVirtualFunctionCheck.cpp
@@ -34,7 +34,6 @@ static constexpr llvm::StringLiteral ErrorMsg =
 
 void ComparePointerToMemberVirtualFunctionCheck::registerMatchers(
     MatchFinder *Finder) {
-
   auto DirectMemberVirtualFunctionPointer = unaryOperator(
       allOf(hasOperatorName("&"),
             hasUnaryOperand(declRefExpr(to(cxxMethodDecl(isVirtual()))))));

--- a/clang-tools-extra/clang-tidy/bugprone/DanglingHandleCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/DanglingHandleCheck.cpp
@@ -31,7 +31,6 @@ handleFrom(const ast_matchers::internal::Matcher<RecordDecl> &IsAHandle,
 
 static ast_matchers::internal::Matcher<Stmt> handleFromTemporaryValue(
     const ast_matchers::internal::Matcher<RecordDecl> &IsAHandle) {
-
   const auto TemporaryExpr = anyOf(
       cxxBindTemporaryExpr(),
       cxxFunctionalCastExpr(

--- a/clang-tools-extra/clang-tidy/bugprone/IncDecInConditionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/IncDecInConditionsCheck.cpp
@@ -64,7 +64,6 @@ void IncDecInConditionsCheck::registerMatchers(MatchFinder *Finder) {
 }
 
 void IncDecInConditionsCheck::check(const MatchFinder::MatchResult &Result) {
-
   SourceLocation ExprLoc;
   bool IsIncrementOp = false;
 

--- a/clang-tools-extra/clang-tidy/bugprone/MacroParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MacroParenthesesCheck.cpp
@@ -152,7 +152,6 @@ void MacroParenthesesPPCallbacks::replacementList(const Token &MacroNameTok,
 
 void MacroParenthesesPPCallbacks::argument(const Token &MacroNameTok,
                                            const MacroInfo *MI) {
-
   // Skip variable declaration.
   bool VarDecl = possibleVarDecl(MI, MI->tokens_begin());
 

--- a/clang-tools-extra/clang-tidy/bugprone/NondeterministicPointerIterationOrderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NondeterministicPointerIterationOrderCheck.cpp
@@ -15,7 +15,6 @@ namespace clang::tidy::bugprone {
 
 void NondeterministicPointerIterationOrderCheck::registerMatchers(
     MatchFinder *Finder) {
-
   auto LoopVariable = varDecl(hasType(
       qualType(hasCanonicalType(anyOf(referenceType(), pointerType())))));
 

--- a/clang-tools-extra/clang-tidy/bugprone/OptionalValueConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/OptionalValueConversionCheck.cpp
@@ -101,11 +101,9 @@ void OptionalValueConversionCheck::registerMatchers(MatchFinder *Finder) {
                                            hasName(MakeOptional),
                                            returns(BindOptionalType)))),
                    hasArgument(0, OptionalDerefMatcher)),
-               callExpr(
+               callExpr(argumentCountIs(1),
 
-                   argumentCountIs(1),
-
-                   hasArgument(0, OptionalDerefMatcher))),
+                        hasArgument(0, OptionalDerefMatcher))),
            unless(anyOf(hasAncestor(typeLoc()),
                         hasAncestor(expr(matchers::hasUnevaluatedContext())))))
           .bind("expr"),

--- a/clang-tools-extra/clang-tidy/bugprone/SpuriouslyWakeUpFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SpuriouslyWakeUpFunctionsCheck.cpp
@@ -15,7 +15,6 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::bugprone {
 
 void SpuriouslyWakeUpFunctionsCheck::registerMatchers(MatchFinder *Finder) {
-
   auto HasUniqueLock = hasDescendant(declRefExpr(
       hasDeclaration(varDecl(hasType(recordDecl(classTemplateSpecializationDecl(
           hasName("::std::unique_lock"),
@@ -45,9 +44,7 @@ void SpuriouslyWakeUpFunctionsCheck::registerMatchers(MatchFinder *Finder) {
                       onImplicitObjectArgument(
                           declRefExpr(to(varDecl(hasType(references(recordDecl(
                               hasName("::std::condition_variable")))))))),
-                      HasUniqueLock)
-
-                    ))
+                      HasUniqueLock)))
           .bind("wait"));
 
   auto HasWaitDescendantC = hasDescendant(

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousMemsetUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousMemsetUsageCheck.cpp
@@ -70,10 +70,8 @@ void SuspiciousMemsetUsageCheck::check(const MatchFinder::MatchResult &Result) {
       return;
     Diag << FixItHint::CreateReplacement(
         CharSourceRange::getTokenRange(CharRange), "0");
-  }
-
-  else if (const auto *NumFill =
-               Result.Nodes.getNodeAs<IntegerLiteral>("num-fill")) {
+  } else if (const auto *NumFill =
+                 Result.Nodes.getNodeAs<IntegerLiteral>("num-fill")) {
     // Case 2: fill_char of memset() is larger in size than an unsigned char
     // so it gets truncated during conversion.
 
@@ -88,9 +86,7 @@ void SuspiciousMemsetUsageCheck::check(const MatchFinder::MatchResult &Result) {
 
     diag(NumFill->getBeginLoc(), "memset fill value is out of unsigned "
                                  "character range, gets truncated");
-  }
-
-  else if (const auto *Call = Result.Nodes.getNodeAs<CallExpr>("call")) {
+  } else if (const auto *Call = Result.Nodes.getNodeAs<CallExpr>("call")) {
     // Case 3: byte_count of memset() is zero. This is most likely an
     // argument swap.
 

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousStringviewDataUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousStringviewDataUsageCheck.cpp
@@ -43,7 +43,6 @@ SuspiciousStringviewDataUsageCheck::getCheckTraversalKind() const {
 }
 
 void SuspiciousStringviewDataUsageCheck::registerMatchers(MatchFinder *Finder) {
-
   auto AncestorCall = anyOf(
       cxxConstructExpr(), callExpr(unless(cxxOperatorCallExpr())), lambdaExpr(),
       initListExpr(

--- a/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
@@ -104,7 +104,6 @@ void TaggedUnionMemberCountCheck::storeOptions(
 }
 
 void TaggedUnionMemberCountCheck::registerMatchers(MatchFinder *Finder) {
-
   auto NotFromSystemHeaderOrStdNamespace =
       unless(anyOf(isExpansionInSystemHeader(), isInStdNamespace()));
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
@@ -103,7 +103,6 @@ void ProBoundsAvoidUncheckedContainerAccessCheck::registerMatchers(
 
 void ProBoundsAvoidUncheckedContainerAccessCheck::check(
     const MatchFinder::MatchResult &Result) {
-
   const auto *MatchedExpr = Result.Nodes.getNodeAs<CallExpr>("caller");
 
   if (FixMode == None) {

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
@@ -541,7 +541,6 @@ void ProTypeMemberInitCheck::checkMissingMemberInitializer(
 void ProTypeMemberInitCheck::checkMissingBaseClassInitializer(
     const ASTContext &Context, const CXXRecordDecl &ClassDecl,
     const CXXConstructorDecl *Ctor) {
-
   // Gather any base classes that need to be initialized.
   SmallVector<const RecordDecl *, 4> AllBases;
   SmallPtrSet<const RecordDecl *, 4> BasesToInit;

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/SpecialMemberFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/SpecialMemberFunctionsCheck.cpp
@@ -102,7 +102,6 @@ toString(SpecialMemberFunctionsCheck::SpecialMemberFunctionKind K) {
 static std::string
 join(ArrayRef<SpecialMemberFunctionsCheck::SpecialMemberFunctionKind> SMFS,
      llvm::StringRef AndOr) {
-
   assert(!SMFS.empty() &&
          "List of defined or undefined members should never be empty.");
   std::string Buffer;

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/VirtualClassDestructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/VirtualClassDestructorCheck.cpp
@@ -167,7 +167,6 @@ static FixItHint changePrivateDestructorVisibilityTo(
 
 void VirtualClassDestructorCheck::check(
     const MatchFinder::MatchResult &Result) {
-
   const auto *MatchedClassOrStruct =
       Result.Nodes.getNodeAs<CXXRecordDecl>("ProblematicClassOrStruct");
 

--- a/clang-tools-extra/clang-tidy/google/AvoidThrowingObjCExceptionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/AvoidThrowingObjCExceptionCheck.cpp
@@ -14,7 +14,6 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::google::objc {
 
 void AvoidThrowingObjCExceptionCheck::registerMatchers(MatchFinder *Finder) {
-
   Finder->addMatcher(objcThrowStmt().bind("throwStmt"), this);
   Finder->addMatcher(
       objcMessageExpr(anyOf(hasSelector("raise:format:"),

--- a/clang-tools-extra/clang-tidy/llvm/PreferStaticOverAnonymousNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/PreferStaticOverAnonymousNamespaceCheck.cpp
@@ -77,7 +77,6 @@ void PreferStaticOverAnonymousNamespaceCheck::registerMatchers(
 
 void PreferStaticOverAnonymousNamespaceCheck::check(
     const MatchFinder::MatchResult &Result) {
-
   if (const auto *Func = Result.Nodes.getNodeAs<FunctionDecl>("function")) {
     if (Func->isCXXClassMember())
       diag(Func->getLocation(),

--- a/clang-tools-extra/clang-tidy/misc/ConfusableIdentifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConfusableIdentifierCheck.cpp
@@ -53,7 +53,6 @@ static llvm::SmallString<64U> skeleton(StringRef Name) {
   const char *Curr = Name.data();
   const char *End = Curr + Name.size();
   while (Curr < End) {
-
     const char *Prev = Curr;
     UTF32 CodePoint = 0;
     const ConversionResult Result = convertUTF8Sequence(

--- a/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
@@ -890,7 +890,6 @@ static bool areStringsSameIgnoreSpaces(const llvm::StringRef Left,
 
 static bool areExprsSameMacroOrLiteral(const BinaryOperator *BinOp,
                                        const ASTContext *Context) {
-
   if (!BinOp)
     return false;
 

--- a/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
@@ -160,7 +160,6 @@ void UnusedParametersCheck::warnOnUnusedParameter(
       !Result.SourceManager->isInMainFile(Function->getLocation()) ||
       !Indexer->getOtherRefs(Function).empty() || isOverrideMethod(Function) ||
       isLambdaCallOperator(Function)) {
-
     // It is illegal to omit parameter name here in C code, so early-out.
     if (!Result.Context->getLangOpts().CPlusPlus)
       return;

--- a/clang-tools-extra/clang-tidy/modernize/AvoidBindCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/AvoidBindCheck.cpp
@@ -259,7 +259,6 @@ buildBindArguments(const MatchFinder::MatchResult &Result,
   // Start at index 1 as first argument to bind is the function name.
   unsigned CaptureIndex = 0;
   for (size_t I = 1, ArgCount = BindCall->getNumArgs(); I < ArgCount; ++I) {
-
     const Expr *E = BindCall->getArg(I);
     BindArgument &B = BindArguments.emplace_back();
 
@@ -327,7 +326,6 @@ static int findPositionOfPlaceholderUse(ArrayRef<BindArgument> Args,
 static void addPlaceholderArgs(const LambdaProperties &LP,
                                llvm::raw_ostream &Stream,
                                bool PermissiveParameterList) {
-
   ArrayRef<BindArgument> Args = LP.BindArguments;
 
   const auto *MaxPlaceholderIt = llvm::max_element(
@@ -465,7 +463,6 @@ static const FunctionDecl *getCallOperator(const CXXRecordDecl *Callable,
 static const FunctionDecl *
 getCallMethodDecl(const MatchFinder::MatchResult &Result, CallableType Type,
                   CallableMaterializationKind Materialization) {
-
   const Expr *Callee = Result.Nodes.getNodeAs<Expr>("ref");
   const Expr *CallExpression = ignoreTemporariesAndPointers(Callee);
 

--- a/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
@@ -135,7 +135,6 @@ IncludeModernizePPCallbacks::IncludeModernizePPCallbacks(
     const LangOptions &LangOpts, const SourceManager &SM, bool CheckHeaderFile)
     : IncludesToBeProcessed(IncludesToBeProcessed), SM(SM),
       CheckHeaderFile(CheckHeaderFile) {
-
   static constexpr std::pair<StringRef, StringRef> CXX98Headers[] = {
       {"assert.h", "cassert"}, {"complex.h", "complex"},
       {"ctype.h", "cctype"},   {"errno.h", "cerrno"},
@@ -167,7 +166,6 @@ void IncludeModernizePPCallbacks::InclusionDirective(
     bool IsAngled, CharSourceRange FilenameRange, OptionalFileEntryRef File,
     StringRef SearchPath, StringRef RelativePath, const Module *SuggestedModule,
     bool ModuleImported, SrcMgr::CharacteristicKind FileType) {
-
   // If we don't want to warn for non-main file reports and this is one, skip
   // it.
   if (!CheckHeaderFile && !SM.isInMainFile(HashLoc))

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
@@ -156,7 +156,6 @@ static StatementMatcher makeArrayLoopMatcher() {
 /// Client code will need to make sure that:
 ///   - The two containers on which 'begin' and 'end' are called are the same.
 static StatementMatcher makeIteratorLoopMatcher(bool IsReverse) {
-
   auto BeginNameMatcher = IsReverse ? hasAnyName("rbegin", "crbegin")
                                     : hasAnyName("begin", "cbegin");
   auto BeginNameMatcherStd = IsReverse
@@ -563,7 +562,6 @@ LoopConvertCheck::LoopConvertCheck(StringRef Name, ClangTidyContext *Context)
       UseCxx20IfAvailable(Options.get("UseCxx20ReverseRanges", true)),
       ReverseFunction(Options.get("MakeReverseRangeFunction", "")),
       ReverseHeader(Options.get("MakeReverseRangeHeader", "")) {
-
   if (ReverseFunction.empty() && !ReverseHeader.empty()) {
     configurationDiag(
         "modernize-loop-convert: 'MakeReverseRangeHeader' is set but "

--- a/clang-tools-extra/clang-tidy/modernize/MinMaxUseInitializerListCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/MinMaxUseInitializerListCheck.cpp
@@ -243,7 +243,6 @@ void MinMaxUseInitializerListCheck::registerPPCallbacks(
 
 void MinMaxUseInitializerListCheck::check(
     const MatchFinder::MatchResult &Match) {
-
   const auto *TopCall = Match.Nodes.getNodeAs<CallExpr>("topCall");
 
   const FindArgsResult Result = findArgs(TopCall);

--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -70,7 +70,6 @@ matchEnableIfSpecializationImplTypename(TypeLoc TheType) {
 
   if (const auto SpecializationLoc =
           TheType.getAs<TemplateSpecializationTypeLoc>()) {
-
     const auto *Specialization =
         dyn_cast<TemplateSpecializationType>(SpecializationLoc.getTypePtr());
     if (!Specialization)
@@ -101,7 +100,6 @@ static std::optional<TemplateSpecializationTypeLoc>
 matchEnableIfSpecializationImplTrait(TypeLoc TheType) {
   if (const auto SpecializationLoc =
           TheType.getAs<TemplateSpecializationTypeLoc>()) {
-
     const auto *Specialization =
         dyn_cast<TemplateSpecializationType>(SpecializationLoc.getTypePtr());
     if (!Specialization)
@@ -182,7 +180,6 @@ matchTrailingTemplateParam(const FunctionTemplateDecl *FunctionTemplate) {
       TemplateParams->getParam(TemplateParams->size() - 1);
   if (const auto *LastTemplateParam =
           dyn_cast<NonTypeTemplateParmDecl>(LastParam)) {
-
     if (!LastTemplateParam->hasDefaultArgument() ||
         !LastTemplateParam->getName().empty())
       return {};

--- a/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
@@ -49,7 +49,6 @@ static unsigned getNumberOfDesignated(const InitListExpr *SyntacticInitList) {
 namespace {
 
 struct Designators {
-
   Designators(const InitListExpr *InitList) : InitList(InitList) {
     assert(InitList->isSyntacticForm());
   };

--- a/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
@@ -35,7 +35,6 @@ void UseOverrideCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void UseOverrideCheck::registerMatchers(MatchFinder *Finder) {
-
   auto IgnoreDestructorMatcher =
       IgnoreDestructors ? cxxMethodDecl(unless(cxxDestructorDecl()))
                         : cxxMethodDecl();

--- a/clang-tools-extra/clang-tidy/modernize/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseRangesCheck.cpp
@@ -135,7 +135,6 @@ class StdNumericReplacer : public StdReplacer {
 } // namespace
 
 utils::UseRangesCheck::ReplacerMap UseRangesCheck::getReplacerMap() const {
-
   utils::UseRangesCheck::ReplacerMap Result;
 
   // template<typename Iter> Func(Iter first, Iter last,...).

--- a/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
@@ -36,7 +36,6 @@ UseStdPrintCheck::UseStdPrintCheck(StringRef Name, ClangTidyContext *Context)
                                                utils::IncludeSorter::IS_LLVM),
                       areDiagsSelfContained()),
       MaybeHeaderToInclude(Options.get("PrintHeader")) {
-
   if (PrintfLikeFunctions.empty() && FprintfLikeFunctions.empty()) {
     PrintfLikeFunctions.emplace_back("::printf");
     PrintfLikeFunctions.emplace_back("absl::PrintF");

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -305,7 +305,6 @@ static SourceRange
 findReturnTypeAndCVSourceRange(const FunctionDecl &F, const TypeLoc &ReturnLoc,
                                const ASTContext &Ctx, const SourceManager &SM,
                                const LangOptions &LangOpts, Preprocessor *PP) {
-
   // We start with the range of the return type and expand to neighboring
   // qualifiers (const, volatile and restrict).
   SourceRange ReturnTypeRange = F.getReturnTypeSourceRange();
@@ -459,7 +458,6 @@ UseTrailingReturnTypeCheck::UseTrailingReturnTypeCheck(
     : ClangTidyCheck(Name, Context),
       TransformFunctions(Options.get("TransformFunctions", true)),
       TransformLambdas(Options.get("TransformLambdas", TransformLambda::All)) {
-
   if (TransformFunctions == false && TransformLambdas == TransformLambda::None)
     this->configurationDiag(
         "The check 'modernize-use-trailing-return-type' will not perform any "
@@ -604,7 +602,6 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
 void UseTrailingReturnTypeCheck::diagOnLambda(
     const LambdaExpr *Lambda,
     const ast_matchers::MatchFinder::MatchResult &Result) {
-
   const CXXMethodDecl *Method = Lambda->getCallOperator();
   if (!Method || Lambda->hasExplicitResultType())
     return;

--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.h
@@ -18,7 +18,6 @@ namespace clang::tidy::modernize {
 /// For the user-facing documentation see:
 /// https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-using.html
 class UseUsingCheck : public ClangTidyCheck {
-
   const bool IgnoreMacros;
   const bool IgnoreExternC;
   SourceLocation LastReplacementEnd;

--- a/clang-tools-extra/clang-tidy/performance/NoexceptSwapCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptSwapCheck.cpp
@@ -17,7 +17,6 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::performance {
 
 void NoexceptSwapCheck::registerMatchers(MatchFinder *Finder) {
-
   // Match non-const method with single argument that is non-const reference to
   // a class type that owns method and return void.
   // Matches: void Class::swap(Class&)

--- a/clang-tools-extra/clang-tidy/readability/AvoidConstParamsInDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/AvoidConstParamsInDeclsCheck.cpp
@@ -26,7 +26,6 @@ static SourceRange getTypeRange(const ParmVarDecl &Param) {
 static std::optional<Token>
 findConstToRemove(const ParmVarDecl &Param,
                   const MatchFinder::MatchResult &Result) {
-
   const CharSourceRange FileRange = Lexer::makeFileCharRange(
       CharSourceRange::getTokenRange(getTypeRange(Param)),
       *Result.SourceManager, Result.Context->getLangOpts());

--- a/clang-tools-extra/clang-tidy/readability/AvoidUnconditionalPreprocessorIfCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/AvoidUnconditionalPreprocessorIfCheck.cpp
@@ -17,7 +17,6 @@ namespace clang::tidy::readability {
 
 namespace {
 struct AvoidUnconditionalPreprocessorIfPPCallbacks : public PPCallbacks {
-
   explicit AvoidUnconditionalPreprocessorIfPPCallbacks(ClangTidyCheck &Check,
                                                        Preprocessor &PP)
       : Check(Check), PP(PP) {}

--- a/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
@@ -185,7 +185,6 @@ void ElseAfterReturnCheck::registerMatchers(MatchFinder *Finder) {
 static bool hasPreprocessorBranchEndBetweenLocations(
     const ElseAfterReturnCheck::ConditionalBranchMap &ConditionalBranchMap,
     const SourceManager &SM, SourceLocation StartLoc, SourceLocation EndLoc) {
-
   const SourceLocation ExpandedStartLoc = SM.getExpansionLoc(StartLoc);
   const SourceLocation ExpandedEndLoc = SM.getExpansionLoc(EndLoc);
   if (!SM.isWrittenInSameFile(ExpandedStartLoc, ExpandedEndLoc))

--- a/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp
@@ -519,7 +519,6 @@ void FunctionCognitiveComplexityCheck::registerMatchers(MatchFinder *Finder) {
 
 void FunctionCognitiveComplexityCheck::check(
     const MatchFinder::MatchResult &Result) {
-
   FunctionASTVisitor Visitor(IgnoreMacros);
   SourceLocation Loc;
 

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -408,7 +408,6 @@ IdentifierNamingCheck::IdentifierNamingCheck(StringRef Name,
     : RenamerClangTidyCheck(Name, Context), Context(Context),
       GetConfigPerFile(Options.get("GetConfigPerFile", true)),
       IgnoreFailedSplit(Options.get("IgnoreFailedSplit", false)) {
-
   auto IterAndInserted = NamingStylesCache.try_emplace(
       llvm::sys::path::parent_path(Context->getCurrentFile()),
       getFileStyleFromOptions(Options));
@@ -447,7 +446,6 @@ bool IdentifierNamingCheck::HungarianNotation::isOptionEnabled(
 void IdentifierNamingCheck::HungarianNotation::loadFileConfig(
     const ClangTidyCheck::OptionsView &Options,
     IdentifierNamingCheck::HungarianNotationOption &HNOption) const {
-
   static constexpr StringRef HNOpts[] = {"TreatStructAsClass"};
   static constexpr StringRef HNDerivedTypes[] = {"Array", "Pointer",
                                                  "FunctionPointer"};
@@ -643,7 +641,6 @@ std::string IdentifierNamingCheck::HungarianNotation::getDataTypePrefix(
 std::string IdentifierNamingCheck::HungarianNotation::getClassPrefix(
     const CXXRecordDecl *CRD,
     const IdentifierNamingCheck::HungarianNotationOption &HNOption) const {
-
   if (CRD->isUnion())
     return {};
 
@@ -723,7 +720,6 @@ size_t IdentifierNamingCheck::HungarianNotation::getAsteriskCount(
 
 void IdentifierNamingCheck::HungarianNotation::loadDefaultConfig(
     IdentifierNamingCheck::HungarianNotationOption &HNOption) const {
-
   // Options
   static constexpr std::pair<StringRef, StringRef> General[] = {
       {"TreatStructAsClass", "false"}};

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -362,7 +362,6 @@ void ImplicitBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
 
 void ImplicitBoolConversionCheck::check(
     const MatchFinder::MatchResult &Result) {
-
   if (const auto *CastToBool =
           Result.Nodes.getNodeAs<ImplicitCastExpr>("implicitCastToBool")) {
     const auto *Parent = Result.Nodes.getNodeAs<Stmt>("parentStmt");
@@ -416,7 +415,6 @@ void ImplicitBoolConversionCheck::handleCastFromBool(
 
   if (const auto *BoolLiteral =
           dyn_cast<CXXBoolLiteralExpr>(Cast->getSubExpr()->IgnoreParens())) {
-
     const auto EquivalentForBoolLiteral =
         getEquivalentForBoolLiteral(BoolLiteral, DestType, Context);
     if (UseUpperCaseLiteralSuffix)

--- a/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
@@ -25,7 +25,6 @@ namespace clang {
 
 static bool isUsedToInitializeAConstant(const MatchFinder::MatchResult &Result,
                                         const DynTypedNode &Node) {
-
   const auto *AsDecl = Node.get<DeclaratorDecl>();
   if (AsDecl) {
     if (AsDecl->getType().isConstQualified())
@@ -45,7 +44,6 @@ static bool isUsedToInitializeAConstant(const MatchFinder::MatchResult &Result,
 
 static bool isUsedToDefineATypeAlias(const MatchFinder::MatchResult &Result,
                                      const DynTypedNode &Node) {
-
   if (Node.get<TypeAliasDecl>() || Node.get<TypedefNameDecl>())
     return true;
 
@@ -144,7 +142,6 @@ void MagicNumbersCheck::registerMatchers(MatchFinder *Finder) {
 }
 
 void MagicNumbersCheck::check(const MatchFinder::MatchResult &Result) {
-
   const TraversalKindScope RAII(*Result.Context, TK_AsIs);
 
   checkBoundMatch<IntegerLiteral>(Result, "integer");

--- a/clang-tools-extra/clang-tidy/readability/OperatorsRepresentationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/OperatorsRepresentationCheck.cpp
@@ -275,7 +275,6 @@ void OperatorsRepresentationCheck::registerMatchers(MatchFinder *Finder) {
 
 void OperatorsRepresentationCheck::check(
     const MatchFinder::MatchResult &Result) {
-
   SourceLocation Loc;
 
   if (const auto *Op = Result.Nodes.getNodeAs<BinaryOperator>("binary_op"))

--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -173,7 +173,6 @@ static bool applySuffixHeuristic(StringRef Arg, StringRef Param,
 
 static bool applySubstringHeuristic(StringRef Arg, StringRef Param,
                                     int8_t Threshold) {
-
   std::size_t MaxLength = 0;
   SmallVector<std::size_t, SmallVectorSize> Current(Param.size());
   SmallVector<std::size_t, SmallVectorSize> Previous(Param.size());

--- a/clang-tools-extra/clang-tidy/readability/UniqueptrDeleteReleaseCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UniqueptrDeleteReleaseCheck.cpp
@@ -28,7 +28,6 @@ UniqueptrDeleteReleaseCheck::UniqueptrDeleteReleaseCheck(
       PreferResetCall(Options.get("PreferResetCall", false)) {}
 
 void UniqueptrDeleteReleaseCheck::registerMatchers(MatchFinder *Finder) {
-
   auto UniquePtrWithDefaultDelete = classTemplateSpecializationDecl(
       hasName("::std::unique_ptr"),
       hasTemplateArgument(1, refersToType(hasDeclaration(cxxRecordDecl(

--- a/clang-tools-extra/clang-tidy/readability/UseAnyOfAllOfCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UseAnyOfAllOfCheck.cpp
@@ -71,7 +71,6 @@ void UseAnyOfAllOfCheck::registerMatchers(MatchFinder *Finder) {
 }
 
 static bool isViableLoop(const CXXForRangeStmt &S, ASTContext &Context) {
-
   ExprMutationAnalyzer Mutations(*S.getBody(), Context);
   if (Mutations.isMutated(S.getLoopVariable()))
     return false;
@@ -86,7 +85,6 @@ static bool isViableLoop(const CXXForRangeStmt &S, ASTContext &Context) {
 }
 
 void UseAnyOfAllOfCheck::check(const MatchFinder::MatchResult &Result) {
-
   if (const auto *S = Result.Nodes.getNodeAs<CXXForRangeStmt>("any_of_loop")) {
     if (!isViableLoop(*S, *Result.Context))
       return;

--- a/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
@@ -193,7 +193,6 @@ static bool isFunctionPointerConvertible(QualType From, QualType To) {
 // The function should only be called in C++ mode.
 static bool isQualificationConvertiblePointer(QualType From, QualType To,
                                               const LangOptions &LangOpts) {
-
   // [N4659 7.5 (1)]
   // A cv-decomposition of a type T is a sequence of cv_i and P_i such that T is
   //    cv_0 P_0 cv_1 P_1 ... cv_n−1 P_n−1 cv_n U” for n > 0,

--- a/clang-tools-extra/clang-tidy/utils/FormatStringConverter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/FormatStringConverter.cpp
@@ -624,7 +624,6 @@ bool FormatStringConverter::HandlePrintfSpecifier(const PrintfSpecifier &FS,
                                                   const char *StartSpecifier,
                                                   unsigned SpecifierLen,
                                                   const TargetInfo &Target) {
-
   const size_t StartSpecifierPos = StartSpecifier - PrintfFormatString.data();
   assert(StartSpecifierPos + SpecifierLen <= PrintfFormatString.size());
 

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.cpp
@@ -170,7 +170,6 @@ static bool breakAndReturnEndPlus1Token(const Stmt &S) {
 static SourceLocation getSemicolonAfterStmtEndLoc(const SourceLocation &EndLoc,
                                                   const SourceManager &SM,
                                                   const LangOptions &LangOpts) {
-
   if (EndLoc.isMacroID()) {
     // Assuming EndLoc points to a function call foo within macro F.
     // This method is supposed to return location of the semicolon within
@@ -206,7 +205,6 @@ static SourceLocation getSemicolonAfterStmtEndLoc(const SourceLocation &EndLoc,
 
 SourceLocation getUnifiedEndLoc(const Stmt &S, const SourceManager &SM,
                                 const LangOptions &LangOpts) {
-
   const Stmt *LastChild = &S;
   while (!LastChild->children().empty() && !breakAndReturnEnd(*LastChild) &&
          !breakAndReturnEndPlus1Token(*LastChild)) {

--- a/clang-tools-extra/clang-tidy/utils/Matchers.cpp
+++ b/clang-tools-extra/clang-tidy/utils/Matchers.cpp
@@ -27,7 +27,6 @@ MatchesAnyListedTypeNameMatcher::~MatchesAnyListedTypeNameMatcher() = default;
 bool MatchesAnyListedTypeNameMatcher::matches(
     const QualType &Node, ast_matchers::internal::ASTMatchFinder *Finder,
     ast_matchers::internal::BoundNodesTreeBuilder *Builder) const {
-
   if (NameMatchers.empty())
     return false;
 


### PR DESCRIPTION
Currently, default `clang-format` LLVM style is configured like this:
```
KeepEmptyLines:
  AtEndOfFile:     false
  AtStartOfBlock:  true
  AtStartOfFile:   true
```
This PR sets `AtStartOfBlock` and `AtStartOfFile` to false.
I think this is the general style pattern we tend to follow, in particular Eugene made comments about empty newlines at start of functions.