### PR TITLE
[compiler-rt] [libFuzzer] Fix merge-posix.test file size test

### DIFF
--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -14,7 +14,7 @@ RUN: echo ....U. > %tmp/T2/2
 RUN: echo ...Z.. > %tmp/T2/3
 RUN: echo ...Z.. > %tmp/T2/4
 RUN: echo ....E. > %tmp/T2/5
-RUN: (echo .....R; for i in {1..1024}; do echo -n X; done) > %tmp/T2/6
+RUN: %python -c "print('.....R' + 'X' * 1024, end='')" > %tmp/T2/6
 
 # Check that we can report an error if file size exceeded
 RUN: (ulimit -f 1; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -14,7 +14,7 @@ RUN: echo ....U. > %tmp/T2/2
 RUN: echo ...Z.. > %tmp/T2/3
 RUN: echo ...Z.. > %tmp/T2/4
 RUN: echo ....E. > %tmp/T2/5
-RUN: echo .....R > %tmp/T2/6
+RUN: (echo .....R; for i in {1..1024}; do echo -n X; done) > %tmp/T2/6
 
 # Check that we can report an error if file size exceeded
 RUN: (ulimit -f 1; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)


### PR DESCRIPTION
This test uses `ulimit -f 1` to test what libFuzzer does when trying to create a file > **_1KB_**. However, the none of the input files used by this test are actually >= 1KB, so there's no reason to expect this test to pass.

This test appears to be passing on accident since the "control file" happens to be > 1KB, but this is not always the case depending upon the length of the path where the test is run from.

This modifies the test to ensure that one of the input file is actually >1KB.