### PR TITLE
[UBSan] [compiler-rt] [NFC] split minimal rt handlers into inc

### DIFF
--- a/compiler-rt/lib/ubsan_minimal/UbsanMinimalHandlers.inc
+++ b/compiler-rt/lib/ubsan_minimal/UbsanMinimalHandlers.inc
@@ -1,0 +1,45 @@
+/*===-- UbsanMinimalHandlers.inc - ubsan minimum handlers ------*- C++ -*-=== *\
+|*
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+|* See https://llvm.org/LICENSE.txt for license information.
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+|*
+\*===----------------------------------------------------------------------===*/
+
+#ifndef UBSAN_HANDLER_PTR
+#define UBSAN_HANDLER_PTR(Enum, String)
+#endif
+
+#ifndef UBSAN_HANDLER
+#define UBSAN_HANDLER(Enum, String)
+#endif
+
+#ifndef UBSAN_HANDLER_RECOVER
+#define UBSAN_HANDLER_RECOVER(Enum, String)
+#endif
+
+UBSAN_HANDLER_PTR(type_mismatch, "type-mismatch")
+UBSAN_HANDLER(alignment_assumption, "alignment-assumption")
+UBSAN_HANDLER(add_overflow, "add-overflow")
+UBSAN_HANDLER(sub_overflow, "sub-overflow")
+UBSAN_HANDLER(mul_overflow, "mul-overflow")
+UBSAN_HANDLER(negate_overflow, "negate-overflow")
+UBSAN_HANDLER(divrem_overflow, "divrem-overflow")
+UBSAN_HANDLER(shift_out_of_bounds, "shift-out-of-bounds")
+UBSAN_HANDLER(out_of_bounds, "out-of-bounds")
+UBSAN_HANDLER(local_out_of_bounds, "local-out-of-bounds")
+UBSAN_HANDLER_RECOVER(builtin_unreachable, "builtin-unreachable")
+UBSAN_HANDLER_RECOVER(missing_return, "missing-return")
+UBSAN_HANDLER(vla_bound_not_positive, "vla-bound-not-positive")
+UBSAN_HANDLER(float_cast_overflow, "float-cast-overflow")
+UBSAN_HANDLER(load_invalid_value, "load-invalid-value")
+UBSAN_HANDLER(invalid_builtin, "invalid-builtin")
+UBSAN_HANDLER(invalid_objc_cast, "invalid-objc-cast")
+UBSAN_HANDLER(function_type_mismatch, "function-type-mismatch")
+UBSAN_HANDLER(implicit_conversion, "implicit-conversion")
+UBSAN_HANDLER(nonnull_arg, "nonnull-arg")
+UBSAN_HANDLER(nonnull_return, "nonnull-return")
+UBSAN_HANDLER(nullability_arg, "nullability-arg")
+UBSAN_HANDLER(nullability_return, "nullability-return")
+UBSAN_HANDLER(pointer_overflow, "pointer-overflow")
+UBSAN_HANDLER(cfi_check_fail, "cfi-check-fail")

--- a/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
+++ b/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
@@ -127,28 +127,28 @@ void NORETURN CheckFailed(const char *file, int, const char *cond, u64, u64) {
 
 #define INTERFACE extern "C" __attribute__((visibility("default")))
 
-#define HANDLER_RECOVER(name, kind)                                            \
+#define UBSAN_HANDLER_RECOVER(name, kind)                                      \
   INTERFACE void __ubsan_handle_##name##_minimal() {                           \
     __ubsan_report_error(kind, GET_CALLER_PC(), nullptr);                      \
   }
 
-#define HANDLER_NORECOVER(name, kind)                                          \
+#define UBSAN_HANDLER_NORECOVER(name, kind)                                    \
   INTERFACE void __ubsan_handle_##name##_minimal_abort() {                     \
     uintptr_t caller = GET_CALLER_PC();                                        \
     __ubsan_report_error_fatal(kind, caller, nullptr);                         \
     abort_with_message(kind, caller, nullptr);                                 \
   }
 
-#define HANDLER(name, kind)                                                    \
-  HANDLER_RECOVER(name, kind)                                                  \
-  HANDLER_NORECOVER(name, kind)
+#define UBSAN_HANDLER(name, kind)                                              \
+  UBSAN_HANDLER_RECOVER(name, kind)                                            \
+  UBSAN_HANDLER_NORECOVER(name, kind)
 
-#define HANDLER_RECOVER_PTR(name, kind)                                        \
+#define UBSAN_HANDLER_RECOVER_PTR(name, kind)                                  \
   INTERFACE void __ubsan_handle_##name##_minimal(const uintptr_t address) {    \
     __ubsan_report_error(kind, GET_CALLER_PC(), &address);                     \
   }
 
-#define HANDLER_NORECOVER_PTR(name, kind)                                      \
+#define UBSAN_HANDLER_NORECOVER_PTR(name, kind)                                \
   INTERFACE void __ubsan_handle_##name##_minimal_abort(                        \
       const uintptr_t address) {                                               \
     uintptr_t caller = GET_CALLER_PC();                                        \
@@ -156,33 +156,9 @@ void NORETURN CheckFailed(const char *file, int, const char *cond, u64, u64) {
     abort_with_message(kind, caller, &address);                                \
   }
 
-// A version of a handler that takes a pointer to a value.
-#define HANDLER_PTR(name, kind)                                                \
-  HANDLER_RECOVER_PTR(name, kind)                                              \
-  HANDLER_NORECOVER_PTR(name, kind)
+// A version of a UBSAN_HANDLER that takes a pointer to a value.
+#define UBSAN_HANDLER_PTR(name, kind)                                          \
+  UBSAN_HANDLER_RECOVER_PTR(name, kind)                                        \
+  UBSAN_HANDLER_NORECOVER_PTR(name, kind)
 
-HANDLER_PTR(type_mismatch, "type-mismatch")
-HANDLER(alignment_assumption, "alignment-assumption")
-HANDLER(add_overflow, "add-overflow")
-HANDLER(sub_overflow, "sub-overflow")
-HANDLER(mul_overflow, "mul-overflow")
-HANDLER(negate_overflow, "negate-overflow")
-HANDLER(divrem_overflow, "divrem-overflow")
-HANDLER(shift_out_of_bounds, "shift-out-of-bounds")
-HANDLER(out_of_bounds, "out-of-bounds")
-HANDLER(local_out_of_bounds, "local-out-of-bounds")
-HANDLER_RECOVER(builtin_unreachable, "builtin-unreachable")
-HANDLER_RECOVER(missing_return, "missing-return")
-HANDLER(vla_bound_not_positive, "vla-bound-not-positive")
-HANDLER(float_cast_overflow, "float-cast-overflow")
-HANDLER(load_invalid_value, "load-invalid-value")
-HANDLER(invalid_builtin, "invalid-builtin")
-HANDLER(invalid_objc_cast, "invalid-objc-cast")
-HANDLER(function_type_mismatch, "function-type-mismatch")
-HANDLER(implicit_conversion, "implicit-conversion")
-HANDLER(nonnull_arg, "nonnull-arg")
-HANDLER(nonnull_return, "nonnull-return")
-HANDLER(nullability_arg, "nullability-arg")
-HANDLER(nullability_return, "nullability-return")
-HANDLER(pointer_overflow, "pointer-overflow")
-HANDLER(cfi_check_fail, "cfi-check-fail")
+#include "UbsanMinimalHandlers.inc"


### PR DESCRIPTION
(A copy of) this will be used later to add the handlers to
libfunc in llvm
