### PR TITLE
[RDF] Rename RegisterId field in RegisterRef Reg->Id. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RDFGraph.h
+++ b/llvm/include/llvm/CodeGen/RDFGraph.h
@@ -462,7 +462,7 @@ struct TargetOperandInfo {
 
 // Packed register reference. Only used for storage.
 struct PackedRegisterRef {
-  RegisterId Reg;
+  RegisterId Id;
   uint32_t MaskId;
 };
 
@@ -779,13 +779,13 @@ struct DataFlowGraph {
   void releaseBlock(NodeId B, DefStackMap &DefM);
 
   PackedRegisterRef pack(RegisterRef RR) {
-    return {RR.Reg, LMI.getIndexForLaneMask(RR.Mask)};
+    return {RR.Id, LMI.getIndexForLaneMask(RR.Mask)};
   }
   PackedRegisterRef pack(RegisterRef RR) const {
-    return {RR.Reg, LMI.getIndexForLaneMask(RR.Mask)};
+    return {RR.Id, LMI.getIndexForLaneMask(RR.Mask)};
   }
   RegisterRef unpack(PackedRegisterRef PR) const {
-    return RegisterRef(PR.Reg, LMI.getLaneMaskForIndex(PR.MaskId));
+    return RegisterRef(PR.Id, LMI.getLaneMaskForIndex(PR.MaskId));
   }
 
   RegisterRef makeRegRef(unsigned Reg, unsigned Sub) const;

--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -91,45 +91,45 @@ private:
   static constexpr RegisterId UnitFlag = 1u << 31;
 
 public:
-  RegisterId Reg = 0;
+  RegisterId Id = 0;
   LaneBitmask Mask = LaneBitmask::getNone(); // Only for registers.
 
   constexpr RegisterRef() = default;
   constexpr explicit RegisterRef(RegisterId R,
                                  LaneBitmask M = LaneBitmask::getAll())
-      : Reg(R), Mask(isRegId(R) && R != 0 ? M : LaneBitmask::getNone()) {}
+      : Id(R), Mask(isRegId(R) && R != 0 ? M : LaneBitmask::getNone()) {}
 
   // Classify null register as a "register".
-  constexpr bool isReg() const { return Reg == 0 || isRegId(Reg); }
-  constexpr bool isUnit() const { return isUnitId(Reg); }
-  constexpr bool isMask() const { return isMaskId(Reg); }
+  constexpr bool isReg() const { return Id == 0 || isRegId(Id); }
+  constexpr bool isUnit() const { return isUnitId(Id); }
+  constexpr bool isMask() const { return isMaskId(Id); }
 
   constexpr MCRegister asMCReg() const {
     assert(isReg());
-    return Reg;
+    return Id;
   }
 
   constexpr MCRegUnit asMCRegUnit() const {
     assert(isUnit());
-    return Reg & ~UnitFlag;
+    return Id & ~UnitFlag;
   }
 
   constexpr unsigned asMaskIdx() const {
     assert(isMask());
-    return Reg & ~MaskFlag;
+    return Id & ~MaskFlag;
   }
 
-  constexpr operator bool() const {
-    return !isReg() || (Reg != 0 && Mask.any());
+  explicit constexpr operator bool() const {
+    return !isReg() || (Id != 0 && Mask.any());
   }
 
   size_t hash() const {
-    return std::hash<RegisterId>{}(Reg) ^
+    return std::hash<RegisterId>{}(Id) ^
            std::hash<LaneBitmask::Type>{}(Mask.getAsInteger());
   }
 
   static constexpr bool isRegId(RegisterId Id) {
-    return !(Id & UnitFlag) && !(Id & MaskFlag);
+    return Id != 0 && !(Id & UnitFlag) && !(Id & MaskFlag);
   }
   static constexpr bool isUnitId(RegisterId Id) { return Id & UnitFlag; }
   static constexpr bool isMaskId(RegisterId Id) { return Id & MaskFlag; }
@@ -151,21 +151,21 @@ struct PhysicalRegisterInfo {
     return RegisterRef::toMaskId(RegMasks.find(RM));
   }
 
-  const uint32_t *getRegMaskBits(RegisterId R) const {
-    return RegMasks.get(RegisterRef(R).asMaskIdx());
+  const uint32_t *getRegMaskBits(RegisterRef RR) const {
+    return RegMasks.get(RR.asMaskIdx());
   }
 
   bool alias(RegisterRef RA, RegisterRef RB) const;
 
   // Returns the set of aliased physical registers.
-  std::set<RegisterId> getAliasSet(RegisterId Reg) const;
+  std::set<RegisterId> getAliasSet(RegisterRef RR) const;
 
   RegisterRef getRefForUnit(uint32_t U) const {
     return RegisterRef(UnitInfos[U].Reg, UnitInfos[U].Mask);
   }
 
-  const BitVector &getMaskUnits(RegisterId MaskId) const {
-    return MaskInfos[RegisterRef(MaskId).asMaskIdx()].Units;
+  const BitVector &getMaskUnits(RegisterRef RR) const {
+    return MaskInfos[RR.asMaskIdx()].Units;
   }
 
   std::set<RegisterId> getUnits(RegisterRef RR) const;

--- a/llvm/lib/CodeGen/RDFGraph.cpp
+++ b/llvm/lib/CodeGen/RDFGraph.cpp
@@ -1061,13 +1061,13 @@ void DataFlowGraph::pushClobbers(Instr IA, DefStackMap &DefM) {
 
     // Push the definition on the stack for the register and all aliases.
     // The def stack traversal in linkNodeUp will check the exact aliasing.
-    DefM[RR.Reg].push(DA);
-    Defined.insert(RR.Reg);
-    for (RegisterId A : getPRI().getAliasSet(RR.Reg)) {
+    DefM[RR.Id].push(DA);
+    Defined.insert(RR.Id);
+    for (RegisterId A : getPRI().getAliasSet(RR)) {
       if (RegisterRef::isRegId(A) && !isTracked(RegisterRef(A)))
         continue;
       // Check that we don't push the same def twice.
-      assert(A != RR.Reg);
+      assert(A != RR.Id);
       if (!Defined.count(A))
         DefM[A].push(DA);
     }
@@ -1109,7 +1109,7 @@ void DataFlowGraph::pushDefs(Instr IA, DefStackMap &DefM) {
 #ifndef NDEBUG
     // Assert if the register is defined in two or more unrelated defs.
     // This could happen if there are two or more def operands defining it.
-    if (!Defined.insert(RR.Reg).second) {
+    if (!Defined.insert(RR.Id).second) {
       MachineInstr *MI = Stmt(IA).Addr->getCode();
       dbgs() << "Multiple definitions of register: " << Print(RR, *this)
              << " in\n  " << *MI << "in " << printMBBReference(*MI->getParent())
@@ -1119,12 +1119,12 @@ void DataFlowGraph::pushDefs(Instr IA, DefStackMap &DefM) {
 #endif
     // Push the definition on the stack for the register and all aliases.
     // The def stack traversal in linkNodeUp will check the exact aliasing.
-    DefM[RR.Reg].push(DA);
-    for (RegisterId A : getPRI().getAliasSet(RR.Reg)) {
+    DefM[RR.Id].push(DA);
+    for (RegisterId A : getPRI().getAliasSet(RR)) {
       if (RegisterRef::isRegId(A) && !isTracked(RegisterRef(A)))
         continue;
       // Check that we don't push the same def twice.
-      assert(A != RR.Reg);
+      assert(A != RR.Id);
       DefM[A].push(DA);
     }
     // Mark all the related defs as visited.
@@ -1465,11 +1465,11 @@ void DataFlowGraph::buildPhis(BlockRefsMap &PhiM, Block BA,
 
   for (RegisterRef RR : Defs.refs()) {
     if (!DefM.empty()) {
-      auto F = DefM.find(RR.Reg);
+      auto F = DefM.find(RR.Id);
       // Do not create a phi for unallocatable registers, or for registers
       // that are never livein to BA.
       // If a phi exists for RR, do not create another.
-      if (!MRI.isAllocatable(RR.Reg) || PhiDefs.hasCoverOf(RR) ||
+      if (!MRI.isAllocatable(RR.asMCReg()) || PhiDefs.hasCoverOf(RR) ||
           F == DefM.end() || F->second.empty())
         continue;
       // Do not create a phi, if all reaching defs are clobbering
@@ -1601,7 +1601,7 @@ void DataFlowGraph::linkStmtRefs(DefStackMap &DefM, Stmt SA, Predicate P) {
     Defs.insert(RR);
 #endif
 
-    auto F = DefM.find(RR.Reg);
+    auto F = DefM.find(RR.Id);
     if (F == DefM.end())
       continue;
     DefStack &DS = F->second;
@@ -1691,7 +1691,7 @@ void DataFlowGraph::linkBlockRefs(DefStackMap &DefM, BlockRefsMap &PhiClobberM,
       for (auto U : IA.Addr->members_if(IsUseForBA, *this)) {
         PhiUse PUA = U;
         RegisterRef RR = PUA.Addr->getRegRef(*this);
-        linkRefUp<UseNode *>(IA, PUA, DefM[RR.Reg]);
+        linkRefUp<UseNode *>(IA, PUA, DefM[RR.Id]);
       }
     }
   }

--- a/llvm/lib/CodeGen/RDFLiveness.cpp
+++ b/llvm/lib/CodeGen/RDFLiveness.cpp
@@ -511,7 +511,7 @@ void Liveness::computePhiInfo() {
         uint16_t F = A.Addr->getFlags();
         if ((F & (NodeAttrs::Undef | NodeAttrs::PhiRef)) == 0) {
           RegisterRef R = A.Addr->getRegRef(DFG);
-          RealUses[R.Reg].insert({A.Id, R.Mask});
+          RealUses[R.Id].insert({A.Id, R.Mask});
         }
         UN = A.Addr->getSibling();
       }
@@ -706,8 +706,8 @@ void Liveness::computePhiInfo() {
             LaneBitmask M = R.Mask & V.second;
             if (M.none())
               continue;
-            if (RegisterRef SS = ClearIn(RegisterRef(R.Reg, M), MidDefs, SM)) {
-              NodeRefSet &RS = RealUseMap[P.first][SS.Reg];
+            if (RegisterRef SS = ClearIn(RegisterRef(R.Id, M), MidDefs, SM)) {
+              NodeRefSet &RS = RealUseMap[P.first][SS.Id];
               Changed |= RS.insert({V.first, SS.Mask}).second;
             }
           }
@@ -839,7 +839,7 @@ void Liveness::computeLiveIns() {
               RegisterAggr TA(PRI);
               TA.insert(D.Addr->getRegRef(DFG)).intersect(S);
               LaneBitmask TM = TA.makeRegRef().Mask;
-              LOX[S.Reg].insert({D.Id, TM});
+              LOX[S.Id].insert({D.Id, TM});
             }
           }
         }
@@ -899,7 +899,7 @@ void Liveness::resetLiveIns() {
     // Add the newly computed live-ins.
     const RegisterAggr &LiveIns = LiveMap[&B];
     for (RegisterRef R : LiveIns.refs())
-      B.addLiveIn({MCPhysReg(R.Reg), R.Mask});
+      B.addLiveIn({R.asMCReg(), R.Mask});
   }
 }
 
@@ -1046,7 +1046,7 @@ void Liveness::traverse(MachineBasicBlock *B, RefMap &LiveIn) {
 
   for (const std::pair<const RegisterId, NodeRefSet> &LE : LiveInCopy) {
     RegisterRef LRef(LE.first);
-    NodeRefSet &NewDefs = LiveIn[LRef.Reg]; // To be filled.
+    NodeRefSet &NewDefs = LiveIn[LRef.Id]; // To be filled.
     const NodeRefSet &OldDefs = LE.second;
     for (NodeRef OR : OldDefs) {
       // R is a def node that was live-on-exit
@@ -1129,7 +1129,7 @@ void Liveness::traverse(MachineBasicBlock *B, RefMap &LiveIn) {
       RegisterRef RR = UA.Addr->getRegRef(DFG);
       for (NodeAddr<DefNode *> D : getAllReachingDefs(UA))
         if (getBlockWithRef(D.Id) != B)
-          LiveIn[RR.Reg].insert({D.Id, RR.Mask});
+          LiveIn[RR.Id].insert({D.Id, RR.Mask});
     }
   }
 

--- a/llvm/lib/CodeGen/RDFRegisters.cpp
+++ b/llvm/lib/CodeGen/RDFRegisters.cpp
@@ -101,13 +101,13 @@ bool PhysicalRegisterInfo::alias(RegisterRef RA, RegisterRef RB) const {
   return !disjoint(getUnits(RA), getUnits(RB));
 }
 
-std::set<RegisterId> PhysicalRegisterInfo::getAliasSet(RegisterId Reg) const {
+std::set<RegisterId> PhysicalRegisterInfo::getAliasSet(RegisterRef RR) const {
   // Do not include Reg in the alias set.
   std::set<RegisterId> AS;
-  assert(!RegisterRef::isUnitId(Reg) && "No units allowed");
-  if (RegisterRef::isMaskId(Reg)) {
+  assert(!RR.isUnit() && "No units allowed");
+  if (RR.isMask()) {
     // XXX SLOW
-    const uint32_t *MB = getRegMaskBits(Reg);
+    const uint32_t *MB = getRegMaskBits(RR);
     for (unsigned i = 1, e = TRI.getNumRegs(); i != e; ++i) {
       if (MB[i / 32] & (1u << (i % 32)))
         continue;
@@ -116,8 +116,8 @@ std::set<RegisterId> PhysicalRegisterInfo::getAliasSet(RegisterId Reg) const {
     return AS;
   }
 
-  assert(RegisterRef::isRegId(Reg));
-  for (MCRegAliasIterator AI(Reg, &TRI, false); AI.isValid(); ++AI)
+  assert(RR.isReg());
+  for (MCRegAliasIterator AI(RR.asMCReg(), &TRI, false); AI.isValid(); ++AI)
     AS.insert(*AI);
 
   return AS;
@@ -139,7 +139,7 @@ std::set<RegisterId> PhysicalRegisterInfo::getUnits(RegisterRef RR) const {
 
   assert(RR.isMask());
   unsigned NumRegs = TRI.getNumRegs();
-  const uint32_t *MB = getRegMaskBits(RR.Reg);
+  const uint32_t *MB = getRegMaskBits(RR);
   for (unsigned I = 0, E = (NumRegs + 31) / 32; I != E; ++I) {
     uint32_t C = ~MB[I]; // Clobbered regs
     if (I == 0)          // Reg 0 should be ignored
@@ -160,7 +160,7 @@ std::set<RegisterId> PhysicalRegisterInfo::getUnits(RegisterRef RR) const {
 }
 
 RegisterRef PhysicalRegisterInfo::mapTo(RegisterRef RR, RegisterId R) const {
-  if (RR.Reg == R)
+  if (RR.Id == R)
     return RR;
   if (unsigned Idx = TRI.getSubRegIndex(RegisterRef(R).asMCReg(), RR.asMCReg()))
     return RegisterRef(R, TRI.composeSubRegIndexLaneMask(Idx, RR.Mask));
@@ -177,11 +177,11 @@ RegisterRef PhysicalRegisterInfo::mapTo(RegisterRef RR, RegisterId R) const {
 
 bool PhysicalRegisterInfo::equal_to(RegisterRef A, RegisterRef B) const {
   if (!A.isReg() || !B.isReg()) {
-    // For non-regs, or comparing reg and non-reg, use only the Reg member.
-    return A.Reg == B.Reg;
+    // For non-regs, or comparing reg and non-reg, use only the Id member.
+    return A.Id == B.Id;
   }
 
-  if (A.Reg == B.Reg)
+  if (A.Id == B.Id)
     return A.Mask == B.Mask;
 
   // Compare reg units lexicographically.
@@ -213,14 +213,14 @@ bool PhysicalRegisterInfo::equal_to(RegisterRef A, RegisterRef B) const {
 
 bool PhysicalRegisterInfo::less(RegisterRef A, RegisterRef B) const {
   if (!A.isReg() || !B.isReg()) {
-    // For non-regs, or comparing reg and non-reg, use only the Reg member.
-    return A.Reg < B.Reg;
+    // For non-regs, or comparing reg and non-reg, use only the Id member.
+    return A.Id < B.Id;
   }
 
-  if (A.Reg == B.Reg)
+  if (A.Id == B.Id)
     return A.Mask < B.Mask;
   if (A.Mask == B.Mask)
-    return A.Reg < B.Reg;
+    return A.Id < B.Id;
 
   // Compare reg units lexicographically.
   llvm::MCRegUnitMaskIterator AI(A.asMCReg(), &getTRI());
@@ -275,7 +275,7 @@ void PhysicalRegisterInfo::print(raw_ostream &OS, const RegisterAggr &A) const {
 
 bool RegisterAggr::hasAliasOf(RegisterRef RR) const {
   if (RR.isMask())
-    return Units.anyCommon(PRI.getMaskUnits(RR.Reg));
+    return Units.anyCommon(PRI.getMaskUnits(RR));
 
   for (MCRegUnitMaskIterator U(RR.asMCReg(), &PRI.getTRI()); U.isValid(); ++U) {
     auto [Unit, LaneMask] = *U;
@@ -288,7 +288,7 @@ bool RegisterAggr::hasAliasOf(RegisterRef RR) const {
 
 bool RegisterAggr::hasCoverOf(RegisterRef RR) const {
   if (RR.isMask()) {
-    BitVector T(PRI.getMaskUnits(RR.Reg));
+    BitVector T(PRI.getMaskUnits(RR));
     return T.reset(Units).none();
   }
 
@@ -303,7 +303,7 @@ bool RegisterAggr::hasCoverOf(RegisterRef RR) const {
 
 RegisterAggr &RegisterAggr::insert(RegisterRef RR) {
   if (RR.isMask()) {
-    Units |= PRI.getMaskUnits(RR.Reg);
+    Units |= PRI.getMaskUnits(RR);
     return *this;
   }
 
@@ -392,7 +392,7 @@ RegisterAggr::ref_iterator::ref_iterator(const RegisterAggr &RG, bool End)
     : Owner(&RG) {
   for (int U = RG.Units.find_first(); U >= 0; U = RG.Units.find_next(U)) {
     RegisterRef R = RG.PRI.getRefForUnit(U);
-    Masks[R.Reg] |= R.Mask;
+    Masks[R.Id] |= R.Mask;
   }
   Pos = End ? Masks.end() : Masks.begin();
   Index = End ? Masks.size() : 0;

--- a/llvm/lib/Target/Hexagon/HexagonOptAddrMode.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonOptAddrMode.cpp
@@ -107,7 +107,7 @@ private:
   bool canRemoveAddasl(NodeAddr<StmtNode *> AddAslSN, MachineInstr &MI,
                        const NodeList &UNodeList);
   bool isSafeToExtLR(NodeAddr<StmtNode *> SN, MachineInstr *MI,
-                     unsigned LRExtReg, const NodeList &UNodeList);
+                     Register LRExtReg, const NodeList &UNodeList);
   void getAllRealUses(NodeAddr<StmtNode *> SN, NodeList &UNodeList);
   bool allValidCandidates(NodeAddr<StmtNode *> SA, NodeList &UNodeList);
   short getBaseWithLongOffset(const MachineInstr &MI) const;
@@ -177,7 +177,7 @@ bool HexagonOptAddrMode::canRemoveAddasl(NodeAddr<StmtNode *> AddAslSN,
   NodeId OffsetRegRD = 0;
   for (NodeAddr<UseNode *> UA : AddAslSN.Addr->members_if(DFG->IsUse, *DFG)) {
     RegisterRef RR = UA.Addr->getRegRef(*DFG);
-    if (OffsetReg == RR.Reg) {
+    if (OffsetReg == RR.asMCReg()) {
       OffsetRR = RR;
       OffsetRegRD = UA.Addr->getReachingDef();
     }
@@ -300,7 +300,7 @@ void HexagonOptAddrMode::getAllRealUses(NodeAddr<StmtNode *> SA,
 }
 
 bool HexagonOptAddrMode::isSafeToExtLR(NodeAddr<StmtNode *> SN,
-                                       MachineInstr *MI, unsigned LRExtReg,
+                                       MachineInstr *MI, Register LRExtReg,
                                        const NodeList &UNodeList) {
   RegisterRef LRExtRR;
   NodeId LRExtRegRD = 0;
@@ -308,7 +308,7 @@ bool HexagonOptAddrMode::isSafeToExtLR(NodeAddr<StmtNode *> SN,
   // for the LRExtReg.
   for (NodeAddr<UseNode *> UA : SN.Addr->members_if(DFG->IsUse, *DFG)) {
     RegisterRef RR = UA.Addr->getRegRef(*DFG);
-    if (LRExtReg == RR.Reg) {
+    if (LRExtReg == RR.asMCReg()) {
       LRExtRR = RR;
       LRExtRegRD = UA.Addr->getReachingDef();
     }
@@ -552,7 +552,7 @@ bool HexagonOptAddrMode::processAddBases(NodeAddr<StmtNode *> AddSN,
   // Find the UseNode that contains the base register and it's reachingDef
   for (NodeAddr<UseNode *> UA : AddSN.Addr->members_if(DFG->IsUse, *DFG)) {
     RegisterRef URR = UA.Addr->getRegRef(*DFG);
-    if (BaseReg != URR.Reg)
+    if (BaseReg != URR.asMCReg())
       continue;
 
     UAReachingDefID = UA.Addr->getReachingDef();
@@ -740,7 +740,7 @@ bool HexagonOptAddrMode::processAddUses(NodeAddr<StmtNode *> AddSN,
   // for the LRExtReg.
   for (NodeAddr<UseNode *> UA : AddSN.Addr->members_if(DFG->IsUse, *DFG)) {
     RegisterRef RR = UA.Addr->getRegRef(*DFG);
-    if (BaseReg == RR.Reg)
+    if (BaseReg == RR.asMCReg())
       LRExtRegRD = UA.Addr->getReachingDef();
   }
 

--- a/llvm/lib/Target/Hexagon/RDFCopy.cpp
+++ b/llvm/lib/Target/Hexagon/RDFCopy.cpp
@@ -43,11 +43,11 @@ bool CopyPropagation::interpretAsCopy(const MachineInstr *MI, EqualityMap &EM) {
       const MachineOperand &Src = MI->getOperand(1);
       RegisterRef DstR = DFG.makeRegRef(Dst.getReg(), Dst.getSubReg());
       RegisterRef SrcR = DFG.makeRegRef(Src.getReg(), Src.getSubReg());
-      assert(Register::isPhysicalRegister(DstR.Reg));
-      assert(Register::isPhysicalRegister(SrcR.Reg));
+      assert(DstR.asMCReg().isPhysical());
+      assert(SrcR.asMCReg().isPhysical());
       const TargetRegisterInfo &TRI = DFG.getTRI();
-      if (TRI.getMinimalPhysRegClass(DstR.Reg) !=
-          TRI.getMinimalPhysRegClass(SrcR.Reg))
+      if (TRI.getMinimalPhysRegClass(DstR.asMCReg()) !=
+          TRI.getMinimalPhysRegClass(SrcR.asMCReg()))
         return false;
       if (!DFG.isTracked(SrcR) || !DFG.isTracked(DstR))
         return false;
@@ -65,7 +65,7 @@ void CopyPropagation::recordCopy(NodeAddr<StmtNode*> SA, EqualityMap &EM) {
   Copies.push_back(SA.Id);
 
   for (auto I : EM) {
-    auto FS = DefM.find(I.second.Reg);
+    auto FS = DefM.find(I.second.Id);
     if (FS == DefM.end() || FS->second.empty())
       continue; // Undefined source
     RDefMap[I.second][SA.Id] = FS->second.top()->Id;
@@ -92,7 +92,7 @@ void CopyPropagation::updateMap(NodeAddr<InstrNode*> IA) {
   for (auto &R : RDefMap) {
     if (!RRs.count(R.first))
       continue;
-    auto F = DefM.find(R.first.Reg);
+    auto F = DefM.find(R.first.Id);
     if (F == DefM.end() || F->second.empty())
       continue;
     R.second[IA.Id] = F->second.top()->Id;
@@ -154,16 +154,16 @@ bool CopyPropagation::run() {
   bool HasLimit = CpLimit.getNumOccurrences() > 0;
 #endif
 
-  auto MinPhysReg = [this] (RegisterRef RR) -> unsigned {
+  auto MinPhysReg = [this](RegisterRef RR) -> MCRegister {
     const TargetRegisterInfo &TRI = DFG.getTRI();
-    const TargetRegisterClass &RC = *TRI.getMinimalPhysRegClass(RR.Reg);
+    const TargetRegisterClass &RC = *TRI.getMinimalPhysRegClass(RR.asMCReg());
     if ((RC.LaneMask & RR.Mask) == RC.LaneMask)
-      return RR.Reg;
-    for (MCSubRegIndexIterator S(RR.Reg, &TRI); S.isValid(); ++S)
+      return RR.asMCReg();
+    for (MCSubRegIndexIterator S(RR.asMCReg(), &TRI); S.isValid(); ++S)
       if (RR.Mask == TRI.getSubRegIndexLaneMask(S.getSubRegIndex()))
         return S.getSubReg();
     llvm_unreachable("Should have found a register");
-    return 0;
+    return MCRegister();
   };
 
   const PhysicalRegisterInfo &PRI = DFG.getPRI();
@@ -214,7 +214,7 @@ bool CopyPropagation::run() {
                  << *NodeAddr<StmtNode*>(IA).Addr->getCode();
         }
 
-        unsigned NewReg = MinPhysReg(SR);
+        MCRegister NewReg = MinPhysReg(SR);
         Op.setReg(NewReg);
         Op.setSubReg(0);
         DFG.unlinkUse(UA, false);


### PR DESCRIPTION
Not all RegisterId values are registers, so Id is a more appropriate name.

Use asMCReg() in some places that assumed it was a register.