### PR TITLE
[clang-format]: Fix JSON casing

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -50,7 +50,7 @@ to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
                                        CSharp: .cs
                                        Java: .java
                                        JavaScript: .js .mjs .cjs .ts
-                                       Json: .json .ipynb
+                                       JSON: .json .ipynb
                                        Objective-C: .m .mm
                                        Proto: .proto .protodevel
                                        TableGen: .td

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -88,7 +88,7 @@ static cl::opt<std::string> AssumeFileName(
              "  CSharp: .cs\n"
              "  Java: .java\n"
              "  JavaScript: .js .mjs .cjs .ts\n"
-             "  Json: .json .ipynb\n"
+             "  JSON: .json .ipynb\n"
              "  Objective-C: .m .mm\n"
              "  Proto: .proto .protodevel\n"
              "  TableGen: .td\n"
@@ -489,7 +489,7 @@ static bool format(StringRef FileName, bool ErrorOnIncompleteFormat = false) {
     auto Err =
         Replaces.add(tooling::Replacement(AssumedFileName, 0, 0, "x = "));
     if (Err)
-      llvm::errs() << "Bad Json variable insertion\n";
+      llvm::errs() << "Bad JSON variable insertion\n";
   }
 
   auto ChangedCode = tooling::applyAllReplacements(Code->getBuffer(), Replaces);

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -115,7 +115,7 @@ def main():
             "ts",  # TypeScript
             "cs",  # C Sharp
             "json",
-            "ipynb",  # Json
+            "ipynb",  # JSON
             "sv",
             "svh",
             "v",


### PR DESCRIPTION
Sorry for the OCD and this spam commit.
This commit aligns the user clang-format output to always show [JSON](https://www.json.org/json-en.html), not Json.

_If I understand this correctly, I have to mention @mydeveloperday and/or @owenca, since I can't manually set reviewers?_