### PR TITLE
[bazel] Add support for multiple tblgen outputs

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -3098,7 +3098,7 @@ llvm_target_lib_list = [lib for lib in [
             ),
             (
                 ["-gen-register-bank"],
-                "lib/Target/SPIRV/SPIRVGenRegisterInfoBank.inc",
+                "lib/Target/SPIRV/SPIRVGenRegisterBank.inc",
             ),
             (
                 ["-gen-register-info"],
@@ -3281,7 +3281,7 @@ llvm_target_lib_list = [lib for lib in [
         "tbl_outs": [
             (
                 ["-gen-register-bank"],
-                "lib/Target/X86/X86GenRegisterInfoBank.inc",
+                "lib/Target/X86/X86GenRegisterBank.inc",
             ),
             (
                 ["-gen-register-info"],

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2193,92 +2193,249 @@ llvm_target_lib_list = [lib for lib in [
     {
         "name": "AArch64",
         "short_name": "AArch64",
-        "tbl_outs": {
-            "lib/Target/AArch64/AArch64GenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/AArch64/AArch64GenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/AArch64/AArch64GenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/AArch64/AArch64GenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/AArch64/AArch64GenMCPseudoLowering.inc": ["-gen-pseudo-lowering"],
-            "lib/Target/AArch64/AArch64GenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/AArch64/AArch64GenAsmWriter1.inc": [
-                "-gen-asm-writer",
-                "-asmwriternum=1",
-            ],
-            "lib/Target/AArch64/AArch64GenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/AArch64/AArch64GenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/AArch64/AArch64GenFastISel.inc": ["-gen-fast-isel"],
-            "lib/Target/AArch64/AArch64GenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/AArch64/AArch64GenO0PreLegalizeGICombiner.inc": [
-                "-gen-global-isel-combiner",
-                "-combiners=AArch64O0PreLegalizerCombiner",
-            ],
-            "lib/Target/AArch64/AArch64GenPreLegalizeGICombiner.inc": [
-                "-gen-global-isel-combiner",
-                "-combiners=AArch64PreLegalizerCombiner",
-            ],
-            "lib/Target/AArch64/AArch64GenPostLegalizeGICombiner.inc": [
-                "-gen-global-isel-combiner",
-                "-combiners=AArch64PostLegalizerCombiner",
-            ],
-            "lib/Target/AArch64/AArch64GenPostLegalizeGILowering.inc": [
-                "-gen-global-isel-combiner",
-                "-combiners=AArch64PostLegalizerLowering",
-            ],
-            "lib/Target/AArch64/AArch64GenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/AArch64/AArch64GenSDNodeInfo.inc": ["-gen-sd-node-info"],
-            "lib/Target/AArch64/AArch64GenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/AArch64/AArch64GenDisassemblerTables.inc": [
-                "-gen-disassembler",
-            ],
-            "lib/Target/AArch64/AArch64GenSystemOperands.inc": ["-gen-searchable-tables"],
-            "lib/Target/AArch64/AArch64GenExegesis.inc": ["-gen-exegesis"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-register-bank"],
+                "lib/Target/AArch64/AArch64GenRegisterBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/AArch64/AArch64GenRegisterInfo.inc",
+                    "lib/Target/AArch64/AArch64GenRegisterInfoEnums.inc",
+                    "lib/Target/AArch64/AArch64GenRegisterInfoMCDesc.inc",
+                    "lib/Target/AArch64/AArch64GenRegisterInfoHeader.inc",
+                    "lib/Target/AArch64/AArch64GenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/AArch64/AArch64GenInstrInfo.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/AArch64/AArch64GenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-pseudo-lowering"],
+                "lib/Target/AArch64/AArch64GenMCPseudoLowering.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/AArch64/AArch64GenAsmWriter.inc",
+            ),
+            (
+                [
+                    "-gen-asm-writer",
+                    "-asmwriternum=1",
+                ],
+                "lib/Target/AArch64/AArch64GenAsmWriter1.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/AArch64/AArch64GenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/AArch64/AArch64GenDAGISel.inc",
+            ),
+            (
+                ["-gen-fast-isel"],
+                "lib/Target/AArch64/AArch64GenFastISel.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/AArch64/AArch64GenGlobalISel.inc",
+            ),
+            (
+                [
+                    "-gen-global-isel-combiner",
+                    "-combiners=AArch64O0PreLegalizerCombiner",
+                ],
+                "lib/Target/AArch64/AArch64GenO0PreLegalizeGICombiner.inc",
+            ),
+            (
+                [
+                    "-gen-global-isel-combiner",
+                    "-combiners=AArch64PreLegalizerCombiner",
+                ],
+                "lib/Target/AArch64/AArch64GenPreLegalizeGICombiner.inc",
+            ),
+            (
+                [
+                    "-gen-global-isel-combiner",
+                    "-combiners=AArch64PostLegalizerCombiner",
+                ],
+                "lib/Target/AArch64/AArch64GenPostLegalizeGICombiner.inc",
+            ),
+            (
+                [
+                    "-gen-global-isel-combiner",
+                    "-combiners=AArch64PostLegalizerLowering",
+                ],
+                "lib/Target/AArch64/AArch64GenPostLegalizeGILowering.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/AArch64/AArch64GenCallingConv.inc",
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/AArch64/AArch64GenSDNodeInfo.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/AArch64/AArch64GenSubtargetInfo.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/AArch64/AArch64GenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-searchable-tables"],
+                "lib/Target/AArch64/AArch64GenSystemOperands.inc",
+            ),
+            (
+                ["-gen-exegesis"],
+                "lib/Target/AArch64/AArch64GenExegesis.inc",
+            ),
+        ],
     },
     {
         "name": "ARM",
         "short_name": "ARM",
-        "tbl_outs": {
-            "lib/Target/ARM/ARMGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/ARM/ARMGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/ARM/ARMGenSystemRegister.inc": ["-gen-searchable-tables"],
-            "lib/Target/ARM/ARMGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/ARM/ARMGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/ARM/ARMGenMCPseudoLowering.inc": ["-gen-pseudo-lowering"],
-            "lib/Target/ARM/ARMGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/ARM/ARMGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/ARM/ARMGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/ARM/ARMGenFastISel.inc": ["-gen-fast-isel"],
-            "lib/Target/ARM/ARMGenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/ARM/ARMGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/ARM/ARMGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/ARM/ARMGenDisassemblerTables.inc": [
-                "-gen-disassembler",
-                "-ignore-non-decodable-operands",
-            ],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-register-bank"],
+                "lib/Target/ARM/ARMGenRegisterBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/ARM/ARMGenRegisterInfo.inc",
+                    "lib/Target/ARM/ARMGenRegisterInfoEnums.inc",
+                    "lib/Target/ARM/ARMGenRegisterInfoMCDesc.inc",
+                    "lib/Target/ARM/ARMGenRegisterInfoHeader.inc",
+                    "lib/Target/ARM/ARMGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-searchable-tables"],
+                "lib/Target/ARM/ARMGenSystemRegister.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/ARM/ARMGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/ARM/ARMGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-pseudo-lowering"],
+                "lib/Target/ARM/ARMGenMCPseudoLowering.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/ARM/ARMGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/ARM/ARMGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/ARM/ARMGenDAGISel.inc",
+            ),
+            (
+                ["-gen-fast-isel"],
+                "lib/Target/ARM/ARMGenFastISel.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/ARM/ARMGenGlobalISel.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/ARM/ARMGenCallingConv.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/ARM/ARMGenSubtargetInfo.inc",
+            ),
+            (
+                [
+                    "-gen-disassembler",
+                    "-ignore-non-decodable-operands",
+                ],
+                "lib/Target/ARM/ARMGenDisassemblerTables.inc",
+            ),
+        ],
     },
     {
         "name": "AMDGPU",
         "short_name": "AMDGPU",
-        "tbl_outs": {
-            "lib/Target/AMDGPU/AMDGPUGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/AMDGPU/AMDGPUGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/AMDGPU/AMDGPUGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/AMDGPU/AMDGPUGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/AMDGPU/AMDGPUGenMCPseudoLowering.inc": ["-gen-pseudo-lowering"],
-            "lib/Target/AMDGPU/AMDGPUGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/AMDGPU/AMDGPUGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/AMDGPU/AMDGPUGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/AMDGPU/AMDGPUGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/AMDGPU/AMDGPUGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/AMDGPU/AMDGPUGenDisassemblerTables.inc": [
-                "-gen-disassembler",
-                "--specialize-decoders-per-bitwidth",
-                "-ignore-non-decodable-operands",
-                "-ignore-fully-defined-operands",
-            ],
-            "lib/Target/AMDGPU/AMDGPUGenSearchableTables.inc": ["-gen-searchable-tables"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-register-bank"],
+                "lib/Target/AMDGPU/AMDGPUGenRegisterBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/AMDGPU/AMDGPUGenRegisterInfo.inc",
+                    "lib/Target/AMDGPU/AMDGPUGenRegisterInfoEnums.inc",
+                    "lib/Target/AMDGPU/AMDGPUGenRegisterInfoMCDesc.inc",
+                    "lib/Target/AMDGPU/AMDGPUGenRegisterInfoHeader.inc",
+                    "lib/Target/AMDGPU/AMDGPUGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/AMDGPU/AMDGPUGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/AMDGPU/AMDGPUGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-pseudo-lowering"],
+                "lib/Target/AMDGPU/AMDGPUGenMCPseudoLowering.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/AMDGPU/AMDGPUGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/AMDGPU/AMDGPUGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/AMDGPU/AMDGPUGenDAGISel.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/AMDGPU/AMDGPUGenCallingConv.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/AMDGPU/AMDGPUGenSubtargetInfo.inc",
+            ),
+            (
+                [
+                    "-gen-disassembler",
+                    "--specialize-decoders-per-bitwidth",
+                    "-ignore-non-decodable-operands",
+                    "-ignore-fully-defined-operands",
+                ],
+                "lib/Target/AMDGPU/AMDGPUGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-searchable-tables"],
+                "lib/Target/AMDGPU/AMDGPUGenSearchableTables.inc",
+            ),
+        ],
         "tbl_deps": [
             ":InstCombineTableGen",
             ":amdgpu_isel_target_gen",
@@ -2288,184 +2445,567 @@ llvm_target_lib_list = [lib for lib in [
     {
         "name": "AVR",
         "short_name": "AVR",
-        "tbl_outs": {
-            "lib/Target/AVR/AVRGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/AVR/AVRGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/AVR/AVRGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/AVR/AVRGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/AVR/AVRGenDisassemblerTables.inc": [
-                "-gen-disassembler",
-            ],
-            "lib/Target/AVR/AVRGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/AVR/AVRGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/AVR/AVRGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/AVR/AVRGenSDNodeInfo.inc": ["-gen-sd-node-info"],
-            "lib/Target/AVR/AVRGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/AVR/AVRGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/AVR/AVRGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/AVR/AVRGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/AVR/AVRGenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/AVR/AVRGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/AVR/AVRGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/AVR/AVRGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/AVR/AVRGenRegisterInfo.inc",
+                    "lib/Target/AVR/AVRGenRegisterInfoEnums.inc",
+                    "lib/Target/AVR/AVRGenRegisterInfoMCDesc.inc",
+                    "lib/Target/AVR/AVRGenRegisterInfoHeader.inc",
+                    "lib/Target/AVR/AVRGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/AVR/AVRGenSDNodeInfo.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/AVR/AVRGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "BPF",
         "short_name": "BPF",
-        "tbl_outs": {
-            "lib/Target/BPF/BPFGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/BPF/BPFGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/BPF/BPFGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/BPF/BPFGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/BPF/BPFGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/BPF/BPFGenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/BPF/BPFGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/BPF/BPFGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/BPF/BPFGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/BPF/BPFGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/BPF/BPFGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/BPF/BPFGenSDNodeInfo.inc": ["-gen-sd-node-info"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-register-bank"],
+                "lib/Target/BPF/BPFGenRegisterBank.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/BPF/BPFGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/BPF/BPFGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/BPF/BPFGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/BPF/BPFGenDAGISel.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/BPF/BPFGenGlobalISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/BPF/BPFGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/BPF/BPFGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/BPF/BPFGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/BPF/BPFGenRegisterInfo.inc",
+                    "lib/Target/BPF/BPFGenRegisterInfoEnums.inc",
+                    "lib/Target/BPF/BPFGenRegisterInfoMCDesc.inc",
+                    "lib/Target/BPF/BPFGenRegisterInfoHeader.inc",
+                    "lib/Target/BPF/BPFGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/BPF/BPFGenSubtargetInfo.inc",
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/BPF/BPFGenSDNodeInfo.inc",
+            ),
+        ],
     },
     {
         "name": "Hexagon",
         "short_name": "Hexagon",
-        "tbl_outs": {
-            "lib/Target/Hexagon/HexagonGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/Hexagon/HexagonGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/Hexagon/HexagonGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/Hexagon/HexagonGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/Hexagon/HexagonGenDFAPacketizer.inc": ["-gen-dfa-packetizer"],
-            "lib/Target/Hexagon/HexagonGenDisassemblerTables.inc": [
-                "-gen-disassembler",
-            ],
-            "lib/Target/Hexagon/HexagonGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/Hexagon/HexagonGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/Hexagon/HexagonGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/Hexagon/HexagonGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/Hexagon/HexagonGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/Hexagon/HexagonGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/Hexagon/HexagonGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/Hexagon/HexagonGenDAGISel.inc",
+            ),
+            (
+                ["-gen-dfa-packetizer"],
+                "lib/Target/Hexagon/HexagonGenDFAPacketizer.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/Hexagon/HexagonGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/Hexagon/HexagonGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/Hexagon/HexagonGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/Hexagon/HexagonGenRegisterInfo.inc",
+                    "lib/Target/Hexagon/HexagonGenRegisterInfoEnums.inc",
+                    "lib/Target/Hexagon/HexagonGenRegisterInfoMCDesc.inc",
+                    "lib/Target/Hexagon/HexagonGenRegisterInfoHeader.inc",
+                    "lib/Target/Hexagon/HexagonGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/Hexagon/HexagonGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "Lanai",
         "short_name": "Lanai",
-        "tbl_outs": {
-            "lib/Target/Lanai/LanaiGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/Lanai/LanaiGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/Lanai/LanaiGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/Lanai/LanaiGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/Lanai/LanaiGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/Lanai/LanaiGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/Lanai/LanaiGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/Lanai/LanaiGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/Lanai/LanaiGenSDNodeInfo.inc": ["-gen-sd-node-info"],
-            "lib/Target/Lanai/LanaiGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/Lanai/LanaiGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/Lanai/LanaiGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/Lanai/LanaiGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/Lanai/LanaiGenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/Lanai/LanaiGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/Lanai/LanaiGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/Lanai/LanaiGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/Lanai/LanaiGenRegisterInfo.inc",
+                    "lib/Target/Lanai/LanaiGenRegisterInfoEnums.inc",
+                    "lib/Target/Lanai/LanaiGenRegisterInfoMCDesc.inc",
+                    "lib/Target/Lanai/LanaiGenRegisterInfoHeader.inc",
+                    "lib/Target/Lanai/LanaiGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/Lanai/LanaiGenSDNodeInfo.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/Lanai/LanaiGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "LoongArch",
         "short_name": "LoongArch",
-        "tbl_outs": {
-            "lib/Target/LoongArch/LoongArchGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/LoongArch/LoongArchGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/LoongArch/LoongArchGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/LoongArch/LoongArchGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/LoongArch/LoongArchGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/LoongArch/LoongArchGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/LoongArch/LoongArchGenMCPseudoLowering.inc": ["-gen-pseudo-lowering"],
-            "lib/Target/LoongArch/LoongArchGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/LoongArch/LoongArchGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/LoongArch/LoongArchGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/LoongArch/LoongArchGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/LoongArch/LoongArchGenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/LoongArch/LoongArchGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/LoongArch/LoongArchGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/LoongArch/LoongArchGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-pseudo-lowering"],
+                "lib/Target/LoongArch/LoongArchGenMCPseudoLowering.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/LoongArch/LoongArchGenRegisterInfo.inc",
+                    "lib/Target/LoongArch/LoongArchGenRegisterInfoEnums.inc",
+                    "lib/Target/LoongArch/LoongArchGenRegisterInfoMCDesc.inc",
+                    "lib/Target/LoongArch/LoongArchGenRegisterInfoHeader.inc",
+                    "lib/Target/LoongArch/LoongArchGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/LoongArch/LoongArchGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "Mips",
         "short_name": "Mips",
-        "tbl_outs": {
-            "lib/Target/Mips/MipsGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/Mips/MipsGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/Mips/MipsGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/Mips/MipsGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/Mips/MipsGenDisassemblerTables.inc": [
-                "-gen-disassembler",
-                "-ignore-non-decodable-operands",
-            ],
-            "lib/Target/Mips/MipsGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/Mips/MipsGenExegesis.inc": ["-gen-exegesis"],
-            "lib/Target/Mips/MipsGenFastISel.inc": ["-gen-fast-isel"],
-            "lib/Target/Mips/MipsGenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/Mips/MipsGenPostLegalizeGICombiner.inc": [
-                "-gen-global-isel-combiner",
-                "-combiners=MipsPostLegalizerCombiner",
-            ],
-            "lib/Target/Mips/MipsGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/Mips/MipsGenMCPseudoLowering.inc": ["-gen-pseudo-lowering"],
-            "lib/Target/Mips/MipsGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/Mips/MipsGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/Mips/MipsGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/Mips/MipsGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/Mips/MipsGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/Mips/MipsGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/Mips/MipsGenDAGISel.inc",
+            ),
+            (
+                [
+                    "-gen-disassembler",
+                    "-ignore-non-decodable-operands",
+                ],
+                "lib/Target/Mips/MipsGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/Mips/MipsGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-exegesis"],
+                "lib/Target/Mips/MipsGenExegesis.inc",
+            ),
+            (
+                ["-gen-fast-isel"],
+                "lib/Target/Mips/MipsGenFastISel.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/Mips/MipsGenGlobalISel.inc",
+            ),
+            (
+                [
+                    "-gen-global-isel-combiner",
+                    "-combiners=MipsPostLegalizerCombiner",
+                ],
+                "lib/Target/Mips/MipsGenPostLegalizeGICombiner.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/Mips/MipsGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-pseudo-lowering"],
+                "lib/Target/Mips/MipsGenMCPseudoLowering.inc",
+            ),
+            (
+                ["-gen-register-bank"],
+                "lib/Target/Mips/MipsGenRegisterBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/Mips/MipsGenRegisterInfo.inc",
+                    "lib/Target/Mips/MipsGenRegisterInfoEnums.inc",
+                    "lib/Target/Mips/MipsGenRegisterInfoMCDesc.inc",
+                    "lib/Target/Mips/MipsGenRegisterInfoHeader.inc",
+                    "lib/Target/Mips/MipsGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/Mips/MipsGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "MSP430",
         "short_name": "MSP430",
-        "tbl_outs": {
-            "lib/Target/MSP430/MSP430GenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/MSP430/MSP430GenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/MSP430/MSP430GenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/MSP430/MSP430GenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/MSP430/MSP430GenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/MSP430/MSP430GenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/MSP430/MSP430GenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/MSP430/MSP430GenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/MSP430/MSP430GenSDNodeInfo.inc": ["-gen-sd-node-info"],
-            "lib/Target/MSP430/MSP430GenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/MSP430/MSP430GenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/MSP430/MSP430GenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/MSP430/MSP430GenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/MSP430/MSP430GenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/MSP430/MSP430GenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/MSP430/MSP430GenInstrInfo.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/MSP430/MSP430GenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/MSP430/MSP430GenRegisterInfo.inc",
+                    "lib/Target/MSP430/MSP430GenRegisterInfoEnums.inc",
+                    "lib/Target/MSP430/MSP430GenRegisterInfoMCDesc.inc",
+                    "lib/Target/MSP430/MSP430GenRegisterInfoHeader.inc",
+                    "lib/Target/MSP430/MSP430GenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/MSP430/MSP430GenSDNodeInfo.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/MSP430/MSP430GenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "NVPTX",
         "short_name": "NVPTX",
-        "tbl_outs": {
-            "lib/Target/NVPTX/NVPTXGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/NVPTX/NVPTXGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/NVPTX/NVPTXGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/NVPTX/NVPTXGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/NVPTX/NVPTXGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/NVPTX/NVPTXGenRegisterInfo.inc",
+                    "lib/Target/NVPTX/NVPTXGenRegisterInfoEnums.inc",
+                    "lib/Target/NVPTX/NVPTXGenRegisterInfoMCDesc.inc",
+                    "lib/Target/NVPTX/NVPTXGenRegisterInfoHeader.inc",
+                    "lib/Target/NVPTX/NVPTXGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/NVPTX/NVPTXGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/NVPTX/NVPTXGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/NVPTX/NVPTXGenDAGISel.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/NVPTX/NVPTXGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "PowerPC",
         "short_name": "PPC",
-        "tbl_outs": {
-            "lib/Target/PowerPC/PPCGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/PowerPC/PPCGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/PowerPC/PPCGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/PowerPC/PPCGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/PowerPC/PPCGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/PowerPC/PPCGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/PowerPC/PPCGenFastISel.inc": ["-gen-fast-isel"],
-            "lib/Target/PowerPC/PPCGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/PowerPC/PPCGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/PowerPC/PPCGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/PowerPC/PPCGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/PowerPC/PPCGenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/PowerPC/PPCGenExegesis.inc": ["-gen-exegesis"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/PowerPC/PPCGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/PowerPC/PPCGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/PowerPC/PPCGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/PowerPC/PPCGenRegisterInfo.inc",
+                    "lib/Target/PowerPC/PPCGenRegisterInfoEnums.inc",
+                    "lib/Target/PowerPC/PPCGenRegisterInfoMCDesc.inc",
+                    "lib/Target/PowerPC/PPCGenRegisterInfoHeader.inc",
+                    "lib/Target/PowerPC/PPCGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/PowerPC/PPCGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/PowerPC/PPCGenDAGISel.inc",
+            ),
+            (
+                ["-gen-fast-isel"],
+                "lib/Target/PowerPC/PPCGenFastISel.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/PowerPC/PPCGenCallingConv.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/PowerPC/PPCGenSubtargetInfo.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/PowerPC/PPCGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-register-bank"],
+                "lib/Target/PowerPC/PPCGenRegisterBank.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/PowerPC/PPCGenGlobalISel.inc",
+            ),
+            (
+                ["-gen-exegesis"],
+                "lib/Target/PowerPC/PPCGenExegesis.inc",
+            ),
+        ],
     },
     {
         "name": "RISCV",
         "short_name": "RISCV",
-        "tbl_outs": {
-            "lib/Target/RISCV/RISCVGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/RISCV/RISCVGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/RISCV/RISCVGenCompressInstEmitter.inc": ["-gen-compress-inst-emitter"],
-            "lib/Target/RISCV/RISCVGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/RISCV/RISCVGenDisassemblerTables.inc": [
-                "-gen-disassembler",
-                "--specialize-decoders-per-bitwidth",
-            ],
-            "lib/Target/RISCV/RISCVGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/RISCV/RISCVGenMacroFusion.inc": ["-gen-macro-fusion-pred"],
-            "lib/Target/RISCV/RISCVGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/RISCV/RISCVGenMCPseudoLowering.inc": ["-gen-pseudo-lowering"],
-            "lib/Target/RISCV/RISCVGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/RISCV/RISCVGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/RISCV/RISCVGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/RISCV/RISCVGenSearchableTables.inc": ["-gen-searchable-tables"],
-            "lib/Target/RISCV/RISCVGenExegesis.inc": ["-gen-exegesis"],
-            "lib/Target/RISCV/RISCVGenSDNodeInfo.inc": ["-gen-sd-node-info"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/RISCV/RISCVGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/RISCV/RISCVGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-compress-inst-emitter"],
+                "lib/Target/RISCV/RISCVGenCompressInstEmitter.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/RISCV/RISCVGenDAGISel.inc",
+            ),
+            (
+                [
+                    "-gen-disassembler",
+                    "--specialize-decoders-per-bitwidth",
+                ],
+                "lib/Target/RISCV/RISCVGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/RISCV/RISCVGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-macro-fusion-pred"],
+                "lib/Target/RISCV/RISCVGenMacroFusion.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/RISCV/RISCVGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-pseudo-lowering"],
+                "lib/Target/RISCV/RISCVGenMCPseudoLowering.inc",
+            ),
+            (
+                ["-gen-register-bank"],
+                "lib/Target/RISCV/RISCVGenRegisterBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/RISCV/RISCVGenRegisterInfo.inc",
+                    "lib/Target/RISCV/RISCVGenRegisterInfoEnums.inc",
+                    "lib/Target/RISCV/RISCVGenRegisterInfoMCDesc.inc",
+                    "lib/Target/RISCV/RISCVGenRegisterInfoHeader.inc",
+                    "lib/Target/RISCV/RISCVGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/RISCV/RISCVGenSubtargetInfo.inc",
+            ),
+            (
+                ["-gen-searchable-tables"],
+                "lib/Target/RISCV/RISCVGenSearchableTables.inc",
+            ),
+            (
+                ["-gen-exegesis"],
+                "lib/Target/RISCV/RISCVGenExegesis.inc",
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/RISCV/RISCVGenSDNodeInfo.inc",
+            ),
+        ],
         "tbl_deps": [
             ":riscv_isel_target_gen",
         ],
@@ -2473,135 +3013,396 @@ llvm_target_lib_list = [lib for lib in [
     {
         "name": "Sparc",
         "short_name": "Sparc",
-        "tbl_outs": {
-            "lib/Target/Sparc/SparcGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/Sparc/SparcGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/Sparc/SparcGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/Sparc/SparcGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/Sparc/SparcGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/Sparc/SparcGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/Sparc/SparcGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/Sparc/SparcGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/Sparc/SparcGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/Sparc/SparcGenSearchableTables.inc": ["-gen-searchable-tables"],
-            "lib/Target/Sparc/SparcGenSDNodeInfo.inc": [
-                "-gen-sd-node-info",
-                "-sdnode-namespace=SPISD",
-            ],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/Sparc/SparcGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/Sparc/SparcGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/Sparc/SparcGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/Sparc/SparcGenRegisterInfo.inc",
+                    "lib/Target/Sparc/SparcGenRegisterInfoEnums.inc",
+                    "lib/Target/Sparc/SparcGenRegisterInfoMCDesc.inc",
+                    "lib/Target/Sparc/SparcGenRegisterInfoHeader.inc",
+                    "lib/Target/Sparc/SparcGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/Sparc/SparcGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/Sparc/SparcGenDAGISel.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/Sparc/SparcGenCallingConv.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/Sparc/SparcGenSubtargetInfo.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/Sparc/SparcGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-searchable-tables"],
+                "lib/Target/Sparc/SparcGenSearchableTables.inc",
+            ),
+            (
+                [
+                    "-gen-sd-node-info",
+                    "-sdnode-namespace=SPISD",
+                ],
+                "lib/Target/Sparc/SparcGenSDNodeInfo.inc",
+            ),
+        ],
     },
     {
         "name": "SPIRV",
         "short_name": "SPIRV",
-        "tbl_outs": {
-            "lib/Target/SPIRV/SPIRVGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/SPIRV/SPIRVGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/SPIRV/SPIRVGenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/SPIRV/SPIRVGenPreLegalizeGICombiner.inc": [
-                "-gen-global-isel-combiner",
-                "-combiners=SPIRVPreLegalizerCombiner",
-            ],
-            "lib/Target/SPIRV/SPIRVGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/SPIRV/SPIRVGenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/SPIRV/SPIRVGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/SPIRV/SPIRVGenTables.inc": ["-gen-searchable-tables"],
-            "lib/Target/SPIRV/SPIRVGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/SPIRV/SPIRVGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/SPIRV/SPIRVGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/SPIRV/SPIRVGenGlobalISel.inc",
+            ),
+            (
+                [
+                    "-gen-global-isel-combiner",
+                    "-combiners=SPIRVPreLegalizerCombiner",
+                ],
+                "lib/Target/SPIRV/SPIRVGenPreLegalizeGICombiner.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/SPIRV/SPIRVGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-bank"],
+                "lib/Target/SPIRV/SPIRVGenRegisterInfoBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/SPIRV/SPIRVGenRegisterInfo.inc",
+                    "lib/Target/SPIRV/SPIRVGenRegisterInfoEnums.inc",
+                    "lib/Target/SPIRV/SPIRVGenRegisterInfoMCDesc.inc",
+                    "lib/Target/SPIRV/SPIRVGenRegisterInfoHeader.inc",
+                    "lib/Target/SPIRV/SPIRVGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-searchable-tables"],
+                "lib/Target/SPIRV/SPIRVGenTables.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/SPIRV/SPIRVGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "SystemZ",
         "short_name": "SystemZ",
-        "tbl_outs": {
-            "lib/Target/SystemZ/SystemZGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/SystemZ/SystemZGenGNUAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/SystemZ/SystemZGenHLASMAsmWriter.inc": [
-                "-gen-asm-writer",
-                "-asmwriternum=1",
-            ],
-            "lib/Target/SystemZ/SystemZGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/SystemZ/SystemZGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/SystemZ/SystemZGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/SystemZ/SystemZGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/SystemZ/SystemZGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/SystemZ/SystemZGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/SystemZ/SystemZGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/SystemZ/SystemZGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/SystemZ/SystemZGenGNUAsmWriter.inc",
+            ),
+            (
+                [
+                    "-gen-asm-writer",
+                    "-asmwriternum=1",
+                ],
+                "lib/Target/SystemZ/SystemZGenHLASMAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/SystemZ/SystemZGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/SystemZ/SystemZGenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/SystemZ/SystemZGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/SystemZ/SystemZGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/SystemZ/SystemZGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/SystemZ/SystemZGenRegisterInfo.inc",
+                    "lib/Target/SystemZ/SystemZGenRegisterInfoEnums.inc",
+                    "lib/Target/SystemZ/SystemZGenRegisterInfoMCDesc.inc",
+                    "lib/Target/SystemZ/SystemZGenRegisterInfoHeader.inc",
+                    "lib/Target/SystemZ/SystemZGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/SystemZ/SystemZGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "VE",
         "short_name": "VE",
-        "tbl_outs": {
-            "lib/Target/VE/VEGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/VE/VEGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/VE/VEGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/VE/VEGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/VE/VEGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/VE/VEGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/VE/VEGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/VE/VEGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/VE/VEGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/VE/VEGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/VE/VEGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/VE/VEGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/VE/VEGenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/VE/VEGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/VE/VEGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/VE/VEGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/VE/VEGenRegisterInfo.inc",
+                    "lib/Target/VE/VEGenRegisterInfoEnums.inc",
+                    "lib/Target/VE/VEGenRegisterInfoMCDesc.inc",
+                    "lib/Target/VE/VEGenRegisterInfoHeader.inc",
+                    "lib/Target/VE/VEGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/VE/VEGenSubtargetInfo.inc",
+            ),
+        ],
     },
     {
         "name": "WebAssembly",
         "short_name": "WebAssembly",
-        "tbl_outs": {
-            "lib/Target/WebAssembly/WebAssemblyGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/WebAssembly/WebAssemblyGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/WebAssembly/WebAssemblyGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/WebAssembly/WebAssemblyGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/WebAssembly/WebAssemblyGenFastISel.inc": ["-gen-fast-isel"],
-            "lib/Target/WebAssembly/WebAssemblyGenMCCodeEmitter.inc": ["-gen-emitter"],
-            "lib/Target/WebAssembly/WebAssemblyGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/WebAssembly/WebAssemblyGenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/WebAssembly/WebAssemblyGenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/WebAssembly/WebAssemblyGenSDNodeInfo.inc": ["-gen-sd-node-info"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-disassembler"],
+                "lib/Target/WebAssembly/WebAssemblyGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/WebAssembly/WebAssemblyGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/WebAssembly/WebAssemblyGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/WebAssembly/WebAssemblyGenDAGISel.inc",
+            ),
+            (
+                ["-gen-fast-isel"],
+                "lib/Target/WebAssembly/WebAssemblyGenFastISel.inc",
+            ),
+            (
+                ["-gen-emitter"],
+                "lib/Target/WebAssembly/WebAssemblyGenMCCodeEmitter.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/WebAssembly/WebAssemblyGenRegisterInfo.inc",
+                    "lib/Target/WebAssembly/WebAssemblyGenRegisterInfoEnums.inc",
+                    "lib/Target/WebAssembly/WebAssemblyGenRegisterInfoMCDesc.inc",
+                    "lib/Target/WebAssembly/WebAssemblyGenRegisterInfoHeader.inc",
+                    "lib/Target/WebAssembly/WebAssemblyGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/WebAssembly/WebAssemblyGenSubtargetInfo.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/WebAssembly/WebAssemblyGenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/WebAssembly/WebAssemblyGenSDNodeInfo.inc",
+            ),
+        ],
     },
     {
         "name": "X86",
         "short_name": "X86",
-        "tbl_outs": {
-            "lib/Target/X86/X86GenRegisterBank.inc": ["-gen-register-bank"],
-            "lib/Target/X86/X86GenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/X86/X86GenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/X86/X86GenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/X86/X86GenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/X86/X86GenAsmWriter1.inc": [
-                "-gen-asm-writer",
-                "-asmwriternum=1",
-            ],
-            "lib/Target/X86/X86GenAsmMatcher.inc": ["-gen-asm-matcher"],
-            "lib/Target/X86/X86GenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/X86/X86GenFastISel.inc": ["-gen-fast-isel"],
-            "lib/Target/X86/X86GenGlobalISel.inc": ["-gen-global-isel"],
-            "lib/Target/X86/X86GenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/X86/X86GenSubtargetInfo.inc": ["-gen-subtarget"],
-            "lib/Target/X86/X86GenFoldTables.inc": [
-                "-gen-x86-fold-tables",
-                "-asmwriternum=1",
-            ],
-            "lib/Target/X86/X86GenInstrMapping.inc": ["-gen-x86-instr-mapping"],
-            "lib/Target/X86/X86GenExegesis.inc": ["-gen-exegesis"],
-            "lib/Target/X86/X86GenMnemonicTables.inc": [
-                "-gen-x86-mnemonic-tables",
-                "-asmwriternum=1",
-            ],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-register-bank"],
+                "lib/Target/X86/X86GenRegisterInfoBank.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/X86/X86GenRegisterInfo.inc",
+                    "lib/Target/X86/X86GenRegisterInfoEnums.inc",
+                    "lib/Target/X86/X86GenRegisterInfoMCDesc.inc",
+                    "lib/Target/X86/X86GenRegisterInfoHeader.inc",
+                    "lib/Target/X86/X86GenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/X86/X86GenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/X86/X86GenInstrInfo.inc",
+            ),
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/X86/X86GenAsmWriter.inc",
+            ),
+            (
+                [
+                    "-gen-asm-writer",
+                    "-asmwriternum=1",
+                ],
+                "lib/Target/X86/X86GenAsmWriter1.inc",
+            ),
+            (
+                ["-gen-asm-matcher"],
+                "lib/Target/X86/X86GenAsmMatcher.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/X86/X86GenDAGISel.inc",
+            ),
+            (
+                ["-gen-fast-isel"],
+                "lib/Target/X86/X86GenFastISel.inc",
+            ),
+            (
+                ["-gen-global-isel"],
+                "lib/Target/X86/X86GenGlobalISel.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/X86/X86GenCallingConv.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/X86/X86GenSubtargetInfo.inc",
+            ),
+            (
+                [
+                    "-gen-x86-fold-tables",
+                    "-asmwriternum=1",
+                ],
+                "lib/Target/X86/X86GenFoldTables.inc",
+            ),
+            (
+                ["-gen-x86-instr-mapping"],
+                "lib/Target/X86/X86GenInstrMapping.inc",
+            ),
+            (
+                ["-gen-exegesis"],
+                "lib/Target/X86/X86GenExegesis.inc",
+            ),
+            (
+                [
+                    "-gen-x86-mnemonic-tables",
+                    "-asmwriternum=1",
+                ],
+                "lib/Target/X86/X86GenMnemonicTables.inc",
+            ),
+        ],
     },
     {
         "name": "XCore",
         "short_name": "XCore",
-        "tbl_outs": {
-            "lib/Target/XCore/XCoreGenAsmWriter.inc": ["-gen-asm-writer"],
-            "lib/Target/XCore/XCoreGenCallingConv.inc": ["-gen-callingconv"],
-            "lib/Target/XCore/XCoreGenDAGISel.inc": ["-gen-dag-isel"],
-            "lib/Target/XCore/XCoreGenDisassemblerTables.inc": ["-gen-disassembler"],
-            "lib/Target/XCore/XCoreGenInstrInfo.inc": ["-gen-instr-info"],
-            "lib/Target/XCore/XCoreGenRegisterInfo.inc": ["-gen-register-info"],
-            "lib/Target/XCore/XCoreGenSDNodeInfo.inc": ["-gen-sd-node-info"],
-            "lib/Target/XCore/XCoreGenSubtargetInfo.inc": ["-gen-subtarget"],
-        },
+        "tbl_outs": [
+            (
+                ["-gen-asm-writer"],
+                "lib/Target/XCore/XCoreGenAsmWriter.inc",
+            ),
+            (
+                ["-gen-callingconv"],
+                "lib/Target/XCore/XCoreGenCallingConv.inc",
+            ),
+            (
+                ["-gen-dag-isel"],
+                "lib/Target/XCore/XCoreGenDAGISel.inc",
+            ),
+            (
+                ["-gen-disassembler"],
+                "lib/Target/XCore/XCoreGenDisassemblerTables.inc",
+            ),
+            (
+                ["-gen-instr-info"],
+                "lib/Target/XCore/XCoreGenInstrInfo.inc",
+            ),
+            (
+                ["-gen-register-info"],
+                [
+                    "lib/Target/XCore/XCoreGenRegisterInfo.inc",
+                    "lib/Target/XCore/XCoreGenRegisterInfoEnums.inc",
+                    "lib/Target/XCore/XCoreGenRegisterInfoMCDesc.inc",
+                    "lib/Target/XCore/XCoreGenRegisterInfoHeader.inc",
+                    "lib/Target/XCore/XCoreGenRegisterInfoTargetDesc.inc",
+                ],
+            ),
+            (
+                ["-gen-sd-node-info"],
+                "lib/Target/XCore/XCoreGenSDNodeInfo.inc",
+            ),
+            (
+                ["-gen-subtarget"],
+                "lib/Target/XCore/XCoreGenSubtargetInfo.inc",
+            ),
+        ],
     },
 ] if lib["name"] in llvm_targets]
 
@@ -2639,16 +3440,46 @@ gentbl_cc_library(
 gentbl_cc_library(
     name = "r600_target_gen",
     strip_include_prefix = "lib/Target/AMDGPU",
-    tbl_outs = {
-        "lib/Target/AMDGPU/R600GenAsmWriter.inc": ["-gen-asm-writer"],
-        "lib/Target/AMDGPU/R600GenCallingConv.inc": ["-gen-callingconv"],
-        "lib/Target/AMDGPU/R600GenDAGISel.inc": ["-gen-dag-isel"],
-        "lib/Target/AMDGPU/R600GenDFAPacketizer.inc": ["-gen-dfa-packetizer"],
-        "lib/Target/AMDGPU/R600GenInstrInfo.inc": ["-gen-instr-info"],
-        "lib/Target/AMDGPU/R600GenMCCodeEmitter.inc": ["-gen-emitter"],
-        "lib/Target/AMDGPU/R600GenRegisterInfo.inc": ["-gen-register-info"],
-        "lib/Target/AMDGPU/R600GenSubtargetInfo.inc": ["-gen-subtarget"],
-    },
+    tbl_outs = [
+        (
+            ["-gen-asm-writer"],
+            "lib/Target/AMDGPU/R600GenAsmWriter.inc",
+        ),
+        (
+            ["-gen-callingconv"],
+            "lib/Target/AMDGPU/R600GenCallingConv.inc",
+        ),
+        (
+            ["-gen-dag-isel"],
+            "lib/Target/AMDGPU/R600GenDAGISel.inc",
+        ),
+        (
+            ["-gen-dfa-packetizer"],
+            "lib/Target/AMDGPU/R600GenDFAPacketizer.inc",
+        ),
+        (
+            ["-gen-instr-info"],
+            "lib/Target/AMDGPU/R600GenInstrInfo.inc",
+        ),
+        (
+            ["-gen-emitter"],
+            "lib/Target/AMDGPU/R600GenMCCodeEmitter.inc",
+        ),
+        (
+            ["-gen-register-info"],
+            [
+                "lib/Target/AMDGPU/R600GenRegisterInfo.inc",
+                "lib/Target/AMDGPU/R600GenRegisterInfoEnums.inc",
+                "lib/Target/AMDGPU/R600GenRegisterInfoMCDesc.inc",
+                "lib/Target/AMDGPU/R600GenRegisterInfoHeader.inc",
+                "lib/Target/AMDGPU/R600GenRegisterInfoTargetDesc.inc",
+            ],
+        ),
+        (
+            ["-gen-subtarget"],
+            "lib/Target/AMDGPU/R600GenSubtargetInfo.inc",
+        ),
+    ],
     tblgen = ":llvm-tblgen",
     td_file = "lib/Target/AMDGPU/R600.td",
     deps = [
@@ -3381,7 +4212,10 @@ cc_library(
 gentbl_cc_library(
     name = "LibOptionsTableGen",
     strip_include_prefix = "lib/ToolDrivers/llvm-lib",
-    tbl_outs = {"lib/ToolDrivers/llvm-lib/Options.inc": ["-gen-opt-parser-defs"]},
+    tbl_outs = [(
+        ["-gen-opt-parser-defs"],
+        "lib/ToolDrivers/llvm-lib/Options.inc",
+    )],
     tblgen = ":llvm-tblgen",
     td_file = "lib/ToolDrivers/llvm-lib/Options.td",
     deps = [":OptParserTdFiles"],


### PR DESCRIPTION
Required after https://github.com/llvm/llvm-project/pull/167700

This adds yet another format for `tbl_outs` where you pass the list of opts, and a list of outputs (where previously you could only have 1 output). In that case all outputs must be produced, but the first is used for the `-o` arg since tblgen is generating the other names based on that single argument.