### PR TITLE
[RISCV] Introduce a new tune feature string syntax and its parser

### DIFF
--- a/llvm/include/llvm/TargetParser/RISCVTargetParser.h
+++ b/llvm/include/llvm/TargetParser/RISCVTargetParser.h
@@ -48,6 +48,22 @@ struct CPUInfo {
   bool is64Bit() const { return DefaultMarch.starts_with("rv64"); }
 };
 
+/// Fatal errors encountered during parsing.
+struct ParserError : public ErrorInfo<ParserError, StringError> {
+  using ErrorInfo<ParserError, StringError>::ErrorInfo;
+  explicit ParserError(const Twine &S)
+      : ErrorInfo(S, inconvertibleErrorCode()) {}
+  static char ID;
+};
+
+/// Warnings encountered during parsing.
+struct ParserWarning : public ErrorInfo<ParserWarning, StringError> {
+  using ErrorInfo<ParserWarning, StringError>::ErrorInfo;
+  explicit ParserWarning(const Twine &S)
+      : ErrorInfo(S, inconvertibleErrorCode()) {}
+  static char ID;
+};
+
 // We use 64 bits as the known part in the scalable vector types.
 static constexpr unsigned RVVBitsPerBlock = 64;
 static constexpr unsigned RVVBytesPerBlock = RVVBitsPerBlock / 8;

--- a/llvm/include/llvm/TargetParser/RISCVTargetParser.h
+++ b/llvm/include/llvm/TargetParser/RISCVTargetParser.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -54,6 +55,9 @@ static constexpr unsigned RVVBytesPerBlock = RVVBitsPerBlock / 8;
 LLVM_ABI void getFeaturesForCPU(StringRef CPU,
                                 SmallVectorImpl<std::string> &EnabledFeatures,
                                 bool NeedPlus = false);
+LLVM_ABI void getAllTuneFeatures(SmallVectorImpl<StringRef> &TuneFeatures);
+LLVM_ABI Error parseTuneFeatureString(
+    StringRef TFString, SmallVectorImpl<std::string> &TuneFeatures);
 LLVM_ABI bool parseCPU(StringRef CPU, bool IsRV64);
 LLVM_ABI bool parseTuneCPU(StringRef CPU, bool IsRV64);
 LLVM_ABI StringRef getMArchFromMcpu(StringRef CPU);

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1740,9 +1740,12 @@ def HasVendorXSMTVDot
 // LLVM specific features and extensions
 //===----------------------------------------------------------------------===//
 
-class RISCVTuneFeature<string name, string field_name, string value,
-                       string description, list<SubtargetFeature> implied = []>
-    : SubtargetFeature<name, field_name, value, description, implied>;
+class RISCVTuneFeatureBase;
+class RISCVSimpleTuneFeature : RISCVTuneFeatureBase;
+class RISCVTuneFeature<string pos_directive, string neg_directive> : RISCVTuneFeatureBase {
+  string PositiveDirectiveName = pos_directive;
+  string NegativeDirectiveName = neg_directive;
+}
 
 // Feature32Bit exists to mark CPUs that support RV32 to distinguish them from
 // tuning CPU names.
@@ -1792,48 +1795,59 @@ def FeatureUnalignedVectorMem
                       "loads and stores">;
 
 def TuneNLogNVRGather
-   : RISCVTuneFeature<"log-vrgather", "RISCVVRGatherCostModel", "NLog2N",
-                      "Has vrgather.vv with LMUL*log2(LMUL) latency">;
+   : SubtargetFeature<"log-vrgather", "RISCVVRGatherCostModel", "NLog2N",
+                      "Has vrgather.vv with LMUL*log2(LMUL) latency">,
+     RISCVSimpleTuneFeature;
 
-def TunePostRAScheduler : RISCVTuneFeature<"use-postra-scheduler",
-    "UsePostRAScheduler", "true", "Schedule again after register allocation">;
+def TunePostRAScheduler : SubtargetFeature<"use-postra-scheduler",
+    "UsePostRAScheduler", "true", "Schedule again after register allocation">,
+    RISCVSimpleTuneFeature;
 
-def TuneDisableMISchedLoadClustering : RISCVTuneFeature<"disable-misched-load-clustering",
-    "EnableMISchedLoadClustering", "false", "Disable load clustering in the machine scheduler">;
+def TuneDisableMISchedLoadClustering : SubtargetFeature<"disable-misched-load-clustering",
+    "EnableMISchedLoadClustering", "false", "Disable load clustering in the machine scheduler">,
+    RISCVTuneFeature<"disable-misched-load-clustering", "enable-misched-load-clustering">;
 
-def TuneDisableMISchedStoreClustering : RISCVTuneFeature<"disable-misched-store-clustering",
-    "EnableMISchedStoreClustering", "false", "Disable store clustering in the machine scheduler">;
+def TuneDisableMISchedStoreClustering : SubtargetFeature<"disable-misched-store-clustering",
+    "EnableMISchedStoreClustering", "false", "Disable store clustering in the machine scheduler">,
+    RISCVTuneFeature<"disable-misched-store-clustering", "enable-misched-store-clustering">;
 
-def TuneDisablePostMISchedLoadClustering : RISCVTuneFeature<"disable-postmisched-load-clustering",
-    "EnablePostMISchedLoadClustering", "false", "Disable PostRA load clustering in the machine scheduler">;
+def TuneDisablePostMISchedLoadClustering : SubtargetFeature<"disable-postmisched-load-clustering",
+    "EnablePostMISchedLoadClustering", "false", "Disable PostRA load clustering in the machine scheduler">,
+    RISCVTuneFeature<"disable-postmisched-load-clustering", "enable-postmisched-load-clustering">;
 
-def TuneDisablePostMISchedStoreClustering : RISCVTuneFeature<"disable-postmisched-store-clustering",
-    "EnablePostMISchedStoreClustering", "false", "Disable PostRA store clustering in the machine scheduler">;
+def TuneDisablePostMISchedStoreClustering : SubtargetFeature<"disable-postmisched-store-clustering",
+    "EnablePostMISchedStoreClustering", "false", "Disable PostRA store clustering in the machine scheduler">,
+    RISCVTuneFeature<"disable-postmisched-store-clustering", "enable-postmisched-store-clustering">;
 
 def TuneDisableLatencySchedHeuristic
-    : RISCVTuneFeature<"disable-latency-sched-heuristic", "DisableLatencySchedHeuristic", "true",
-                       "Disable latency scheduling heuristic">;
+    : SubtargetFeature<"disable-latency-sched-heuristic", "DisableLatencySchedHeuristic", "true",
+                       "Disable latency scheduling heuristic">,
+      RISCVTuneFeature<"disable-latency-sched-heuristic", "enable-latency-sched-heuristic">;
 
 def TunePredictableSelectIsExpensive
-    : RISCVTuneFeature<"predictable-select-expensive", "PredictableSelectIsExpensive", "true",
-                       "Prefer likely predicted branches over selects">;
+    : SubtargetFeature<"predictable-select-expensive", "PredictableSelectIsExpensive", "true",
+                       "Prefer likely predicted branches over selects">,
+      RISCVSimpleTuneFeature;
 
 def TuneOptimizedZeroStrideLoad
-   : RISCVTuneFeature<"optimized-zero-stride-load", "HasOptimizedZeroStrideLoad",
+   : SubtargetFeature<"optimized-zero-stride-load", "HasOptimizedZeroStrideLoad",
                       "true", "Optimized (perform fewer memory operations)"
-                      "zero-stride vector load">;
+                      "zero-stride vector load">,
+      RISCVSimpleTuneFeature;
 
 foreach nf = {2-8} in
   def TuneOptimizedNF#nf#SegmentLoadStore :
-      RISCVTuneFeature<"optimized-nf"#nf#"-segment-load-store",
+      SubtargetFeature<"optimized-nf"#nf#"-segment-load-store",
                        "HasOptimizedNF"#nf#"SegmentLoadStore",
                        "true", "vlseg"#nf#"eN.v and vsseg"#nf#"eN.v are "
-                       "implemented as a wide memory op and shuffle">;
+                       "implemented as a wide memory op and shuffle">,
+      RISCVSimpleTuneFeature;
 
 def TuneVLDependentLatency
-    : RISCVTuneFeature<"vl-dependent-latency", "HasVLDependentLatency", "true",
+    : SubtargetFeature<"vl-dependent-latency", "HasVLDependentLatency", "true",
                        "Latency of vector instructions is dependent on the "
-                       "dynamic value of vl">;
+                       "dynamic value of vl">,
+      RISCVSimpleTuneFeature;
 
 def Experimental
    : SubtargetFeature<"experimental", "HasExperimental",
@@ -1843,52 +1857,61 @@ def Experimental
 // and instead split over multiple cycles. DLEN refers to the datapath width
 // that can be done in parallel.
 def TuneDLenFactor2
-   : RISCVTuneFeature<"dlen-factor-2", "DLenFactor2", "true",
-                      "Vector unit DLEN(data path width) is half of VLEN">;
+   : SubtargetFeature<"dlen-factor-2", "DLenFactor2", "true",
+                      "Vector unit DLEN(data path width) is half of VLEN">,
+      RISCVSimpleTuneFeature;
 
 def TuneNoDefaultUnroll
-    : RISCVTuneFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
-                       "Disable default unroll preference.">;
+    : SubtargetFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
+                       "Disable default unroll preference.">,
+      RISCVTuneFeature<"no-default-unroll", "enable-default-unroll">;
 
 // SiFive 7 is able to fuse integer ALU operations with a preceding branch
 // instruction.
 def TuneShortForwardBranchOpt
-    : RISCVTuneFeature<"short-forward-branch-opt", "HasShortForwardBranchOpt",
-                       "true", "Enable short forward branch optimization">;
+    : SubtargetFeature<"short-forward-branch-opt", "HasShortForwardBranchOpt",
+                       "true", "Enable short forward branch optimization">,
+      RISCVSimpleTuneFeature;
 def HasShortForwardBranchOpt : Predicate<"Subtarget->hasShortForwardBranchOpt()">;
 def NoShortForwardBranchOpt : Predicate<"!Subtarget->hasShortForwardBranchOpt()">;
 
 def TuneShortForwardBranchIMinMax
-    : RISCVTuneFeature<"short-forward-branch-i-minmax", "HasShortForwardBranchIMinMax",
+    : SubtargetFeature<"short-forward-branch-i-minmax", "HasShortForwardBranchIMinMax",
                        "true", "Enable short forward branch optimization for min,max instructions in Zbb",
-                       [TuneShortForwardBranchOpt]>;
+                       [TuneShortForwardBranchOpt]>,
+      RISCVSimpleTuneFeature;
 
 def TuneShortForwardBranchIMul
-    : RISCVTuneFeature<"short-forward-branch-i-mul", "HasShortForwardBranchIMul",
+    : SubtargetFeature<"short-forward-branch-i-mul", "HasShortForwardBranchIMul",
                        "true", "Enable short forward branch optimization for mul instruction",
-                       [TuneShortForwardBranchOpt]>;
+                       [TuneShortForwardBranchOpt]>,
+      RISCVSimpleTuneFeature;
 
 // Some subtargets require a S2V transfer buffer to move scalars into vectors.
 // FIXME: Forming .vx/.vf/.wx/.wf can reduce register pressure.
 def TuneNoSinkSplatOperands
-    : RISCVTuneFeature<"no-sink-splat-operands", "SinkSplatOperands",
+    : SubtargetFeature<"no-sink-splat-operands", "SinkSplatOperands",
                        "false", "Disable sink splat operands to enable .vx, .vf,"
-                       ".wx, and .wf instructions">;
+                       ".wx, and .wf instructions">,
+      RISCVTuneFeature<"no-sink-splat-operands", "sink-splat-operands">;
 
 def TunePreferWInst
-    : RISCVTuneFeature<"prefer-w-inst", "PreferWInst", "true",
-                       "Prefer instructions with W suffix">;
+    : SubtargetFeature<"prefer-w-inst", "PreferWInst", "true",
+                       "Prefer instructions with W suffix">,
+      RISCVSimpleTuneFeature;
 
 def TuneConditionalCompressedMoveFusion
-    : RISCVTuneFeature<"conditional-cmv-fusion", "HasConditionalCompressedMoveFusion",
-                       "true", "Enable branch+c.mv fusion">;
+    : SubtargetFeature<"conditional-cmv-fusion", "HasConditionalCompressedMoveFusion",
+                       "true", "Enable branch+c.mv fusion">,
+      RISCVSimpleTuneFeature;
 def HasConditionalMoveFusion : Predicate<"Subtarget->hasConditionalMoveFusion()">;
 def NoConditionalMoveFusion  : Predicate<"!Subtarget->hasConditionalMoveFusion()">;
 
 def TuneHasSingleElementVecFP64
-    : RISCVTuneFeature<"single-element-vec-fp64", "HasSingleElementVectorFP64", "true",
+    : SubtargetFeature<"single-element-vec-fp64", "HasSingleElementVectorFP64", "true",
                        "Certain vector FP64 operations produce a single result "
-                       "element per cycle">;
+                       "element per cycle">,
+      RISCVSimpleTuneFeature;
 
 def TuneMIPSP8700
     : SubtargetFeature<"mips-p8700", "RISCVProcFamily", "MIPSP8700",
@@ -1903,14 +1926,16 @@ def TuneVentanaVeyron : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "V
 def TuneAndes45 : SubtargetFeature<"andes45", "RISCVProcFamily", "Andes45",
                                    "Andes 45-Series processors">;
 
-def TuneVXRMPipelineFlush : RISCVTuneFeature<"vxrm-pipeline-flush", "HasVXRMPipelineFlush",
-                                             "true", "VXRM writes causes pipeline flush">;
+def TuneVXRMPipelineFlush : SubtargetFeature<"vxrm-pipeline-flush", "HasVXRMPipelineFlush",
+                                             "true", "VXRM writes causes pipeline flush">,
+                            RISCVSimpleTuneFeature;
 
 def TunePreferVsetvliOverReadVLENB
-    : RISCVTuneFeature<"prefer-vsetvli-over-read-vlenb",
+    : SubtargetFeature<"prefer-vsetvli-over-read-vlenb",
                        "PreferVsetvliOverReadVLENB",
                        "true",
-                       "Prefer vsetvli over read vlenb CSR to calculate VLEN">;
+                       "Prefer vsetvli over read vlenb CSR to calculate VLEN">,
+      RISCVSimpleTuneFeature;
 
 // Assume that lock-free native-width atomics are available, even if the target
 // and operating system combination would not usually provide them. The user

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1740,6 +1740,10 @@ def HasVendorXSMTVDot
 // LLVM specific features and extensions
 //===----------------------------------------------------------------------===//
 
+class RISCVTuneFeature<string name, string field_name, string value,
+                       string description, list<SubtargetFeature> implied = []>
+    : SubtargetFeature<name, field_name, value, description, implied>;
+
 // Feature32Bit exists to mark CPUs that support RV32 to distinguish them from
 // tuning CPU names.
 def Feature32Bit
@@ -1788,46 +1792,46 @@ def FeatureUnalignedVectorMem
                       "loads and stores">;
 
 def TuneNLogNVRGather
-   : SubtargetFeature<"log-vrgather", "RISCVVRGatherCostModel", "NLog2N",
+   : RISCVTuneFeature<"log-vrgather", "RISCVVRGatherCostModel", "NLog2N",
                       "Has vrgather.vv with LMUL*log2(LMUL) latency">;
 
-def TunePostRAScheduler : SubtargetFeature<"use-postra-scheduler",
+def TunePostRAScheduler : RISCVTuneFeature<"use-postra-scheduler",
     "UsePostRAScheduler", "true", "Schedule again after register allocation">;
 
-def TuneDisableMISchedLoadClustering : SubtargetFeature<"disable-misched-load-clustering",
+def TuneDisableMISchedLoadClustering : RISCVTuneFeature<"disable-misched-load-clustering",
     "EnableMISchedLoadClustering", "false", "Disable load clustering in the machine scheduler">;
 
-def TuneDisableMISchedStoreClustering : SubtargetFeature<"disable-misched-store-clustering",
+def TuneDisableMISchedStoreClustering : RISCVTuneFeature<"disable-misched-store-clustering",
     "EnableMISchedStoreClustering", "false", "Disable store clustering in the machine scheduler">;
 
-def TuneDisablePostMISchedLoadClustering : SubtargetFeature<"disable-postmisched-load-clustering",
+def TuneDisablePostMISchedLoadClustering : RISCVTuneFeature<"disable-postmisched-load-clustering",
     "EnablePostMISchedLoadClustering", "false", "Disable PostRA load clustering in the machine scheduler">;
 
-def TuneDisablePostMISchedStoreClustering : SubtargetFeature<"disable-postmisched-store-clustering",
+def TuneDisablePostMISchedStoreClustering : RISCVTuneFeature<"disable-postmisched-store-clustering",
     "EnablePostMISchedStoreClustering", "false", "Disable PostRA store clustering in the machine scheduler">;
 
 def TuneDisableLatencySchedHeuristic
-    : SubtargetFeature<"disable-latency-sched-heuristic", "DisableLatencySchedHeuristic", "true",
+    : RISCVTuneFeature<"disable-latency-sched-heuristic", "DisableLatencySchedHeuristic", "true",
                        "Disable latency scheduling heuristic">;
 
 def TunePredictableSelectIsExpensive
-    : SubtargetFeature<"predictable-select-expensive", "PredictableSelectIsExpensive", "true",
+    : RISCVTuneFeature<"predictable-select-expensive", "PredictableSelectIsExpensive", "true",
                        "Prefer likely predicted branches over selects">;
 
 def TuneOptimizedZeroStrideLoad
-   : SubtargetFeature<"optimized-zero-stride-load", "HasOptimizedZeroStrideLoad",
+   : RISCVTuneFeature<"optimized-zero-stride-load", "HasOptimizedZeroStrideLoad",
                       "true", "Optimized (perform fewer memory operations)"
                       "zero-stride vector load">;
 
 foreach nf = {2-8} in
   def TuneOptimizedNF#nf#SegmentLoadStore :
-      SubtargetFeature<"optimized-nf"#nf#"-segment-load-store",
+      RISCVTuneFeature<"optimized-nf"#nf#"-segment-load-store",
                        "HasOptimizedNF"#nf#"SegmentLoadStore",
                        "true", "vlseg"#nf#"eN.v and vsseg"#nf#"eN.v are "
                        "implemented as a wide memory op and shuffle">;
 
 def TuneVLDependentLatency
-    : SubtargetFeature<"vl-dependent-latency", "HasVLDependentLatency", "true",
+    : RISCVTuneFeature<"vl-dependent-latency", "HasVLDependentLatency", "true",
                        "Latency of vector instructions is dependent on the "
                        "dynamic value of vl">;
 
@@ -1839,50 +1843,50 @@ def Experimental
 // and instead split over multiple cycles. DLEN refers to the datapath width
 // that can be done in parallel.
 def TuneDLenFactor2
-   : SubtargetFeature<"dlen-factor-2", "DLenFactor2", "true",
+   : RISCVTuneFeature<"dlen-factor-2", "DLenFactor2", "true",
                       "Vector unit DLEN(data path width) is half of VLEN">;
 
 def TuneNoDefaultUnroll
-    : SubtargetFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
+    : RISCVTuneFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
                        "Disable default unroll preference.">;
 
 // SiFive 7 is able to fuse integer ALU operations with a preceding branch
 // instruction.
 def TuneShortForwardBranchOpt
-    : SubtargetFeature<"short-forward-branch-opt", "HasShortForwardBranchOpt",
+    : RISCVTuneFeature<"short-forward-branch-opt", "HasShortForwardBranchOpt",
                        "true", "Enable short forward branch optimization">;
 def HasShortForwardBranchOpt : Predicate<"Subtarget->hasShortForwardBranchOpt()">;
 def NoShortForwardBranchOpt : Predicate<"!Subtarget->hasShortForwardBranchOpt()">;
 
 def TuneShortForwardBranchIMinMax
-    : SubtargetFeature<"short-forward-branch-i-minmax", "HasShortForwardBranchIMinMax",
+    : RISCVTuneFeature<"short-forward-branch-i-minmax", "HasShortForwardBranchIMinMax",
                        "true", "Enable short forward branch optimization for min,max instructions in Zbb",
                        [TuneShortForwardBranchOpt]>;
 
 def TuneShortForwardBranchIMul
-    : SubtargetFeature<"short-forward-branch-i-mul", "HasShortForwardBranchIMul",
+    : RISCVTuneFeature<"short-forward-branch-i-mul", "HasShortForwardBranchIMul",
                        "true", "Enable short forward branch optimization for mul instruction",
                        [TuneShortForwardBranchOpt]>;
 
 // Some subtargets require a S2V transfer buffer to move scalars into vectors.
 // FIXME: Forming .vx/.vf/.wx/.wf can reduce register pressure.
 def TuneNoSinkSplatOperands
-    : SubtargetFeature<"no-sink-splat-operands", "SinkSplatOperands",
+    : RISCVTuneFeature<"no-sink-splat-operands", "SinkSplatOperands",
                        "false", "Disable sink splat operands to enable .vx, .vf,"
                        ".wx, and .wf instructions">;
 
 def TunePreferWInst
-    : SubtargetFeature<"prefer-w-inst", "PreferWInst", "true",
+    : RISCVTuneFeature<"prefer-w-inst", "PreferWInst", "true",
                        "Prefer instructions with W suffix">;
 
 def TuneConditionalCompressedMoveFusion
-    : SubtargetFeature<"conditional-cmv-fusion", "HasConditionalCompressedMoveFusion",
+    : RISCVTuneFeature<"conditional-cmv-fusion", "HasConditionalCompressedMoveFusion",
                        "true", "Enable branch+c.mv fusion">;
 def HasConditionalMoveFusion : Predicate<"Subtarget->hasConditionalMoveFusion()">;
 def NoConditionalMoveFusion  : Predicate<"!Subtarget->hasConditionalMoveFusion()">;
 
 def TuneHasSingleElementVecFP64
-    : SubtargetFeature<"single-element-vec-fp64", "HasSingleElementVectorFP64", "true",
+    : RISCVTuneFeature<"single-element-vec-fp64", "HasSingleElementVectorFP64", "true",
                        "Certain vector FP64 operations produce a single result "
                        "element per cycle">;
 
@@ -1899,11 +1903,11 @@ def TuneVentanaVeyron : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "V
 def TuneAndes45 : SubtargetFeature<"andes45", "RISCVProcFamily", "Andes45",
                                    "Andes 45-Series processors">;
 
-def TuneVXRMPipelineFlush : SubtargetFeature<"vxrm-pipeline-flush", "HasVXRMPipelineFlush",
+def TuneVXRMPipelineFlush : RISCVTuneFeature<"vxrm-pipeline-flush", "HasVXRMPipelineFlush",
                                              "true", "VXRM writes causes pipeline flush">;
 
 def TunePreferVsetvliOverReadVLENB
-    : SubtargetFeature<"prefer-vsetvli-over-read-vlenb",
+    : RISCVTuneFeature<"prefer-vsetvli-over-read-vlenb",
                        "PreferVsetvliOverReadVLENB",
                        "true",
                        "Prefer vsetvli over read vlenb CSR to calculate VLEN">;

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1796,8 +1796,7 @@ def FeatureUnalignedVectorMem
 
 def TuneNLogNVRGather
    : SubtargetFeature<"log-vrgather", "RISCVVRGatherCostModel", "NLog2N",
-                      "Has vrgather.vv with LMUL*log2(LMUL) latency">,
-     RISCVSimpleTuneFeature;
+                      "Has vrgather.vv with LMUL*log2(LMUL) latency">;
 
 def TunePostRAScheduler : SubtargetFeature<"use-postra-scheduler",
     "UsePostRAScheduler", "true", "Schedule again after register allocation">,
@@ -1858,8 +1857,7 @@ def Experimental
 // that can be done in parallel.
 def TuneDLenFactor2
    : SubtargetFeature<"dlen-factor-2", "DLenFactor2", "true",
-                      "Vector unit DLEN(data path width) is half of VLEN">,
-      RISCVSimpleTuneFeature;
+                      "Vector unit DLEN(data path width) is half of VLEN">;
 
 def TuneNoDefaultUnroll
     : SubtargetFeature<"no-default-unroll", "EnableDefaultUnroll", "false",

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1831,16 +1831,14 @@ def TunePredictableSelectIsExpensive
 def TuneOptimizedZeroStrideLoad
    : SubtargetFeature<"optimized-zero-stride-load", "HasOptimizedZeroStrideLoad",
                       "true", "Optimized (perform fewer memory operations)"
-                      "zero-stride vector load">,
-      RISCVSimpleTuneFeature;
+                      "zero-stride vector load">;
 
 foreach nf = {2-8} in
   def TuneOptimizedNF#nf#SegmentLoadStore :
       SubtargetFeature<"optimized-nf"#nf#"-segment-load-store",
                        "HasOptimizedNF"#nf#"SegmentLoadStore",
                        "true", "vlseg"#nf#"eN.v and vsseg"#nf#"eN.v are "
-                       "implemented as a wide memory op and shuffle">,
-      RISCVSimpleTuneFeature;
+                       "implemented as a wide memory op and shuffle">;
 
 def TuneVLDependentLatency
     : SubtargetFeature<"vl-dependent-latency", "HasVLDependentLatency", "true",

--- a/llvm/lib/TargetParser/RISCVTargetParser.cpp
+++ b/llvm/lib/TargetParser/RISCVTargetParser.cpp
@@ -152,6 +152,7 @@ void getFeaturesForCPU(StringRef CPU,
       EnabledFeatures.push_back(F.substr(1));
 }
 
+namespace {
 class RISCVTuneFeatureLookupTable {
   struct RISCVTuneFeature {
     unsigned PosIdx;
@@ -209,8 +210,8 @@ public:
   }
 
   /// Returns the implied features, or empty ArrayRef if not found. Note:
-  /// ImpliedFeatureMap / InvImpliedFeatureMap are the owner of these implied
-  /// feature list, so we can just return the ArrayRef.
+  /// ImpliedFeatureMap / InvImpliedFeatureMap are the owners of these implied
+  /// feature lists, so we can just return the ArrayRef.
   ArrayRef<StringRef> featureImplies(StringRef FeatureName,
                                      bool Inverse = false) const {
     const auto &Map = Inverse ? InvImpliedFeatureMap : ImpliedFeatureMap;
@@ -220,6 +221,7 @@ public:
     return It->second;
   }
 };
+} // namespace
 
 void getAllTuneFeatures(SmallVectorImpl<StringRef> &Features) {
   RISCVTuneFeatureLookupTable::getAllTuneFeatures(Features);
@@ -235,7 +237,7 @@ Error parseTuneFeatureString(StringRef TFString,
   std::string WarningMsg;
 
   TFString = TFString.trim();
-  // Note: StringSet is not really ergnomic to use in this case here.
+  // Note: StringSet is not really ergonomic to use in this case here.
   SmallStringSet PositiveFeatures;
   SmallStringSet NegativeFeatures;
   // Phase 1: Collect explicit features.

--- a/llvm/test/TableGen/riscv-target-def.td
+++ b/llvm/test/TableGen/riscv-target-def.td
@@ -1,4 +1,6 @@
 // RUN: llvm-tblgen -gen-riscv-target-def -I %p/../../include %s | FileCheck %s
+// RUN: not llvm-tblgen -gen-riscv-target-def -DINVALID_IMPLY -I %p/../../include %s 2>&1 | FileCheck %s --check-prefix=INVALID-IMPLY
+// RUN: not llvm-tblgen -gen-riscv-target-def -DDUPLICATE -I %p/../../include %s 2>&1 | FileCheck %s --check-prefix=DUPLICATE
 
 include "llvm/Target/Target.td"
 
@@ -24,6 +26,13 @@ class RISCVExperimentalExtension<string name, int major, int minor, string desc,
     : RISCVExtension<"experimental-"#name, major, minor, desc, implies,
                      fieldname, value> {
   let Experimental = true;
+}
+
+class RISCVTuneFeatureBase;
+class RISCVSimpleTuneFeature : RISCVTuneFeatureBase;
+class RISCVTuneFeature<string pos_directive, string neg_directive> : RISCVTuneFeatureBase {
+  string PositiveDirectiveName = pos_directive;
+  string NegativeDirectiveName = neg_directive;
 }
 
 def FeatureStdExtI
@@ -188,3 +197,29 @@ def ROCKET : RISCVTuneProcessorModel<"rocket",
 // CHECK-NEXT:     {"i", 0, 8ULL},
 // CHECK-NEXT: };
 // CHECK-NEXT: #endif
+
+#ifdef INVALID_IMPLY
+def TuneFeatureBar : SubtargetFeature<"bar", "HasBar", "true", "TBA">;
+
+def TuneFeatureFoo : SubtargetFeature<"foo", "HasFoo", "true", "TBA",
+                                      [TuneFeatureBar]>,
+                     RISCVSimpleTuneFeature;
+
+// INVALID-IMPLY: error: A RISC-V tune feature can only imply another tune feature
+// INVALID-IMPLY-NEXT: def TuneFeatureBar
+// INVALID-IMPLY: note: implied by this tune feature
+// INVALID-IMPLY-NEXT: def TuneFeatureFoo
+#endif
+
+#ifdef DUPLICATE
+def TuneFeatureBar : SubtargetFeature<"bar", "HasBar", "true", "TBA">,
+                     RISCVTuneFeature<"abc", "def">;
+
+def TuneFeatureFoo : SubtargetFeature<"foo", "HasFoo", "true", "TBA">,
+                     RISCVTuneFeature<"xyz", "abc">;
+
+// DUPLICATE: error: RISC-V tune feature negative directive 'abc' was already defined
+// DUPLICATE-NEXT: def TuneFeatureFoo
+// DUPLICATE: note: Previously defined here
+// DUPLICATE-NEXT: def TuneFeatureBar
+#endif

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -95,7 +95,10 @@ TEST(RISCVTuneFeature, LegalTuneFeatureStrings) {
 
 TEST(RISCVTuneFeature, UnrecognizedTuneFeature) {
   SmallVector<std::string> Result;
-  EXPECT_EQ(toString(RISCV::parseTuneFeatureString("32bit", Result)),
+  auto Err = RISCV::parseTuneFeatureString("32bit", Result);
+  // This should be an warning.
+  EXPECT_TRUE(Err.isA<RISCV::ParserWarning>());
+  EXPECT_EQ(toString(std::move(Err)),
             "unrecognized tune feature directive '32bit'");
 }
 

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -93,13 +93,14 @@ TEST(RISCVTuneFeature, LegalTuneFeatureStrings) {
   EXPECT_TRUE(is_contained(Result, "-no-default-unroll"));
 }
 
-TEST(RISCVTuneFeature, UnrecognizedTuneFeature) {
+TEST(RISCVTuneFeature, IgnoreUnrecognizedTuneFeature) {
   SmallVector<std::string> Result;
-  auto Err = RISCV::parseTuneFeatureString("32bit", Result);
+  auto Err = RISCV::parseTuneFeatureString("32bit,log-vrgather", Result);
   // This should be an warning.
   EXPECT_TRUE(Err.isA<RISCV::ParserWarning>());
   EXPECT_EQ(toString(std::move(Err)),
             "unrecognized tune feature directive '32bit'");
+  EXPECT_TRUE(is_contained(Result, "+log-vrgather"));
 }
 
 TEST(RISCVTuneFeature, DuplicatedFeatures) {

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TargetParser/RISCVTargetParser.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
@@ -29,5 +31,91 @@ TEST(RISCVVType, CheckSameRatioLMUL) {
   // Bigger fractional LMUL.
   EXPECT_EQ(RISCVVType::LMUL_F2,
             RISCVVType::getSameRatioLMUL(8, RISCVVType::LMUL_F4, 16));
+}
+
+TEST(RISCVTuneFeature, AllTuneFeatures) {
+  SmallVector<StringRef> AllTuneFeatures;
+  RISCV::getAllTuneFeatures(AllTuneFeatures);
+  EXPECT_EQ(AllTuneFeatures.size(), 28U);
+  for (auto F : {"conditional-cmv-fusion",
+                 "dlen-factor-2",
+                 "disable-latency-sched-heuristic",
+                 "disable-misched-load-clustering",
+                 "disable-misched-store-clustering",
+                 "disable-postmisched-load-clustering",
+                 "disable-postmisched-store-clustering",
+                 "single-element-vec-fp64",
+                 "log-vrgather",
+                 "no-default-unroll",
+                 "no-sink-splat-operands",
+                 "optimized-nf2-segment-load-store",
+                 "optimized-nf3-segment-load-store",
+                 "optimized-nf4-segment-load-store",
+                 "optimized-nf5-segment-load-store",
+                 "optimized-nf6-segment-load-store",
+                 "optimized-nf7-segment-load-store",
+                 "optimized-nf8-segment-load-store",
+                 "optimized-zero-stride-load",
+                 "use-postra-scheduler",
+                 "predictable-select-expensive",
+                 "prefer-vsetvli-over-read-vlenb",
+                 "prefer-w-inst",
+                 "short-forward-branch-i-minmax",
+                 "short-forward-branch-i-mul",
+                 "short-forward-branch-opt",
+                 "vl-dependent-latency",
+                 "vxrm-pipeline-flush"})
+    EXPECT_TRUE(is_contained(AllTuneFeatures, F));
+}
+
+TEST(RISCVTuneFeature, LegalTuneFeatureStrings) {
+  SmallVector<std::string> Result;
+  EXPECT_FALSE(errorToBool(RISCV::parseTuneFeatureString(
+      "log-vrgather,no-short-forward-branch-opt,vl-dependent-latency",
+      Result)));
+  EXPECT_TRUE(is_contained(Result, "+log-vrgather"));
+  EXPECT_TRUE(is_contained(Result, "+vl-dependent-latency"));
+  EXPECT_TRUE(is_contained(Result, "-short-forward-branch-opt"));
+  EXPECT_TRUE(is_contained(Result, "-short-forward-branch-i-minmax"));
+  EXPECT_TRUE(is_contained(Result, "-short-forward-branch-i-mul"));
+
+  Result.clear();
+  EXPECT_FALSE(errorToBool(RISCV::parseTuneFeatureString(
+      "no-short-forward-branch-i-mul,short-forward-branch-i-minmax", Result)));
+  EXPECT_TRUE(is_contained(Result, "+short-forward-branch-i-minmax"));
+  EXPECT_TRUE(is_contained(Result, "+short-forward-branch-opt"));
+  EXPECT_TRUE(is_contained(Result, "-short-forward-branch-i-mul"));
+
+  Result.clear();
+  EXPECT_FALSE(errorToBool(RISCV::parseTuneFeatureString(
+      "no-no-default-unroll,no-sink-splat-operands", Result)));
+  EXPECT_TRUE(is_contained(Result, "+no-sink-splat-operands"));
+  EXPECT_TRUE(is_contained(Result, "-no-default-unroll"));
+}
+
+TEST(RISCVTuneFeature, UnrecognizedTuneFeature) {
+  SmallVector<std::string> Result;
+  EXPECT_EQ(toString(RISCV::parseTuneFeatureString("32bit", Result)),
+            "unrecognized tune feature directive '32bit'");
+}
+
+TEST(RISCVTuneFeature, DuplicatedFeatures) {
+  SmallVector<std::string> Result;
+  EXPECT_EQ(toString(RISCV::parseTuneFeatureString("log-vrgather,log-vrgather",
+                                                   Result)),
+            "cannot specify more than one instance of 'log-vrgather'");
+
+  EXPECT_EQ(toString(RISCV::parseTuneFeatureString(
+                "log-vrgather,no-log-vrgather,short-forward-branch-i-mul,no-"
+                "short-forward-branch-i-mul",
+                Result)),
+            "Feature(s) 'log-vrgather', 'short-forward-branch-i-mul' cannot "
+            "appear in both positive and negative directives");
+
+  EXPECT_EQ(
+      toString(RISCV::parseTuneFeatureString(
+          "short-forward-branch-i-mul,no-short-forward-branch-opt", Result)),
+      "Feature(s) 'short-forward-branch-i-mul', 'short-forward-branch-opt' "
+      "were implied by both positive and negative directives");
 }
 } // namespace

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -38,16 +38,14 @@ TEST(RISCVTuneFeature, AllTuneFeatures) {
   RISCV::getAllTuneFeatures(AllTuneFeatures);
   // Only allowed subtarget features that are explicitly marked by
   // special TableGen class.
-  EXPECT_EQ(AllTuneFeatures.size(), 28U);
+  EXPECT_EQ(AllTuneFeatures.size(), 26U);
   for (auto F : {"conditional-cmv-fusion",
-                 "dlen-factor-2",
                  "disable-latency-sched-heuristic",
                  "disable-misched-load-clustering",
                  "disable-misched-store-clustering",
                  "disable-postmisched-load-clustering",
                  "disable-postmisched-store-clustering",
                  "single-element-vec-fp64",
-                 "log-vrgather",
                  "no-default-unroll",
                  "no-sink-splat-operands",
                  "optimized-nf2-segment-load-store",
@@ -73,9 +71,9 @@ TEST(RISCVTuneFeature, AllTuneFeatures) {
 TEST(RISCVTuneFeature, LegalTuneFeatureStrings) {
   SmallVector<std::string> Result;
   EXPECT_FALSE(errorToBool(RISCV::parseTuneFeatureString(
-      "log-vrgather,no-short-forward-branch-opt,vl-dependent-latency",
+      "prefer-w-inst,no-short-forward-branch-opt,vl-dependent-latency",
       Result)));
-  EXPECT_TRUE(is_contained(Result, "+log-vrgather"));
+  EXPECT_TRUE(is_contained(Result, "+prefer-w-inst"));
   EXPECT_TRUE(is_contained(Result, "+vl-dependent-latency"));
   EXPECT_TRUE(is_contained(Result, "-short-forward-branch-opt"));
   EXPECT_TRUE(is_contained(Result, "-short-forward-branch-i-minmax"));
@@ -102,25 +100,25 @@ TEST(RISCVTuneFeature, LegalTuneFeatureStrings) {
 
 TEST(RISCVTuneFeature, IgnoreUnrecognizedTuneFeature) {
   SmallVector<std::string> Result;
-  auto Err = RISCV::parseTuneFeatureString("32bit,log-vrgather", Result);
+  auto Err = RISCV::parseTuneFeatureString("32bit,prefer-w-inst", Result);
   // This should be an warning.
   EXPECT_TRUE(Err.isA<RISCV::ParserWarning>());
   EXPECT_EQ(toString(std::move(Err)),
             "unrecognized tune feature directive '32bit'");
-  EXPECT_TRUE(is_contained(Result, "+log-vrgather"));
+  EXPECT_TRUE(is_contained(Result, "+prefer-w-inst"));
 }
 
 TEST(RISCVTuneFeature, DuplicatedFeatures) {
   SmallVector<std::string> Result;
-  EXPECT_EQ(toString(RISCV::parseTuneFeatureString("log-vrgather,log-vrgather",
-                                                   Result)),
-            "cannot specify more than one instance of 'log-vrgather'");
+  EXPECT_EQ(toString(RISCV::parseTuneFeatureString(
+                "prefer-w-inst,prefer-w-inst", Result)),
+            "cannot specify more than one instance of 'prefer-w-inst'");
 
   EXPECT_EQ(toString(RISCV::parseTuneFeatureString(
-                "log-vrgather,no-log-vrgather,short-forward-branch-i-mul,no-"
+                "prefer-w-inst,no-prefer-w-inst,short-forward-branch-i-mul,no-"
                 "short-forward-branch-i-mul",
                 Result)),
-            "Feature(s) 'log-vrgather', 'short-forward-branch-i-mul' cannot "
+            "Feature(s) 'prefer-w-inst', 'short-forward-branch-i-mul' cannot "
             "appear in both positive and negative directives");
 
   // The error message should show the feature name for those using custom

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -38,33 +38,17 @@ TEST(RISCVTuneFeature, AllTuneFeatures) {
   RISCV::getAllTuneFeatures(AllTuneFeatures);
   // Only allowed subtarget features that are explicitly marked by
   // special TableGen class.
-  EXPECT_EQ(AllTuneFeatures.size(), 26U);
-  for (auto F : {"conditional-cmv-fusion",
-                 "disable-latency-sched-heuristic",
-                 "disable-misched-load-clustering",
-                 "disable-misched-store-clustering",
-                 "disable-postmisched-load-clustering",
-                 "disable-postmisched-store-clustering",
-                 "single-element-vec-fp64",
-                 "no-default-unroll",
-                 "no-sink-splat-operands",
-                 "optimized-nf2-segment-load-store",
-                 "optimized-nf3-segment-load-store",
-                 "optimized-nf4-segment-load-store",
-                 "optimized-nf5-segment-load-store",
-                 "optimized-nf6-segment-load-store",
-                 "optimized-nf7-segment-load-store",
-                 "optimized-nf8-segment-load-store",
-                 "optimized-zero-stride-load",
-                 "use-postra-scheduler",
-                 "predictable-select-expensive",
-                 "prefer-vsetvli-over-read-vlenb",
-                 "prefer-w-inst",
-                 "short-forward-branch-i-minmax",
-                 "short-forward-branch-i-mul",
-                 "short-forward-branch-opt",
-                 "vl-dependent-latency",
-                 "vxrm-pipeline-flush"})
+  EXPECT_EQ(AllTuneFeatures.size(), 18U);
+  for (auto F :
+       {"conditional-cmv-fusion", "disable-latency-sched-heuristic",
+        "disable-misched-load-clustering", "disable-misched-store-clustering",
+        "disable-postmisched-load-clustering",
+        "disable-postmisched-store-clustering", "single-element-vec-fp64",
+        "no-default-unroll", "no-sink-splat-operands", "use-postra-scheduler",
+        "predictable-select-expensive", "prefer-vsetvli-over-read-vlenb",
+        "prefer-w-inst", "short-forward-branch-i-minmax",
+        "short-forward-branch-i-mul", "short-forward-branch-opt",
+        "vl-dependent-latency", "vxrm-pipeline-flush"})
     EXPECT_TRUE(is_contained(AllTuneFeatures, F));
 }
 


### PR DESCRIPTION
This patch creates a new syntax intended for `-mtune`, such that we can write
```
-mtune=xyz:foo,no-bar
```
to reuse the tune CPU definition of `xyz` but "customize" it by enabling feature `foo` while disabling feature `bar`. The "foo,no-bar" is the new tune feature string we're introducing here.

The grammar is simple:
```
simpleDirective ::= ("no-")? featureName
directive       ::= simpleDirective
                    | [a-zA-Z0-9_-]+
tuneFeatureStr  ::= directive ("," directive)*
```
We can further categorized directives into _positive_ and _negative_ ones. Positive directives add new subtarget features; negative directives, on the other hand, can only subtract subtarget features from the base tune CPU.

Both of them are derived from an existing subtarget feature. For example, we can use `RISCVSimpleTuneFeature` to designate `TuneVLDependentLatency` as a tuning feature:
```
def TuneVLDependentLatency
    : SubtargetFeature<"vl-dependent-latency", "HasVLDependentLatency", "true",
                       "Latency of vector instructions is dependent on the "
                       "dynamic value of vl">,
     RISCVSimpleTuneFeature;
```
In which case its positive directive is the same as its feature name, "vl-dependent-latency", and its negative directive is "no-" + feature name -- "no-vl-dependent-latency"

One can also use `RISCVTuneFeature` to designate custom directive names:
```
def TuneNoDefaultUnroll
    : SubtargetFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
                       "Disable default unroll preference.">,
      RISCVTuneFeature<pos_directive="no-default-unroll", neg_directive="default-unroll">;
```
In this case, feature `no-default-unroll` will be subtracted from tune CPU's feature list in the presence of "default-unroll" directive -- which is its negative directive. Conversely, this feature will be added when there is a "no-default-unroll", its positive directive.

None of the subtarget features generated from positive directives -- either explicitly or implicitly (i.e. implied features) -- should overlaps with those generated from the negative directives. This is a deliberated decision to simplify the logics and prevent it from becoming unmanageable in the future.

---------

Credit to Sam for the rules and semantics describes in https://github.com/llvm/llvm-project/pull/162716#issuecomment-3387400859 of which this PR builds on top.

I still need to add documentation. There will also be another follow-up patch to integrate this into Clang.